### PR TITLE
Fixing an NPE when there is a session mismatch in HelixTaskExecutor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -552,7 +552,8 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
       SessionId tgtSessionId = message.getTypedTgtSessionId();
 
       // sessionId mismatch normally means message comes from expired session, just remove it
-      if (!sessionId.equals(tgtSessionId.toString()) && !tgtSessionId.toString().equals("*")) {
+      if (tgtSessionId == null ||
+		      (!sessionId.equals(tgtSessionId.toString()) && !tgtSessionId.toString().equals("*"))) {
         String warningMessage =
             "SessionId does NOT match. expected sessionId: " + sessionId
                 + ", tgtSessionId in message: " + tgtSessionId + ", messageId: "


### PR DESCRIPTION
We've occasionally experienced a NullPointerException in HelixTaskExecutor on some of our Helix machines. This occurs during HelixManager.connect(), which means the uncaught NPE aborts the connect and that particular machine never comes up.

We're running v0.7.1 and this change is meant to go against that (as well as master), but I can't find the appropriate branch.

Signed-off-by: Adam Lugowski <alugowski@turn.com>