### PR TITLE
[HELIX-631] AutoRebalanceStrategy does not work correctly all the time.

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/controller/strategy/TestAutoRebalanceStrategy.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/strategy/TestAutoRebalanceStrategy.java
@@ -1,4 +1,4 @@
-package org.apache.helix.controller.Strategy;
+package org.apache.helix.controller.strategy;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,6 +20,7 @@ package org.apache.helix.controller.Strategy;
  */
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -762,5 +763,32 @@ public class TestAutoRebalanceStrategy {
       firstNodes.add(preferenceList.get(0));
     }
     Assert.assertEquals(firstNodes.size(), 2, "masters not evenly distributed");
+  }
+
+
+  @Test public void test() {
+    int nPartitions = 16;
+    final String resourceName = "something";
+    final List<String> instanceNames =
+        Arrays.asList("node-1", "node-2", "node-3", "node-4"); // Initialize to 4 unique strings
+
+    final int nReplicas = 3;
+
+    List<String> partitions = new ArrayList<String>(nPartitions);
+    for (int i = 0; i < nPartitions; i++) {
+      partitions.add(Integer.toString(i));
+    }
+
+    LinkedHashMap<String, Integer> states = new LinkedHashMap<String, Integer>(2);
+    states.put("OFFLINE", 0);
+    states.put("ONLINE", nReplicas);
+
+    AutoRebalanceStrategy strategy = new AutoRebalanceStrategy(resourceName, partitions, states);
+    ZNRecord znRecord = strategy.computePartitionAssignment(instanceNames, instanceNames,
+        new HashMap<String, Map<String, String>>(0), null);
+
+    for (List p : znRecord.getListFields().values()) {
+      Assert.assertEquals(p.size(), nReplicas);
+    }
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/TestAutoRebalanceWithDisabledInstance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestAutoRebalanceWithDisabledInstance.java
@@ -22,7 +22,6 @@ package org.apache.helix.integration;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.model.ExternalView;
-import org.apache.helix.model.IdealState;
 import org.apache.helix.model.IdealState.RebalanceMode;
 import org.apache.helix.tools.ClusterStateVerifier;
 import org.testng.Assert;
@@ -30,7 +29,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -57,26 +55,19 @@ public class TestAutoRebalanceWithDisabledInstance extends ZkStandAloneCMTestBas
   public void testDisableEnableInstanceAutoRebalance() throws Exception {
     String disabledInstance = _participants[0].getInstanceName();
 
-    Set<String> assignedPartitions = getPartitionsAssignedtoInstance(CLUSTER_NAME, TEST_DB_2,
-        disabledInstance);
-    Assert.assertFalse(assignedPartitions.isEmpty());
     Set<String> currentPartitions = getCurrentPartitionsOnInstance(CLUSTER_NAME, TEST_DB_2,
         disabledInstance);
     Assert.assertFalse(currentPartitions.isEmpty());
 
     // disable instance
     _setupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, disabledInstance, false);
-    Thread.sleep(400);
-    assignedPartitions = getPartitionsAssignedtoInstance(CLUSTER_NAME, TEST_DB_2, disabledInstance);
-    Assert.assertTrue(assignedPartitions.isEmpty());
+    Thread.sleep(1000);
     currentPartitions = getCurrentPartitionsOnInstance(CLUSTER_NAME, TEST_DB_2, disabledInstance);
     Assert.assertTrue(currentPartitions.isEmpty());
 
     //enable instance
     _setupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, disabledInstance, true);
-    Thread.sleep(400);
-    assignedPartitions = getPartitionsAssignedtoInstance(CLUSTER_NAME, TEST_DB_2, disabledInstance);
-    Assert.assertFalse(assignedPartitions.isEmpty());
+    Thread.sleep(1000);
     currentPartitions = getCurrentPartitionsOnInstance(CLUSTER_NAME, TEST_DB_2, disabledInstance);
     Assert.assertFalse(currentPartitions.isEmpty());
   }
@@ -93,8 +84,6 @@ public class TestAutoRebalanceWithDisabledInstance extends ZkStandAloneCMTestBas
     participant.syncStart();
 
     Thread.sleep(400);
-    Set<String> assignedPartitions = getPartitionsAssignedtoInstance(CLUSTER_NAME, TEST_DB_2, nodeName);
-    Assert.assertTrue(assignedPartitions.isEmpty());
     Set<String> currentPartitions = getCurrentPartitionsOnInstance(CLUSTER_NAME, TEST_DB_2,
         nodeName);
     Assert.assertTrue(currentPartitions.isEmpty());
@@ -102,27 +91,10 @@ public class TestAutoRebalanceWithDisabledInstance extends ZkStandAloneCMTestBas
     //enable instance
     _setupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, nodeName, true);
     Thread.sleep(400);
-    assignedPartitions = getPartitionsAssignedtoInstance(CLUSTER_NAME, TEST_DB_2, nodeName);
-    Assert.assertFalse(assignedPartitions.isEmpty());
     currentPartitions = getCurrentPartitionsOnInstance(CLUSTER_NAME, TEST_DB_2, nodeName);
     Assert.assertFalse(currentPartitions.isEmpty());
   }
 
-  private Set<String> getPartitionsAssignedtoInstance(String cluster, String dbName, String instance) {
-    HelixAdmin admin = _setupTool.getClusterManagementTool();
-    Set<String> partitionSet = new HashSet<String>();
-    IdealState is = admin.getResourceIdealState(cluster, dbName);
-    for (String partition : is.getRecord().getListFields().keySet()) {
-      List<String> assignments = is.getRecord().getListField(partition);
-      for (String ins : assignments) {
-        if (ins.equals(instance)) {
-          partitionSet.add(partition);
-        }
-      }
-    }
-
-    return partitionSet;
-  }
 
   private Set<String> getCurrentPartitionsOnInstance(String cluster, String dbName, String instance) {
     HelixAdmin admin = _setupTool.getClusterManagementTool();


### PR DESCRIPTION
What happened here is: Helix always assigns a random node for a new (unassigned) replica (logic in assignOrphans()), and then try to move it to its preferred node later. The random node chosen is based on the hashing of replica name. Given a specific partition name and number of replicas, there could be a case that no node can be found for a replica.

The fix is to always assign its preferred node to a new replica unless that node is full, then randomly find another non-preferred node.