### PR TITLE
[Helix-624] Fix NPE in TestMessageService.TestMultiMessageCriteria

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/TestMessagingService.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestMessagingService.java
@@ -286,7 +286,7 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
     for (int i = 0; i < NODE_NR; i++) {
       TestMessagingHandlerFactory factory = new TestMessagingHandlerFactory();
       String hostDest = "localhost_" + (START_PORT + i);
-      _participants[0].getMessagingService().registerMessageHandlerFactory(
+      _participants[i].getMessagingService().registerMessageHandlerFactory(
           factory.getMessageType(), factory);
 
     }


### PR DESCRIPTION
Fix NPE in TestMessageService.TestMultiMessageCriteria.
The messageHandlerFactory is not correctly set and cause the pipeline broken.