### PR TITLE
[HELIX-592] addCluster should respect overwriteExisitng when adding stateModel Definations.

### DIFF
--- a/helix-admin-webapp/src/test/java/org/apache/helix/webapp/TestHelixAdminScenariosRest.java
+++ b/helix-admin-webapp/src/test/java/org/apache/helix/webapp/TestHelixAdminScenariosRest.java
@@ -220,7 +220,7 @@ public class TestHelixAdminScenariosRest extends AdminTestBase {
     Assert.assertTrue(response.contains("\\ClusterTest"));
 
     // Add already exist cluster
-    response = assertSuccessPostOperation(url, addClusterCmd("clusterTest"), true);
+    response = assertSuccessPostOperation(url, addClusterCmd("clusterTest"), false);
 
     // delete cluster without resource and instance
     Assert.assertTrue(ZKUtil.isClusterSetup("Klazt3rz", _gZkClient));

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -232,8 +232,20 @@ public interface HelixAdmin {
    * @param clusterName
    * @param stateModelDef
    * @param record
+   * @return true if successfully created, or if state model definition already exists
    */
   void addStateModelDef(String clusterName, String stateModelDef, StateModelDefinition record);
+
+  /**
+   * Add a state model definition
+   * @param clusterName
+   * @param stateModelDef
+   * @param record
+   * @param recreateIfExists If the state definition already exists, it will delete it and recreate
+   * @return true if successfully created, or if state model definition already exists
+   */
+  void addStateModelDef(String clusterName, String stateModelDef, StateModelDefinition record,
+      boolean recreateIfExists);
 
   /**
    * Drop a resource from a cluster

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterSetup.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterSetup.java
@@ -153,7 +153,7 @@ public class ClusterSetup {
 
     for (BuiltInStateModelDefinitions def : BuiltInStateModelDefinitions.values()) {
       addStateModelDef(clusterName, def.getStateModelDefinition().getId(),
-                       def.getStateModelDefinition());
+                       def.getStateModelDefinition(), overwritePrevious);
     }
   }
 
@@ -330,8 +330,14 @@ public class ClusterSetup {
     return _admin;
   }
 
-  public void addStateModelDef(String clusterName, String stateModelDef, StateModelDefinition record) {
+  public void addStateModelDef(String clusterName, String stateModelDef,
+      StateModelDefinition record) {
     _admin.addStateModelDef(clusterName, stateModelDef, record);
+  }
+
+  public void addStateModelDef(String clusterName, String stateModelDef,
+      StateModelDefinition record, boolean overwritePrevious) {
+    _admin.addStateModelDef(clusterName, stateModelDef, record, overwritePrevious);
   }
 
   public void addResourceToCluster(String clusterName, String resourceName, int numResources,

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -127,13 +127,8 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     tool.addStateModelDef(clusterName, "MasterSlave", new StateModelDefinition(
         StateModelConfigGenerator.generateConfigForMasterSlave()));
     stateModelRecord = StateModelConfigGenerator.generateConfigForMasterSlave();
-    try {
-      tool.addStateModelDef(clusterName, stateModelRecord.getId(), new StateModelDefinition(
-          stateModelRecord));
-      Assert.fail("should fail if add an already-existing state model");
-    } catch (HelixException e) {
-      // OK
-    }
+    tool.addStateModelDef(clusterName, stateModelRecord.getId(), new StateModelDefinition(
+        stateModelRecord));
     list = tool.getStateModelDefs(clusterName);
     AssertJUnit.assertEquals(list.size(), 1);
 

--- a/helix-core/src/test/java/org/apache/helix/tools/TestHelixAdminCli.java
+++ b/helix-core/src/test/java/org/apache/helix/tools/TestHelixAdminCli.java
@@ -69,12 +69,7 @@ public class TestHelixAdminCli extends ZkIntegrationTestBase {
 
     // Add already exist cluster
     command = "--zkSvr localhost:2183 -addCluster clusterTest";
-    try {
-      ClusterSetup.processCommandLineArgs(command.split("\\s+"));
-      Assert.fail("ClusterSetup should fail since clusterTest already exists");
-    } catch (Exception e) {
-      // OK
-    }
+    ClusterSetup.processCommandLineArgs(command.split("\\s+"));
 
     // make sure clusters are properly setup
     Assert.assertTrue(ZKUtil.isClusterSetup("Klazt3rz", _gZkClient));


### PR DESCRIPTION
Congrui Ji has sent this fix before, and got some comments.  But he is on vacation, and we (LinkedIn) do need the fix ASAP, so I am sending this again.  Thanks