### PR TITLE
[HELIX-543] Avoid moving partitions unnecessarily when auto-rebalancing.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/AutoRebalanceStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/AutoRebalanceStrategy.java
@@ -21,6 +21,7 @@ package org.apache.helix.controller.rebalancer.strategy;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -83,18 +84,28 @@ public class AutoRebalanceStrategy implements RebalanceStrategy {
     if (liveNodes.size() == 0) {
       return znRecord;
     }
-    int distRemainder = (numReplicas * _partitions.size()) % liveNodes.size();
-    int distFloor = (numReplicas * _partitions.size()) / liveNodes.size();
+
+    List<String> sortedAllNodes = new ArrayList<String>(allNodes);
+    Collections.sort(sortedAllNodes);
+
+    Comparator<String> currentStateNodeComparator =
+        new CurrentStateNodeComparator(currentMapping);
+
+    List<String> sortedLiveNodes = new ArrayList<String>(liveNodes);
+    Collections.sort(sortedLiveNodes, currentStateNodeComparator);
+
+    int distRemainder = (numReplicas * _partitions.size()) % sortedLiveNodes.size();
+    int distFloor = (numReplicas * _partitions.size()) / sortedLiveNodes.size();
     _nodeMap = new HashMap<String, Node>();
     _liveNodesList = new ArrayList<Node>();
 
-    for (String id : allNodes) {
+    for (String id : sortedAllNodes) {
       Node node = new Node(id);
       node.capacity = 0;
       node.hasCeilingCapacity = false;
       _nodeMap.put(id, node);
     }
-    for (int i = 0; i < liveNodes.size(); i++) {
+    for (int i = 0; i < sortedLiveNodes.size(); i++) {
       boolean usingCeiling = false;
       int targetSize = (_maximumPerNode > 0) ? Math.min(distFloor, _maximumPerNode) : distFloor;
       if (distRemainder > 0 && targetSize < _maximumPerNode) {
@@ -102,7 +113,7 @@ public class AutoRebalanceStrategy implements RebalanceStrategy {
         distRemainder = distRemainder - 1;
         usingCeiling = true;
       }
-      Node node = _nodeMap.get(liveNodes.get(i));
+      Node node = _nodeMap.get(sortedLiveNodes.get(i));
       node.isAlive = true;
       node.capacity = targetSize;
       node.hasCeilingCapacity = usingCeiling;
@@ -113,7 +124,7 @@ public class AutoRebalanceStrategy implements RebalanceStrategy {
     _stateMap = generateStateMap();
 
     // compute the preferred mapping if all nodes were up
-    _preferredAssignment = computePreferredPlacement(allNodes);
+    _preferredAssignment = computePreferredPlacement(sortedAllNodes);
 
     // logger.info("preferred mapping:"+ preferredAssignment);
     // from current mapping derive the ones in preferred location
@@ -776,6 +787,47 @@ public class AutoRebalanceStrategy implements RebalanceStrategy {
         index = (partitionId + replicaId) % nodeNames.size();
       }
       return nodeNames.get(index);
+    }
+  }
+
+  /**
+   * Sorter for live nodes that sorts firstly according to the number of partitions currently
+   * registered against a node (more partitions means sort earlier), then by node name.
+   * This prevents unnecessarily moving partitions due to the capacity assignment
+   * unnecessarily reducing the capacity of lower down elements.
+   */
+  private static class CurrentStateNodeComparator implements Comparator<String> {
+
+    /**
+     * The number of partitions that are active for each participant.
+     */
+    private final Map<String, Integer> partitionCounts;
+
+    /**
+     * Create it.
+     * @param currentMapping The current mapping of partitions to participants.
+     */
+    public CurrentStateNodeComparator(Map<String, Map<String, String>> currentMapping) {
+      partitionCounts = new HashMap<String, Integer>();
+      for (Entry<String, Map<String, String>> entry : currentMapping.entrySet()) {
+        for (String participantId : entry.getValue().keySet()) {
+          Integer existing = partitionCounts.get(participantId);
+          partitionCounts.put(participantId, existing != null ? existing + 1 : 1);
+        }
+      }
+    }
+
+    @Override
+    public int compare(String o1, String o2) {
+      Integer c1 = partitionCounts.get(o1);
+      if (c1 == null) {
+        c1 = 0;
+      }
+      Integer c2 = partitionCounts.get(o2);
+      if (c2 == null) {
+        c2 = 0;
+      }
+      return c1 < c2 ? 1 : (c1 > c2 ? -1 : o1.toString().compareTo(o2.toString()));
     }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/model/IdealState.java
+++ b/helix-core/src/main/java/org/apache/helix/model/IdealState.java
@@ -410,6 +410,7 @@ public class IdealState extends HelixProperty {
     // HACK: if replica doesn't exists, use the length of the first list field
     // instead
     // TODO: remove it when Dbus fixed the IdealState writer
+    // TODO: replica could be "ANY_INSTANCE".
     String replica = _record.getSimpleField(IdealStateProperty.REPLICAS.toString());
     if (replica == null) {
       String firstPartition = null;

--- a/helix-core/src/test/java/org/apache/helix/integration/SinglePartitionLeaderStandByTest.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/SinglePartitionLeaderStandByTest.java
@@ -1,0 +1,103 @@
+package org.apache.helix.integration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Arrays;
+import java.util.Date;
+
+import org.apache.helix.HelixConstants;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.IdealState.RebalanceMode;
+import org.apache.helix.tools.ClusterStateVerifier;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * This is a simple integration test. We will use this until we have framework
+ * which helps us write integration tests easily
+ */
+
+public class SinglePartitionLeaderStandByTest extends ZkIntegrationTestBase {
+  @Test
+  public void test()
+      throws Exception {
+    String clusterName = TestHelper.getTestMethodName();
+    int n = 4;
+
+    System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+
+    // Thread.currentThread().join();
+    TestHelper.setupCluster(clusterName, ZK_ADDR, 12918, // participant port
+        "localhost", // participant name prefix
+        "TestDB", // resource name prefix
+        1, // resources
+        2, // partitions per resource
+        n, // number of nodes
+        0, // replicas
+        "LeaderStandby", RebalanceMode.FULL_AUTO, false); // dont rebalance
+
+    // rebalance ideal-state to use ANY_LIVEINSTANCE for preference list
+    ZKHelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, _baseAccessor);
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    PropertyKey key = keyBuilder.idealStates("TestDB0");
+    IdealState idealState = accessor.getProperty(key);
+    idealState.setReplicas(HelixConstants.StateModelToken.ANY_LIVEINSTANCE.toString());
+    idealState.getRecord()
+        .setListField("TestDB0_0", Arrays.asList(HelixConstants.StateModelToken.ANY_LIVEINSTANCE.toString()));
+    accessor.setProperty(key, idealState);
+
+    ClusterControllerManager controller = new ClusterControllerManager(ZK_ADDR, clusterName, "controller_0");
+    controller.syncStart();
+
+    // start participants
+    MockParticipantManager[] participants = new MockParticipantManager[n];
+    for (int i = 0; i < n; i++) {
+      String instanceName = "localhost_" + (12918 + i);
+
+      participants[i] = new MockParticipantManager(ZK_ADDR, clusterName, instanceName);
+      participants[i].syncStart();
+    }
+
+    boolean result = ClusterStateVerifier
+        .verifyByZkCallback(new ClusterStateVerifier.BestPossAndExtViewZkVerifier(ZK_ADDR, clusterName));
+
+    Assert.assertTrue(result);
+    //stop the first participatn
+    participants[0].syncStop();
+    Thread.sleep(10000);
+    for (int i = 0; i < 1; i++) {
+      String instanceName = "localhost_" + (12918 + i);
+      participants[i] = new MockParticipantManager(ZK_ADDR, clusterName, instanceName);
+      participants[i].syncStart();
+    }
+    // clean up
+    controller.syncStop();
+    for (int i = 0; i < n; i++) {
+      participants[i].syncStop();
+    }
+    System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
+  }
+}


### PR DESCRIPTION
Port fix to HELIX-543 (https://issues.apache.org/jira/browse/HELIX-543) to 0.6.x branch.  Will include this fix in 0.6.6 release.