### PR TITLE
[HELIX-635] GenericTaskAssignmentCalculator does not balance task assignment

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/CrushRebalanceStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/CrushRebalanceStrategy.java
@@ -24,7 +24,7 @@ import com.google.common.base.Predicates;
 import org.apache.helix.HelixException;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.controller.rebalancer.strategy.crushMapping.CRUSHPlacementAlgorithm;
-import org.apache.helix.controller.rebalancer.strategy.crushMapping.JenkinsHash;
+import org.apache.helix.util.JenkinsHash;
 import org.apache.helix.controller.rebalancer.topology.Node;
 import org.apache.helix.controller.rebalancer.topology.Topology;
 import org.apache.helix.controller.stages.ClusterDataCache;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/CRUSHPlacementAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/CRUSHPlacementAlgorithm.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.helix.controller.rebalancer.topology.Node;
+import org.apache.helix.util.JenkinsHash;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
@@ -453,21 +453,35 @@ public class ClusterDataCache {
   }
 
   /**
-   * Return all the nodes that are enabled and tagged same as the job.
-   * @param allInstances List of instances to filter with instance tag
-   * @param instanceTag The instance group tag
-   * @return A new set contains instance name and that are marked enabled and have same
-   *         tag with job. The original set will not be changed during the filtering
+   * Return all the live nodes that are enabled
+   * @return A new set contains live instance name and that are marked enabled
    */
