### PR TITLE
[HELIX-637] Populate the StateModelDefinition once it is updated

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/StateModelDefinition.java
+++ b/helix-core/src/main/java/org/apache/helix/model/StateModelDefinition.java
@@ -364,4 +364,22 @@ public class StateModelDefinition extends HelixProperty {
 
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+
+    if (!(o instanceof StateModelDefinition)) {
+      return false;
+    }
+
+    StateModelDefinition stateModelDefinition = (StateModelDefinition) o;
+    return _initialState.equals(stateModelDefinition._initialState) && _statesCountMap
+        .equals(stateModelDefinition._statesCountMap) && _statesPriorityList
+        .equals(stateModelDefinition._statesPriorityList) && _stateTransitionPriorityList
+        .equals(stateModelDefinition._stateTransitionPriorityList) &&
+        _stateTransitionTable.equals(stateModelDefinition._stateTransitionTable);
+  }
+
 }


### PR DESCRIPTION
Did a check for StateModeDefinition. Will be rewrite once it is updated.

Currently, if StateModelDefinition already exists in the Znode, even it has already been changed, Helix will not populate the latest version.
It is because in the StateModelDefinition write into ZK function, it only does create operation instead of update.
Fix: 1. Check whether there already exists StateModelDefition.
2. Compare if it is different or not.