### PR TITLE
Support delaying jobs schedule with configurable delay time and start time

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskRebalancer.java
@@ -36,12 +36,12 @@ import org.apache.helix.PropertyKey;
 import org.apache.helix.controller.rebalancer.Rebalancer;
 import org.apache.helix.controller.rebalancer.internal.MappingCalculator;
 import org.apache.helix.controller.stages.ClusterDataCache;
-import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceAssignment;
+import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
 import org.apache.log4j.Logger;
 
 import com.google.common.collect.Maps;
@@ -50,6 +50,7 @@ import com.google.common.collect.Maps;
  * Abstract rebalancer class for the {@code Task} state model.
  */
 public abstract class TaskRebalancer implements Rebalancer, MappingCalculator {
+  public static final String START_TIME_KEY = "StartTime";
   private static final Logger LOG = Logger.getLogger(TaskRebalancer.class);
 
   // For connection management
@@ -194,8 +195,8 @@ public abstract class TaskRebalancer implements Rebalancer, MappingCalculator {
       // If this job comes from a generic workflow, job will not be scheduled until
       // all the direct parent jobs finished
       if (incompleteParentCount > 0) {
-        LOG.debug(String
-            .format("Job %s is not ready to start, notFinishedParent(s)=%d.", job, incompleteParentCount));
+        LOG.debug(String.format("Job %s is not ready to start, notFinishedParent(s)=%d.", job,
+            incompleteParentCount));
         return false;
       }
     }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestScheduleDelayTask.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestScheduleDelayTask.java
@@ -1,0 +1,156 @@
+package org.apache.helix.integration.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.TestHelper;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.JobQueue;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestScheduleDelayTask extends TaskTestBase {
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _numDbs = 1;
+    _numNodes = 1;
+    _numReplicas = 1;
+    _numParitions = 1;
+    super.beforeClass();
+  }
+
+  @Test
+  public void testScheduleDelayTaskWithDelayTime() throws InterruptedException {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder builder = new Workflow.Builder(workflowName);
+
+    JobConfig.Builder jobBuilder =
+        new JobConfig.Builder().setTargetResource(WorkflowGenerator.DEFAULT_TGT_DB)
+            .setCommand(MockTask.TASK_COMMAND).setMaxAttemptsPerTask(2)
+            .setJobCommandConfigMap(WorkflowGenerator.DEFAULT_COMMAND_CONFIG);
+
+    builder.addParentChildDependency("Job1", "Job4");
+    builder.addParentChildDependency("Job2", "Job4");
+    builder.addParentChildDependency("Job3", "Job4");
+    builder.addJob("Job1", jobBuilder);
+    builder.addJob("Job2", jobBuilder);
+    builder.addJob("Job3", jobBuilder);
+    builder.addJob("Job4", jobBuilder.setExecutionDelay(2000L));
+
+    _driver.start(builder.build());
+    _driver.pollForJobState(workflowName, TaskUtil.getNamespacedJobName(workflowName, "Job4"),
+        TaskState.COMPLETED);
+
+    long jobFinishTime = 0L;
+    for (int i = 1; i <= 3; i++) {
+      jobFinishTime = Math.max(jobFinishTime,
+          _driver.getJobContext(TaskUtil.getNamespacedJobName(workflowName, "Job1"))
+              .getFinishTime());
+    }
+    long jobTwoStartTime =
+        _driver.getJobContext(TaskUtil.getNamespacedJobName(workflowName, "Job4")).getStartTime();
+
+    Assert.assertTrue(jobTwoStartTime - jobFinishTime >= 2000L);
+  }
+
+  @Test
+  public void testScheduleDelayTaskWithStartTime() throws InterruptedException {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder builder = new Workflow.Builder(workflowName);
+
+    JobConfig.Builder jobBuilder =
+        new JobConfig.Builder().setTargetResource(WorkflowGenerator.DEFAULT_TGT_DB)
+            .setCommand(MockTask.TASK_COMMAND).setMaxAttemptsPerTask(2)
+            .setJobCommandConfigMap(WorkflowGenerator.DEFAULT_COMMAND_CONFIG);
+
+    long currentTime = System.currentTimeMillis();
+    builder.addParentChildDependency("Job1", "Job2");
+    builder.addJob("Job1", jobBuilder);
+    builder.addJob("Job2", jobBuilder.setExecutionStart(currentTime + 5000L));
+
+    _driver.start(builder.build());
+    _driver.pollForJobState(workflowName, TaskUtil.getNamespacedJobName(workflowName, "Job2"),
+        TaskState.COMPLETED);
+
+    long jobTwoStartTime =
+        _driver.getJobContext(TaskUtil.getNamespacedJobName(workflowName, "Job2")).getStartTime();
+
+    Assert.assertTrue(jobTwoStartTime - currentTime >= 5000L);
+  }
+
+  @Test
+  public void testJobQueueDelay() throws InterruptedException {
+    String workflowName = TestHelper.getTestMethodName();
+    JobQueue.Builder queueBuild = TaskTestUtil.buildJobQueue(workflowName);
+
+    JobConfig.Builder jobBuilder =
+        new JobConfig.Builder().setTargetResource(WorkflowGenerator.DEFAULT_TGT_DB)
+            .setCommand(MockTask.TASK_COMMAND).setMaxAttemptsPerTask(2)
+            .setJobCommandConfigMap(WorkflowGenerator.DEFAULT_COMMAND_CONFIG);
+
+    for (int i = 1; i < 4; i++) {
+      queueBuild.enqueueJob("Job" + i, jobBuilder);
+    }
+    queueBuild.enqueueJob("Job4", jobBuilder.setExecutionDelay(2000L));
+
+    _driver.start(queueBuild.build());
+    _driver.pollForJobState(workflowName, TaskUtil.getNamespacedJobName(workflowName, "Job4"),
+        TaskState.COMPLETED);
+
+    long jobFinishTime =
+        _driver.getJobContext(TaskUtil.getNamespacedJobName(workflowName, "Job3")).getFinishTime();
+
+    long jobTwoStartTime =
+        _driver.getJobContext(TaskUtil.getNamespacedJobName(workflowName, "Job4")).getStartTime();
+
+    Assert.assertTrue(jobTwoStartTime - jobFinishTime >= 2000L);
+  }
+
+  @Test
+  public void testDeplayTimeAndStartTime() throws InterruptedException {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder builder = new Workflow.Builder(workflowName);
+
+    JobConfig.Builder jobBuilder =
+        new JobConfig.Builder().setTargetResource(WorkflowGenerator.DEFAULT_TGT_DB)
+            .setCommand(MockTask.TASK_COMMAND).setMaxAttemptsPerTask(2)
+            .setJobCommandConfigMap(WorkflowGenerator.DEFAULT_COMMAND_CONFIG);
+
+    builder.addParentChildDependency("Job1", "Job2");
+
+    long currentTime = System.currentTimeMillis();
+    builder.addJob("Job1", jobBuilder);
+    builder
+        .addJob("Job2", jobBuilder.setExecutionDelay(2000L).setExecutionStart(currentTime + 5000L));
+
+    _driver.start(builder.build());
+    _driver.pollForJobState(workflowName, TaskUtil.getNamespacedJobName(workflowName, "Job2"),
+        TaskState.COMPLETED);
+
+    long jobTwoStartTime =
+        _driver.getJobContext(TaskUtil.getNamespacedJobName(workflowName, "Job2")).getStartTime();
+
+    Assert.assertTrue(jobTwoStartTime - currentTime >= 5000L);
+  }
+}


