### PR TITLE
[HELIX-636] Add Java API and REST API for clean up JobQueue

### DIFF
--- a/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/JobQueueResource.java
+++ b/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/JobQueueResource.java
@@ -91,7 +91,7 @@ public class JobQueueResource extends ServerResource {
     // Get job queue config
     // TODO: fix this to use workflowConfig.
     ResourceConfig jobQueueConfig = accessor.getProperty(keyBuilder.resourceConfig(jobQueueName));
-    
+
     // Get job queue context
     WorkflowContext ctx = taskDriver.getWorkflowContext(jobQueueName);
 
@@ -177,6 +177,10 @@ public class JobQueueResource extends ServerResource {
       }
       case delete: {
         driver.delete(jobQueueName);
+        break;
+      }
+      case clean: {
+        driver.cleanupJobQueue(jobQueueName);
         break;
       }
       default:

--- a/helix-core/src/main/java/org/apache/helix/task/TaskRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskRebalancer.java
@@ -79,7 +79,7 @@ public abstract class TaskRebalancer implements Rebalancer, MappingCalculator {
     int failedJobs = 0;
     for (String job : cfg.getJobDag().getAllNodes()) {
       TaskState jobState = ctx.getJobState(job);
-      if (jobState == TaskState.FAILED) {
+      if (!cfg.isJobQueue() && jobState == TaskState.FAILED) {
         failedJobs ++;
         if (failedJobs > cfg.getFailureThreshold()) {
           ctx.setWorkflowState(TaskState.FAILED);

--- a/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
@@ -180,6 +180,33 @@ public class TaskUtil {
   }
 
   /**
+   * Remove the runtime context of a single job.
+   * This method is internal API.
+   *
+   * @param manager     A connection to Helix
+   * @param jobResource The name of the job
+   * @return            True if remove success, otherwise false
+   */
+  protected static boolean removeJobContext(HelixManager manager, String jobResource) {
+    return removeJobContext(manager.getHelixPropertyStore(), jobResource);
+  }
+
+  /**
+   * Remove the runtime context of a single job.
+   * This method is internal API.
+   *
+   * @param propertyStore Property store for the cluster
+   * @param jobResource   The name of the job
+   * @return              True if remove success, otherwise false
+   */
+  protected static boolean removeJobContext(HelixPropertyStore<ZNRecord> propertyStore,
+      String jobResource) {
+    return propertyStore.remove(
+        Joiner.on("/").join(TaskConstants.REBALANCER_CONTEXT_ROOT, jobResource),
+        AccessOption.PERSISTENT);
+  }
+
+  /**
    * Get the runtime context of a single workflow.
    * This method is internal API, please use the corresponding one in TaskDriver.getWorkflowContext();
    *
@@ -219,6 +246,33 @@ public class TaskUtil {
     manager.getHelixPropertyStore().set(
         Joiner.on("/").join(TaskConstants.REBALANCER_CONTEXT_ROOT, workflowResource, CONTEXT_NODE),
         ctx.getRecord(), AccessOption.PERSISTENT);
+  }
+
+  /**
+   * Remove the runtime context of a single workflow.
+   * This method is internal API.
+   *
+   * @param manager     A connection to Helix
+   * @param workflowResource The name of the workflow
+   * @return            True if remove success, otherwise false
+   */
+  protected static boolean removeWorkflowContext(HelixManager manager, String workflowResource) {
+    return removeWorkflowContext(manager.getHelixPropertyStore(), workflowResource);
+  }
+
+  /**
+   * Remove the runtime context of a single workflow.
+   * This method is internal API.
+   *
+   * @param propertyStore      Property store for the cluster
+   * @param workflowResource   The name of the workflow
+   * @return                   True if remove success, otherwise false
+   */
+  protected static boolean removeWorkflowContext(HelixPropertyStore<ZNRecord> propertyStore,
+      String workflowResource) {
+    return propertyStore.remove(
+        Joiner.on("/").join(TaskConstants.REBALANCER_CONTEXT_ROOT, workflowResource),
+        AccessOption.PERSISTENT);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowRebalancer.java
@@ -428,12 +428,11 @@ public class WorkflowRebalancer extends TaskRebalancer {
         }
       }
       // Delete workflow context
-      String workflowPropStoreKey = TaskUtil.getWorkflowContextKey(workflow);
-      LOG.info("Removing workflow context: " + workflowPropStoreKey);
-      if (!_manager.getHelixPropertyStore().remove(workflowPropStoreKey, AccessOption.PERSISTENT)) {
+      LOG.info("Removing workflow context: " + workflow);
+      if (!TaskUtil.removeWorkflowContext(_manager, workflow)) {
         LOG.error(String.format(
-            "Error occurred while trying to clean up workflow %s. Failed to remove node %s from Helix. Aborting further clean up steps.",
-            workflow, workflowPropStoreKey));
+            "Error occurred while trying to clean up workflow %s. Aborting further clean up steps.",
+            workflow));
       }
 
       // Remove pending timer task for this workflow if exists
@@ -496,11 +495,8 @@ public class WorkflowRebalancer extends TaskRebalancer {
 
     // Delete job context
     // For recurring workflow, it's OK if the node doesn't exist.
-    String propStoreKey = TaskUtil.getWorkflowContextKey(job);
-    if (!_manager.getHelixPropertyStore().remove(propStoreKey, AccessOption.PERSISTENT)) {
-      LOG.warn(String.format(
-          "Error occurred while trying to clean up job %s. Failed to remove node %s from Helix.",
-          job, propStoreKey));
+    if (!TaskUtil.removeJobContext(_manager, job)) {
+      LOG.warn(String.format("Error occurred while trying to clean up job %s.", job));
     }
 
     LOG.info(String.format("Successfully cleaned up job context %s.", job));

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureDependence.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureDependence.java
@@ -93,7 +93,6 @@ public class TestJobFailureDependence extends TaskTestBase {
 
     String namedSpaceJob1 = String.format("%s_%s", queueName, currentJobNames.get(2));
     _driver.pollForJobState(queueName, namedSpaceJob1, TaskState.FAILED);
-    _driver.pollForWorkflowState(queueName, TaskState.FAILED);
   }
 
   @Test
@@ -175,7 +174,6 @@ public class TestJobFailureDependence extends TaskTestBase {
 
     namedSpaceJob1 = String.format("%s_%s", queueName, currentJobNames.get(1));
     _driver.pollForJobState(queueName, namedSpaceJob1, TaskState.FAILED);
-    _driver.pollForWorkflowState(queueName, TaskState.FAILED);
   }
 }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobQueueCleanUp.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobQueueCleanUp.java
@@ -1,0 +1,77 @@
+package org.apache.helix.integration.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.TestHelper;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.JobQueue;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskUtil;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+public class TestJobQueueCleanUp extends TaskTestBase {
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    // TODO: Reenable this after Test Refactoring code checkin
+    // setSingleTestEnvironment();
+    super.beforeClass();
+  }
+
+  @Test
+  public void testJobQueueCleanUp() throws InterruptedException {
+    String queueName = TestHelper.getTestMethodName();
+    JobQueue.Builder builder = TaskTestUtil.buildJobQueue(queueName);
+    JobConfig.Builder jobBuilder =
+        new JobConfig.Builder().setTargetResource(WorkflowGenerator.DEFAULT_TGT_DB)
+            .setCommand(MockTask.TASK_COMMAND).setMaxAttemptsPerTask(2)
+            .setJobCommandConfigMap(ImmutableMap.of(MockTask.SUCCESS_COUNT_BEFORE_FAIL, "2"));
+    for (int i = 0; i < 5; i++) {
+      builder.enqueueJob("JOB" + i, jobBuilder);
+    }
+    _driver.start(builder.build());
+    _driver.pollForJobState(queueName, TaskUtil.getNamespacedJobName(queueName, "JOB" + 4),
+        TaskState.FAILED);
+    _driver.cleanupJobQueue(queueName);
+    Assert.assertEquals(_driver.getWorkflowConfig(queueName).getJobDag().size(), 0);
+  }
+
+  @Test public void testJobQueueNotCleanupRunningJobs() throws InterruptedException {
+    String queueName = TestHelper.getTestMethodName();
+    JobQueue.Builder builder = TaskTestUtil.buildJobQueue(queueName);
+    JobConfig.Builder jobBuilder =
+        new JobConfig.Builder().setTargetResource(WorkflowGenerator.DEFAULT_TGT_DB)
+            .setCommand(MockTask.TASK_COMMAND).setMaxAttemptsPerTask(2);
+    for (int i = 0; i < 3; i++) {
+      builder.enqueueJob("JOB" + i, jobBuilder);
+    }
+    builder.enqueueJob("JOB" + 3,
+        jobBuilder.setJobCommandConfigMap(ImmutableMap.of(MockTask.TIMEOUT_CONFIG, "1000000L")));
+    builder.enqueueJob("JOB" + 4, jobBuilder);
+    _driver.start(builder.build());
+    _driver.pollForJobState(queueName, TaskUtil.getNamespacedJobName(queueName, "JOB" + 3),
+        TaskState.IN_PROGRESS);
+    _driver.cleanupJobQueue(queueName);
+    Assert.assertEquals(_driver.getWorkflowConfig(queueName).getJobDag().size(), 2);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestRunJobsWithMissingTarget.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestRunJobsWithMissingTarget.java
@@ -26,6 +26,8 @@ import org.apache.helix.TestHelper;
 import org.apache.helix.task.JobConfig;
 import org.apache.helix.task.JobQueue;
 import org.apache.helix.task.TaskState;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
 import org.apache.log4j.Logger;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -43,11 +45,11 @@ public class TestRunJobsWithMissingTarget extends TaskTestBase {
 
   @Test
   public void testJobFailsWithMissingTarget() throws Exception {
-    String queueName = TestHelper.getTestMethodName();
+    String workflowName = TestHelper.getTestMethodName();
 
-    // Create a queue
-    LOG.info("Starting job-queue: " + queueName);
-    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName);
+    // Create a workflow
+    LOG.info("Starting job-queue: " + workflowName);
+    Workflow.Builder builder = new Workflow.Builder(workflowName);
     // Create and Enqueue jobs
     List<String> currentJobNames = new ArrayList<String>();
     for (int i = 0; i < _numDbs; i++) {
@@ -56,74 +58,83 @@ public class TestRunJobsWithMissingTarget extends TaskTestBase {
               _testDbs.get(i))
               .setTargetPartitionStates(Sets.newHashSet("SLAVE"));
       String jobName = "job" + _testDbs.get(i);
-      queueBuilder.enqueueJob(jobName, jobConfig);
+      builder.addJob(jobName, jobConfig);
+      if (i > 0) {
+        builder.addParentChildDependency("job" + _testDbs.get(i - 1), "job" + _testDbs.get(i));
+      }
       currentJobNames.add(jobName);
     }
 
     _setupTool.dropResourceFromCluster(CLUSTER_NAME, _testDbs.get(1));
-    _driver.start(queueBuilder.build());
+    _driver.start(builder.build());
 
-    String namedSpaceJob = String.format("%s_%s", queueName, currentJobNames.get(1));
-    _driver.pollForJobState(queueName, namedSpaceJob, TaskState.FAILED);
-    _driver.pollForWorkflowState(queueName, TaskState.FAILED);
+    String namedSpaceJob = String.format("%s_%s", workflowName, currentJobNames.get(1));
+    _driver.pollForJobState(workflowName, namedSpaceJob, TaskState.FAILED);
+    _driver.pollForWorkflowState(workflowName, TaskState.FAILED);
 
-    _driver.delete(queueName);
+    _driver.delete(workflowName);
   }
 
   @Test(dependsOnMethods = "testJobFailsWithMissingTarget")
   public void testJobContinueUponParentJobFailure() throws Exception {
-    String queueName = TestHelper.getTestMethodName();
+    String workflowName = TestHelper.getTestMethodName();
 
-    // Create a queue
-    LOG.info("Starting job-queue: " + queueName);
-    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 3);
-    // Create and Enqueue jobs
+    // Create a workflow
+    LOG.info("Starting job-queue: " + workflowName);
+    Workflow.Builder builder = new Workflow.Builder(workflowName)
+        .setWorkflowConfig(new WorkflowConfig.Builder().setFailureThreshold(10).build());
+    // Create and add jobs
     List<String> currentJobNames = new ArrayList<String>();
     for (int i = 0; i < _numDbs; i++) {
       JobConfig.Builder jobConfig =
           new JobConfig.Builder().setCommand(MockTask.TASK_COMMAND).setTargetResource(_testDbs.get(i))
               .setTargetPartitionStates(Sets.newHashSet("SLAVE")).setIgnoreDependentJobFailure(true);
       String jobName = "job" + _testDbs.get(i);
-      queueBuilder.enqueueJob(jobName, jobConfig);
+      builder.addJob(jobName, jobConfig);
+      if (i > 0) {
+        builder.addParentChildDependency("job" + _testDbs.get(i - 1), "job" + _testDbs.get(i));
+      }
       currentJobNames.add(jobName);
     }
 
-    _driver.start(queueBuilder.build());
+    _driver.start(builder.build());
 
-    String namedSpaceJob1 = String.format("%s_%s", queueName, currentJobNames.get(1));
-    _driver.pollForJobState(queueName, namedSpaceJob1, TaskState.FAILED);
+    String namedSpaceJob1 = String.format("%s_%s", workflowName, currentJobNames.get(1));
+    _driver.pollForJobState(workflowName, namedSpaceJob1, TaskState.FAILED);
     String lastJob =
-        String.format("%s_%s", queueName, currentJobNames.get(currentJobNames.size() - 1));
-    _driver.pollForJobState(queueName, lastJob, TaskState.COMPLETED);
+        String.format("%s_%s", workflowName, currentJobNames.get(currentJobNames.size() - 1));
+    _driver.pollForJobState(workflowName, lastJob, TaskState.COMPLETED);
 
-    _driver.delete(queueName);
+    _driver.delete(workflowName);
   }
 
   @Test(dependsOnMethods = "testJobContinueUponParentJobFailure")
   public void testJobFailsWithMissingTargetInRunning() throws Exception {
-    String queueName = TestHelper.getTestMethodName();
+    String workflowName = TestHelper.getTestMethodName();
 
-    // Create a queue
-    LOG.info("Starting job-queue: " + queueName);
-    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName);
-    // Create and Enqueue jobs
+    // Create a workflow
+    LOG.info("Starting job-queue: " + workflowName);
+    Workflow.Builder builder = new Workflow.Builder(workflowName);
+    // Create and add jobs
     List<String> currentJobNames = new ArrayList<String>();
     for (int i = 0; i < _numDbs; i++) {
       JobConfig.Builder jobConfig =
           new JobConfig.Builder().setCommand(MockTask.TASK_COMMAND).setTargetResource(_testDbs.get(i))
               .setTargetPartitionStates(Sets.newHashSet("SLAVE"));
       String jobName = "job" + _testDbs.get(i);
-      queueBuilder.enqueueJob(jobName, jobConfig);
-      currentJobNames.add(jobName);
+      builder.addJob(jobName, jobConfig);
+      if (i > 0) {
+        builder.addParentChildDependency("job" + _testDbs.get(i - 1), "job" + _testDbs.get(i));
+      }      currentJobNames.add(jobName);
     }
 
-    _driver.start(queueBuilder.build());
+    _driver.start(builder.build());
     _setupTool.dropResourceFromCluster(CLUSTER_NAME, _testDbs.get(0));
 
-    String namedSpaceJob1 = String.format("%s_%s", queueName, currentJobNames.get(0));
-    _driver.pollForJobState(queueName, namedSpaceJob1, TaskState.FAILED);
-    _driver.pollForWorkflowState(queueName, TaskState.FAILED);
+    String namedSpaceJob1 = String.format("%s_%s", workflowName, currentJobNames.get(0));
+    _driver.pollForJobState(workflowName, namedSpaceJob1, TaskState.FAILED);
+    _driver.pollForWorkflowState(workflowName, TaskState.FAILED);
 
-    _driver.delete(queueName);
+    _driver.delete(workflowName);
   }
 }


### PR DESCRIPTION
Since JobQueue never cleans up the jobs in the final stage (FAILED, COMPLETED, ABORTED), JobQueue will reach the capacity limit when jobs keep adding in.

1. Current fix will be adding an API in TaskDriver to clean up the final statge. To clean up the jobs in the final states, call the API cleanUpJobQueue()
2. As JobQueue is dynamic queue running, JobQueue should not be failed due to job failed threshold. Fix it with check whether failing due to other jobs fail is for JobQueue or generic workflow.
