### PR TITLE
[HELIX-626] Enable maxRecipient in Criteria

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/Criteria.java
+++ b/helix-core/src/main/java/org/apache/helix/Criteria.java
@@ -61,6 +61,12 @@ public class Criteria {
    */
   boolean selfExcluded = true;
   /**
+   * How many copies of messages to be sent.
+   * E.g. if maxRecipient == 1 and partitionState is SLAVE,
+   *      then the message is sent to only one SLAVE rather than all SLAVES
+   */
+  Integer maxRecipient = null;
+  /**
    * Determine if use external view or ideal state as source of truth
    */
   DataSource _dataSource = DataSource.EXTERNALVIEW;
@@ -192,6 +198,15 @@ public class Criteria {
    */
   public void setPartitionState(String partitionState) {
     this.partitionState = partitionState;
+  }
+
+  public Integer getMaxRecipient() {
+    return maxRecipient;
+  }
+
+  public Criteria setMaxRecipient(Integer maxRecipient) {
+    this.maxRecipient = maxRecipient;
+    return this;
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/messaging/CriteriaEvaluator.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/CriteriaEvaluator.java
@@ -71,6 +71,11 @@ public class CriteriaEvaluator {
         result.add(row);
       }
     }
+    if (recipientCriteria.getMaxRecipient() != null && recipientCriteria.getMaxRecipient() < result.size()) {
+      // would destroy the original order but seems to be OK
+      Collections.shuffle(result);
+      result = result.subList(0, recipientCriteria.getMaxRecipient());
+    }
 
     // deduplicate and convert the matches into the required format
     for (ZNRecordRow row : result) {

--- a/helix-core/src/test/java/org/apache/helix/integration/TestMessagingService.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestMessagingService.java
@@ -33,6 +33,7 @@ import org.apache.helix.messaging.handling.MessageHandlerFactory;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Message.MessageState;
 import org.apache.helix.model.Message.MessageType;
+import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
@@ -308,9 +309,9 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
     int messageSent1 =
         _participants[0].getMessagingService().sendAndWait(cr, msg, callback1, 10000);
 
-    AssertJUnit.assertTrue(callback1.getMessageReplied().get(0).getRecord()
-        .getMapField(Message.Attributes.MESSAGE_RESULT.toString()).get("ReplyMessage")
-        .equals("TestReplyMessage"));
+    AssertJUnit.assertTrue(
+        callback1.getMessageReplied().get(0).getRecord().getMapField(Message.Attributes.MESSAGE_RESULT.toString())
+            .get("ReplyMessage").equals("TestReplyMessage"));
     AssertJUnit.assertTrue(callback1.getMessageReplied().size() == NODE_NR - 1);
 
     AsyncCallback callback2 = new MockAsyncCallback();
@@ -336,11 +337,17 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
         _participants[0].getMessagingService().sendAndWait(cr, msg, callback5, 10000);
     AssertJUnit.assertTrue(callback5.getMessageReplied().size() == _replica - 1);
 
-    cr.setDataSource(DataSource.IDEALSTATES);
+    cr.setMaxRecipient(1);
     AsyncCallback callback6 = new MockAsyncCallback();
-    int messageSent6 =
-        _participants[0].getMessagingService().sendAndWait(cr, msg, callback6, 10000);
-    AssertJUnit.assertTrue(callback6.getMessageReplied().size() == _replica - 1);
+    int messageSent6 = _participants[0].getMessagingService().sendAndWait(cr, msg, callback6, 10000);
+    Assert.assertEquals(callback6.getMessageReplied().size(), 1);
+
+    cr.setMaxRecipient(null);
+    cr.setDataSource(DataSource.IDEALSTATES);
+    AsyncCallback callback7 = new MockAsyncCallback();
+    int messageSent7 =
+        _participants[0].getMessagingService().sendAndWait(cr, msg, callback7, 10000);
+    AssertJUnit.assertTrue(callback7.getMessageReplied().size() == _replica - 1);
   }
 
   @Test()


### PR DESCRIPTION
Helix allow messages to be sent to a partition with specific state. e.g. Sending message to PARTITION_8 whose state is SLAVE.
However, sometimes user wish the message is sent to only ONE SLAVE rather than ALL SLAVEs, e.g. A backup message should be sent to only ONE SLAVE.

This diff adds a new field in Criteria which allows user to specify maxReceipts, by default maxReceipts is null means no uplimit. In previous case, user just set maxReceipts as 1 and message would be sent to only 1 SLAVE.