### PR DESCRIPTION
Overview
Currently, Workflows and Jobs running by Helix requires more flexibility. For example, some of the jobs need to be started after some jobs finished for a certain mount of time. Same as Workflow, it may run at specific time, when some operations have been done.  To better support Workflow and Job scheduling, Helix should provide a new feature to let user setup the delay time or starting for specific Workflows and Jobs. Workflows and Jobs should have an option that allow user set starting time of this Workflow or Job or set the delaying time for this Workflow and Job, when they are ready to start. Then Workflows and Jobs can be scheduled at correct time.
Purposed Design
The whole design has been split into two parts, generic rebalancer scheduling and delay time calculation. Since Job scheduling can be done via rerun WorkflowRebalancer, Workflow and Job delay scheduling can rely on the same generic scheduling mechanism. Generic task scheduling tasks the responsibiliy to set the running time for specific Workflow object. Then each object has its own starting time calculation algorithm.

Generic Task Scheduling
For generic task scheduling, it is better to have a centralized scheduler, RebalanceScheduler. It provides four public APIs:
public class RebalanceScheduler {
    public void scheduleRebalance(HelixManager manager, String resource, long startTime);
 
    public long getRebalanceTime(String resource);
 
    public long removeScheduledRebalance(String resource);
 
    public static void invokeRebalance(HelixDataAccessor accessor, String resource);
}
 
Obviously, it offers schedule a rebalancer, get schedule time of a rebalancer and remove a rebalancer schedule. It also have an API that can invoke rebalancer immediately. With this RebalancerScheduler, each resource can be scheduled at certain start time. 
Delay Time Calculation
Workflows have a property expiryTime, which is the delay time that for the Workflow. User can set it by call setExpiry method in WorkflowConfig. For Job, two methods, in JobConfig, will be provided: setExecutionStart and setExecutionDelay. Through these API, user can set the delay time and start time for Workflows and Jobs. Internally, Helix will take the delay time and start time, which is later.
For the logic implemented in computing Workflows and Jobs, Helix choose to do real time computation. User can set delay time or start time at JobConfig. When the job is ready to run, Helix will calculate the "start time" for delay via current time plus the delay time. Then compare it with start time if user set it up in JobConfig.
Inline image 1
Impact
From user perspective, user have to understand the difference between delay time and start time.
The WorkflowRebalancer will be called multiple times, which might be considered for performance.