### PR TITLE
[Helix-606] Add an option in IdealState to allow a resource to disable showing external view.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/IdealState.java
+++ b/helix-core/src/main/java/org/apache/helix/model/IdealState.java
@@ -57,7 +57,8 @@ public class IdealState extends HelixProperty {
     REBALANCER_CLASS_NAME,
     HELIX_ENABLED,
     RESOURCE_GROUP_NAME,
-    GROUP_ROUTING_ENABLED
+    GROUP_ROUTING_ENABLED,
+    EXTERNAL_VIEW_DISABLED
   }
 
   public static final String QUERY_LIST = "PREFERENCE_LIST_QUERYS";
@@ -196,6 +197,24 @@ public class IdealState extends HelixProperty {
   public void enableGroupRouting(boolean enabled) {
     _record.setSimpleField(IdealStateProperty.GROUP_ROUTING_ENABLED.name(),
         Boolean.toString(enabled));
+  }
+
+  /**
+   * If the external view for this resource is disabled. by default, it is false.
+   *
+   * @return true if the external view should be disabled for this resource.
+   */
+  public boolean isExternalViewDisabled() {
+    return _record.getBooleanField(IdealStateProperty.EXTERNAL_VIEW_DISABLED.name(), false);
+  }
+
+  /**
+   * Disable (true) or enable (false) External View for this resource.
+   */
+  public void setDisableExternalView(boolean disableExternalView) {
+    _record
+        .setSimpleField(IdealStateProperty.EXTERNAL_VIEW_DISABLED.name(),
+            Boolean.toString(disableExternalView));
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/builder/IdealStateBuilder.java
+++ b/helix-core/src/main/java/org/apache/helix/model/builder/IdealStateBuilder.java
@@ -63,6 +63,11 @@ public abstract class IdealStateBuilder {
    */
   private String nodeGroup = "*";
 
+  /**
+   * Whether to disable external view for this resource
+   */
+  private Boolean disableExternalView = null;
+
   protected ZNRecord _record;
 
   /**
@@ -122,6 +127,14 @@ public abstract class IdealStateBuilder {
   }
 
   /**
+   * @param disableExternalView
+   */
+  public IdealStateBuilder setDisableExternalView(boolean disableExternalView) {
+    this.disableExternalView = disableExternalView;
+    return this;
+  }
+
+  /**
    * sub-class should implement this to set ideal-state mode
    * @return
    */
@@ -141,6 +154,9 @@ public abstract class IdealStateBuilder {
     idealstate.setStateModelFactoryName(stateModelFactoryName);
     idealstate.setRebalanceMode(rebalancerMode);
     idealstate.setReplicas("" + numReplica);
+    if (disableExternalView != null) {
+      idealstate.setDisableExternalView(disableExternalView);
+    }
 
     if (!idealstate.isValid()) {
       throw new HelixException("invalid ideal-state: " + idealstate);

--- a/helix-core/src/main/java/org/apache/helix/task/JobConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobConfig.java
@@ -73,6 +73,10 @@ public class JobConfig {
   /** The individual task configurations, if any **/
   public static final String TASK_CONFIGS = "TaskConfigs";
 
+  /** Disable external view (not showing) for this job resource */
+  public static final String DISABLE_EXTERNALVIEW = "DisableExternalView";
+
+
   // // Default property values ////
 
   public static final long DEFAULT_TIMEOUT_PER_TASK = 60 * 60 * 1000; // 1 hr.
@@ -81,6 +85,7 @@ public class JobConfig {
   public static final int DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE = 1;
   public static final int DEFAULT_FAILURE_THRESHOLD = 0;
   public static final int DEFAULT_MAX_FORCED_REASSIGNMENTS_PER_TASK = 0;
+  public static final boolean DEFAULT_DISABLE_EXTERNALVIEW = false;
 
   private final String _workflow;
   private final String _targetResource;
@@ -94,12 +99,14 @@ public class JobConfig {
   private final int _maxForcedReassignmentsPerTask;
   private final int _failureThreshold;
   private final long _retryDelay;
+  private final boolean _disableExternalView;
   private final Map<String, TaskConfig> _taskConfigMap;
 
   private JobConfig(String workflow, String targetResource, List<String> targetPartitions,
       Set<String> targetPartitionStates, String command, Map<String, String> jobCommandConfigMap,
       long timeoutPerTask, int numConcurrentTasksPerInstance, int maxAttemptsPerTask,
       int maxForcedReassignmentsPerTask, int failureThreshold, long retryDelay,
+      boolean disableExternalView,
       Map<String, TaskConfig> taskConfigMap) {
     _workflow = workflow;
     _targetResource = targetResource;
@@ -113,6 +120,7 @@ public class JobConfig {
     _maxForcedReassignmentsPerTask = maxForcedReassignmentsPerTask;
     _failureThreshold = failureThreshold;
     _retryDelay = retryDelay;
+    _disableExternalView = disableExternalView;
     if (taskConfigMap != null) {
       _taskConfigMap = taskConfigMap;
     } else {
@@ -168,6 +176,10 @@ public class JobConfig {
     return _retryDelay;
   }
 
+  public boolean isDisableExternalView() {
+    return _disableExternalView;
+  }
+
   public Map<String, TaskConfig> getTaskConfigMap() {
     return _taskConfigMap;
   }
@@ -204,6 +216,7 @@ public class JobConfig {
     cfgMap.put(JobConfig.MAX_ATTEMPTS_PER_TASK, "" + _maxAttemptsPerTask);
     cfgMap.put(JobConfig.MAX_FORCED_REASSIGNMENTS_PER_TASK, "" + _maxForcedReassignmentsPerTask);
     cfgMap.put(JobConfig.FAILURE_THRESHOLD, "" + _failureThreshold);
+    cfgMap.put(JobConfig.DISABLE_EXTERNALVIEW, Boolean.toString(_disableExternalView));
     return cfgMap;
   }
 
@@ -224,6 +237,7 @@ public class JobConfig {
     private int _maxForcedReassignmentsPerTask = DEFAULT_MAX_FORCED_REASSIGNMENTS_PER_TASK;
     private int _failureThreshold = DEFAULT_FAILURE_THRESHOLD;
     private long _retryDelay = DEFAULT_TASK_RETRY_DELAY;
+    private boolean _disableExternalView = DEFAULT_DISABLE_EXTERNALVIEW;
 
     public JobConfig build() {
       validate();
@@ -231,7 +245,7 @@ public class JobConfig {
       return new JobConfig(_workflow, _targetResource, _targetPartitions, _targetPartitionStates,
           _command, _commandConfig, _timeoutPerTask, _numConcurrentTasksPerInstance,
           _maxAttemptsPerTask, _maxForcedReassignmentsPerTask, _failureThreshold, _retryDelay,
-          _taskConfigMap);
+          _disableExternalView, _taskConfigMap);
     }
 
     /**
@@ -281,6 +295,9 @@ public class JobConfig {
       }
       if (cfg.containsKey(TASK_RETRY_DELAY)) {
         b.setTaskRetryDelay(Long.parseLong(cfg.get(TASK_RETRY_DELAY)));
+      }
+      if (cfg.containsKey(DISABLE_EXTERNALVIEW)) {
+        b.setDisableExternalView(Boolean.valueOf(cfg.get(DISABLE_EXTERNALVIEW)));
       }
       return b;
     }
@@ -342,6 +359,11 @@ public class JobConfig {
 
     public Builder setTaskRetryDelay(long v) {
       _retryDelay = v;
+      return this;
+    }
+
+    public Builder setDisableExternalView(boolean disableExternalView) {
+      _disableExternalView = disableExternalView;
       return this;
     }
 

--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -533,6 +533,11 @@ public class TaskDriver {
     builder.setNumReplica(1);
     builder.setNumPartitions(numPartitions);
     builder.setStateModel(TaskConstants.STATE_MODEL_NAME);
+
+    if (jobConfig.isDisableExternalView()) {
+      builder.setDisableExternalView(jobConfig.isDisableExternalView());
+    }
+
     IdealState is = builder.build();
     for (int i = 0; i < numPartitions; i++) {
       is.getRecord().setListField(jobResource + "_" + i, new ArrayList<String>());

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterStateVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterStateVerifier.java
@@ -320,8 +320,13 @@ public class ClusterStateVerifier {
       for (String resourceName : idealStates.keySet()) {
         ExternalView extView = extViews.get(resourceName);
         if (extView == null) {
-          LOG.info("externalView for " + resourceName + " is not available");
-          return false;
+          IdealState is = idealStates.get(resourceName);
+          if (is.isExternalViewDisabled()) {
+            continue;
+          } else {
+            LOG.info("externalView for " + resourceName + " is not available");
+            return false;
+          }
         }
 
         // step 0: remove empty map and DROPPED state from best possible state

--- a/helix-core/src/test/java/org/apache/helix/ZkUnitTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/ZkUnitTestBase.java
@@ -76,6 +76,7 @@ public class ZkUnitTestBase {
   public void beforeSuite() throws Exception {
     _zkServer = TestHelper.startZkServer(ZK_ADDR);
     AssertJUnit.assertTrue(_zkServer != null);
+    ZKClientPool.reset();
 
     // System.out.println("Number of open zkClient before ZkUnitTests: "
     // + ZkClient.getNumberOfConnections());

--- a/helix-core/src/test/java/org/apache/helix/integration/TestDisableExternalView.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestDisableExternalView.java
@@ -1,0 +1,166 @@
+package org.apache.helix.integration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Arrays;
+import java.util.Date;
+import org.apache.helix.HelixProperty;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.tools.ClusterStateVerifier;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import com.google.common.collect.Lists;
+
+/**
+ * Test disable external-view in resource ideal state -
+ * if DISABLE_EXTERNAL_VIEW is set to true in a resource's idealstate,
+ * there should be no external view for this resource.
+ */
+public class TestDisableExternalView extends ZkIntegrationTestBase {
+  private static final String TEST_DB1 = "test_db1";
+  private static final String TEST_DB2 = "test_db2";
+
+  private static final int NODE_NR = 5;
+  private static final int START_PORT = 12918;
+  private static final String STATE_MODEL = "MasterSlave";
+  private static final int _PARTITIONS = 20;
+
+  private final String CLASS_NAME = getShortClassName();
+  private final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + CLASS_NAME;
+
+  private MockParticipantManager[] _participants = new MockParticipantManager[NODE_NR];
+  private ClusterControllerManager _controller;
+  private String [] instances = new String[NODE_NR];
+
+  private ZKHelixAdmin _admin;
+
+  int _replica = 3;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    System.out.println("START " + CLASS_NAME + " at " + new Date(System.currentTimeMillis()));
+
+    _admin = new ZKHelixAdmin(_gZkClient);
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursive(namespace);
+    }
+
+    // setup storage cluster
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, TEST_DB1, _PARTITIONS, STATE_MODEL,
+        IdealState.RebalanceMode.FULL_AUTO + "");
+
+    IdealState idealState = _admin.getResourceIdealState(CLUSTER_NAME, TEST_DB1);
+    idealState.setDisableExternalView(true);
+    _admin.setResourceIdealState(CLUSTER_NAME, TEST_DB1, idealState);
+
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, TEST_DB2, _PARTITIONS, STATE_MODEL,
+        IdealState.RebalanceMode.FULL_AUTO + "");
+
+    for (int i = 0; i < NODE_NR; i++) {
+      instances[i] = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      _gSetupTool.addInstanceToCluster(CLUSTER_NAME, instances[i]);
+    }
+
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, TEST_DB1, _replica);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, TEST_DB2, _replica);
+
+    // start dummy participants
+    for (int i = 0; i < NODE_NR; i++) {
+      String instanceName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      MockParticipantManager participant =
+          new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+      participant.syncStart();
+      _participants[i] = participant;
+
+    }
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    boolean result = ClusterStateVerifier.verifyByPolling(
+        new ClusterStateVerifier.BestPossAndExtViewZkVerifier(ZK_ADDR, CLUSTER_NAME));
+    Assert.assertTrue(result);
+  }
+
+  @Test
+  public void testDisableExternalView() throws InterruptedException {
+    ZKHelixDataAccessor accessor =
+        new ZKHelixDataAccessor(CLUSTER_NAME, new ZkBaseDataAccessor<ZNRecord>(_gZkClient));
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+
+    // verify external view for TEST_DB1 does not exist
+    ExternalView externalView = null;
+    externalView = accessor.getProperty(keyBuilder.externalView(TEST_DB1));
+    Assert.assertNull(externalView,
+        "There should be no external-view for " + TEST_DB1 + ", but is: " + externalView);
+
+    // verify external view for TEST_DB2 exists
+    externalView = accessor.getProperty(keyBuilder.externalView(TEST_DB2));
+    Assert.assertNotNull(externalView,
+        "Could not find external-view for " + TEST_DB2);
+
+    // disable external view in IS
+    IdealState idealState = _admin.getResourceIdealState(CLUSTER_NAME, TEST_DB2);
+    idealState.setDisableExternalView(true);
+    _admin.setResourceIdealState(CLUSTER_NAME, TEST_DB2, idealState);
+
+    // touch liveinstance to trigger externalview compute stage
+    String instance = PARTICIPANT_PREFIX + "_" + START_PORT;
+    HelixProperty liveInstance = accessor.getProperty(keyBuilder.liveInstance(instance));
+    accessor.setProperty(keyBuilder.liveInstance(instance), liveInstance);
+
+    // verify the external view for the db got removed
+    for (int i = 0; i < 10; i++) {
+      Thread.sleep(100);
+      externalView = accessor.getProperty(keyBuilder.externalView(TEST_DB2));
+      if (externalView == null) {
+        break;
+      }
+    }
+
+    Assert.assertNull(externalView, "external-view for " + TEST_DB2 + " should be removed, but was: "
+        + externalView);
+  }
+
+  @AfterClass
+  public void afterClass() {
+    // clean up
+    _controller.syncStop();
+    for (int i = 0; i < NODE_NR; i++) {
+      _participants[i].syncStop();
+    }
+  }
+
+}


### PR DESCRIPTION
Add an option in IdealState to allow a resource to choose not showing external view. This will add flexibility for some resources that the client or application does not care about its external view (such as scheduled jobs), and reduces the ZK traffic when there are a large number of external view listeners.

Add a new configure option in JobConfig to allow use to disable external view when job is scheduling.