### PR TITLE
add CustomSemiAutoRebalancer

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomSemiAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomSemiAutoRebalancer.java
@@ -1,0 +1,136 @@
+package org.apache.helix.controller.rebalancer;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.helix.HelixDefinedState;
+import org.apache.helix.HelixManager;
+import org.apache.helix.controller.rebalancer.internal.MappingCalculator;
+import org.apache.helix.controller.rebalancer.util.ConstraintBasedAssignment;
+import org.apache.helix.controller.stages.ClusterDataCache;
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.Partition;
+import org.apache.helix.model.Resource;
+import org.apache.helix.model.ResourceAssignment;
+import org.apache.helix.model.StateModelDefinition;
+import org.apache.log4j.Logger;
+
+public class CustomSemiAutoRebalancer implements Rebalancer, MappingCalculator {
+  
+  private static final Logger LOG = Logger.getLogger(AutoRebalancer.class);
+  
+  @Override
+  public void init(HelixManager manager) {
+  }
+
+  @Override
+  public IdealState computeNewIdealState(String resourceName,
+      IdealState currentIdealState,
+      CurrentStateOutput currentStateOutput, ClusterDataCache clusterData) {
+    return currentIdealState;
+  }
+  
+  @Override
+  public ResourceAssignment computeBestPossiblePartitionState(
+      ClusterDataCache cache, IdealState idealState, Resource resource,
+      CurrentStateOutput currentStateOutput) {
+    String stateModelDefName = idealState.getStateModelDefRef();
+    StateModelDefinition stateModelDef = cache.getStateModelDef(stateModelDefName);
+    ResourceAssignment partitionMapping = new ResourceAssignment(resource.getResourceName());
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("before, resource: " + resource.getResourceName() + ", idealState " + idealState.toString());
+    }
+    for (Partition partition : resource.getPartitions()) {
+      Map<String, String> currentStateMap = currentStateOutput.getCurrentStateMap(resource.getResourceName(), partition);
+      Set<String> disabledInstancesForPartition = cache.getDisabledInstancesForPartition(partition.toString());
+      List<String> preferenceList = ConstraintBasedAssignment.getPreferenceList(cache, partition, idealState, stateModelDef);
+      // first check error/drop case
+      Map<String, String> errorStateMap = errorOrDropForPartition(
+          stateModelDef, preferenceList, currentStateMap,
+          disabledInstancesForPartition, idealState.isEnabled());
+      // then check whether idealState has preferred state
+      Map<String, String> idealStateMap = idealState.getInstanceStateMap(partition.getPartitionName());
+      Map<String, String> preferredStateForPartition = computeCustomizedBestStateForPartition(
+          cache, errorStateMap, idealStateMap, currentStateMap,
+          disabledInstancesForPartition, idealState.isEnabled());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("preferredStateForPartition " + preferredStateForPartition.toString());
+      }
+      // lastly according to state preference list to calc best state for partition
+      Map<String, String> bestStateForPartition = ConstraintBasedAssignment.computeCustomAutoBestStateForPartition(
+                  cache, stateModelDef,
+              preferenceList, currentStateMap,
+              preferredStateForPartition,
+              disabledInstancesForPartition,
+              idealState.isEnabled());
+      partitionMapping.addReplicaMap(partition, bestStateForPartition);
+    }
+    
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(String.format("%s, bestPossiblePartitionState: ", resource.getResourceName(), partitionMapping.toString()));
+    }
+    
+    return partitionMapping;
+  }
+  
+  private Map<String, String> errorOrDropForPartition(
+      StateModelDefinition stateModelDef,
+      List<String> instancePreferenceList,
+      Map<String, String> currentStateMap,
+      Set<String> disabledInstancesForPartition, 
+      boolean isResourceEnabled
+      ) {
+    Map<String, String> instanceStateMap = new HashMap<String, String>();
+    // if the ideal state is deleted, instancePreferenceList will be empty
+    // and we should drop all resources.
+    if (currentStateMap != null) {
+      for (String instance : currentStateMap.keySet()) {
+        if ((instancePreferenceList == null || !instancePreferenceList.contains(instance))
+            && !disabledInstancesForPartition.contains(instance) && isResourceEnabled) {
+          instanceStateMap.put(instance, HelixDefinedState.DROPPED.toString());
+        } else if ((currentStateMap.get(instance) == null || !currentStateMap.get(instance).equals(HelixDefinedState.ERROR.name()))
+            && (disabledInstancesForPartition.contains(instance) || !isResourceEnabled)) {
+          // if disabled and not in ERROR state, transit to initial-state (e.g. OFFLINE)
+          instanceStateMap.put(instance, stateModelDef.getInitialState());
+        }
+      }
+    }
+    
+    return instanceStateMap;
+  }
+
+  /**
+   * compute best state for resource in CUSTOMIZED ideal state mode
+   */
+  private Map<String, String> computeCustomizedBestStateForPartition(
+      ClusterDataCache cache,
+      Map<String, String> errorStateMap,
+      Map<String, String> idealStateMap,
+      Map<String, String> currentStateMap,
+      Set<String> disabledInstancesForPartition, boolean isResourceEnabled) {
+    Map<String, String> instanceStateMap = errorStateMap;
+
+    // ideal state does not contain this partition
+    if (idealStateMap == null) {
+      return instanceStateMap;
+    }
+
+    Map<String, LiveInstance> liveInstancesMap = cache.getLiveInstances();
+    for (String instance : idealStateMap.keySet()) {
+      boolean notInErrorState = currentStateMap == null || currentStateMap.get(instance) == null
+          || !currentStateMap.get(instance).equals(HelixDefinedState.ERROR.toString());
+
+      boolean enabled = !disabledInstancesForPartition.contains(instance) && isResourceEnabled;
+
+      if (liveInstancesMap.containsKey(instance) && notInErrorState && enabled && idealStateMap.containsKey(instance)) {
+        instanceStateMap.put(instance, idealStateMap.get(instance));
+      }
+    }
+    
+    return instanceStateMap;
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/TestCustomSemiAutoRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestCustomSemiAutoRebalancer.java
@@ -1,0 +1,170 @@
+package org.apache.helix.integration;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.controller.rebalancer.CustomSemiAutoRebalancer;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.IdealState.IdealStateProperty;
+import org.apache.helix.model.IdealState.RebalanceMode;
+import org.apache.helix.tools.ClusterSetup;
+import org.apache.helix.tools.ClusterStateVerifier;
+import org.apache.helix.tools.ClusterStateVerifier.MasterNbInExtViewVerifier;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class TestCustomSemiAutoRebalancer extends ZkStandAloneCMTestBase {
+
+  private final int _replica = 2;
+  private final int _PARTITIONS = 4;
+  private final int NODE_NR = 3;
+  
+  private HelixDataAccessor accessor;
+  
+  String getInstanceName(int idx) {
+    return String.format("%s_%d", PARTICIPANT_PREFIX, idx);
+  }
+  
+  @Override
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    System.out.println("START " + CLUSTER_NAME + " at " + new Date(System.currentTimeMillis()));
+    
+    _setupTool = new ClusterSetup(ZK_ADDR);
+
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursive(namespace);
+    }
+    _setupTool = new ClusterSetup(_gZkClient);
+
+    // setup storage cluster
+    _setupTool.addCluster(CLUSTER_NAME, true);
+    _setupTool.addResourceToCluster(CLUSTER_NAME, TEST_DB, _PARTITIONS, "MasterSlave");
+    _setupTool.addResourceProperty(CLUSTER_NAME, TEST_DB,
+      IdealStateProperty.REBALANCER_CLASS_NAME.toString(),
+      CustomSemiAutoRebalancer.class.getName());
+    _setupTool.addResourceProperty(CLUSTER_NAME, TEST_DB, IdealStateProperty.REBALANCE_MODE.toString(),
+      RebalanceMode.USER_DEFINED.toString());
+    _setupTool.addResourceProperty(CLUSTER_NAME, TEST_DB, IdealStateProperty.REPLICAS.toString(), 
+      Integer.toString(_replica));
+    
+    for (int i = 0; i < NODE_NR; i++) {
+      _setupTool.addInstanceToCluster(CLUSTER_NAME, getInstanceName(i));
+    }
+
+    IdealState idealState = _setupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, TEST_DB);
+    ZNRecord znRecord = idealState.getRecord();
+    for (int i = 0; i < _PARTITIONS / 2; i++) {
+      znRecord.setListField(String.format("%s_%d", TEST_DB, i), ImmutableList.of(getInstanceName(0), getInstanceName(1)));
+    }
+    for (int i = _PARTITIONS / 2; i < _PARTITIONS; i++) {
+      znRecord.setListField(String.format("%s_%d", TEST_DB, i), ImmutableList.of(getInstanceName(1), getInstanceName(0)));
+    }
+    _setupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, TEST_DB, new IdealState(znRecord));
+    
+    // start dummy participants
+    for (int i = 0; i < NODE_NR; i++) {
+      MockParticipantManager participant = new MockParticipantManager(
+          ZK_ADDR, CLUSTER_NAME, getInstanceName(i));
+      participant.syncStart();
+      _participants[i] = participant;
+    }
+
+    // start controller
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, CONTROLLER_PREFIX + "_0");
+    _controller.syncStart();
+    
+    accessor = new ZKHelixDataAccessor(CLUSTER_NAME, new ZkBaseDataAccessor<ZNRecord>(_gZkClient));
+
+    boolean result = ClusterStateVerifier.verifyByZkCallback(
+        new MasterNbInExtViewVerifier(ZK_ADDR, CLUSTER_NAME));
+    ZNRecord extView = getExternalView();
+
+    Assert.assertTrue(result);
+  }
+  
+  @AfterClass
+  @Override
+  public void afterClass() throws Exception {
+    // shutdown order: 1) disconnect the controller 2) disconnect participants
+    _controller.syncStop();
+    for (int i = 0; i < NODE_NR; i++) {
+      _participants[i].syncStop();
+    }
+    System.out.println("END " + CLUSTER_NAME + " at " + new Date(System.currentTimeMillis()));
+  }
+  
+  private ZNRecord getExternalView() {
+    return accessor.getProperty(accessor.keyBuilder().externalView(TEST_DB)).getRecord();
+  }
+  
+  @Test
+  public void testCustomSemiAutoRebalancer() throws InterruptedException {
+    ZNRecord extViewRecord = null;
+    Map<String, String> extView = null;
+    
+    // first stop one instance
+    _participants[0].syncStop();
+    Thread.sleep(1000L);
+    Assert.assertTrue(ClusterStateVerifier.verifyByZkCallback(
+        new MasterNbInExtViewVerifier(ZK_ADDR, CLUSTER_NAME)));
+    
+    // add node back
+    _participants[0] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, getInstanceName(0));
+    _participants[0].syncStart();
+    Thread.sleep(1000L);
+    Assert.assertTrue(ClusterStateVerifier.verifyByZkCallback(
+        new MasterNbInExtViewVerifier(ZK_ADDR, CLUSTER_NAME)));
+    
+    // swap instance 
+    IdealState idealState = _setupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, TEST_DB);
+    ZNRecord znRecord = idealState.getRecord();
+    znRecord.setListField(String.format("%s_%d",  TEST_DB, 0), ImmutableList.of(getInstanceName(0), getInstanceName(2)));
+    _setupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, TEST_DB, new IdealState(znRecord));
+    Thread.sleep(1000L);
+    Assert.assertTrue(ClusterStateVerifier.verifyByZkCallback(
+        new MasterNbInExtViewVerifier(ZK_ADDR, CLUSTER_NAME)));
+    extViewRecord = getExternalView();
+    extView = extViewRecord.getMapField(String.format("%s_%d", TEST_DB, 0));
+    Assert.assertEquals(extView.get(getInstanceName(0)), "MASTER");
+    Assert.assertEquals(extView.get(getInstanceName(2)), "SLAVE");
+    znRecord.setListField(String.format("%s_%d",  TEST_DB, 0), ImmutableList.of(getInstanceName(0), getInstanceName(1)));
+    _setupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, TEST_DB, new IdealState(znRecord));
+    
+    // change mapping field
+    idealState = _setupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, TEST_DB);
+    znRecord = idealState.getRecord();
+    znRecord.setMapField(String.format("%s_%d", TEST_DB, 0), ImmutableMap.of(getInstanceName(0), "SLAVE"));
+    _setupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, TEST_DB, new IdealState(znRecord));
+    Thread.sleep(1000L);
+    Assert.assertTrue(ClusterStateVerifier.verifyByZkCallback(
+        new MasterNbInExtViewVerifier(ZK_ADDR, CLUSTER_NAME)));
+    extViewRecord = getExternalView();
+    extView = extViewRecord.getMapField(String.format("%s_%d", TEST_DB, 0));
+    Assert.assertEquals(extView.get(getInstanceName(0)), "SLAVE");
+    Assert.assertEquals(extView.get(getInstanceName(1)), "MASTER");
+  
+    znRecord.setMapField(String.format("%s_%d", TEST_DB, 0), Collections.EMPTY_MAP);
+    _setupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, TEST_DB, new IdealState(znRecord));
+    Thread.sleep(1000L);
+    Assert.assertTrue(ClusterStateVerifier.verifyByZkCallback(
+        new MasterNbInExtViewVerifier(ZK_ADDR, CLUSTER_NAME)));  
+    extViewRecord = getExternalView();
+    extView = extViewRecord.getMapField(String.format("%s_%d", TEST_DB, 0));
+    Assert.assertEquals(extView.get(getInstanceName(0)), "MASTER");
+    Assert.assertEquals(extView.get(getInstanceName(1)), "SLAVE");
+  }
+}


### PR DESCRIPTION
This is just a prove of concept, introducing a new rebalancer which combining both SemiAutoRebalancer and CustomRebalancer. 

The idea is very simple, normally, partitions still follow SemiAutoRebalancer to perform the state transition, but it also allows admin to specify specific state for specific partition of specific node in idealState as Custom mode but could only specify a portion of it. 
