### PR TITLE
Several Fixes to Task Framework.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/JobConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobConfig.java
@@ -217,6 +217,7 @@ public class JobConfig {
     cfgMap.put(JobConfig.MAX_FORCED_REASSIGNMENTS_PER_TASK, "" + _maxForcedReassignmentsPerTask);
     cfgMap.put(JobConfig.FAILURE_THRESHOLD, "" + _failureThreshold);
     cfgMap.put(JobConfig.DISABLE_EXTERNALVIEW, Boolean.toString(_disableExternalView));
+    cfgMap.put(JobConfig.NUM_CONCURRENT_TASKS_PER_INSTANCE, "" + _numConcurrentTasksPerInstance);
     return cfgMap;
   }
 

--- a/helix-core/src/main/java/org/apache/helix/task/TaskConstants.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskConstants.java
@@ -39,8 +39,4 @@ public class TaskConstants {
    * The root property store path at which the {@link TaskRebalancer} stores context information.
    */
   public static final String REBALANCER_CONTEXT_ROOT = "/TaskRebalancer";
-  /**
-   * Resource prefix for scheduled workflows
-   */
-  public static final String SCHEDULED = "SCHEDULED";
 }

--- a/helix-core/src/main/java/org/apache/helix/task/TaskRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskRebalancer.java
@@ -19,6 +19,8 @@ package org.apache.helix.task;
  * under the License.
  */
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -579,8 +581,9 @@ public abstract class TaskRebalancer implements Rebalancer, MappingCalculator {
         long timeToSchedule = period * offsetMultiplier + startTime.getTime();
 
         // Now clone the workflow if this clone has not yet been created
-        String newWorkflowName =
-            workflowResource + "_" + TaskConstants.SCHEDULED + "_" + offsetMultiplier;
+        DateFormat df = new SimpleDateFormat("yyyyMMdd'T'HHmmssZ");
+        // Now clone the workflow if this clone has not yet been created
+        String newWorkflowName = workflowResource + "_" + df.format(new java.util.Date(timeToSchedule));
         LOG.debug("Ready to start workflow " + newWorkflowName);
         if (!newWorkflowName.equals(lastScheduled)) {
           Workflow clonedWf =

--- a/helix-core/src/main/java/org/apache/helix/task/TaskRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskRunner.java
@@ -48,6 +48,7 @@ public class TaskRunner implements Runnable {
   // If true, indicates that the task has finished.
   private volatile boolean _done = false;
 
+
   public TaskRunner(Task task, String taskName, String taskPartition, String instance,
       HelixManager manager, String sessionId) {
     _task = task;
@@ -111,7 +112,9 @@ public class TaskRunner implements Runnable {
    * Signals the task to cancel itself.
    */
   public void cancel() {
-    _task.cancel();
+    if (!_done) {
+      _task.cancel();
+    }
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModel.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModel.java
@@ -205,22 +205,22 @@ public class TaskStateModel extends StateModel {
 
   @Transition(to = "INIT", from = "COMPLETED")
   public void onBecomeInitFromCompleted(Message msg, NotificationContext context) {
-    _taskRunner = null;
+    reset();
   }
 
   @Transition(to = "INIT", from = "STOPPED")
   public void onBecomeInitFromStopped(Message msg, NotificationContext context) {
-    _taskRunner = null;
+    reset();
   }
 
   @Transition(to = "INIT", from = "TIMED_OUT")
   public void onBecomeInitFromTimedOut(Message msg, NotificationContext context) {
-    _taskRunner = null;
+    reset();
   }
 
   @Transition(to = "INIT", from = "TASK_ERROR")
   public void onBecomeInitFromTaskError(Message msg, NotificationContext context) {
-    _taskRunner = null;
+    reset();
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
@@ -349,6 +349,7 @@ public class TaskUtil {
     IdealState is = accessor.getProperty(key);
     if (is != null) {
       accessor.updateProperty(key, is);
+      LOG.debug("invoke rebalance for " + key);
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowConfig.java
@@ -100,6 +100,20 @@ public class WorkflowConfig {
     return defaultDateFormat;
   }
 
+  /**
+   * Get the scheduled start time of the workflow.
+   *
+   * @return start time if the workflow schedule is set, null if no schedule config set.
+   */
+  public Date getStartTime() {
+    // Workflow with non-scheduled config is ready to schedule immediately.
+    if (_scheduleConfig == null) {
+      return null;
+    }
+
+    return _scheduleConfig.getStartTime();
+  }
+
   public Map<String, String> getResourceConfigMap() throws Exception {
     Map<String, String> cfgMap = new HashMap<String, String>();
     cfgMap.put(WorkflowConfig.DAG, getJobDag().toJson());

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestIndependentTaskRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestIndependentTaskRebalancer.java
@@ -274,7 +274,6 @@ public class TestIndependentTaskRebalancer extends ZkIntegrationTestBase {
     _driver.start(workflowBuilder.build());
 
     // Ensure the job completes
-    TestUtil.pollForWorkflowState(_manager, jobName, TaskState.IN_PROGRESS);
     TestUtil.pollForWorkflowState(_manager, jobName, TaskState.COMPLETED);
 
     // Ensure that the class was invoked

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestRecurringJobQueue.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestRecurringJobQueue.java
@@ -22,6 +22,7 @@ package org.apache.helix.integration.task;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;;
@@ -157,10 +158,31 @@ public class TestRecurringJobQueue extends ZkIntegrationTestBase {
     _manager.disconnect();
   }
 
+  private Date getDateFromStartTime(String startTime)
+  {
+    int splitIndex = startTime.indexOf(':');
+    int hourOfDay = 0, minutes = 0;
+    try
+    {
+      hourOfDay = Integer.parseInt(startTime.substring(0, splitIndex));
+      minutes = Integer.parseInt(startTime.substring(splitIndex + 1));
+    }
+    catch (NumberFormatException e)
+    {
+
+    }
+    Calendar cal = Calendar.getInstance();
+    cal.set(Calendar.HOUR_OF_DAY, hourOfDay);
+    cal.set(Calendar.MINUTE, minutes);
+    cal.set(Calendar.SECOND, 0);
+    cal.set(Calendar.MILLISECOND, 0);
+    return cal.getTime();
+  }
+
   private JobQueue buildRecurrentJobQueue(String jobQueueName, int delayStart) {
     Map<String, String> cfgMap = new HashMap<String, String>();
-    cfgMap.put(WorkflowConfig.EXPIRY, String.valueOf(500000));
-    cfgMap.put(WorkflowConfig.RECURRENCE_INTERVAL, String.valueOf(120));
+    cfgMap.put(WorkflowConfig.EXPIRY, String.valueOf(120000));
+    cfgMap.put(WorkflowConfig.RECURRENCE_INTERVAL, String.valueOf(60));
     cfgMap.put(WorkflowConfig.RECURRENCE_UNIT, "SECONDS");
     Calendar cal = Calendar.getInstance();
     cal.set(Calendar.MINUTE, cal.get(Calendar.MINUTE) + delayStart / 60);
@@ -168,6 +190,8 @@ public class TestRecurringJobQueue extends ZkIntegrationTestBase {
     cal.set(Calendar.MILLISECOND, 0);
     cfgMap.put(WorkflowConfig.START_TIME,
         WorkflowConfig.getDefaultDateFormat().format(cal.getTime()));
+    //cfgMap.put(WorkflowConfig.START_TIME,
+        //WorkflowConfig.getDefaultDateFormat().format(getDateFromStartTime("00:00")));
     return (new JobQueue.Builder(jobQueueName).fromMap(cfgMap)).build();
   }
 
@@ -186,7 +210,7 @@ public class TestRecurringJobQueue extends ZkIntegrationTestBase {
 
     // Create and Enqueue jobs
     List<String> currentJobNames = new ArrayList<String>();
-    for (int i = 0; i <= 2; i++) {
+    for (int i = 0; i <= 1; i++) {
       String targetPartition = (i == 0) ? "MASTER" : "SLAVE";
 
       JobConfig.Builder job =
@@ -213,7 +237,7 @@ public class TestRecurringJobQueue extends ZkIntegrationTestBase {
     queue = buildRecurrentJobQueue(queueName, 5);
     _driver.createQueue(queue);
     currentJobNames.clear();
-    for (int i = 0; i <= 2; i++) {
+    for (int i = 0; i <= 1; i++) {
       String targetPartition = (i == 0) ? "MASTER" : "SLAVE";
 
       JobConfig.Builder job =

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestRecurringJobQueue.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestRecurringJobQueue.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;;
+import java.util.Map;
 
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerParallel.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerParallel.java
@@ -156,7 +156,9 @@ public class TestTaskRebalancerParallel extends ZkIntegrationTestBase {
 
     String queueName = TestHelper.getTestMethodName();
 
-    JobQueue queue = new JobQueue.Builder(queueName).parallelJobs(PARALLEL_COUNT).build();
+    JobQueue.Builder queueBuild = new JobQueue.Builder(queueName);
+    queueBuild.parallelJobs(PARALLEL_COUNT);
+    JobQueue queue = queueBuild.build();
     _driver.createQueue(queue);
 
     List<JobConfig.Builder> jobConfigBuilders = new ArrayList<JobConfig.Builder>();


### PR DESCRIPTION
This change contains 3 commits:

[HELIX-614]:
When job expiry time is shorter than job schedule interval in recurring job queue. The lastScheduled workflow context will be null, this will block the following workflow schedule.

[HELIX-615]:
Jobs from a recurrent queue are named with original job + index (for example, if job named backup_job_testdb, the first scheduled job is called backup_job_testdb_0, the second time it gets schedule will be named backup_job_testdb_1, etc. This will create name conflict if the workflow is deleted and recreated recently.

Proposed Change:
Jobs from a recurring are named with original job + schedule_time (for example, if job named backup_job_testdb, scheduled job will be named backup_job_testdb_20151028T230011Z (Date follows ISO 8601 format). This will avoid name conflict even if the workflow is deleted and recreated again.


[HELIX-616]:
Currently, JobQueue is subclass of WorkflowConfig instead of Workflow. It is not possible for client to create an initial queue with jobs in it. It has to call create() to create an empty queue, and call enqueue() to add job to the queue. The problem is once create() call returns, the queue is already starts to run, if the queue is recurrent queue, the initial schedule run of the queue contains empty job set.

