### PR TITLE
[HELIX-584] SimpleDateFormat should not be used as singleton due to its race conditions

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -575,7 +575,7 @@ public class TaskDriver {
     // find a task
     for (String resource : _admin.getResourcesInCluster(_clusterName)) {
       IdealState is = _admin.getResourceIdealState(_clusterName, resource);
-      if (is.getStateModelDefRef().equals(TaskConstants.STATE_MODEL_NAME)) {
+      if (is != null && is.getStateModelDefRef().equals(TaskConstants.STATE_MODEL_NAME)) {
         HelixDataAccessor accessor = _manager.getHelixDataAccessor();
         accessor.updateProperty(accessor.keyBuilder().idealStates(resource), is);
         break;

--- a/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
@@ -343,7 +343,7 @@ public class TaskUtil {
     Date startTime = null;
     if (cfg.containsKey(WorkflowConfig.START_TIME)) {
       try {
-        startTime = WorkflowConfig.DEFAULT_DATE_FORMAT.parse(cfg.get(WorkflowConfig.START_TIME));
+        startTime = WorkflowConfig.getDefaultDateFormat().parse(cfg.get(WorkflowConfig.START_TIME));
       } catch (ParseException e) {
         LOG.error("Unparseable date " + cfg.get(WorkflowConfig.START_TIME), e);
         return null;

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowConfig.java
@@ -40,11 +40,6 @@ public class WorkflowConfig {
 
   /* Default values */
   public static final long DEFAULT_EXPIRY = 24 * 60 * 60 * 1000;
-  public static final SimpleDateFormat DEFAULT_DATE_FORMAT = new SimpleDateFormat(
-      "MM-dd-yyyy HH:mm:ss");
-  static {
-    DEFAULT_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
-  }
 
   /* Member variables */
   private final JobDag _jobDag;
@@ -82,6 +77,13 @@ public class WorkflowConfig {
     return _scheduleConfig;
   }
 
+  public static SimpleDateFormat getDefaultDateFormat() {
+    SimpleDateFormat defaultDateFormat = new SimpleDateFormat("MM-dd-yyyy HH:mm:ss");
+    defaultDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+    return defaultDateFormat;
+  }
+
   public Map<String, String> getResourceConfigMap() throws Exception {
     Map<String, String> cfgMap = new HashMap<String, String>();
     cfgMap.put(WorkflowConfig.DAG, getJobDag().toJson());
@@ -94,7 +96,7 @@ public class WorkflowConfig {
     if (scheduleConfig != null) {
       Date startTime = scheduleConfig.getStartTime();
       if (startTime != null) {
-        String formattedTime = WorkflowConfig.DEFAULT_DATE_FORMAT.format(startTime);
+        String formattedTime = WorkflowConfig.getDefaultDateFormat().format(startTime);
         cfgMap.put(WorkflowConfig.START_TIME, formattedTime);
       }
       if (scheduleConfig.isRecurring()) {


### PR DESCRIPTION
[HELIX-584] SimpleDateFormat should not be used as singleton due to its race conditions.