### PR TITLE
Back-pressure handler in NettyHelixIPCService

### DIFF
--- a/helix-ipc/src/test/java/org/apache/helix/ipc/benchmark/BenchmarkDriver.java
+++ b/helix-ipc/src/test/java/org/apache/helix/ipc/benchmark/BenchmarkDriver.java
@@ -64,20 +64,17 @@ public class BenchmarkDriver implements Runnable {
   private final AtomicBoolean isShutdown;
   private final byte[] messageBytes;
   private final int numConnections;
-  private final long maxChannelLifeMillis;
 
   private HelixIPCService ipcService;
   private String localhost;
   private Thread[] trafficThreads;
 
-  public BenchmarkDriver(int port, int numPartitions, int numThreads, int messageSize,
-      int numConnections, long maxChannelLifeMillis) {
+  public BenchmarkDriver(int port, int numPartitions, int numThreads, int messageSize, int numConnections) {
     this.port = port;
     this.numPartitions = numPartitions;
     this.isShutdown = new AtomicBoolean(true);
     this.trafficThreads = new Thread[numThreads];
     this.numConnections = numConnections;
-    this.maxChannelLifeMillis = maxChannelLifeMillis;
 
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < messageSize; i++) {
@@ -108,7 +105,7 @@ public class BenchmarkDriver implements Runnable {
       ipcService =
           new NettyHelixIPCService(new NettyHelixIPCService.Config()
               .setInstanceName(localhost + "_" + port).setPort(port)
-              .setNumConnections(numConnections).setMaxChannelLifeMillis(maxChannelLifeMillis));
+              .setNumConnections(numConnections));
 
       // Counts number of messages received, and ack them
       ipcService.registerCallback(MESSAGE_TYPE, new HelixIPCCallback() {
@@ -182,21 +179,17 @@ public class BenchmarkDriver implements Runnable {
   @MXBean
   public interface Controller {
     void startTraffic(String remoteHost, int remotePort);
-
     void stopTraffic();
   }
 
   public static void main(String[] args) throws Exception {
     BasicConfigurator.configure();
-    Logger.getRootLogger().setLevel(Level.DEBUG);
 
     Options options = new Options();
     options.addOption("partitions", true, "Number of partitions");
     options.addOption("threads", true, "Number of threads");
     options.addOption("messageSize", true, "Message size in bytes");
     options.addOption("numConnections", true, "Number of connections between nodes");
-    options.addOption("maxChannelLifeMillis", true,
-        "Maximum length of time to keep Netty Channel open");
 
     CommandLine commandLine = new GnuParser().parse(options, args);
 
@@ -218,8 +211,7 @@ public class BenchmarkDriver implements Runnable {
     new BenchmarkDriver(Integer.parseInt(commandLine.getArgs()[0]), Integer.parseInt(commandLine
         .getOptionValue("partitions", "1")), Integer.parseInt(commandLine.getOptionValue("threads",
         "1")), Integer.parseInt(commandLine.getOptionValue("messageSize", "1024")),
-        Integer.parseInt(commandLine.getOptionValue("numConnections", "1")),
-        Long.parseLong(commandLine.getOptionValue("maxChannelLifeMillis", "5000"))).run();
+        Integer.parseInt(commandLine.getOptionValue("numConnections", "1"))).run();
 
     latch.await();
   }


### PR DESCRIPTION
Removes hack in which Netty Channel was periodically closed to allow Netty objects to be GC'ed in favor of properly using channel writability changed events.

Before calling `Channel#writeAndFlush`, we call `BackPressureHandler#waitUntilWritable`, which will block if the channel is not writable until `#channelWritabilityChanged` is called.

Ran `BenchmarkDriver` locally to verify that heap usage stays relatively low and constant when NIC saturated.
