### PR TITLE
helix-ipc artifact now includes both resolvers and ipc package

### DIFF
--- a/helix-ipc/pom.xml
+++ b/helix-ipc/pom.xml
@@ -40,8 +40,7 @@ under the License.
     <osgi.ignore>
       org.apache.helix.tools*
     </osgi.ignore>
-    <osgi.export>org.apache.helix.ipc*;version="${project.version};-noimport:=true</osgi.export>
-    <osgi.export>org.apache.helix.resolver*;version="${project.version};-noimport:=true</osgi.export>
+    <osgi.export>org.apache.helix.resolver*,org.apache.helix.ipc*;version="${project.version};-noimport:=true</osgi.export> 
   </properties>
 
   <dependencies>


### PR DESCRIPTION
helix-ipc-0.7.1 only included the resolvers package in the JAR but both resolvers and ipc are needed. The problem was there were two export tags in the build file with the latter overriding the ipc export. Including both package names in a single tag gets the artifact publishing correctly on my 0.7.2-snapshot build. 
