### PR TITLE
helix-core: AutoRebalancer should include only numbered states in `currentMapping`

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
@@ -227,14 +227,18 @@ public class AutoRebalancer implements Rebalancer, MappingCalculator {
       map.put(partition, new HashMap<String, String>());
       for (String node : curStateMap.keySet()) {
         String state = curStateMap.get(node);
-        map.get(partition).put(node, state);
+        if (stateCountMap.containsKey(state)) {
+          map.get(partition).put(node, state);
+        }
       }
 
       Map<String, String> pendingStateMap =
           currentStateOutput.getPendingStateMap(resourceName, new Partition(partition));
       for (String node : pendingStateMap.keySet()) {
         String state = pendingStateMap.get(node);
-        map.get(partition).put(node, state);
+        if (stateCountMap.containsKey(state)) {
+          map.get(partition).put(node, state);
+        }
       }
     }
     return map;


### PR DESCRIPTION
AutoRebalancer constructs a `currentMapping` (`Map<PartitionId, Map<ParticipantId, State>>`) which it passes to `AutoRebalanceStrategy#computePartitionAssignment()`. `ARS` uses the mapping to sort the live nodes by # of partitions they hold.

In `helix-0.6.x`, `currentMapping` includes _all states_, including "null" states like `DROPPED` or `OFFLINE`. This breaks `ARS`'s node sorting, causing it to incorrectly move partitions when nodes restart after disconnecting.

`helix-0.7.x` does not have this issue. It was introduced between `0.6.2-incubating` and `0.6.3`:

> [[HELIX-400] Remove all references to the old full auto rebalancing code](https://github.com/apache/helix/commit/8d99778a30d10f529ee0757286efa84ea581b5bf)

See also
- the recent port of [HELIX-543] (#56) to `helix-0.6.x`, which intended to avoid unnecessary partition movement. That port was ineffective due to this issue.
- [mailing list](http://mail-archives.apache.org/mod_mbox/helix-user/201610.mbox/%3CCAC56g41ejjcSi1P-Ohp3esyGqemBgFoji2Gy8tZQnJMo156OpA%40mail.gmail.com%3E) thread for more background


### Example

Consider this scenario:

```
OnlineOffline state model
2 nodes "NODE_0" and "NODE_1"
1 resource "P" w/ 1 replica, 1 partition
----------
rebalance
> currentMapping: `{P: {NODE_0: ONLINE}}`
stop NODE_0
> currentMapping: `{P: {NODE_1: ONLINE}}`
start NODE_0
> currentMapping: `{P: {NODE_0: OFFLINE, NODE_1: ONLINE}}`
```

`ARS#computePartitionAssignment()` sorts the live nodes by the # of partitions they hold, based on `currentMapping`, then reassigns partitions based on that sort. (The sort breaks ties by comparing the node names.) So after restarting `NODE_0`, the sort is `[NODE_0, NODE_1]`, and the `ONLINE` partition is incorrectly moved back to `NODE_0`.