### PR TITLE
[HELIX-601] Allow work flow to schedule dependency jobs in parallel

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/JobDag.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobDag.java
@@ -19,6 +19,7 @@ package org.apache.helix.task;
  * under the License.
  */
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -122,6 +123,22 @@ public class JobDag {
       return new TreeSet<String>();
     }
     return _childrenToParents.get(node);
+  }
+
+  public Set<String> getAncestors(String node) {
+    Set<String> ret = new TreeSet<String>();
+    Set<String> current = Collections.singleton(node);
+
+    while (!current.isEmpty()) {
+      Set<String> next = new TreeSet<String>();
+      for (String currentNode : current) {
+        next.addAll(getDirectParents(currentNode));
+      }
+      ret.addAll(next);
+      current = next;
+    }
+
+    return ret;
   }
 
   public String toJson() throws Exception {

--- a/helix-core/src/main/java/org/apache/helix/task/JobQueue.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobQueue.java
@@ -32,8 +32,8 @@ public class JobQueue extends WorkflowConfig {
   private final int _capacity;
 
   private JobQueue(String name, int capacity, WorkflowConfig config) {
-    super(config.getJobDag(), config.getTargetState(), config.getExpiry(), config.isTerminable(),
-        config.getScheduleConfig());
+    super(config.getJobDag(), config.getParallelJobs(), config.getTargetState(), config.getExpiry(),
+        config.isTerminable(), config.getScheduleConfig());
     _name = name;
     _capacity = capacity;
   }
@@ -70,6 +70,11 @@ public class JobQueue extends WorkflowConfig {
     public Builder(String name) {
       _builder = new WorkflowConfig.Builder();
       _name = name;
+    }
+
+    public Builder parallelJobs(int parallelJobs) {
+      _builder.setParallelJobs(parallelJobs);
+      return this;
     }
 
     public Builder expiry(long expiry) {

--- a/helix-core/src/main/java/org/apache/helix/task/TaskRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskRebalancer.java
@@ -134,12 +134,20 @@ public abstract class TaskRebalancer implements Rebalancer, MappingCalculator {
       workflowCtx.setStartTime(System.currentTimeMillis());
     }
 
-    // Check parent dependencies
-    for (String parent : workflowCfg.getJobDag().getDirectParents(resourceName)) {
-      if (workflowCtx.getJobState(parent) == null
-          || !workflowCtx.getJobState(parent).equals(TaskState.COMPLETED)) {
-        return emptyAssignment(resourceName, currStateOutput);
+    // check ancestor job status
+    int unStartCount = 0;
+    int inCompleteCount = 0;
+    for (String ancestor : workflowCfg.getJobDag().getAncestors(resourceName)) {
+      TaskState jobState = workflowCtx.getJobState(ancestor);
+      if (jobState == null || jobState == TaskState.NOT_STARTED) {
+        ++unStartCount;
+      } else if (jobState == TaskState.IN_PROGRESS || jobState == TaskState.STOPPED) {
+        ++inCompleteCount;
       }
+    }
+
+    if (unStartCount > 0 || inCompleteCount >= workflowCfg.getParallelJobs()) {
+      return emptyAssignment(resourceName, currStateOutput);
     }
 
     // Clean up if workflow marked for deletion
@@ -219,6 +227,32 @@ public abstract class TaskRebalancer implements Rebalancer, MappingCalculator {
     return newAssignment;
   }
 
+  private Set<String> getWorkflowAssignedInstances(String currentJobName,
+      WorkflowConfig workflowCfg) {
+
+    Set<String> ret = new HashSet<String>();
+
+    for (String jobName : workflowCfg.getJobDag().getAllNodes()) {
+      if (jobName.equals(currentJobName)) {
+        continue;
+      }
+
+      JobContext jobContext = TaskUtil.getJobContext(_manager, jobName);
+      if (jobContext == null) {
+        continue;
+      }
+      for (int partition : jobContext.getPartitionSet()) {
+        TaskPartitionState partitionState = jobContext.getPartitionState(partition);
+        if (partitionState == TaskPartitionState.INIT ||
+            partitionState == TaskPartitionState.RUNNING) {
+          ret.add(jobContext.getAssignedParticipant(partition));
+        }
+      }
+    }
+
+    return ret;
+  }
+
   private ResourceAssignment computeResourceMapping(String jobResource,
       WorkflowConfig workflowConfig, JobConfig jobCfg, ResourceAssignment prevAssignment,
       Collection<String> liveInstances, CurrentStateOutput currStateOutput,
@@ -248,6 +282,8 @@ public abstract class TaskRebalancer implements Rebalancer, MappingCalculator {
     // Keeps a mapping of (partition) -> (instance, state)
     Map<Integer, PartitionAssignment> paMap = new TreeMap<Integer, PartitionAssignment>();
 
+    Set<String> excludedInstances = getWorkflowAssignedInstances(jobResource, workflowConfig);
+
     // Process all the current assignments of tasks.
     Set<Integer> allPartitions =
         getAllTaskPartitions(jobCfg, jobCtx, workflowConfig, workflowCtx, cache);
@@ -255,6 +291,10 @@ public abstract class TaskRebalancer implements Rebalancer, MappingCalculator {
         getTaskPartitionAssignments(liveInstances, prevAssignment, allPartitions);
     long currentTime = System.currentTimeMillis();
     for (String instance : taskAssignments.keySet()) {
+      if (excludedInstances.contains(instance)) {
+        continue;
+      }
+
       Set<Integer> pSet = taskAssignments.get(instance);
       // Used to keep track of partitions that are in one of the final states: COMPLETED, TIMED_OUT,
       // TASK_ERROR, ERROR.
@@ -430,7 +470,7 @@ public abstract class TaskRebalancer implements Rebalancer, MappingCalculator {
               workflowConfig, workflowCtx, allPartitions, cache);
       for (Map.Entry<String, SortedSet<Integer>> entry : taskAssignments.entrySet()) {
         String instance = entry.getKey();
-        if (!tgtPartitionAssignments.containsKey(instance)) {
+        if (!tgtPartitionAssignments.containsKey(instance) || excludedInstances.contains(instance)) {
           continue;
         }
         // Contains the set of task partitions currently assigned to the instance.

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerParallel.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerParallel.java
@@ -1,5 +1,24 @@
 package org.apache.helix.integration.task;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerParallel.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerParallel.java
@@ -1,0 +1,195 @@
+package org.apache.helix.integration.task;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.helix.AccessOption;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.ZkIntegrationTestBase;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.JobContext;
+import org.apache.helix.task.JobQueue;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskConstants;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskPartitionState;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.tools.ClusterSetup;
+import org.apache.helix.tools.ClusterStateVerifier;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+
+public class TestTaskRebalancerParallel extends ZkIntegrationTestBase {
+  private static final int n = 5;
+  private static final int START_PORT = 12918;
+  private static final String MASTER_SLAVE_STATE_MODEL = "MasterSlave";
+  private static final int NUM_PARTITIONS = 20;
+  private static final int NUM_REPLICAS = 3;
+  private final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + getShortClassName();
+  private final List<String> testDbNames =
+      Arrays.asList("TestDB_1", "TestDB_2", "TestDB_3", "TestDB_4");
+
+
+  private final MockParticipantManager[] _participants = new MockParticipantManager[n];
+  private ClusterControllerManager _controller;
+
+  private HelixManager _manager;
+  private TaskDriver _driver;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursive(namespace);
+    }
+
+    ClusterSetup setupTool = new ClusterSetup(ZK_ADDR);
+    setupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < n; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+
+    for (String testDbName : testDbNames) {
+      setupTool.addResourceToCluster(CLUSTER_NAME, testDbName, NUM_PARTITIONS,
+          MASTER_SLAVE_STATE_MODEL);
+      setupTool.rebalanceStorageCluster(CLUSTER_NAME, testDbName, NUM_REPLICAS);
+    }
+
+    // start dummy participants
+    for (int i = 0; i < n; i++) {
+      String instanceName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+
+      final long delay = (i + 1) * 1000L;
+      Map<String, TaskFactory> taskFactoryReg = new HashMap<String, TaskFactory>();
+      taskFactoryReg.put("Reindex", new TaskFactory() {
+        @Override
+        public Task createNewTask(TaskCallbackContext context) {
+          return new ReindexTask(delay);
+        }
+      });
+
+      // Register a Task state model factory.
+      StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+      stateMachine.registerStateModelFactory("Task",
+          new TaskStateModelFactory(_participants[i], taskFactoryReg));
+      _participants[i].syncStart();
+    }
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    // create cluster manager
+    _manager =
+        HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "Admin", InstanceType.ADMINISTRATOR,
+            ZK_ADDR);
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+
+    boolean result =
+        ClusterStateVerifier
+            .verifyByZkCallback(new ClusterStateVerifier.BestPossAndExtViewZkVerifier(ZK_ADDR,
+                CLUSTER_NAME));
+    Assert.assertTrue(result);
+  }
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    _controller.syncStop();
+    // _controller = null;
+    for (int i = 0; i < n; i++) {
+      _participants[i].syncStop();
+      // _participants[i] = null;
+    }
+
+    _manager.disconnect();
+  }
+
+  @Test
+  public void test() throws Exception {
+    final int PARALLEL_COUNT = 2;
+
+    String queueName = TestHelper.getTestMethodName();
+
+    JobQueue queue = new JobQueue.Builder(queueName).parallelJobs(PARALLEL_COUNT).build();
+    _driver.createQueue(queue);
+
+    List<JobConfig.Builder> jobConfigBuilders = new ArrayList<JobConfig.Builder>();
+    for (String testDbName : testDbNames) {
+      jobConfigBuilders.add(
+          new JobConfig.Builder().setCommand("Reindex").setTargetResource(testDbName)
+              .setTargetPartitionStates(Collections.singleton("SLAVE")));
+    }
+
+    for (int i = 0; i < jobConfigBuilders.size(); ++i) {
+      _driver.enqueueJob(queueName, "job_" + (i + 1), jobConfigBuilders.get(i));
+    }
+
+    Assert.assertTrue(TestUtil.pollForWorkflowParallelState(_manager, queueName));
+  }
+
+  public static class ReindexTask implements Task {
+    private final long _delay;
+    private volatile boolean _canceled;
+
+    public ReindexTask(long delay) {
+      _delay = delay;
+    }
+
+    @Override
+    public TaskResult run() {
+      long expiry = System.currentTimeMillis() + _delay;
+      long timeLeft;
+      while (System.currentTimeMillis() < expiry) {
+        if (_canceled) {
+          timeLeft = expiry - System.currentTimeMillis();
+          return new TaskResult(TaskResult.Status.CANCELED, String.valueOf(timeLeft < 0 ? 0
+              : timeLeft));
+        }
+        sleep(50);
+      }
+      timeLeft = expiry - System.currentTimeMillis();
+      return new TaskResult(TaskResult.Status.COMPLETED,
+          String.valueOf(timeLeft < 0 ? 0 : timeLeft));
+    }
+
+    @Override
+    public void cancel() {
+      _canceled = true;
+    }
+
+    private static void sleep(long d) {
+      try {
+        Thread.sleep(d);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/task/WorkflowGenerator.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/WorkflowGenerator.java
@@ -62,7 +62,7 @@ public class WorkflowGenerator {
       throw new IllegalArgumentException(
           "Additional configs should have even number of keys and values");
     }
-    Workflow.Builder bldr = generateDefaultSingleJobWorkflowBuilder(jobName);
+    Workflow.Builder bldr = generateSingleJobWorkflowBuilder(jobName, commandConfig, DEFAULT_JOB_CONFIG);
     for (int i = 0; i < cfgs.length; i += 2) {
       bldr.addConfig(jobName, cfgs[i], cfgs[i + 1]);
     }


### PR DESCRIPTION
Currently, Helix won't schedule dependency jobs in a same work flow. For example, if Job2 depends on Job1, Job2 won't be scheduled until every partition of Job1 is completed.
However, if some participant is very slow, then all dependency jobs is waiting for that single participant.
Helix should be able to schedule multiple jobs according to a parameter.
A.C.
1. Introduce parallel count parameter in work flow and job queue.
2. Dependency jobs can be scheduled according to the parameter (Now the parameter is always 1, so no parallel)
3. If Job2 depends on Job1, Job1 is scheduled before Job2.
4. No parallel jobs on the same instance. If a instance is running Job1, it won't run Job2 until Job1 is finished.