### PR TITLE
[HELIX-569] - Update docs to correctly pass rebalance mode during helix-admin.sh resource creation

### DIFF
--- a/recipes/distributed-lock-manager/README.md
+++ b/recipes/distributed-lock-manager/README.md
@@ -137,7 +137,7 @@ This provides more details on how to setup the cluster and where to plugin appli
 Create a lock group and specify the number of locks in the lock group. 
 
 ```
-./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline FULL_AUTO
+./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline --mode FULL_AUTO
 ```
 
 ##### Start the nodes

--- a/website/0.6.1-incubating/src/site/markdown/recipes/lock_manager.md
+++ b/website/0.6.1-incubating/src/site/markdown/recipes/lock_manager.md
@@ -138,7 +138,7 @@ This provides more details on how to setup the cluster and where to plugin appli
 Create a lock group and specify the number of locks in the lock group.
 
 ```
-./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline AUTO_REBALANCE
+./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline --mode AUTO_REBALANCE
 ```
 
 #### Start the Nodes

--- a/website/0.6.1-incubating/src/site/markdown/tutorial_admin.md
+++ b/website/0.6.1-incubating/src/site/markdown/tutorial_admin.md
@@ -65,7 +65,7 @@ Add a State model to a cluster
 Add a resource to a cluster
 
 ```
---addResource <clusterName> <resourceName> <partitionNum> <stateModelRef> <mode (AUTO_REBALANCE|AUTO|CUSTOMIZED)>
+--addResource <clusterName> <resourceName> <partitionNum> <stateModelRef> <--mode (AUTO_REBALANCE|AUTO|CUSTOMIZED)>
 ```
 
 Upload an IdealState (Partition to Node Mapping)

--- a/website/0.6.2-incubating/src/site/markdown/recipes/lock_manager.md
+++ b/website/0.6.2-incubating/src/site/markdown/recipes/lock_manager.md
@@ -138,7 +138,7 @@ This provides more details on how to setup the cluster and where to plugin appli
 Create a lock group and specify the number of locks in the lock group.
 
 ```
-./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline AUTO_REBALANCE
+./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline --mode AUTO_REBALANCE
 ```
 
 #### Start the Nodes

--- a/website/0.6.3/src/site/markdown/recipes/lock_manager.md
+++ b/website/0.6.3/src/site/markdown/recipes/lock_manager.md
@@ -138,7 +138,7 @@ This provides more details on how to setup the cluster and where to plugin appli
 Create a lock group and specify the number of locks in the lock group.
 
 ```
-./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline AUTO_REBALANCE
+./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline --mode AUTO_REBALANCE
 ```
 
 #### Start the Nodes

--- a/website/0.6.4/src/site/markdown/recipes/lock_manager.md
+++ b/website/0.6.4/src/site/markdown/recipes/lock_manager.md
@@ -138,7 +138,7 @@ This provides more details on how to setup the cluster and where to plugin appli
 Create a lock group and specify the number of locks in the lock group.
 
 ```
-./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline AUTO_REBALANCE
+./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline --mode AUTO_REBALANCE
 ```
 
 #### Start the Nodes

--- a/website/0.7.0-incubating/src/site/markdown/recipes/lock_manager.md
+++ b/website/0.7.0-incubating/src/site/markdown/recipes/lock_manager.md
@@ -138,7 +138,7 @@ This provides more details on how to setup the cluster and where to plugin appli
 Create a lock group and specify the number of locks in the lock group.
 
 ```
-./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline AUTO_REBALANCE
+./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline --mode AUTO_REBALANCE
 ```
 
 #### Start the Nodes

--- a/website/0.7.1/src/site/markdown/recipes/lock_manager.md
+++ b/website/0.7.1/src/site/markdown/recipes/lock_manager.md
@@ -138,7 +138,7 @@ This provides more details on how to setup the cluster and where to plugin appli
 Create a lock group and specify the number of locks in the lock group.
 
 ```
-./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline AUTO_REBALANCE
+./helix-admin --zkSvr localhost:2199  --addResource lock-manager-demo lock-group 6 OnlineOffline --mode AUTO_REBALANCE
 ```
 
 #### Start the Nodes


### PR DESCRIPTION
I stumbled upon this the other day in #apachehelix irc. I couldn't get the distributed locks example to work in full auto rebalance mode, and it turns out the docs just needed an update. Since the default rebalance mode since 0.6.2 is SEMI_AUTO, my testing halfway worked and exhibited very confusing behavior.

This updates the docs to keep future new users headed in the right direction.

https://issues.apache.org/jira/browse/HELIX-569