### PR TITLE
[HELIX-596] fix throttled messages still take constraints' quota

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageThrottleStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageThrottleStage.java
@@ -173,13 +173,14 @@ public class MessageThrottleStage extends AbstractBaseStage {
       matches = selectConstraints(matches, msgAttr);
 
       boolean msgThrottled = false;
+      Map<String, Integer> perMessageThrottleQuotaMap = new HashMap<String, Integer>();
       for (ConstraintItem item : matches) {
         String key = item.filter(msgAttr).toString();
         if (!throttleMap.containsKey(key)) {
           throttleMap.put(key, valueOf(item.getConstraintValue()));
         }
         int value = throttleMap.get(key);
-        throttleMap.put(key, --value);
+        perMessageThrottleQuotaMap.put(key, --value);
 
         if (needThrottle && value < 0) {
           msgThrottled = true;
@@ -193,6 +194,10 @@ public class MessageThrottleStage extends AbstractBaseStage {
 
       if (!msgThrottled) {
         throttleOutputMsgs.add(message);
+        // copy back perMessageThrottleQuotaMap to throttleMap
+        for (Map.Entry<String, Integer> entry: perMessageThrottleQuotaMap.entrySet()) {
+          throttleMap.put(entry.getKey(), entry.getValue());
+        }
       }
     }
 

--- a/helix-core/src/test/java/org/apache/helix/testutil/HelixTestUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/testutil/HelixTestUtil.java
@@ -30,6 +30,7 @@ import org.apache.helix.PropertyKey;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.api.State;
 import org.apache.helix.api.id.MessageId;
+import org.apache.helix.api.id.PartitionId;
 import org.apache.helix.api.id.StateModelDefId;
 import org.apache.helix.controller.pipeline.Pipeline;
 import org.apache.helix.controller.pipeline.Stage;
@@ -235,6 +236,13 @@ public class HelixTestUtil {
     msg.setToState(State.from(toState));
     msg.getRecord().setSimpleField(Attributes.RESOURCE_NAME.toString(), resourceName);
     msg.setTgtName(tgtName);
+    return msg;
+  }
+
+  public static Message newMessage(MessageType type, MessageId msgId, String fromState,
+      String toState, String resourceName, String tgtName, String partitionId) {
+    Message msg = newMessage(type, msgId, fromState, toState, resourceName, tgtName);
+    msg.setPartitionId(PartitionId.from(partitionId));
     return msg;
   }
 }


### PR DESCRIPTION
Corresponding review request:  https://reviews.apache.org/r/34345/

Main changes in this pull request:

perMessageThrottleQuotaMap records all matched constraints quota for this message, and update the overall throttleMap iff the message has not been throttled. Originally not matter the message will be sent out or not, it will always take the quota of the matched constraints.