-  public Set<String> getAllEnabledInstanceWithTag(final Set<String> allInstances,
-      String instanceTag) {
+  public Set<String> getAllEnabledLiveInstances() {
+    return getAllEnabledInstances(null);
+  }
+
+  /**
+   * Return all the live nodes that are enabled and tagged same as the job.
+   * @param instanceTag The instance group tag, could be null, when no instance group specified
+   * @return A new set contains live instance name and that are marked enabled and have same
+   *         tag with job, only if instance tag input is not null.
+   */
+  public Set<String> getAllEnabledLiveInstancesWithTag(String instanceTag) {
+    return getAllEnabledInstances(instanceTag);
+  }
+
+  private Set<String> getAllEnabledInstances(String instanceTag) {
     Set<String> enabledTagInstances = new HashSet<String>();
-    for (String instance : allInstances) {
+    for (String instance : _liveInstanceMap.keySet()) {
       InstanceConfig instanceConfig = _instanceConfigMap.get(instance);
 
-      if (instanceConfig != null && instanceConfig.getInstanceEnabled() && instanceConfig
-          .containsTag(instanceTag)) {
-        enabledTagInstances.add(instance);
+      // Check instance is enabled
+      if (instanceConfig != null && instanceConfig.getInstanceEnabled()) {
+        // Check whether it has instance group or not
+        // If it has instance group, check whether it belongs to that group or not
+        if (instanceTag == null || instanceConfig.containsTag(instanceTag)) {
+          enabledTagInstances.add(instance);
+        }
       }
     }
 

--- a/helix-core/src/main/java/org/apache/helix/task/FixedTargetTaskRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/FixedTargetTaskRebalancer.java
@@ -43,7 +43,7 @@ import org.apache.helix.model.ResourceAssignment;
   @Override public Set<Integer> getAllTaskPartitions(JobConfig jobCfg, JobContext jobCtx,
       WorkflowConfig workflowCfg, WorkflowContext workflowCtx, ClusterDataCache cache) {
     return taskAssignmentCalculator
-        .getAllTaskPartitions(jobCfg, jobCtx, workflowCfg, workflowCtx, cache);
+        .getAllTaskPartitions(jobCfg, jobCtx, workflowCfg, workflowCtx, cache.getIdealStates());
   }
 
   @Override public Map<String, SortedSet<Integer>> getTaskAssignment(
@@ -53,6 +53,6 @@ import org.apache.helix.model.ResourceAssignment;
       ClusterDataCache cache) {
     return taskAssignmentCalculator
         .getTaskAssignment(currStateOutput, prevAssignment, instances, jobCfg, jobContext,
-            workflowCfg, workflowCtx, partitionSet, cache);
+            workflowCfg, workflowCtx, partitionSet, cache.getIdealStates());
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/task/GenericTaskAssignmentCalculator.java
+++ b/helix-core/src/main/java/org/apache/helix/task/GenericTaskAssignmentCalculator.java
@@ -34,6 +34,7 @@ import java.util.TreeSet;
 import org.apache.helix.HelixException;
 import org.apache.helix.controller.stages.ClusterDataCache;
 import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.util.JenkinsHash;
@@ -52,7 +53,8 @@ public class GenericTaskAssignmentCalculator extends TaskAssignmentCalculator {
 
   @Override
   public Set<Integer> getAllTaskPartitions(JobConfig jobCfg, JobContext jobCtx,
-      WorkflowConfig workflowCfg, WorkflowContext workflowCtx, ClusterDataCache cache) {
+      WorkflowConfig workflowCfg, WorkflowContext workflowCtx,
+      Map<String, IdealState> idealStateMap) {
     Map<String, TaskConfig> taskMap = jobCfg.getTaskConfigMap();
     Map<String, Integer> taskIdMap = jobCtx.getTaskIdPartitionMap();
     for (TaskConfig taskCfg : taskMap.values()) {
@@ -69,7 +71,7 @@ public class GenericTaskAssignmentCalculator extends TaskAssignmentCalculator {
   public Map<String, SortedSet<Integer>> getTaskAssignment(CurrentStateOutput currStateOutput,
       ResourceAssignment prevAssignment, Collection<String> instances, JobConfig jobCfg,
       final JobContext jobContext, WorkflowConfig workflowCfg, WorkflowContext workflowCtx,
-      Set<Integer> partitionSet, ClusterDataCache cache) {
+      Set<Integer> partitionSet, Map<String, IdealState> idealStateMap) {
     // Gather input to the full auto rebalancing algorithm
     LinkedHashMap<String, Integer> states = new LinkedHashMap<String, Integer>();
     states.put("ONLINE", 1);

--- a/helix-core/src/main/java/org/apache/helix/task/GenericTaskAssignmentCalculator.java
+++ b/helix-core/src/main/java/org/apache/helix/task/GenericTaskAssignmentCalculator.java
@@ -19,30 +19,26 @@ package org.apache.helix.task;
  * under the License.
  */
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
-import org.apache.helix.ZNRecord;
+import org.apache.helix.HelixException;
 import org.apache.helix.controller.stages.ClusterDataCache;
 import org.apache.helix.controller.stages.CurrentStateOutput;
-import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
-import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
-import org.apache.helix.model.IdealState;
-import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.ResourceAssignment;
+import org.apache.helix.util.JenkinsHash;
 import org.apache.log4j.Logger;
 
-import com.google.common.base.Function;
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -53,9 +49,6 @@ import com.google.common.collect.Sets;
  */
 public class GenericTaskAssignmentCalculator extends TaskAssignmentCalculator {
   private static final Logger LOG = Logger.getLogger(GenericTaskAssignmentCalculator.class);
-
-  /** Reassignment policy for this algorithm */
-  private RetryPolicy _retryPolicy = new DefaultRetryReassigner();
 
   @Override
   public Set<Integer> getAllTaskPartitions(JobConfig jobCfg, JobContext jobCtx,
@@ -96,14 +89,7 @@ public class GenericTaskAssignmentCalculator extends TaskAssignmentCalculator {
     // Transform from partition id to fully qualified partition name
     List<Integer> partitionNums = Lists.newArrayList(partitionSet);
     Collections.sort(partitionNums);
-    final String resourceId = prevAssignment.getResourceName();
-    List<String> partitions =
-        new ArrayList<String>(Lists.transform(partitionNums, new Function<Integer, String>() {
-          @Override
-          public String apply(Integer partitionNum) {
-            return resourceId + "_" + partitionNum;
-          }
-        }));
+    String resourceId = prevAssignment.getResourceName();
 
     // Compute the current assignment
     Map<String, Map<String, String>> currentMapping = Maps.newHashMap();
@@ -122,156 +108,108 @@ public class GenericTaskAssignmentCalculator extends TaskAssignmentCalculator {
     }
 
     // Get the assignment keyed on partition
-    RebalanceStrategy strategy = new AutoRebalanceStrategy(resourceId, partitions, states);
-    List<String> allNodes =
-        Lists.newArrayList(getEligibleInstances(jobCfg, currStateOutput, instances, cache));
-    Collections.sort(allNodes);
-    ZNRecord record =
-        strategy.computePartitionAssignment(allNodes, allNodes, currentMapping, cache);
-    Map<String, List<String>> preferenceLists = record.getListFields();
-
-    // Convert to an assignment keyed on participant
-    Map<String, SortedSet<Integer>> taskAssignment = Maps.newHashMap();
-    for (Map.Entry<String, List<String>> e : preferenceLists.entrySet()) {
-      String partitionName = e.getKey();
-      partitionName = String.valueOf(TaskUtil.getPartitionId(partitionName));
-      List<String> preferenceList = e.getValue();
-      for (String participantName : preferenceList) {
-        if (!taskAssignment.containsKey(participantName)) {
-          taskAssignment.put(participantName, new TreeSet<Integer>());
-        }
-        taskAssignment.get(participantName).add(Integer.valueOf(partitionName));
-      }
+    if (jobCfg.getTargetResource() != null) {
+      LOG.error(
+          "Target resource is not null, should call FixedTaskAssignmentCalculator, target resource : "
+              + jobCfg.getTargetResource());
+      return new HashMap<String, SortedSet<Integer>>();
     }
 
-    // Finally, adjust the assignment if tasks have been failing
-    taskAssignment = _retryPolicy.reassign(jobCfg, jobContext, allNodes, taskAssignment);
+    List<String> allNodes = Lists.newArrayList(instances);
+    ConsistentHashingPlacement placement = new ConsistentHashingPlacement(allNodes);
+    Map<String, SortedSet<Integer>> taskAssignment =
+        placement.computeMapping(jobCfg, jobContext, partitionNums, resourceId);
+
     return taskAssignment;
   }
 
-  /**
-   * Filter a list of instances based on targeted resource policies
-   * @param jobCfg the job configuration
-   * @param currStateOutput the current state of all instances in the cluster
-   * @param instances valid instances
-   * @param cache current snapshot of the cluster
-   * @return a set of instances that can be assigned to
-   */
-  private Set<String> getEligibleInstances(JobConfig jobCfg, CurrentStateOutput currStateOutput,
-      Iterable<String> instances, ClusterDataCache cache) {
-    // No target resource means any instance is available
-    Set<String> allInstances = Sets.newHashSet(instances);
-    String targetResource = jobCfg.getTargetResource();
-    if (targetResource == null) {
-      return allInstances;
+  private class ConsistentHashingPlacement {
+    private JenkinsHash _hashFunction;
+    private ConsistentHashSelector _selector;
+    private int _numInstances;
+
+    public ConsistentHashingPlacement(List<String> potentialInstances) {
+      _hashFunction = new JenkinsHash();
+      _selector = new ConsistentHashSelector(potentialInstances);
+      _numInstances = potentialInstances.size();
     }
 
-    // Bad ideal state means don't assign
-    IdealState idealState = cache.getIdealState(targetResource);
-    if (idealState == null) {
-      return Collections.emptySet();
-    }
-
-    // Get the partitions on the target resource to use
-    Set<String> partitions = idealState.getPartitionSet();
-    List<String> targetPartitions = jobCfg.getTargetPartitions();
-    if (targetPartitions != null && !targetPartitions.isEmpty()) {
-      partitions.retainAll(targetPartitions);
-    }
-
-    // Based on state matches, add eligible instances
-    Set<String> eligibleInstances = Sets.newHashSet();
-    Set<String> targetStates = jobCfg.getTargetPartitionStates();
-    for (String partition : partitions) {
-      Map<String, String> stateMap =
-          currStateOutput.getCurrentStateMap(targetResource, new Partition(partition));
-      Map<String, String> pendingStateMap =
-          currStateOutput.getPendingStateMap(targetResource, new Partition(partition));
-      for (Map.Entry<String, String> e : stateMap.entrySet()) {
-        String instanceName = e.getKey();
-        String state = e.getValue();
-        String pending = pendingStateMap.get(instanceName);
-        if (pending != null) {
-          continue;
-        }
-        if (targetStates == null || targetStates.isEmpty() || targetStates.contains(state)) {
-          eligibleInstances.add(instanceName);
-        }
-      }
-    }
-    allInstances.retainAll(eligibleInstances);
-    return allInstances;
-  }
-
-  public interface RetryPolicy {
-    /**
-     * Adjust the assignment to allow for reassignment if a task keeps failing where it's currently
-     * assigned
-     * @param jobCfg the job configuration
-     * @param jobCtx the job context
-     * @param instances instances that can serve tasks
-     * @param origAssignment the unmodified assignment
-     * @return the adjusted assignment
-     */
-    Map<String, SortedSet<Integer>> reassign(JobConfig jobCfg, JobContext jobCtx,
-        Collection<String> instances, Map<String, SortedSet<Integer>> origAssignment);
-  }
-
-  private static class DefaultRetryReassigner implements RetryPolicy {
-    @Override
-    public Map<String, SortedSet<Integer>> reassign(JobConfig jobCfg, JobContext jobCtx,
-        Collection<String> instances, Map<String, SortedSet<Integer>> origAssignment) {
-      // Compute an increasing integer ID for each instance
-      BiMap<String, Integer> instanceMap = HashBiMap.create(instances.size());
-      int instanceIndex = 0;
-      for (String instance : instances) {
-        instanceMap.put(instance, instanceIndex++);
+    public Map<String, SortedSet<Integer>> computeMapping(JobConfig jobConfig,
+        JobContext jobContext, List<Integer> partitions, String resourceId) {
+      if (_numInstances == 0) {
+        return new HashMap<String, SortedSet<Integer>>();
       }
 
-      // Move partitions
-      Map<String, SortedSet<Integer>> newAssignment = Maps.newHashMap();
-      for (Map.Entry<String, SortedSet<Integer>> e : origAssignment.entrySet()) {
-        String instance = e.getKey();
-        SortedSet<Integer> partitions = e.getValue();
-        Integer instanceId = instanceMap.get(instance);
-        if (instanceId != null) {
-          for (int p : partitions) {
-            // Determine for each partition if there have been failures with the current assignment
-            // strategy, and if so, force a shift in assignment for that partition only
-            int shiftValue = getNumInstancesToShift(jobCfg, jobCtx, instances, p);
-            int newInstanceId = (instanceId + shiftValue) % instances.size();
-            String newInstance = instanceMap.inverse().get(newInstanceId);
-            if (newInstance == null) {
-              newInstance = instance;
-            }
-            if (!newAssignment.containsKey(newInstance)) {
-              newAssignment.put(newInstance, new TreeSet<Integer>());
-            }
-            newAssignment.get(newInstance).add(p);
-          }
+      Map<String, SortedSet<Integer>> taskAssignment = Maps.newHashMap();
+
+      for (int partition : partitions) {
+        long hashedValue = new String(resourceId + "_" + partition).hashCode();
+        int shiftTimes;
+        int numAttempts = jobContext.getPartitionNumAttempts(partition);
+        int maxAttempts = jobConfig.getMaxAttemptsPerTask();
+
+        if (jobConfig.getMaxAttemptsPerTask() < _numInstances) {
+          shiftTimes = numAttempts == -1 ? 0 : numAttempts;
         } else {
-          // In case something goes wrong, just keep the previous assignment
-          newAssignment.put(instance, partitions);
+          shiftTimes = (maxAttempts == 0)
+              ? 0
+              : jobContext.getPartitionNumAttempts(partition) / (maxAttempts / _numInstances);
+        }
+        // Hash the value based on the shifting time. The default shift time will be 0.
+        for (int i = 0; i <= shiftTimes; i++) {
+          hashedValue = _hashFunction.hash(hashedValue);
+        }
+        String selectedInstance = select(hashedValue);
+        if (selectedInstance != null) {
+          if (!taskAssignment.containsKey(selectedInstance)) {
+            taskAssignment.put(selectedInstance, new TreeSet<Integer>());
+          }
+          taskAssignment.get(selectedInstance).add(partition);
         }
       }
-      return newAssignment;
+      return taskAssignment;
     }
 
-    /**
-     * In case tasks fail, we may not want to schedule them in the same place. This method allows us
-     * to compute a shifting value so that we can systematically choose other instances to try
-     * @param jobCfg the job configuration
-     * @param jobCtx the job context
-     * @param instances instances that can be chosen
-     * @param p the partition to look up
-     * @return the shifting value
-     */
-    private int getNumInstancesToShift(JobConfig jobCfg, JobContext jobCtx,
-        Collection<String> instances, int p) {
-      int numAttempts = jobCtx.getPartitionNumAttempts(p);
-      int maxNumAttempts = jobCfg.getMaxAttemptsPerTask();
-      int numInstances = Math.min(instances.size(), jobCfg.getMaxForcedReassignmentsPerTask() + 1);
-      return numAttempts / (maxNumAttempts / numInstances);
+    private String select(long data) throws HelixException {
+      return _selector.get(data);
+    }
+
+    private class ConsistentHashSelector {
+      private final static int DEFAULT_TOKENS_PER_INSTANCE = 1000;
+      private final SortedMap<Long, String> circle = new TreeMap<Long, String>();
+      protected int instanceSize = 0;
+
+      public ConsistentHashSelector(List<String> instances) {
+        for (String instance : instances) {
+          long tokenCount = DEFAULT_TOKENS_PER_INSTANCE;
+          add(instance, tokenCount);
+          instanceSize++;
+        }
+      }
+
+      public void add(String instance, long numberOfReplicas) {
+        for (int i = 0; i < numberOfReplicas; i++) {
+          circle.put(_hashFunction.hash(instance.hashCode(), i), instance);
+        }
+      }
+
+      public void remove(String instance, long numberOfReplicas) {
+        for (int i = 0; i < numberOfReplicas; i++) {
+          circle.remove(_hashFunction.hash(instance.hashCode(), i));
+        }
+      }
+
+      public String get(long data) {
+        if (circle.isEmpty()) {
+          return null;
+        }
+        long hash = _hashFunction.hash(data);
+        if (!circle.containsKey(hash)) {
+          SortedMap<Long, String> tailMap = circle.tailMap(hash);
+          hash = tailMap.isEmpty() ? circle.firstKey() : tailMap.firstKey();
+        }
+        return circle.get(hash);
+      }
     }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/task/GenericTaskRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/GenericTaskRebalancer.java
@@ -42,7 +42,7 @@ public class GenericTaskRebalancer extends DeprecatedTaskRebalancer {
   public Set<Integer> getAllTaskPartitions(JobConfig jobCfg, JobContext jobCtx,
       WorkflowConfig workflowCfg, WorkflowContext workflowCtx, ClusterDataCache cache) {
     return taskAssignmentCalculator
-        .getAllTaskPartitions(jobCfg, jobCtx, workflowCfg, workflowCtx, cache);
+        .getAllTaskPartitions(jobCfg, jobCtx, workflowCfg, workflowCtx, cache.getIdealStates());
   }
 
   @Override
@@ -52,6 +52,6 @@ public class GenericTaskRebalancer extends DeprecatedTaskRebalancer {
       Set<Integer> partitionSet, ClusterDataCache cache) {
     return taskAssignmentCalculator
         .getTaskAssignment(currStateOutput, prevAssignment, instances, jobCfg, jobContext,
-            workflowCfg, workflowCtx, partitionSet, cache);
+            workflowCfg, workflowCtx, partitionSet, cache.getIdealStates());
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/task/JobRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobRebalancer.java
@@ -345,24 +345,9 @@ public class JobRebalancer extends TaskRebalancer {
           // maximum number of attempts or task is in ABORTED state.
           if (jobCtx.getPartitionNumAttempts(pId) >= jobCfg.getMaxAttemptsPerTask() ||
               currState.equals(TaskPartitionState.TASK_ABORTED)) {
-            // If the user does not require this task to succeed in order for the job to succeed,
-            // then we don't have to fail the job right now
-            boolean successOptional = false;
-            String taskId = jobCtx.getTaskIdForPartition(pId);
-            if (taskId != null) {
-              TaskConfig taskConfig = jobCfg.getTaskConfig(taskId);
-              if (taskConfig != null) {
-                successOptional = taskConfig.isSuccessOptional();
-              }
-            }
-
-            // Similarly, if we have some leeway for how many tasks we can fail, then we don't have
+            // If we have some leeway for how many tasks we can fail, then we don't have
             // to fail the job immediately
-            if (skippedPartitions.size() < jobCfg.getFailureThreshold()) {
-              successOptional = true;
-            }
-
-            if (!successOptional) {
+            if (skippedPartitions.size() >= jobCfg.getFailureThreshold()) {
               markJobFailed(jobResource, jobCtx, workflowConfig, workflowCtx);
               markAllPartitionsError(jobCtx, currState, false);
               addAllPartitions(allPartitions, partitionsToDropFromIs);

--- a/helix-core/src/main/java/org/apache/helix/task/TaskAssignmentCalculator.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskAssignmentCalculator.java
@@ -2,6 +2,7 @@ package org.apache.helix.task;
 
 import org.apache.helix.controller.stages.ClusterDataCache;
 import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.ResourceAssignment;
 
 import java.util.Collection;
@@ -17,11 +18,12 @@ public abstract class TaskAssignmentCalculator {
    * @param jobCtx the task context
    * @param workflowCfg the workflow configuration
    * @param workflowCtx the workflow context
-   * @param cache cluster snapshot
+   * @param idealStateMap the map of resource name map to ideal state
    * @return set of partition numbers
    */
   public abstract Set<Integer> getAllTaskPartitions(JobConfig jobCfg, JobContext jobCtx,
-      WorkflowConfig workflowCfg, WorkflowContext workflowCtx, ClusterDataCache cache);
+      WorkflowConfig workflowCfg, WorkflowContext workflowCtx,
+      Map<String, IdealState> idealStateMap);
 
   /**
    * Compute an assignment of tasks to instances
@@ -34,12 +36,12 @@ public abstract class TaskAssignmentCalculator {
    * @param workflowCfg the workflow configuration
    * @param workflowCtx the workflow context
    * @param partitionSet the partitions to assign
-   * @param cache cluster snapshot
+   * @param idealStateMap the map of resource name map to ideal state
    * @return map of instances to set of partition numbers
    */
   public abstract Map<String, SortedSet<Integer>> getTaskAssignment(
       CurrentStateOutput currStateOutput, ResourceAssignment prevAssignment,
       Collection<String> instances, JobConfig jobCfg, JobContext jobContext,
       WorkflowConfig workflowCfg, WorkflowContext workflowCtx, Set<Integer> partitionSet,
-      ClusterDataCache cache);
+      Map<String, IdealState> idealStateMap);
 }

--- a/helix-core/src/main/java/org/apache/helix/task/TaskConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskConfig.java
@@ -36,6 +36,7 @@ public class TaskConfig {
   private enum TaskConfigProperty {
     TASK_ID,
     TASK_COMMAND,
+    @Deprecated
     TASK_SUCCESS_OPTIONAL,
     TASK_TARGET_PARTITION
   }
@@ -44,18 +45,26 @@ public class TaskConfig {
 
   private final Map<String, String> _configMap;
 
+  @Deprecated
+  public TaskConfig(String command, Map<String, String> configMap, boolean successOptional,
+      String id, String target) {
+    this(command, configMap, id, target);
+  }
+
+  @Deprecated
+  public TaskConfig(String command, Map<String, String> configMap, boolean successOptional) {
+    this(command, configMap, null, null);
+  }
+
   /**
    * Instantiate the task config
    *
    * @param command         the command to invoke for the task
    * @param configMap       configuration to be passed as part of the invocation
-   * @param successOptional true if this task need not pass for the job to succeed, false
-   *                        otherwise
    * @param id              existing task ID
    * @param target          target partition for a task
    */
-  public TaskConfig(String command, Map<String, String> configMap, boolean successOptional,
-      String id, String target) {
+  public TaskConfig(String command, Map<String, String> configMap, String id, String target) {
     if (configMap == null) {
       configMap = Maps.newHashMap();
     }
@@ -65,8 +74,6 @@ public class TaskConfig {
     if (command != null) {
       configMap.put(TaskConfigProperty.TASK_COMMAND.name(), command);
     }
-    configMap
-        .put(TaskConfigProperty.TASK_SUCCESS_OPTIONAL.name(), Boolean.toString(successOptional));
     configMap.put(TaskConfigProperty.TASK_ID.name(), id);
     if (target != null) {
       configMap.put(TaskConfigProperty.TASK_TARGET_PARTITION.name(), target);
@@ -79,11 +86,9 @@ public class TaskConfig {
    *
    * @param command         the command to invoke for the task
    * @param configMap       configuration to be passed as part of the invocation
-   * @param successOptional true if this task need not pass for the job to succeed, false
-   *                        otherwise
    */
-  public TaskConfig(String command, Map<String, String> configMap, boolean successOptional) {
-    this(command, configMap, successOptional, null, null);
+  public TaskConfig(String command, Map<String, String> configMap) {
+    this(command, configMap, null, null);
   }
 
   /**
@@ -115,16 +120,13 @@ public class TaskConfig {
 
   /**
    * Check if this task must succeed for a job to succeed
-   *
+   * This field has been ignored by Helix
    * @return true if success is optional, false otherwise
    */
+  @Deprecated
   public boolean isSuccessOptional() {
-    String successOptionalStr = _configMap.get(TaskConfigProperty.TASK_SUCCESS_OPTIONAL.name());
-    if (successOptionalStr == null) {
-      return false;
-    } else {
-      return Boolean.parseBoolean(successOptionalStr);
-    }
+    // This option will not be used in rebalancer anymore, deprecate it.
+    return true;
   }
 
   /**
@@ -154,7 +156,7 @@ public class TaskConfig {
     private Map<String, String> _configMap;
 
     public TaskConfig build() {
-      return new TaskConfig(_command, _configMap, _successOptional, _taskId, _targetPartition);
+      return new TaskConfig(_command, _configMap, _taskId, _targetPartition);
     }
 
     public String getTaskId() {
@@ -184,10 +186,12 @@ public class TaskConfig {
       return this;
     }
 
+    @Deprecated
     public boolean isSuccessOptional() {
       return _successOptional;
     }
 
+    @Deprecated
     public Builder setSuccessOptional(boolean successOptional) {
       _successOptional = successOptional;
       return this;
@@ -208,7 +212,7 @@ public class TaskConfig {
      * @return instantiated TaskConfig
      */
     public static TaskConfig from(String target) {
-      return new TaskConfig(null, null, false, null, target);
+      return new TaskConfig(null, null, null, target);
     }
 
     /**
@@ -218,7 +222,7 @@ public class TaskConfig {
      * @return instantiated TaskConfig
      */
     public static TaskConfig from(TaskBean bean) {
-      return new TaskConfig(bean.command, bean.taskConfigMap, bean.successOptional);
+      return new TaskConfig(bean.command, bean.taskConfigMap);
     }
 
     /**
@@ -232,11 +236,7 @@ public class TaskConfig {
       String taskId = rawConfigMap.get(TaskConfigProperty.TASK_ID.name());
       String command = rawConfigMap.get(TaskConfigProperty.TASK_COMMAND.name());
       String targetPartition = rawConfigMap.get(TaskConfigProperty.TASK_TARGET_PARTITION.name());
-      String successOptionalStr =
-          rawConfigMap.get(TaskConfigProperty.TASK_SUCCESS_OPTIONAL.name());
-      boolean successOptional =
-          (successOptionalStr != null) ? Boolean.valueOf(successOptionalStr) : false;
-      return new TaskConfig(command, rawConfigMap, successOptional, taskId, targetPartition);
+      return new TaskConfig(command, rawConfigMap, taskId, targetPartition);
     }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/task/beans/JobBean.java
+++ b/helix-core/src/main/java/org/apache/helix/task/beans/JobBean.java
@@ -41,9 +41,9 @@ public class JobBean {
   public long timeoutPerPartition = JobConfig.DEFAULT_TIMEOUT_PER_TASK;
   public int numConcurrentTasksPerInstance = JobConfig.DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE;
   public int maxAttemptsPerTask = JobConfig.DEFAULT_MAX_ATTEMPTS_PER_TASK;
-  public int maxForcedReassignmentsPerTask = JobConfig.DEFAULT_MAX_FORCED_REASSIGNMENTS_PER_TASK;
   public int failureThreshold = JobConfig.DEFAULT_FAILURE_THRESHOLD;
   public long taskRetryDelay = JobConfig.DEFAULT_TASK_RETRY_DELAY;
   public boolean disableExternalView = JobConfig.DEFAULT_DISABLE_EXTERNALVIEW;
   public boolean ignoreDependentJobFailure = JobConfig.DEFAULT_IGNORE_DEPENDENT_JOB_FAILURE;
+  public int numberOfTasks = JobConfig.DEFAULT_NUMBER_OF_TASKS;
 }

--- a/helix-core/src/main/java/org/apache/helix/task/beans/TaskBean.java
+++ b/helix-core/src/main/java/org/apache/helix/task/beans/TaskBean.java
@@ -29,5 +29,6 @@ import java.util.Map;
 public class TaskBean {
   public String command;
   public Map<String, String> taskConfigMap;
+  @Deprecated
   public boolean successOptional = false;
 }

--- a/helix-core/src/main/java/org/apache/helix/util/JenkinsHash.java
+++ b/helix-core/src/main/java/org/apache/helix/util/JenkinsHash.java
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-package org.apache.helix.controller.rebalancer.strategy.crushMapping;
+package org.apache.helix.util;
 
 public class JenkinsHash {
   // max value to limit it to 4 bytes

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestGenericTaskAssignmentCalculator.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestGenericTaskAssignmentCalculator.java
@@ -1,0 +1,171 @@
+package org.apache.helix.integration.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.tools.ClusterSetup;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.testng.collections.Sets;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+public class TestGenericTaskAssignmentCalculator extends TaskTestBase {
+  private Set<String> _invokedClasses = Sets.newHashSet();
+  private Map<String, Integer> _runCounts = Maps.newHashMap();
+  private TaskConfig _taskConfig;
+  private Map<String, String> _jobCommandMap;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursive(namespace);
+    }
+
+    // Setup cluster and instances
+    ClusterSetup setupTool = new ClusterSetup(ZK_ADDR);
+    setupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < _numNodes; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+      setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+
+    // start dummy participants
+    for (int i = 0; i < _numNodes; i++) {
+      final String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+
+      // Set task callbacks
+      Map<String, TaskFactory> taskFactoryReg = new HashMap<String, TaskFactory>();
+
+      taskFactoryReg.put("TaskOne", new TaskFactory() {
+        @Override public Task createNewTask(TaskCallbackContext context) {
+          return new TaskOne(context, instanceName);
+        }
+      });
+
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+
+      // Register a Task state model factory.
+      StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+      stateMachine.registerStateModelFactory("Task",
+          new TaskStateModelFactory(_participants[i], taskFactoryReg));
+      _participants[i].syncStart();
+    }
+
+    // Start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    // Start an admin connection
+    _manager = HelixManagerFactory
+        .getZKHelixManager(CLUSTER_NAME, "Admin", InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+
+    Map<String, String> taskConfigMap = Maps.newHashMap();
+    _taskConfig = new TaskConfig("TaskOne", taskConfigMap, false);
+    _jobCommandMap = Maps.newHashMap();
+  }
+
+  @Test
+  public void testMultipleJobAssignment() throws InterruptedException {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(1);
+    taskConfigs.add(_taskConfig);
+    JobConfig.Builder jobBuilder =
+        new JobConfig.Builder().setCommand("DummyCommand").addTaskConfigs(taskConfigs)
+            .setJobCommandConfigMap(_jobCommandMap);
+
+    for (int i = 0; i < 25; i++) {
+      workflowBuilder.addJob("JOB" + i, jobBuilder);
+    }
+
+    _driver.start(workflowBuilder.build());
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    Assert.assertEquals(_runCounts.size(), 5);
+  }
+
+  @Test
+  public void testMultipleTaskAssignment() throws InterruptedException {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+
+    List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(20);
+    for (int i = 0; i < 50; i++) {
+      Map<String, String> taskConfigMap = Maps.newHashMap();
+      taskConfigs.add(new TaskConfig("TaskOne", taskConfigMap, false));
+    }
+    JobConfig.Builder jobBuilder =
+        new JobConfig.Builder().setCommand("DummyCommand").setJobCommandConfigMap(_jobCommandMap)
+            .addTaskConfigs(taskConfigs);
+    workflowBuilder.addJob("JOB", jobBuilder);
+    _driver.start(workflowBuilder.build());
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    Assert.assertEquals(_runCounts.size(), 5);
+  }
+
+  private class TaskOne extends MockTask {
+    private final String _instanceName;
+
+    public TaskOne(TaskCallbackContext context, String instanceName) {
+      super(context);
+
+      // Initialize the count for this instance if not already done
+      if (!_runCounts.containsKey(instanceName)) {
+        _runCounts.put(instanceName, 0);
+      }
+      _instanceName = instanceName;
+    }
+
+    @Override
+    public TaskResult run() {
+      _invokedClasses.add(getClass().getName());
+      _runCounts.put(_instanceName, _runCounts.get(_instanceName) + 1);
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
+    }
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestGenericTaskAssignmentCalculator.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestGenericTaskAssignmentCalculator.java
@@ -104,7 +104,7 @@ public class TestGenericTaskAssignmentCalculator extends TaskTestBase {
     _driver = new TaskDriver(_manager);
 
     Map<String, String> taskConfigMap = Maps.newHashMap();
-    _taskConfig = new TaskConfig("TaskOne", taskConfigMap, false);
+    _taskConfig = new TaskConfig("TaskOne", taskConfigMap);
     _jobCommandMap = Maps.newHashMap();
   }
 
@@ -136,7 +136,7 @@ public class TestGenericTaskAssignmentCalculator extends TaskTestBase {
     List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(20);
     for (int i = 0; i < 50; i++) {
       Map<String, String> taskConfigMap = Maps.newHashMap();
-      taskConfigs.add(new TaskConfig("TaskOne", taskConfigMap, false));
+      taskConfigs.add(new TaskConfig("TaskOne", taskConfigMap));
     }
     JobConfig.Builder jobBuilder =
         new JobConfig.Builder().setCommand("DummyCommand").setJobCommandConfigMap(_jobCommandMap)

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestIndependentTaskRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestIndependentTaskRebalancer.java
@@ -215,12 +215,12 @@ public class TestIndependentTaskRebalancer extends TaskTestBase {
   }
 
   @Test public void testReassignment() throws Exception {
-    final int NUM_INSTANCES = 2;
+    final int NUM_INSTANCES = 5;
     String jobName = TestHelper.getTestMethodName();
     Workflow.Builder workflowBuilder = new Workflow.Builder(jobName);
     List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(2);
-    Map<String, String> taskConfigMap = Maps.newHashMap(
-        ImmutableMap.of("fail", "" + true, "failInstance", PARTICIPANT_PREFIX + '_' + _startPort));
+    Map<String, String> taskConfigMap = Maps.newHashMap(ImmutableMap
+        .of("fail", "" + true, "failInstance", PARTICIPANT_PREFIX + '_' + (_startPort + 1)));
     TaskConfig taskConfig1 = new TaskConfig("TaskOne", taskConfigMap, false);
     taskConfigs.add(taskConfig1);
     Map<String, String> jobCommandMap = Maps.newHashMap();
@@ -242,7 +242,7 @@ public class TestIndependentTaskRebalancer extends TaskTestBase {
 
     // Ensure that this was tried on two different instances, the first of which exhausted the
     // attempts number, and the other passes on the first try
-    Assert.assertEquals(_runCounts.size(), NUM_INSTANCES);
+    Assert.assertEquals(_runCounts.size(), 2);
     Assert.assertTrue(
         _runCounts.values().contains(JobConfig.DEFAULT_MAX_ATTEMPTS_PER_TASK / NUM_INSTANCES));
     Assert.assertTrue(_runCounts.values().contains(1));

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestIndependentTaskRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestIndependentTaskRebalancer.java
@@ -136,8 +136,8 @@ public class TestIndependentTaskRebalancer extends TaskTestBase {
     String jobName = TestHelper.getTestMethodName();
     Workflow.Builder workflowBuilder = new Workflow.Builder(jobName);
     List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(2);
-    TaskConfig taskConfig1 = new TaskConfig("TaskOne", null, true);
-    TaskConfig taskConfig2 = new TaskConfig("TaskTwo", null, true);
+    TaskConfig taskConfig1 = new TaskConfig("TaskOne", null);
+    TaskConfig taskConfig2 = new TaskConfig("TaskTwo", null);
     taskConfigs.add(taskConfig1);
     taskConfigs.add(taskConfig2);
     Map<String, String> jobCommandMap = Maps.newHashMap();
@@ -164,8 +164,8 @@ public class TestIndependentTaskRebalancer extends TaskTestBase {
     Workflow.Builder workflowBuilder = new Workflow.Builder(jobName);
     List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(2);
     Map<String, String> taskConfigMap = Maps.newHashMap(ImmutableMap.of("fail", "" + true));
-    TaskConfig taskConfig1 = new TaskConfig("TaskOne", taskConfigMap, false);
-    TaskConfig taskConfig2 = new TaskConfig("TaskTwo", null, false);
+    TaskConfig taskConfig1 = new TaskConfig("TaskOne", taskConfigMap);
+    TaskConfig taskConfig2 = new TaskConfig("TaskTwo", null);
     taskConfigs.add(taskConfig1);
     taskConfigs.add(taskConfig2);
     Map<String, String> jobConfigMap = Maps.newHashMap();
@@ -185,35 +185,6 @@ public class TestIndependentTaskRebalancer extends TaskTestBase {
     Assert.assertTrue(_invokedClasses.contains(TaskTwo.class.getName()));
   }
 
-  @Test public void testOptionalTaskFailure() throws Exception {
-    // Create a job with two different tasks
-    String jobName = TestHelper.getTestMethodName();
-    Workflow.Builder workflowBuilder = new Workflow.Builder(jobName);
-    List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(2);
-    Map<String, String> taskConfigMap = Maps.newHashMap(ImmutableMap.of("fail", "" + true));
-    TaskConfig taskConfig1 = new TaskConfig("TaskOne", taskConfigMap, true);
-    TaskConfig taskConfig2 = new TaskConfig("TaskTwo", null, false);
-    taskConfigs.add(taskConfig1);
-    taskConfigs.add(taskConfig2);
-    Map<String, String> jobCommandMap = Maps.newHashMap();
-    jobCommandMap.put("Timeout", "1000");
-
-    JobConfig.Builder jobBuilder =
-        new JobConfig.Builder().setCommand("DummyCommand").addTaskConfigs(taskConfigs)
-            .setJobCommandConfigMap(jobCommandMap);
-    workflowBuilder.addJob(jobName, jobBuilder);
-
-    _driver.start(workflowBuilder.build());
-
-    // Ensure the job completes
-    _driver.pollForWorkflowState(jobName, TaskState.IN_PROGRESS);
-    _driver.pollForWorkflowState(jobName, TaskState.COMPLETED);
-
-    // Ensure that each class was invoked
-    Assert.assertTrue(_invokedClasses.contains(TaskOne.class.getName()));
-    Assert.assertTrue(_invokedClasses.contains(TaskTwo.class.getName()));
-  }
-
   @Test public void testReassignment() throws Exception {
     final int NUM_INSTANCES = 5;
     String jobName = TestHelper.getTestMethodName();
@@ -221,13 +192,13 @@ public class TestIndependentTaskRebalancer extends TaskTestBase {
     List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(2);
     Map<String, String> taskConfigMap = Maps.newHashMap(ImmutableMap
         .of("fail", "" + true, "failInstance", PARTICIPANT_PREFIX + '_' + (_startPort + 1)));
-    TaskConfig taskConfig1 = new TaskConfig("TaskOne", taskConfigMap, false);
+    TaskConfig taskConfig1 = new TaskConfig("TaskOne", taskConfigMap);
     taskConfigs.add(taskConfig1);
     Map<String, String> jobCommandMap = Maps.newHashMap();
     jobCommandMap.put("Timeout", "1000");
 
     JobConfig.Builder jobBuilder = new JobConfig.Builder().setCommand("DummyCommand")
-        .setMaxForcedReassignmentsPerTask(NUM_INSTANCES - 1).addTaskConfigs(taskConfigs)
+        .addTaskConfigs(taskConfigs)
         .setJobCommandConfigMap(jobCommandMap);
     workflowBuilder.addJob(jobName, jobBuilder);
 
@@ -254,7 +225,7 @@ public class TestIndependentTaskRebalancer extends TaskTestBase {
     Workflow.Builder workflowBuilder = new Workflow.Builder(jobName);
     List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(1);
     Map<String, String> taskConfigMap = Maps.newHashMap();
-    TaskConfig taskConfig1 = new TaskConfig("TaskOne", taskConfigMap, false);
+    TaskConfig taskConfig1 = new TaskConfig("TaskOne", taskConfigMap);
     taskConfigs.add(taskConfig1);
     Map<String, String> jobCommandMap = Maps.newHashMap();
     jobCommandMap.put("Timeout", "1000");
@@ -289,7 +260,7 @@ public class TestIndependentTaskRebalancer extends TaskTestBase {
     Workflow.Builder workflowBuilder = new Workflow.Builder(jobName);
     List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(1);
     Map<String, String> taskConfigMap = Maps.newHashMap();
-    TaskConfig taskConfig1 = new TaskConfig("SingleFailTask", taskConfigMap, false);
+    TaskConfig taskConfig1 = new TaskConfig("SingleFailTask", taskConfigMap);
     taskConfigs.add(taskConfig1);
     Map<String, String> jobCommandMap = Maps.newHashMap();
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestUserContentStore.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestUserContentStore.java
@@ -123,7 +123,7 @@ public class TestUserContentStore extends TaskTestBase {
     Workflow.Builder workflowBuilder = new Workflow.Builder(jobName);
     List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(1);
     Map<String, String> taskConfigMap = Maps.newHashMap();
-    TaskConfig taskConfig1 = new TaskConfig("ContentStoreTask", taskConfigMap, false);
+    TaskConfig taskConfig1 = new TaskConfig("ContentStoreTask", taskConfigMap);
     taskConfigs.add(taskConfig1);
     Map<String, String> jobCommandMap = Maps.newHashMap();
     jobCommandMap.put("Timeout", "1000");
@@ -148,8 +148,8 @@ public class TestUserContentStore extends TaskTestBase {
     List<TaskConfig> taskConfigs2 = Lists.newArrayListWithCapacity(1);
     Map<String, String> taskConfigMap1 = Maps.newHashMap();
     Map<String, String> taskConfigMap2 = Maps.newHashMap();
-    TaskConfig taskConfig1 = new TaskConfig("TaskOne", taskConfigMap1, false);
-    TaskConfig taskConfig2 = new TaskConfig("TaskTwo", taskConfigMap2, false);
+    TaskConfig taskConfig1 = new TaskConfig("TaskOne", taskConfigMap1);
+    TaskConfig taskConfig2 = new TaskConfig("TaskTwo", taskConfigMap2);
 
     taskConfigs1.add(taskConfig1);
     taskConfigs2.add(taskConfig2);


### PR DESCRIPTION
Currently, GenericTaskAssignmentCalculator using AutoRebalancerStrategy compute the assignment mapping. There is a bug that all the tasks from same job will be assigned to one node, which is not balanced.

This fix contains:
    1. Implement consistent hashing mapping calculation for GenericTaskAssignmentCalculator
    2. Remove reassign logics and applied in consistent hashing
    3. Add tests for GenericTaskAssignmentCalculator
    4. Refactoring TaskAssignmentCalculator API, since ClusterDataCache is too large and not all the contents inside are used.
    5. Support identical task initialization with job command and number of tasks
    6. Remove unused MaxForcedReassignmentPerTask field
    7. Refactor logics of failure.
    