### PR TITLE
Few improvements and bug fixings

### DIFF
--- a/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/ClusterRepresentationUtil.java
+++ b/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/ClusterRepresentationUtil.java
@@ -32,6 +32,7 @@ import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyKey.Builder;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
@@ -39,7 +40,6 @@ import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.model.LiveInstance.LiveInstanceProperty;
-import org.apache.helix.util.HelixUtil;
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
@@ -74,8 +74,7 @@ public class ClusterRepresentationUtil {
   public static String getInstancePropertyNameListAsString(ZkClient zkClient, String clusterName,
       String instanceName, PropertyType instanceProperty, String key, MediaType mediaType)
       throws JsonGenerationException, JsonMappingException, IOException {
-    String path =
-        HelixUtil.getInstancePropertyPath(clusterName, instanceName, instanceProperty) + "/" + key;
+    String path = PropertyPathBuilder.instanceProperty(clusterName, instanceName, instanceProperty, key);
     if (zkClient.exists(path)) {
       List<String> recordNames = zkClient.getChildren(path);
       return ObjectToJson(recordNames);
@@ -212,10 +211,7 @@ public class ClusterRepresentationUtil {
 
   public static List<String> getInstancePropertyList(ZkClient zkClient, String clusterName,
       String instanceName, PropertyType property, String key) {
-    String propertyPath =
-        HelixUtil.getInstancePropertyPath(clusterName, instanceName, property) + "/" + key;
-
+    String propertyPath = PropertyPathBuilder.instanceProperty(clusterName, instanceName, property, key);
     return zkClient.getChildren(propertyPath);
-
   }
 }

--- a/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/JobResource.java
+++ b/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/JobResource.java
@@ -22,8 +22,6 @@ package org.apache.helix.webapp.resources;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.PropertyKey;
-import org.apache.helix.PropertyPathConfig;
-import org.apache.helix.PropertyType;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.task.JobContext;

--- a/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/SchedulerTasksResource.java
+++ b/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/SchedulerTasksResource.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.InstanceType;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.manager.zk.DefaultSchedulerMessageHandlerFactory;
 import org.apache.helix.manager.zk.ZkClient;
@@ -148,7 +148,7 @@ public class SchedulerTasksResource extends ServerResource {
           schedulerMessage);
 
       Map<String, String> resultMap = new HashMap<String, String>();
-      resultMap.put("StatusUpdatePath", PropertyPathConfig.getPath(
+      resultMap.put("StatusUpdatePath", PropertyPathBuilder.getPath(
           PropertyType.STATUSUPDATES_CONTROLLER, clusterName, MessageType.SCHEDULER_MSG.toString(),
           schedulerMessage.getMsgId()));
       resultMap.put("MessageType", Message.MessageType.SCHEDULER_MSG.toString());

--- a/helix-admin-webapp/src/test/java/org/apache/helix/webapp/TestClusterManagementWebapp.java
+++ b/helix-admin-webapp/src/test/java/org/apache/helix/webapp/TestClusterManagementWebapp.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.InstanceConfig.InstanceConfigProperty;
@@ -562,7 +562,7 @@ public class TestClusterManagementWebapp extends AdminTestBase {
     System.out.println(sw.toString());
 
     // verify pause znode exists
-    String pausePath = PropertyPathConfig.getPath(PropertyType.PAUSE, clusterName);
+    String pausePath = PropertyPathBuilder.getPath(PropertyType.PAUSE, clusterName);
     System.out.println("pausePath: " + pausePath);
     boolean exists = _gZkClient.exists(pausePath);
     Assert.assertTrue(exists, pausePath + " should exist");

--- a/helix-core/src/main/java/org/apache/helix/HelixDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixDataAccessor.java
@@ -23,6 +23,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.I0Itec.zkclient.DataUpdater;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.Message;
+import org.apache.helix.model.PauseSignal;
+import org.apache.helix.model.StateModelDefinition;
+
 
 /**
  * Interface used to interact with Helix Data Types like IdealState, Config,
@@ -30,15 +35,10 @@ import org.I0Itec.zkclient.DataUpdater;
  * type. See {@link PropertyKey.Builder} to get more information on building a propertyKey.
  */
 public interface HelixDataAccessor {
-  /**
-   * Create a helix property only if it does not exist.
-   * @param key
-   * @param value
-   * @return true if creation was successful. False if already exists or if it
-   *         failed to create
-   */
-
-  <T extends HelixProperty> boolean createProperty(PropertyKey key, T value);
+  boolean createStateModelDef(StateModelDefinition stateModelDef);
+  boolean createControllerMessage(Message message);
+  boolean createControllerLeader(LiveInstance leader);
+  boolean createPause(PauseSignal pauseSignal);
 
   /**
    * Set a property, overwrite if it exists and creates if not exists. This api

--- a/helix-core/src/main/java/org/apache/helix/PropertyKey.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyKey.java
@@ -54,7 +54,6 @@ import org.apache.helix.model.PauseSignal;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.model.StatusUpdate;
-import org.apache.helix.tools.YAMLClusterSetup;
 import org.apache.log4j.Logger;
 
 /**
@@ -116,7 +115,7 @@ public class PropertyKey {
   public String getPath() {
     String clusterName = _params[0];
     String[] subKeys = Arrays.copyOfRange(_params, 1, _params.length);
-    String path = PropertyPathConfig.getPath(_type, clusterName, subKeys);
+    String path = PropertyPathBuilder.getPath(_type, clusterName, subKeys);
     if (path == null) {
       LOG.error("Invalid property key with type:" + _type + "subKeys:" + Arrays.toString(_params));
     }

--- a/helix-core/src/main/java/org/apache/helix/PropertyPathBuilder.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyPathBuilder.java
@@ -201,4 +201,113 @@ public class PropertyPathBuilder {
     }
     return null;
   }
+
+  public static String idealState(String clusterName) {
+    return String.format("/%s/IDEALSTATES", clusterName);
+  }
+
+  public static String idealState(String clusterName, String resourceName) {
+    return String.format("/%s/IDEALSTATES/%s", clusterName, resourceName);
+  }
+
+  public static String stateModelDef(String clusterName) {
+    return String.format("/%s/STATEMODELDEFS", clusterName);
+  }
+
+  public static String stateModelDef(String clusterName, String stateModelName) {
+    return String.format("/%s/STATEMODELDEFS/%s", clusterName, stateModelName);
+  }
+
+  public static String externalView(String clusterName) {
+    return String.format("/%s/EXTERNALVIEW", clusterName);
+  }
+
+  public static String externalView(String clusterName, String resourceName) {
+    return String.format("/%s/EXTERNALVIEW/%s", clusterName, resourceName);
+  }
+
+  public static String liveInstance(String clusterName) {
+    return String.format("/%s/LIVEINSTANCES", clusterName);
+  }
+
+  public static String liveInstance(String clusterName, String instanceName) {
+    return String.format("/%s/LIVEINSTANCES/%s", clusterName, instanceName);
+  }
+
+  public static String instance(String clusterName) {
+    return String.format("/%s/INSTANCES", clusterName);
+  }
+
+  @Deprecated
+  public static String instanceProperty(String clusterName, String instanceName, PropertyType type, String key) {
+    return String.format("/%s/INSTANCES/%s/%s/%s", clusterName, instanceName, type, key);
+  }
+
+  public static String instance(String clusterName, String instanceName) {
+    return String.format("/%s/INSTANCES/%s", clusterName, instanceName);
+  }
+
+  public static String instanceMessage(String clusterName, String instanceName) {
+    return String.format("/%s/INSTANCES/%s/MESSAGES", clusterName, instanceName);
+  }
+
+  public static String instanceMessage(String clusterName, String instanceName, String messageId) {
+    return String.format("/%s/INSTANCES/%s/MESSAGES/%s", clusterName, instanceName, messageId);
+  }
+
+  public static String instanceCurrentState(String clusterName, String instanceName) {
+    return String.format("/%s/INSTANCES/%s/CURRENTSTATES", clusterName, instanceName);
+  }
+
+  public static String instanceCurrentState(String clusterName, String instanceName, String sessionId) {
+    return String.format("/%s/INSTANCES/%s/CURRENTSTATES/%s", clusterName, instanceName, sessionId);
+  }
+
+  public static String instanceError(String clusterName, String instanceName) {
+    return String.format("/%s/INSTANCES/%s/ERRORS", clusterName, instanceName);
+  }
+
+  public static String instanceStatusUpdate(String clusterName, String instanceName) {
+    return String.format("/%s/INSTANCES/%s/STATUSUPDATES", clusterName, instanceName);
+  }
+
+  public static String propertyStore(String clusterName) {
+    return String.format("/%s/PROPERTYSTORE", clusterName);
+  }
+
+  public static String instanceConfig(String clusterName) {
+    return String.format("/%s/CONFIGS/PARTICIPANT", clusterName);
+  }
+
+  public static String instanceConfig(String clusterName, String instanceName) {
+    return String.format("/%s/CONFIGS/PARTICIPANT/%s", clusterName, instanceName);
+  }
+
+  public static String controller(String clusterName) {
+    return String.format("/%s/CONTROLLER", clusterName);
+  }
+
+  public static String controllerLeader(String clusterName) {
+    return String.format("/%s/CONTROLLER/LEADER", clusterName);
+  }
+
+  public static String controllerMessage(String clusterName) {
+    return String.format("/%s/CONTROLLER/MESSAGES", clusterName);
+  }
+
+  public static String controllerStatusUpdate(String clusterName) {
+    return String.format("/%s/CONTROLLER/STATUSUPDATES", clusterName);
+  }
+
+  public static String controllerStatusUpdate(String clusterName, String subPath, String recordName) {
+    return String.format("/%s/CONTROLLER/STATUSUPDATES/%s/%s", clusterName, subPath, recordName);
+  }
+
+  public static String controllerError(String clusterName) {
+    return String.format("/%s/CONTROLLER/ERRORS", clusterName);
+  }
+
+  public static String pause(String clusterName) {
+    return String.format("/%s/CONTROLLER/PAUSE", clusterName);
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/PropertyPathBuilder.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyPathBuilder.java
@@ -51,8 +51,8 @@ import org.apache.log4j.Logger;
 /**
  * Utility mapping properties to their Zookeeper locations
  */
-public class PropertyPathConfig {
-  private static Logger logger = Logger.getLogger(PropertyPathConfig.class);
+public class PropertyPathBuilder {
+  private static Logger logger = Logger.getLogger(PropertyPathBuilder.class);
 
   static final Map<PropertyType, Map<Integer, String>> templateMap =
       new HashMap<PropertyType, Map<Integer, String>>();

--- a/helix-core/src/main/java/org/apache/helix/PropertyPathBuilder.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyPathBuilder.java
@@ -295,6 +295,10 @@ public class PropertyPathBuilder {
     return String.format("/%s/CONTROLLER/MESSAGES", clusterName);
   }
 
+  public static String controllerMessage(String clusterName, String messageId) {
+    return String.format("/%s/CONTROLLER/MESSAGES/%s", clusterName, messageId);
+  }
+
   public static String controllerStatusUpdate(String clusterName) {
     return String.format("/%s/CONTROLLER/STATUSUPDATES", clusterName);
   }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -53,7 +53,7 @@ import org.apache.helix.MessageListener;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.NotificationContext.Type;
 import org.apache.helix.PropertyKey;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.ScopedConfigChangeListener;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.CurrentState;
@@ -176,7 +176,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener
         CurrentStateChangeListener currentStateChangeListener =
             (CurrentStateChangeListener) _listener;
         subscribeForChanges(changeContext, _path, true, true);
-        String instanceName = PropertyPathConfig.getInstanceNameFromPath(_path);
+        String instanceName = PropertyPathBuilder.getInstanceNameFromPath(_path);
 
         List<CurrentState> currentStates = _accessor.getChildValues(_propertyKey);
 
@@ -185,7 +185,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener
       } else if (_changeType == MESSAGE) {
         MessageListener messageListener = (MessageListener) _listener;
         subscribeForChanges(changeContext, _path, true, false);
-        String instanceName = PropertyPathConfig.getInstanceNameFromPath(_path);
+        String instanceName = PropertyPathBuilder.getInstanceNameFromPath(_path);
         List<Message> messages = _accessor.getChildValues(_propertyKey);
 
         messageListener.onMessage(instanceName, messages, changeContext);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/DistributedLeaderElection.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/DistributedLeaderElection.java
@@ -35,6 +35,7 @@ import org.apache.helix.model.LeaderHistory;
 import org.apache.helix.model.LiveInstance;
 import org.apache.log4j.Logger;
 
+
 /**
  * do distributed leader election
  */
@@ -121,7 +122,7 @@ public class DistributedLeaderElection implements ControllerChangeListener {
       leader.setLiveInstance(ManagementFactory.getRuntimeMXBean().getName());
       leader.setSessionId(manager.getSessionId());
       leader.setHelixVersion(manager.getVersion());
-      boolean success = accessor.createProperty(keyBuilder.controllerLeader(), leader);
+      boolean success = accessor.createControllerLeader(leader);
       if (success) {
         return true;
       } else {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -58,7 +58,6 @@ import org.apache.helix.model.ConstraintItem;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HelixConfigScope;
-import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.IdealState.RebalanceMode;
 import org.apache.helix.model.InstanceConfig;
@@ -72,6 +71,7 @@ import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.tools.DefaultIdealStateCalculator;
 import org.apache.helix.util.RebalanceUtil;
 import org.apache.log4j.Logger;
+
 
 public class ZKHelixAdmin implements HelixAdmin {
   public static final String CONNECTION_TIMEOUT = "helixAdmin.timeOutInSec";
@@ -329,7 +329,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     if (enabled) {
       accessor.removeProperty(keyBuilder.pause());
     } else {
-      accessor.createProperty(keyBuilder.pause(), new PauseSignal("pause"));
+      accessor.createPause(new PauseSignal("pause"));
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -48,7 +48,7 @@ import org.apache.helix.HelixException;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyKey.Builder;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
@@ -100,7 +100,7 @@ public class ZKHelixAdmin implements HelixAdmin {
       throw new HelixException("cluster " + clusterName + " is not setup yet");
     }
     String instanceConfigsPath =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString());
     String nodeId = instanceConfig.getId();
     String instanceConfigPath = instanceConfigsPath + "/" + nodeId;
@@ -120,7 +120,7 @@ public class ZKHelixAdmin implements HelixAdmin {
   @Override
   public void dropInstance(String clusterName, InstanceConfig instanceConfig) {
     String instanceConfigsPath =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString());
     String nodeId = instanceConfig.getId();
     String instanceConfigPath = instanceConfigsPath + "/" + nodeId;
@@ -146,7 +146,7 @@ public class ZKHelixAdmin implements HelixAdmin {
   @Override
   public InstanceConfig getInstanceConfig(String clusterName, String instanceName) {
     String instanceConfigPath =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString(), instanceName);
     if (!_zkClient.exists(instanceConfigPath)) {
       throw new HelixException("instance" + instanceName + " does not exist in cluster "
@@ -163,7 +163,7 @@ public class ZKHelixAdmin implements HelixAdmin {
   @Override
   public boolean setInstanceConfig(String clusterName, String instanceName,
       InstanceConfig newInstanceConfig) {
-    String instanceConfigPath = PropertyPathConfig
+    String instanceConfigPath = PropertyPathBuilder
         .getPath(PropertyType.CONFIGS, clusterName, ConfigScopeProperty.PARTICIPANT.toString(),
             instanceName);
     if (!_zkClient.exists(instanceConfigPath)) {
@@ -190,7 +190,7 @@ public class ZKHelixAdmin implements HelixAdmin {
   public void enableInstance(final String clusterName, final String instanceName,
       final boolean enabled) {
     String path =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString(), instanceName);
 
     BaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_zkClient);
@@ -217,7 +217,7 @@ public class ZKHelixAdmin implements HelixAdmin {
   @Override
   public void enableResource(final String clusterName, final String resourceName,
       final boolean enabled) {
-    String path = PropertyPathConfig.getPath(PropertyType.IDEALSTATES, clusterName, resourceName);
+    String path = PropertyPathBuilder.getPath(PropertyType.IDEALSTATES, clusterName, resourceName);
     BaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_zkClient);
     if (!baseAccessor.exists(path, 0)) {
       throw new HelixException("Cluster " + clusterName + ", resource: " + resourceName
@@ -241,7 +241,7 @@ public class ZKHelixAdmin implements HelixAdmin {
   public void enablePartition(final boolean enabled, final String clusterName,
       final String instanceName, final String resourceName, final List<String> partitionNames) {
     String path =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString(), instanceName);
 
     BaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_zkClient);
@@ -254,7 +254,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     // check resource exists
     String idealStatePath =
-        PropertyPathConfig.getPath(PropertyType.IDEALSTATES, clusterName, resourceName);
+        PropertyPathBuilder.getPath(PropertyType.IDEALSTATES, clusterName, resourceName);
 
     ZNRecord idealStateRecord = null;
     try {
@@ -552,20 +552,20 @@ public class ZKHelixAdmin implements HelixAdmin {
     _zkClient.createPersistent(HelixUtil.getIdealStatePath(clusterName));
     // CONFIGURATIONS
     path =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.CLUSTER.toString(), clusterName);
     _zkClient.createPersistent(path, true);
     _zkClient.writeData(path, new ZNRecord(clusterName));
     path =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString());
     _zkClient.createPersistent(path);
     path =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.RESOURCE.toString());
     _zkClient.createPersistent(path);
     // PROPERTY STORE
-    path = PropertyPathConfig.getPath(PropertyType.PROPERTYSTORE, clusterName);
+    path = PropertyPathBuilder.getPath(PropertyType.PROPERTYSTORE, clusterName);
     _zkClient.createPersistent(path);
     // LIVE INSTANCES
     _zkClient.createPersistent(HelixUtil.getLiveInstancesPath(clusterName));
@@ -578,19 +578,19 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     // controller
     _zkClient.createPersistent(HelixUtil.getControllerPath(clusterName));
-    path = PropertyPathConfig.getPath(PropertyType.HISTORY, clusterName);
+    path = PropertyPathBuilder.getPath(PropertyType.HISTORY, clusterName);
     final ZNRecord emptyHistory = new ZNRecord(PropertyType.HISTORY.toString());
     final List<String> emptyList = new ArrayList<String>();
     emptyHistory.setListField(clusterName, emptyList);
     _zkClient.createPersistent(path, emptyHistory);
 
-    path = PropertyPathConfig.getPath(PropertyType.MESSAGES_CONTROLLER, clusterName);
+    path = PropertyPathBuilder.getPath(PropertyType.MESSAGES_CONTROLLER, clusterName);
     _zkClient.createPersistent(path);
 
-    path = PropertyPathConfig.getPath(PropertyType.STATUSUPDATES_CONTROLLER, clusterName);
+    path = PropertyPathBuilder.getPath(PropertyType.STATUSUPDATES_CONTROLLER, clusterName);
     _zkClient.createPersistent(path);
 
-    path = PropertyPathConfig.getPath(PropertyType.ERRORS_CONTROLLER, clusterName);
+    path = PropertyPathBuilder.getPath(PropertyType.ERRORS_CONTROLLER, clusterName);
     _zkClient.createPersistent(path);
   }
 
@@ -643,7 +643,7 @@ public class ZKHelixAdmin implements HelixAdmin {
   public void addResource(String clusterName, String resourceName, IdealState idealstate) {
     String stateModelRef = idealstate.getStateModelDefRef();
     String stateModelDefPath =
-        PropertyPathConfig.getPath(PropertyType.STATEMODELDEFS, clusterName, stateModelRef);
+        PropertyPathBuilder.getPath(PropertyType.STATEMODELDEFS, clusterName, stateModelRef);
     if (!_zkClient.exists(stateModelDefPath)) {
       throw new HelixException("State model " + stateModelRef
           + " not found in the cluster STATEMODELDEFS path");

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -70,7 +70,6 @@ import org.apache.helix.model.Message.MessageType;
 import org.apache.helix.model.PauseSignal;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.tools.DefaultIdealStateCalculator;
-import org.apache.helix.util.HelixUtil;
 import org.apache.helix.util.RebalanceUtil;
 import org.apache.log4j.Logger;
 
@@ -111,10 +110,10 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     ZKUtil.createChildren(_zkClient, instanceConfigsPath, instanceConfig.getRecord());
 
-    _zkClient.createPersistent(HelixUtil.getMessagePath(clusterName, nodeId), true);
-    _zkClient.createPersistent(HelixUtil.getCurrentStateBasePath(clusterName, nodeId), true);
-    _zkClient.createPersistent(HelixUtil.getErrorsPath(clusterName, nodeId), true);
-    _zkClient.createPersistent(HelixUtil.getStatusUpdatesPath(clusterName, nodeId), true);
+    _zkClient.createPersistent(PropertyPathBuilder.instanceMessage(clusterName, nodeId), true);
+    _zkClient.createPersistent(PropertyPathBuilder.instanceCurrentState(clusterName, nodeId), true);
+    _zkClient.createPersistent(PropertyPathBuilder.instanceError(clusterName, nodeId), true);
+    _zkClient.createPersistent(PropertyPathBuilder.instanceStatusUpdate(clusterName, nodeId), true);
   }
 
   @Override
@@ -124,7 +123,7 @@ public class ZKHelixAdmin implements HelixAdmin {
             ConfigScopeProperty.PARTICIPANT.toString());
     String nodeId = instanceConfig.getId();
     String instanceConfigPath = instanceConfigsPath + "/" + nodeId;
-    String instancePath = HelixUtil.getInstancePath(clusterName, nodeId);
+    String instancePath = PropertyPathBuilder.instance(clusterName, nodeId);
 
     if (!_zkClient.exists(instanceConfigPath)) {
       throw new HelixException("Node " + nodeId + " does not exist in config for cluster "
@@ -549,7 +548,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     String path;
 
     // IDEAL STATE
-    _zkClient.createPersistent(HelixUtil.getIdealStatePath(clusterName));
+    _zkClient.createPersistent(PropertyPathBuilder.idealState(clusterName));
     // CONFIGURATIONS
     path =
         PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
@@ -568,16 +567,16 @@ public class ZKHelixAdmin implements HelixAdmin {
     path = PropertyPathBuilder.getPath(PropertyType.PROPERTYSTORE, clusterName);
     _zkClient.createPersistent(path);
     // LIVE INSTANCES
-    _zkClient.createPersistent(HelixUtil.getLiveInstancesPath(clusterName));
+    _zkClient.createPersistent(PropertyPathBuilder.liveInstance(clusterName));
     // MEMBER INSTANCES
-    _zkClient.createPersistent(HelixUtil.getMemberInstancesPath(clusterName));
+    _zkClient.createPersistent(PropertyPathBuilder.instance(clusterName));
     // External view
-    _zkClient.createPersistent(HelixUtil.getExternalViewPath(clusterName));
+    _zkClient.createPersistent(PropertyPathBuilder.externalView(clusterName));
     // State model definition
-    _zkClient.createPersistent(HelixUtil.getStateModelDefinitionPath(clusterName));
+    _zkClient.createPersistent(PropertyPathBuilder.stateModelDef(clusterName));
 
     // controller
-    _zkClient.createPersistent(HelixUtil.getControllerPath(clusterName));
+    _zkClient.createPersistent(PropertyPathBuilder.controller(clusterName));
     path = PropertyPathBuilder.getPath(PropertyType.HISTORY, clusterName);
     final ZNRecord emptyHistory = new ZNRecord(PropertyType.HISTORY.toString());
     final List<String> emptyList = new ArrayList<String>();
@@ -596,13 +595,13 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   @Override
   public List<String> getInstancesInCluster(String clusterName) {
-    String memberInstancesPath = HelixUtil.getMemberInstancesPath(clusterName);
+    String memberInstancesPath = PropertyPathBuilder.instance(clusterName);
     return _zkClient.getChildren(memberInstancesPath);
   }
 
   @Override
   public List<String> getInstancesInClusterWithTag(String clusterName, String tag) {
-    String memberInstancesPath = HelixUtil.getMemberInstancesPath(clusterName);
+    String memberInstancesPath = PropertyPathBuilder.instance(clusterName);
     List<String> instances = _zkClient.getChildren(memberInstancesPath);
     List<String> result = new ArrayList<String>();
 
@@ -649,7 +648,7 @@ public class ZKHelixAdmin implements HelixAdmin {
           + " not found in the cluster STATEMODELDEFS path");
     }
 
-    String idealStatePath = HelixUtil.getIdealStatePath(clusterName);
+    String idealStatePath = PropertyPathBuilder.idealState(clusterName);
     String resourceIdealStatePath = idealStatePath + "/" + resourceName;
     if (_zkClient.exists(resourceIdealStatePath)) {
       throw new HelixException("Skip the operation. Resource ideal state directory already exists:"
@@ -713,7 +712,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   @Override
   public List<String> getResourcesInCluster(String clusterName) {
-    return _zkClient.getChildren(HelixUtil.getIdealStatePath(clusterName));
+    return _zkClient.getChildren(PropertyPathBuilder.idealState(clusterName));
   }
 
   @Override
@@ -772,7 +771,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("cluster " + clusterName + " is not setup yet");
     }
-    String stateModelDefPath = HelixUtil.getStateModelDefinitionPath(clusterName);
+    String stateModelDefPath = PropertyPathBuilder.stateModelDef(clusterName);
     String stateModelPath = stateModelDefPath + "/" + stateModelDef;
     if (_zkClient.exists(stateModelPath)) {
       if (recreateIfExists) {
@@ -803,7 +802,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   @Override
   public List<String> getStateModelDefs(String clusterName) {
-    return _zkClient.getChildren(HelixUtil.getStateModelDefinitionPath(clusterName));
+    return _zkClient.getChildren(PropertyPathBuilder.stateModelDef(clusterName));
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -53,7 +53,7 @@ import org.apache.helix.MessageListener;
 import org.apache.helix.PreConnectCallback;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyKey.Builder;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.ScopedConfigChangeListener;
 import org.apache.helix.ZNRecord;
@@ -661,7 +661,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     checkConnected();
 
     if (_helixPropertyStore == null) {
-      String path = PropertyPathConfig.getPath(PropertyType.PROPERTYSTORE, _clusterName);
+      String path = PropertyPathBuilder.getPath(PropertyType.PROPERTYSTORE, _clusterName);
       String fallbackPath = String.format("/%s/%s", _clusterName, "HELIX_PROPERTYSTORE");
       _helixPropertyStore =
           new AutoFallbackPropertyStore<ZNRecord>(new ZkBaseDataAccessor<ZNRecord>(_zkclient),

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -462,24 +462,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
    */
   private void addBuiltInStateModelDefinitions() {
     for (BuiltInStateModelDefinitions def : BuiltInStateModelDefinitions.values()) {
-      String path = String
-          .format("/%s/STATEMODELDEFS/%s", _clusterName, def.getStateModelDefinition().getId());
-
-      HelixProperty property = _dataAccessor.getProperty(new PropertyKey.Builder(_clusterName)
-          .stateModelDef(def.getStateModelDefinition().getId()));
-
-      // Set new StateModelDefinition if it is different from old one.
-      if (property != null) {
-        // StateModelDefinition need to be updated
-        if (!new StateModelDefinition(property.getRecord()).equals(def.getStateModelDefinition())) {
-          _baseDataAccessor
-              .set(path, def.getStateModelDefinition().getRecord(), AccessOption.PERSISTENT);
-        }
-      } else {
-        // StateModeDefinition does not exist
-        _baseDataAccessor
-            .create(path, def.getStateModelDefinition().getRecord(), AccessOption.PERSISTENT);
-      }
+      _dataAccessor.createStateModelDef(def.getStateModelDefinition());
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.I0Itec.zkclient.DataUpdater;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.InstanceType;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
@@ -46,24 +46,24 @@ public final class ZKUtil {
       return false;
     }
     ArrayList<String> requiredPaths = new ArrayList<String>();
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.IDEALSTATES, clusterName));
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.IDEALSTATES, clusterName));
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
         ConfigScopeProperty.CLUSTER.toString(), clusterName));
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
         ConfigScopeProperty.PARTICIPANT.toString()));
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
         ConfigScopeProperty.RESOURCE.toString()));
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.PROPERTYSTORE, clusterName));
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.LIVEINSTANCES, clusterName));
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.INSTANCES, clusterName));
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName));
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.CONTROLLER, clusterName));
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.STATEMODELDEFS, clusterName));
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.MESSAGES_CONTROLLER, clusterName));
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.ERRORS_CONTROLLER, clusterName));
-    requiredPaths.add(PropertyPathConfig
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.PROPERTYSTORE, clusterName));
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.LIVEINSTANCES, clusterName));
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.INSTANCES, clusterName));
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName));
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.CONTROLLER, clusterName));
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.STATEMODELDEFS, clusterName));
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.MESSAGES_CONTROLLER, clusterName));
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.ERRORS_CONTROLLER, clusterName));
+    requiredPaths.add(PropertyPathBuilder
         .getPath(PropertyType.STATUSUPDATES_CONTROLLER, clusterName));
-    requiredPaths.add(PropertyPathConfig.getPath(PropertyType.HISTORY, clusterName));
+    requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.HISTORY, clusterName));
     boolean isValid = true;
 
     BaseDataAccessor<Object> baseAccessor = new ZkBaseDataAccessor<Object>(zkClient);
@@ -83,15 +83,15 @@ public final class ZKUtil {
       InstanceType type) {
     if (type == InstanceType.PARTICIPANT || type == InstanceType.CONTROLLER_PARTICIPANT) {
       ArrayList<String> requiredPaths = new ArrayList<String>();
-      requiredPaths.add(PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+      requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
           ConfigScopeProperty.PARTICIPANT.toString(), instanceName));
-      requiredPaths.add(PropertyPathConfig
+      requiredPaths.add(PropertyPathBuilder
           .getPath(PropertyType.MESSAGES, clusterName, instanceName));
-      requiredPaths.add(PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName,
+      requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName,
           instanceName));
-      requiredPaths.add(PropertyPathConfig.getPath(PropertyType.STATUSUPDATES, clusterName,
+      requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.STATUSUPDATES, clusterName,
           instanceName));
-      requiredPaths.add(PropertyPathConfig.getPath(PropertyType.ERRORS, clusterName, instanceName));
+      requiredPaths.add(PropertyPathBuilder.getPath(PropertyType.ERRORS, clusterName, instanceName));
       boolean isValid = true;
 
       for (String path : requiredPaths) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -42,7 +42,13 @@ public final class ZKUtil {
   }
 
   public static boolean isClusterSetup(String clusterName, ZkClient zkClient) {
-    if (clusterName == null || zkClient == null) {
+    if (clusterName == null) {
+      logger.info("Fail to check cluster setup : cluster name is null!");
+      return false;
+    }
+
+    if (zkClient == null) {
+      logger.info("Fail to check cluster setup : zookeeper client is null!");
       return false;
     }
     ArrayList<String> requiredPaths = new ArrayList<String>();
@@ -68,14 +74,20 @@ public final class ZKUtil {
 
     BaseDataAccessor<Object> baseAccessor = new ZkBaseDataAccessor<Object>(zkClient);
     boolean[] ret = baseAccessor.exists(requiredPaths, 0);
+    StringBuilder errorMsg = new StringBuilder();
+
     for (int i = 0; i < ret.length; i++) {
       if (!ret[i]) {
         isValid = false;
-        if (logger.isDebugEnabled()) {
-          logger.debug("Invalid cluster setup, missing znode path: " + requiredPaths.get(i));
-        }
+        errorMsg
+            .append(("Invalid cluster setup, missing znode path: " + requiredPaths.get(i)) + "\n");
       }
     }
+
+    if (!isValid) {
+      logger.info(errorMsg.toString());
+    }
+
     return isValid;
   }
 

--- a/helix-core/src/main/java/org/apache/helix/messaging/AsyncCallback.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/AsyncCallback.java
@@ -104,7 +104,7 @@ public abstract class AsyncCallback {
     _messagesSent = generatedMessage;
   }
 
-  final void startTimer() {
+  final synchronized void startTimer() {
     if (_timer == null && _timeout > 0) {
       if (_startTimeStamp == 0) {
         _startTimeStamp = new Date().getTime();

--- a/helix-core/src/main/java/org/apache/helix/monitoring/ZKPathDataDumpTask.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/ZKPathDataDumpTask.java
@@ -26,10 +26,9 @@ import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.PropertyKey.Builder;
-import org.apache.helix.PropertyType;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
-import org.apache.helix.util.HelixUtil;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.data.Stat;
 
@@ -74,28 +73,19 @@ public class ZKPathDataDumpTask extends TimerTask {
     List<String> instances = accessor.getChildNames(keyBuilder.instanceConfigs());
     for (String instance : instances) {
       // dump participant status updates
-      String statusUpdatePath =
-          HelixUtil.getInstancePropertyPath(_manager.getClusterName(), instance,
-              PropertyType.STATUSUPDATES);
+      String statusUpdatePath = PropertyPathBuilder.instanceStatusUpdate(_manager.getClusterName(), instance);
       dump(baseAccessor, statusUpdatePath, _thresholdNoChangeMsForStatusUpdates, _maxLeafCount);
 
       // dump participant errors
-      String errorPath =
-          HelixUtil.getInstancePropertyPath(_manager.getClusterName(), instance,
-              PropertyType.ERRORS);
+      String errorPath = PropertyPathBuilder.instanceError(_manager.getClusterName(), instance);
       dump(baseAccessor, errorPath, _thresholdNoChangeMsForErrors, _maxLeafCount);
     }
     // dump controller status updates
-    String controllerStatusUpdatePath =
-        HelixUtil.getControllerPropertyPath(_manager.getClusterName(),
-            PropertyType.STATUSUPDATES_CONTROLLER);
-    dump(baseAccessor, controllerStatusUpdatePath, _thresholdNoChangeMsForStatusUpdates,
-        _maxLeafCount);
+    String controllerStatusUpdatePath = PropertyPathBuilder.controllerStatusUpdate(_manager.getClusterName());
+    dump(baseAccessor, controllerStatusUpdatePath, _thresholdNoChangeMsForStatusUpdates, _maxLeafCount);
 
     // dump controller errors
-    String controllerErrorPath =
-        HelixUtil.getControllerPropertyPath(_manager.getClusterName(),
-            PropertyType.ERRORS_CONTROLLER);
+    String controllerErrorPath = PropertyPathBuilder.controllerError(_manager.getClusterName());
     dump(baseAccessor, controllerErrorPath, _thresholdNoChangeMsForErrors, _maxLeafCount);
   }
 

--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -48,7 +48,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyKey;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
@@ -118,7 +118,7 @@ public class TaskDriver {
   public TaskDriver(ZkClient client, ZkBaseDataAccessor<ZNRecord> baseAccessor, String clusterName) {
     this(new ZKHelixAdmin(client), new ZKHelixDataAccessor(clusterName, baseAccessor),
         new ConfigAccessor(client), new ZkHelixPropertyStore<ZNRecord>(baseAccessor,
-            PropertyPathConfig.getPath(PropertyType.PROPERTYSTORE, clusterName), null), clusterName);
+            PropertyPathBuilder.getPath(PropertyType.PROPERTYSTORE, clusterName), null), clusterName);
   }
 
   public TaskDriver(HelixAdmin admin, HelixDataAccessor accessor, ConfigAccessor cfgAccessor,

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterStateVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterStateVerifier.java
@@ -43,7 +43,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.PropertyKey.Builder;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.controller.pipeline.Stage;
@@ -579,7 +579,7 @@ public class ClusterStateVerifier {
 
     ExtViewVeriferZkListener listener = new ExtViewVeriferZkListener(countDown, zkClient, verifier);
 
-    String extViewPath = PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName);
+    String extViewPath = PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName);
     zkClient.subscribeChildChanges(extViewPath, listener);
     for (String child : zkClient.getChildren(extViewPath)) {
       String childPath = extViewPath.equals("/") ? extViewPath + child : extViewPath + "/" + child;

--- a/helix-core/src/main/java/org/apache/helix/tools/MessagePoster.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/MessagePoster.java
@@ -21,6 +21,7 @@ package org.apache.helix.tools;
 
 import java.util.UUID;
 
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkClient;
@@ -28,17 +29,15 @@ import org.apache.helix.model.Message;
 import org.apache.helix.model.LiveInstance.LiveInstanceProperty;
 import org.apache.helix.model.Message.MessageState;
 import org.apache.helix.model.Message.MessageType;
-import org.apache.helix.util.HelixUtil;
 
 public class MessagePoster {
   public void post(String zkServer, Message message, String clusterName, String instanceName) {
     ZkClient client = new ZkClient(zkServer);
     client.setZkSerializer(new ZNRecordSerializer());
-    String path = HelixUtil.getMessagePath(clusterName, instanceName) + "/" + message.getId();
+    String path = PropertyPathBuilder.instanceMessage(clusterName, instanceName, message.getId());
     client.delete(path);
-    ZNRecord record = client.readData(HelixUtil.getLiveInstancePath(clusterName, instanceName));
-    message.setTgtSessionId(record.getSimpleField(LiveInstanceProperty.SESSION_ID.toString())
-        .toString());
+    ZNRecord record = client.readData(PropertyPathBuilder.liveInstance(clusterName, instanceName));
+    message.setTgtSessionId(record.getSimpleField(LiveInstanceProperty.SESSION_ID.toString()));
     message.setTgtName(record.getId());
     // System.out.println(message);
     client.createPersistent(path, message.getRecord());

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -32,86 +32,6 @@ public final class HelixUtil {
   private HelixUtil() {
   }
 
-  public static String getPropertyPath(String clusterName, PropertyType type) {
-    return "/" + clusterName + "/" + type.toString();
-  }
-
-  public static String getInstancePropertyPath(String clusterName, String instanceName,
-      PropertyType type) {
-    return getPropertyPath(clusterName, PropertyType.INSTANCES) + "/" + instanceName + "/"
-        + type.toString();
-  }
-
-  public static String getInstancePath(String clusterName, String instanceName) {
-    return getPropertyPath(clusterName, PropertyType.INSTANCES) + "/" + instanceName;
-  }
-
-  public static String getIdealStatePath(String clusterName, String resourceName) {
-    return getPropertyPath(clusterName, PropertyType.IDEALSTATES) + "/" + resourceName;
-  }
-
-  public static String getIdealStatePath(String clusterName) {
-    return getPropertyPath(clusterName, PropertyType.IDEALSTATES);
-  }
-
-  public static String getLiveInstancesPath(String clusterName) {
-    return getPropertyPath(clusterName, PropertyType.LIVEINSTANCES);
-  }
-
-  public static String getMessagePath(String clusterName, String instanceName) {
-    return getInstancePropertyPath(clusterName, instanceName, PropertyType.MESSAGES);
-  }
-
-  public static String getCurrentStateBasePath(String clusterName, String instanceName) {
-    return getInstancePropertyPath(clusterName, instanceName, PropertyType.CURRENTSTATES);
-  }
-
-  /**
-   * Even though this is simple we want to have the mechanism of bucketing the
-   * partitions. If we have P partitions and N nodes with K replication factor
-   * and D databases. Then on each node we will have (P/N)*K*D partitions. And
-   * cluster manager neeeds to maintain watch on each of these nodes for every
-   * node. So over all cluster manager will have P*K*D watches which can be
-   * quite large given that we over partition.
-   * The other extreme is having one znode per storage per database. This will
-   * result in N*D watches which is good. But data in every node might become
-   * really big since it has to save partition
-   * Ideally we want to balance between the two models
-   */
-  public static String getCurrentStatePath(String clusterName, String instanceName,
-      String sessionId, String stateUnitKey) {
-    return getInstancePropertyPath(clusterName, instanceName, PropertyType.CURRENTSTATES) + "/"
-        + sessionId + "/" + stateUnitKey;
-  }
-
-  public static String getExternalViewPath(String clusterName) {
-    return getPropertyPath(clusterName, PropertyType.EXTERNALVIEW);
-  }
-
-  public static String getStateModelDefinitionPath(String clusterName) {
-    return getPropertyPath(clusterName, PropertyType.STATEMODELDEFS);
-  }
-
-  public static String getExternalViewPath(String clusterName, String resourceName) {
-    return getPropertyPath(clusterName, PropertyType.EXTERNALVIEW) + "/" + resourceName;
-  }
-
-  public static String getLiveInstancePath(String clusterName, String instanceName) {
-    return getPropertyPath(clusterName, PropertyType.LIVEINSTANCES) + "/" + instanceName;
-  }
-
-  public static String getMemberInstancesPath(String clusterName) {
-    return getPropertyPath(clusterName, PropertyType.INSTANCES);
-  }
-
-  public static String getErrorsPath(String clusterName, String instanceName) {
-    return getInstancePropertyPath(clusterName, instanceName, PropertyType.ERRORS);
-  }
-
-  public static String getStatusUpdatesPath(String clusterName, String instanceName) {
-    return getInstancePropertyPath(clusterName, instanceName, PropertyType.STATUSUPDATES);
-  }
-
   public static String getInstanceNameFromPath(String path) {
     // path structure
     // /<cluster_name>/instances/<instance_name>/[currentStates/messages]
@@ -122,15 +42,6 @@ public final class HelixUtil {
       }
     }
     return null;
-  }
-
-  // distributed cluster controller
-  public static String getControllerPath(String clusterName) {
-    return getPropertyPath(clusterName, PropertyType.CONTROLLER);
-  }
-
-  public static String getControllerPropertyPath(String clusterName, PropertyType type) {
-    return PropertyPathBuilder.getPath(type, clusterName);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -22,7 +22,7 @@ package org.apache.helix.util;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.log4j.Logger;
 
@@ -130,7 +130,7 @@ public final class HelixUtil {
   }
 
   public static String getControllerPropertyPath(String clusterName, PropertyType type) {
-    return PropertyPathConfig.getPath(type, clusterName);
+    return PropertyPathBuilder.getPath(type, clusterName);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/Mocks.java
+++ b/helix-core/src/test/java/org/apache/helix/Mocks.java
@@ -38,13 +38,17 @@ import org.apache.helix.messaging.handling.HelixTaskResult;
 import org.apache.helix.messaging.handling.MessageHandlerFactory;
 import org.apache.helix.messaging.handling.MessageTask;
 import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
+import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
+import org.apache.helix.model.PauseSignal;
+import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelInfo;
 import org.apache.helix.participant.statemachine.Transition;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.zookeeper.data.Stat;
+
 
 public class Mocks {
   public static class MockBaseDataAccessor implements BaseDataAccessor<ZNRecord> {
@@ -471,6 +475,26 @@ public class Mocks {
     Map<String, ZNRecord> map = new HashMap<String, ZNRecord>();
 
     @Override
+    public boolean createStateModelDef(StateModelDefinition stateModelDef) {
+      return false;
+    }
+
+    @Override
+    public boolean createControllerMessage(Message message) {
+      return false;
+    }
+
+    @Override
+    public boolean createControllerLeader(LiveInstance leader) {
+      return false;
+    }
+
+    @Override
+    public boolean createPause(PauseSignal pauseSignal) {
+      return false;
+    }
+
+    @Override
     public boolean setProperty(PropertyKey key, HelixProperty value) {
       String path = key.getPath();
       data.put(path, value.getRecord());
@@ -567,12 +591,6 @@ public class Mocks {
     public <T extends HelixProperty> Map<String, T> getChildValuesMap(PropertyKey key) {
       List<T> list = getChildValues(key);
       return HelixProperty.convertListToMap(list);
-    }
-
-    @Override
-    public <T extends HelixProperty> boolean createProperty(PropertyKey key, T value) {
-      // TODO Auto-generated method stub
-      return false;
     }
 
     @Override

--- a/helix-core/src/test/java/org/apache/helix/Mocks.java
+++ b/helix-core/src/test/java/org/apache/helix/Mocks.java
@@ -517,7 +517,7 @@ public class Mocks {
 
     @Override
     public boolean removeProperty(PropertyKey key) {
-      String path = key.getPath(); // PropertyPathConfig.getPath(type,
+      String path = key.getPath(); // PropertyPathBuilder.getPath(type,
       // _clusterName, keys);
       data.remove(path);
       return true;
@@ -543,7 +543,7 @@ public class Mocks {
     @Override
     public <T extends HelixProperty> List<T> getChildValues(PropertyKey propertyKey) {
       List<ZNRecord> childs = new ArrayList<ZNRecord>();
-      String path = propertyKey.getPath(); // PropertyPathConfig.getPath(type,
+      String path = propertyKey.getPath(); // PropertyPathBuilder.getPath(type,
       // _clusterName, keys);
       for (String key : data.keySet()) {
         if (key.startsWith(path)) {

--- a/helix-core/src/test/java/org/apache/helix/TestPropertyPathBuilder.java
+++ b/helix-core/src/test/java/org/apache/helix/TestPropertyPathBuilder.java
@@ -23,30 +23,30 @@ import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
 @Test
-public class TestPropertyPathConfig {
+public class TestPropertyPathBuilder {
   @Test
   public void testGetPath() {
     String actual;
-    actual = PropertyPathConfig.getPath(PropertyType.IDEALSTATES, "test_cluster");
+    actual = PropertyPathBuilder.getPath(PropertyType.IDEALSTATES, "test_cluster");
     AssertJUnit.assertEquals(actual, "/test_cluster/IDEALSTATES");
-    actual = PropertyPathConfig.getPath(PropertyType.IDEALSTATES, "test_cluster", "resource");
+    actual = PropertyPathBuilder.getPath(PropertyType.IDEALSTATES, "test_cluster", "resource");
     AssertJUnit.assertEquals(actual, "/test_cluster/IDEALSTATES/resource");
 
-    actual = PropertyPathConfig.getPath(PropertyType.INSTANCES, "test_cluster", "instanceName1");
+    actual = PropertyPathBuilder.getPath(PropertyType.INSTANCES, "test_cluster", "instanceName1");
     AssertJUnit.assertEquals(actual, "/test_cluster/INSTANCES/instanceName1");
 
     actual =
-        PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, "test_cluster", "instanceName1");
+        PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, "test_cluster", "instanceName1");
     AssertJUnit.assertEquals(actual, "/test_cluster/INSTANCES/instanceName1/CURRENTSTATES");
     actual =
-        PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, "test_cluster", "instanceName1",
+        PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, "test_cluster", "instanceName1",
             "sessionId");
     AssertJUnit.assertEquals(actual,
         "/test_cluster/INSTANCES/instanceName1/CURRENTSTATES/sessionId");
 
-    actual = PropertyPathConfig.getPath(PropertyType.CONTROLLER, "test_cluster");
+    actual = PropertyPathBuilder.getPath(PropertyType.CONTROLLER, "test_cluster");
     AssertJUnit.assertEquals(actual, "/test_cluster/CONTROLLER");
-    actual = PropertyPathConfig.getPath(PropertyType.MESSAGES_CONTROLLER, "test_cluster");
+    actual = PropertyPathBuilder.getPath(PropertyType.MESSAGES_CONTROLLER, "test_cluster");
     AssertJUnit.assertEquals(actual, "/test_cluster/CONTROLLER/MESSAGES");
 
   }

--- a/helix-core/src/test/java/org/apache/helix/ZkUnitTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/ZkUnitTestBase.java
@@ -152,7 +152,7 @@ public class ZkUnitTestBase {
       boolean wantExists) {
     // String instanceConfigsPath = HelixUtil.getConfigPath(clusterName);
     String instanceConfigsPath =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString());
     String instanceConfigPath = instanceConfigsPath + "/" + instance;
     String instancePath = HelixUtil.getInstancePath(clusterName, instance);

--- a/helix-core/src/test/java/org/apache/helix/ZkUnitTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/ZkUnitTestBase.java
@@ -50,7 +50,6 @@ import org.apache.helix.model.Message.MessageType;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.tools.ClusterStateVerifier.ZkVerifier;
 import org.apache.helix.tools.StateModelConfigGenerator;
-import org.apache.helix.util.HelixUtil;
 import org.apache.helix.util.ZKClientPool;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.WatchedEvent;
@@ -102,7 +101,7 @@ public class ZkUnitTestBase {
   }
 
   protected String getCurrentLeader(ZkClient zkClient, String clusterName) {
-    String leaderPath = HelixUtil.getControllerPropertyPath(clusterName, PropertyType.LEADER);
+    String leaderPath = PropertyPathBuilder.controllerLeader(clusterName);
     ZNRecord leaderRecord = zkClient.<ZNRecord> readData(leaderPath);
     if (leaderRecord == null) {
       return null;
@@ -150,19 +149,19 @@ public class ZkUnitTestBase {
 
   public void verifyInstance(ZkClient zkClient, String clusterName, String instance,
       boolean wantExists) {
-    // String instanceConfigsPath = HelixUtil.getConfigPath(clusterName);
+    // String instanceConfigsPath = PropertyPathBuilder.getConfigPath(clusterName);
     String instanceConfigsPath =
         PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString());
     String instanceConfigPath = instanceConfigsPath + "/" + instance;
-    String instancePath = HelixUtil.getInstancePath(clusterName, instance);
+    String instancePath = PropertyPathBuilder.instance(clusterName, instance);
     AssertJUnit.assertEquals(wantExists, zkClient.exists(instanceConfigPath));
     AssertJUnit.assertEquals(wantExists, zkClient.exists(instancePath));
   }
 
   public void verifyResource(ZkClient zkClient, String clusterName, String resource,
       boolean wantExists) {
-    String resourcePath = HelixUtil.getIdealStatePath(clusterName) + "/" + resource;
+    String resourcePath = PropertyPathBuilder.idealState(clusterName) + "/" + resource;
     AssertJUnit.assertEquals(wantExists, zkClient.exists(resourcePath));
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestAddNodeAfterControllerStart.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestAddNodeAfterControllerStart.java
@@ -22,7 +22,7 @@ package org.apache.helix.integration;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZkTestHelper;
@@ -66,7 +66,7 @@ public class TestAddNodeAfterControllerStart extends ZkIntegrationTestBase {
             ZK_ADDR, clusterName));
     Assert.assertTrue(result);
     String msgPath =
-        PropertyPathConfig.getPath(PropertyType.MESSAGES, clusterName, "localhost_12918");
+        PropertyPathBuilder.getPath(PropertyType.MESSAGES, clusterName, "localhost_12918");
     result = checkHandlers(controller.getHandlers(), msgPath);
     Assert.assertTrue(result);
 
@@ -79,7 +79,7 @@ public class TestAddNodeAfterControllerStart extends ZkIntegrationTestBase {
         ClusterStateVerifier.verifyByPolling(new ClusterStateVerifier.BestPossAndExtViewZkVerifier(
             ZK_ADDR, clusterName));
     Assert.assertTrue(result);
-    msgPath = PropertyPathConfig.getPath(PropertyType.MESSAGES, clusterName, "localhost_12922");
+    msgPath = PropertyPathBuilder.getPath(PropertyType.MESSAGES, clusterName, "localhost_12922");
     result = checkHandlers(controller.getHandlers(), msgPath);
     Assert.assertTrue(result);
 
@@ -140,7 +140,7 @@ public class TestAddNodeAfterControllerStart extends ZkIntegrationTestBase {
 
     // check if controller_0 has message listener for localhost_12918
     String msgPath =
-        PropertyPathConfig.getPath(PropertyType.MESSAGES, clusterName, "localhost_12918");
+        PropertyPathBuilder.getPath(PropertyType.MESSAGES, clusterName, "localhost_12918");
     int numberOfListeners = ZkTestHelper.numberOfListeners(ZK_ADDR, msgPath);
     // System.out.println("numberOfListeners(" + msgPath + "): " + numberOfListeners);
     Assert.assertEquals(numberOfListeners, 2); // 1 of participant, and 1 of controller
@@ -155,7 +155,7 @@ public class TestAddNodeAfterControllerStart extends ZkIntegrationTestBase {
             ZK_ADDR, clusterName));
     Assert.assertTrue(result);
     // check if controller_0 has message listener for localhost_12919
-    msgPath = PropertyPathConfig.getPath(PropertyType.MESSAGES, clusterName, "localhost_12919");
+    msgPath = PropertyPathBuilder.getPath(PropertyType.MESSAGES, clusterName, "localhost_12919");
     numberOfListeners = ZkTestHelper.numberOfListeners(ZK_ADDR, msgPath);
     // System.out.println("numberOfListeners(" + msgPath + "): " + numberOfListeners);
     Assert.assertEquals(numberOfListeners, 2); // 1 of participant, and 1 of controller

--- a/helix-core/src/test/java/org/apache/helix/integration/TestAutoIsWithEmptyMap.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestAutoIsWithEmptyMap.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
@@ -54,7 +54,7 @@ public class TestAutoIsWithEmptyMap extends ZkIntegrationTestBase {
         "LeaderStandby", false); // do not rebalance
 
     // calculate and set custom ideal state
-    String idealPath = PropertyPathConfig.getPath(PropertyType.IDEALSTATES, clusterName, "TestDB0");
+    String idealPath = PropertyPathBuilder.getPath(PropertyType.IDEALSTATES, clusterName, "TestDB0");
     ZNRecord curIdealState = _gZkClient.readData(idealPath);
 
     List<String> instanceNames = new ArrayList<String>(5);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestCarryOverBadCurState.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestCarryOverBadCurState.java
@@ -21,7 +21,7 @@ package org.apache.helix.integration;
 
 import java.util.Date;
 
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
@@ -53,7 +53,7 @@ public class TestCarryOverBadCurState extends ZkIntegrationTestBase {
     // add a bad current state
     ZNRecord badCurState = new ZNRecord("TestDB0");
     String path =
-        PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_12918",
+        PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_12918",
             "session_0", "TestDB0");
     _gZkClient.createPersistent(path, true);
     _gZkClient.writeData(path, badCurState);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestClusterStartsup.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestClusterStartsup.java
@@ -25,9 +25,8 @@ import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
-import org.apache.helix.PropertyType;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.tools.ClusterSetup;
-import org.apache.helix.util.HelixUtil;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
@@ -68,8 +67,7 @@ public class TestClusterStartsup extends ZkStandAloneCMTestBase {
   @Test()
   public void testParticipantStartUp() throws Exception {
     setupCluster();
-    String controllerMsgPath =
-        HelixUtil.getControllerPropertyPath(CLUSTER_NAME, PropertyType.MESSAGES_CONTROLLER);
+    String controllerMsgPath = PropertyPathBuilder.controllerMessage(CLUSTER_NAME);
     _gZkClient.deleteRecursive(controllerMsgPath);
     HelixManager manager = null;
 
@@ -102,7 +100,7 @@ public class TestClusterStartsup extends ZkStandAloneCMTestBase {
     }
 
     setupCluster();
-    String stateModelPath = HelixUtil.getStateModelDefinitionPath(CLUSTER_NAME);
+    String stateModelPath = PropertyPathBuilder.stateModelDef(CLUSTER_NAME);
     _gZkClient.deleteRecursive(stateModelPath);
 
     try {
@@ -120,8 +118,7 @@ public class TestClusterStartsup extends ZkStandAloneCMTestBase {
 
     setupCluster();
     String instanceStatusUpdatePath =
-        HelixUtil.getInstancePropertyPath(CLUSTER_NAME, "localhost_" + (START_PORT + 1),
-            PropertyType.STATUSUPDATES);
+        PropertyPathBuilder.instanceStatusUpdate(CLUSTER_NAME, "localhost_" + (START_PORT + 1));
     _gZkClient.deleteRecursive(instanceStatusUpdatePath);
 
     try {

--- a/helix-core/src/test/java/org/apache/helix/integration/TestDriver.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestDriver.java
@@ -27,7 +27,7 @@ import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.helix.HelixManager;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.integration.manager.ClusterControllerManager;
@@ -355,7 +355,7 @@ public class TestDriver {
       nextIS = nextIdealState(initIS, destIS, step);
       // testInfo._idealStateMap.put(dbName, nextIS);
       String idealStatePath =
-          PropertyPathConfig.getPath(PropertyType.IDEALSTATES, clusterName, TEST_DB_PREFIX + i);
+          PropertyPathBuilder.getPath(PropertyType.IDEALSTATES, clusterName, TEST_DB_PREFIX + i);
       ZnodeOpArg arg = new ZnodeOpArg(idealStatePath, ZnodePropertyType.ZNODE, "+", nextIS);
       TestCommand command = new TestCommand(CommandType.MODIFY, new TestTrigger(beginTime), arg);
       commandList.add(command);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestEnableCompression.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestEnableCompression.java
@@ -6,10 +6,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
-import org.apache.helix.ZNRecord;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.manager.zk.ZkClient;
@@ -115,9 +114,9 @@ public class TestEnableCompression extends ZkIntegrationTestBase {
     // ONLY IDEALSTATE and EXTERNAL VIEW must be compressed
     Assert.assertEquals(compressedPaths.size(), 2);
     String idealstatePath =
-        PropertyPathConfig.getPath(PropertyType.IDEALSTATES, clusterName, resourceName);
+        PropertyPathBuilder.getPath(PropertyType.IDEALSTATES, clusterName, resourceName);
     String externalViewPath =
-        PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName, resourceName);
+        PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName, resourceName);
     Assert.assertTrue(compressedPaths.contains(idealstatePath));
     Assert.assertTrue(compressedPaths.contains(externalViewPath));
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestMessageThrottle.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestMessageThrottle.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.I0Itec.zkclient.IZkChildListener;
 import org.apache.helix.HelixAdmin;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
@@ -85,7 +85,7 @@ public class TestMessageThrottle extends ZkIntegrationTestBase {
     final AtomicBoolean success = new AtomicBoolean(true);
     for (int i = 0; i < 5; i++) {
       String instanceName = "localhost_" + (12918 + i);
-      String msgPath = PropertyPathConfig.getPath(PropertyType.MESSAGES, clusterName, instanceName);
+      String msgPath = PropertyPathBuilder.getPath(PropertyType.MESSAGES, clusterName, instanceName);
 
       _gZkClient.subscribeChildChanges(msgPath, new IZkChildListener() {
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestNullReplica.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestNullReplica.java
@@ -21,7 +21,7 @@ package org.apache.helix.integration;
 
 import java.util.Date;
 
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
@@ -56,7 +56,7 @@ public class TestNullReplica extends ZkIntegrationTestBase {
         "MasterSlave", true); // do rebalance
     // set replica in ideal state to null
     String idealStatePath =
-        PropertyPathConfig.getPath(PropertyType.IDEALSTATES, clusterName, "TestDB0");
+        PropertyPathBuilder.getPath(PropertyType.IDEALSTATES, clusterName, "TestDB0");
     ZNRecord idealState = _gZkClient.readData(idealStatePath);
     idealState.getSimpleFields().remove(IdealState.IdealStateProperty.REPLICAS.toString());
     _gZkClient.writeData(idealStatePath, idealState);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMessage.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMessage.java
@@ -185,7 +185,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     }
   }
 
-  @Test()
+  @Test(dependsOnMethods = "testSchedulerZeroMsg")
   public void testSchedulerMsg() throws Exception {
     Logger.getRootLogger().setLevel(Level.INFO);
     _factory._results.clear();
@@ -325,13 +325,13 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     }
   }
 
-  @Test()
+  @Test
   public void testSchedulerZeroMsg() throws Exception {
-    TestMessagingHandlerFactory factory = new TestMessagingHandlerFactory();
+    _factory._results.clear();
     HelixManager manager = null;
     for (int i = 0; i < NODE_NR; i++) {
       _participants[i].getMessagingService().registerMessageHandlerFactory(
-          factory.getMessageType(), factory);
+          _factory.getMessageType(), _factory);
 
       manager = _participants[i]; // _startCMResultMap.get(hostDest)._manager;
     }
@@ -344,7 +344,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     schedulerMessage.setSrcName("CONTROLLER");
 
     // Template for the individual message sent to each participant
-    Message msg = new Message(factory.getMessageType(), "Template");
+    Message msg = new Message(_factory.getMessageType(), "Template");
     msg.setTgtSessionId("*");
     msg.setMsgState(MessageState.NEW);
 
@@ -376,7 +376,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
 
     Thread.sleep(3000);
 
-    Assert.assertEquals(0, factory._results.size());
+    Assert.assertEquals(0, _factory._results.size());
     PropertyKey controllerTaskStatus =
         keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(),
             schedulerMessage.getMsgId());
@@ -389,13 +389,13 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     ZNRecord statusUpdate = helixDataAccessor.getProperty(controllerTaskStatus).getRecord();
     Assert.assertTrue(statusUpdate.getMapField("SentMessageCount").get("MessageCount").equals("0"));
     int count = 0;
-    for (Set<String> val : factory._results.values()) {
+    for (Set<String> val : _factory._results.values()) {
       count += val.size();
     }
     Assert.assertEquals(count, 0);
   }
 
-  @Test()
+  @Test(dependsOnMethods = "testSchedulerMsg")
   public void testSchedulerMsg3() throws Exception {
     _factory._results.clear();
     Thread.sleep(2000);
@@ -517,7 +517,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     }
   }
 
-  @Test()
+  @Test(dependsOnMethods = "testSchedulerMsg3")
   public void testSchedulerMsg4() throws Exception {
     _factory._results.clear();
     HelixManager manager = null;

--- a/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMessage.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMessage.java
@@ -58,6 +58,7 @@ import org.codehaus.jackson.map.SerializationConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+
 public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
 
   public static class MockAsyncCallback extends AsyncCallback {
@@ -232,8 +233,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
 
     HelixDataAccessor helixDataAccessor = manager.getHelixDataAccessor();
     Builder keyBuilder = helixDataAccessor.keyBuilder();
-    helixDataAccessor.createProperty(keyBuilder.controllerMessage(schedulerMessage.getMsgId()),
-        schedulerMessage);
+    helixDataAccessor.createControllerMessage(schedulerMessage);
 
     for (int i = 0; i < 30; i++) {
       Thread.sleep(2000);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMessage.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMessage.java
@@ -37,7 +37,7 @@ import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyKey.Builder;
-import org.apache.helix.PropertyType;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.DefaultSchedulerMessageHandlerFactory;
 import org.apache.helix.messaging.AsyncCallback;
@@ -51,7 +51,6 @@ import org.apache.helix.model.Message.MessageState;
 import org.apache.helix.model.Message.MessageType;
 import org.apache.helix.model.StatusUpdate;
 import org.apache.helix.monitoring.ZKPathDataDumpTask;
-import org.apache.helix.util.HelixUtil;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -274,9 +273,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     Assert.assertEquals(count, _PARTITIONS * 3);
 
     // test the ZkPathDataDumpTask
-    String controllerStatusPath =
-        HelixUtil.getControllerPropertyPath(manager.getClusterName(),
-            PropertyType.STATUSUPDATES_CONTROLLER);
+    String controllerStatusPath = PropertyPathBuilder.controllerStatusUpdate(manager.getClusterName());
     List<String> subPaths = _gZkClient.getChildren(controllerStatusPath);
     Assert.assertTrue(subPaths.size() > 0);
     for (String subPath : subPaths) {
@@ -286,9 +283,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     }
 
     String instanceStatusPath =
-        HelixUtil.getInstancePropertyPath(manager.getClusterName(), "localhost_" + (START_PORT),
-            PropertyType.STATUSUPDATES);
-
+        PropertyPathBuilder.instanceStatusUpdate(manager.getClusterName(), "localhost_" + (START_PORT));
     subPaths = _gZkClient.getChildren(instanceStatusPath);
     Assert.assertTrue(subPaths.size() == 0);
     for (String subPath : subPaths) {

--- a/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMsgUsingQueue.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMsgUsingQueue.java
@@ -38,6 +38,7 @@ import org.codehaus.jackson.map.SerializationConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+
 public class TestSchedulerMsgUsingQueue extends ZkStandAloneCMTestBase {
   TestSchedulerMessage.TestMessagingHandlerFactory _factory =
       new TestSchedulerMessage.TestMessagingHandlerFactory();
@@ -91,8 +92,7 @@ public class TestSchedulerMsgUsingQueue extends ZkStandAloneCMTestBase {
 
     HelixDataAccessor helixDataAccessor = manager.getHelixDataAccessor();
     PropertyKey.Builder keyBuilder = helixDataAccessor.keyBuilder();
-    helixDataAccessor.createProperty(keyBuilder.controllerMessage(schedulerMessage.getMsgId()),
-        schedulerMessage);
+    helixDataAccessor.createControllerMessage(schedulerMessage);
 
     for (int i = 0; i < 30; i++) {
       Thread.sleep(2000);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestSemiAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestSemiAutoRebalance.java
@@ -1,0 +1,228 @@
+package org.apache.helix.integration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.MasterSlaveSMD;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestSemiAutoRebalance extends ZkIntegrationTestBase {
+  protected final String CLASS_NAME = getShortClassName();
+  protected final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + CLASS_NAME;
+
+  protected static final int PARTICIPANT_NUMBER = 5;
+  protected static final int PARTICIPANT_START_PORT = 12918;
+
+  protected static final String DB_NAME = "TestDB";
+  protected static final int PARTITION_NUMBER = 20;
+  protected static final int REPLICA_NUMBER = 3;
+  protected static final String STATE_MODEL = "MasterSlave";
+
+  protected List<MockParticipantManager> _participants = new ArrayList<MockParticipantManager>();
+  protected ClusterControllerManager _controller;
+
+  protected HelixDataAccessor _accessor;
+  protected PropertyKey.Builder _keyBuilder;
+
+  @BeforeClass
+  public void beforeClass()
+      throws InterruptedException {
+    System.out.println(
+        "START " + getShortClassName() + " at " + new Date(System.currentTimeMillis()));
+
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursive(namespace);
+    }
+
+    // setup storage cluster
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, DB_NAME, PARTITION_NUMBER, STATE_MODEL,
+        IdealState.RebalanceMode.SEMI_AUTO.toString());
+
+    _accessor = new ZKHelixDataAccessor(CLUSTER_NAME, _baseAccessor);
+    _keyBuilder = _accessor.keyBuilder();
+
+    List<String> instances = new ArrayList<String>();
+    for (int i = 0; i < PARTICIPANT_NUMBER; i++) {
+      String instance = PARTICIPANT_PREFIX + "_" + (PARTICIPANT_START_PORT + i);
+      _gSetupTool.addInstanceToCluster(CLUSTER_NAME, instance);
+      instances.add(instance);
+    }
+
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, DB_NAME, REPLICA_NUMBER);
+
+    // start dummy participants
+    for (int i = 0; i < PARTICIPANT_NUMBER; i++) {
+      MockParticipantManager participant =
+          new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instances.get(i));
+      participant.syncStart();
+      _participants.add(participant);
+    }
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    Thread.sleep(1000);
+
+    // verify ideal state and external view
+    IdealState idealState = _accessor.getProperty(_keyBuilder.idealStates(DB_NAME));
+    Assert.assertNotNull(idealState);
+    Assert.assertEquals(idealState.getNumPartitions(), PARTITION_NUMBER);
+    for (String partition : idealState.getPartitionSet()) {
+      List<String> preferenceList = idealState.getPreferenceList(partition);
+      Assert.assertNotNull(preferenceList);
+      Assert.assertEquals(preferenceList.size(), REPLICA_NUMBER);
+    }
+
+    ExternalView externalView = _accessor.getProperty(_keyBuilder.externalView(DB_NAME));
+    Assert.assertNotNull(externalView);
+    Assert.assertEquals(externalView.getPartitionSet().size(), PARTITION_NUMBER);
+    for (String partition : externalView.getPartitionSet()) {
+      Map<String, String> stateMap = externalView.getStateMap(partition);
+      Assert.assertEquals(stateMap.size(), REPLICA_NUMBER);
+
+      int masters = 0;
+      for (String state : stateMap.values()) {
+        if (state.equals(MasterSlaveSMD.States.MASTER.name())) {
+          ++masters;
+        }
+      }
+      Assert.assertEquals(masters, 1);
+    }
+  }
+
+  @Test
+  public void testAddParticipant()
+      throws InterruptedException {
+    String newInstance = PARTICIPANT_PREFIX + "_" + (PARTICIPANT_START_PORT + _participants.size());
+    _gSetupTool.addInstanceToCluster(CLUSTER_NAME, newInstance);
+
+    MockParticipantManager newParticipant =
+        new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, newInstance);
+    newParticipant.syncStart();
+
+    Thread.sleep(1000);
+
+    List<String> instances = _accessor.getChildNames(_keyBuilder.instanceConfigs());
+    Assert.assertEquals(instances.size(), _participants.size() + 1);
+    Assert.assertTrue(instances.contains(newInstance));
+
+    List<String> liveInstances = _accessor.getChildNames(_keyBuilder.liveInstances());
+    Assert.assertEquals(liveInstances.size(), _participants.size() + 1);
+    Assert.assertTrue(liveInstances.contains(newInstance));
+
+    // nothing for new participant
+    ExternalView externalView = _accessor.getProperty(_keyBuilder.externalView(DB_NAME));
+    Assert.assertNotNull(externalView);
+    for (String partition : externalView.getPartitionSet()) {
+      Map<String, String> stateMap = externalView.getStateMap(partition);
+      Assert.assertFalse(stateMap.containsKey(newInstance));
+    }
+
+    // clear
+    newParticipant.syncStop();
+    _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, newInstance, false);
+    _gSetupTool.dropInstanceFromCluster(CLUSTER_NAME, newInstance);
+
+    instances = _accessor.getChildNames(_keyBuilder.instanceConfigs());
+    Assert.assertEquals(instances.size(), _participants.size());
+
+    liveInstances = _accessor.getChildNames(_keyBuilder.liveInstances());
+    Assert.assertEquals(liveInstances.size(), _participants.size());
+  }
+
+  @Test(dependsOnMethods = "testAddParticipant")
+  public void testStopAndReStartParticipant()
+      throws InterruptedException {
+    MockParticipantManager participant = _participants.get(0);
+    String instance = participant.getInstanceName();
+
+    Map<String, MasterSlaveSMD.States> affectedPartitions =
+        new HashMap<String, MasterSlaveSMD.States>();
+
+    ExternalView externalView = _accessor.getProperty(_keyBuilder.externalView(DB_NAME));
+
+    for (String partition : externalView.getPartitionSet()) {
+      Map<String, String> stateMap = externalView.getStateMap(partition);
+      if (stateMap.containsKey(instance)) {
+        affectedPartitions.put(partition, MasterSlaveSMD.States.valueOf(stateMap.get(instance)));
+      }
+    }
+
+    stopParticipant(participant, affectedPartitions);
+
+    // create a new participant
+    participant = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instance);
+    _participants.set(0, participant);
+    startParticipant(participant, affectedPartitions);
+  }
+
+  private void stopParticipant(
+      MockParticipantManager participant, Map<String, MasterSlaveSMD.States> affectedPartitions)
+      throws InterruptedException {
+    participant.syncStop();
+
+    Thread.sleep(1000);
+
+    ExternalView externalView = _accessor.getProperty(_keyBuilder.externalView(DB_NAME));
+    // No re-assignment of partition, if a MASTER is removed, one of SLAVE would be prompted
+    for (Map.Entry<String, MasterSlaveSMD.States> entry : affectedPartitions.entrySet()) {
+      Map<String, String> stateMap = externalView.getStateMap(entry.getKey());
+      Assert.assertEquals(stateMap.size(), REPLICA_NUMBER - 1);
+      Assert.assertTrue(stateMap.values().contains(MasterSlaveSMD.States.MASTER.toString()));
+    }
+  }
+
+  private void startParticipant(
+      MockParticipantManager participant, Map<String, MasterSlaveSMD.States> affectedPartitions)
+      throws InterruptedException {
+    String instance = participant.getInstanceName();
+    participant.syncStart();
+
+    Thread.sleep(1000);
+
+    ExternalView externalView = _accessor.getProperty(_keyBuilder.externalView(DB_NAME));
+    // Everything back to the initial state
+    for (Map.Entry<String, MasterSlaveSMD.States> entry : affectedPartitions.entrySet()) {
+      Map<String, String> stateMap = externalView.getStateMap(entry.getKey());
+      Assert.assertEquals(stateMap.size(), REPLICA_NUMBER);
+
+      Assert.assertTrue(stateMap.containsKey(instance));
+      Assert.assertEquals(stateMap.get(instance), entry.getValue().toString());
+    }
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/TestStartMultipleControllersWithSameName.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestStartMultipleControllersWithSameName.java
@@ -21,7 +21,7 @@ package org.apache.helix.integration;
 
 import java.util.Date;
 
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZkTestHelper;
@@ -61,7 +61,7 @@ public class TestStartMultipleControllersWithSameName extends ZkIntegrationTestB
     }
 
     Thread.sleep(500); // wait leader election finishes
-    String liPath = PropertyPathConfig.getPath(PropertyType.LIVEINSTANCES, clusterName);
+    String liPath = PropertyPathBuilder.getPath(PropertyType.LIVEINSTANCES, clusterName);
     int listenerNb = ZkTestHelper.numberOfListeners(ZK_ADDR, liPath);
     // System.out.println("listenerNb: " + listenerNb);
     Assert.assertEquals(listenerNb, 1, "Only one controller should succeed in becoming leader");

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
@@ -28,7 +28,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.PropertyKey;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
@@ -237,7 +237,7 @@ public class TestParticipantManager extends ZkIntegrationTestBase {
 
     // assert interrupt exception error in old session
     String errPath =
-        PropertyPathConfig.getPath(PropertyType.ERRORS, clusterName, "localhost_12918",
+        PropertyPathBuilder.getPath(PropertyType.ERRORS, clusterName, "localhost_12918",
             oldSessionId, "TestDB0", "TestDB0_0");
     ZNRecord error = _gZkClient.readData(errPath);
     Assert

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerStopResume.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerStopResume.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.task.JobConfig;
@@ -459,7 +459,7 @@ public class TestTaskRebalancerStopResume extends TaskTestBase {
             = Lists.newArrayList(keyBuilder.resourceConfigs().getPath(),
             keyBuilder.idealStates().getPath(),
             keyBuilder.externalViews().getPath(),
-            PropertyPathConfig.getPath(PropertyType.PROPERTYSTORE, CLUSTER_NAME)
+            PropertyPathBuilder.getPath(PropertyType.PROPERTYSTORE, CLUSTER_NAME)
                 + TaskConstants.REBALANCER_CONTEXT_ROOT);
 
         for (String path : paths) {

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestWtCacheAsyncOpMultiThread.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestWtCacheAsyncOpMultiThread.java
@@ -27,14 +27,12 @@ import java.util.concurrent.Callable;
 
 import org.I0Itec.zkclient.DataUpdater;
 import org.apache.helix.AccessOption;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.ZNRecordUpdater;
 import org.apache.helix.ZkUnitTestBase;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.manager.zk.ZkCacheBaseDataAccessor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -73,7 +71,7 @@ public class TestWtCacheAsyncOpMultiThread extends ZkUnitTestBase {
         for (int i = 0; i < 5; i++) {
           int k = j * 5 + i;
           String path =
-              PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, _clusterName,
+              PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, _clusterName,
                   "localhost_8901", "session_0", "TestDB" + k);
           ZNRecord record = new ZNRecord("TestDB" + k);
 
@@ -117,7 +115,7 @@ public class TestWtCacheAsyncOpMultiThread extends ZkUnitTestBase {
 
         for (int i = 0; i < 10; i++) {
           String path =
-              PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, _clusterName,
+              PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, _clusterName,
                   "localhost_8901", "session_0", "TestDB" + i);
 
           ZNRecord newRecord = new ZNRecord("TestDB" + i);
@@ -173,7 +171,7 @@ public class TestWtCacheAsyncOpMultiThread extends ZkUnitTestBase {
         for (int i = 0; i < 5; i++) {
           int k = j * 5 + i;
           String path =
-              PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, _clusterName, "TestDB" + k);
+              PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, _clusterName, "TestDB" + k);
           ZNRecord record = new ZNRecord("TestDB" + k);
 
           paths.add(path);
@@ -200,8 +198,8 @@ public class TestWtCacheAsyncOpMultiThread extends ZkUnitTestBase {
 
     // init zkCacheDataAccessor
     String curStatePath =
-        PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
-    String extViewPath = PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName);
+        PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
+    String extViewPath = PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName);
 
     ZkBaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_gZkClient);
 

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestWtCacheAsyncOpSingleThread.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestWtCacheAsyncOpSingleThread.java
@@ -26,14 +26,12 @@ import java.util.List;
 
 import org.I0Itec.zkclient.DataUpdater;
 import org.apache.helix.AccessOption;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.ZNRecordUpdater;
 import org.apache.helix.ZkUnitTestBase;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.manager.zk.ZkCacheBaseDataAccessor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -47,8 +45,8 @@ public class TestWtCacheAsyncOpSingleThread extends ZkUnitTestBase {
 
     // init zkCacheDataAccessor
     String curStatePath =
-        PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
-    String extViewPath = PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName);
+        PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
+    String extViewPath = PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName);
 
     ZkBaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_gZkClient);
 
@@ -66,7 +64,7 @@ public class TestWtCacheAsyncOpSingleThread extends ZkUnitTestBase {
     List<ZNRecord> records = new ArrayList<ZNRecord>();
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
+          PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
               "session_0", "TestDB" + i);
       ZNRecord record = new ZNRecord("TestDB" + i);
 
@@ -114,7 +112,7 @@ public class TestWtCacheAsyncOpSingleThread extends ZkUnitTestBase {
     records.clear();
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
+          PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
       ZNRecord record = new ZNRecord("TestDB" + i);
 
       paths.add(path);
@@ -135,7 +133,7 @@ public class TestWtCacheAsyncOpSingleThread extends ZkUnitTestBase {
     records.clear();
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
+          PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
       paths.add(path);
     }
 
@@ -155,7 +153,7 @@ public class TestWtCacheAsyncOpSingleThread extends ZkUnitTestBase {
     paths.clear();
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
+          PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
               "session_0", "TestDB" + i);
       paths.add(path);
     }
@@ -176,8 +174,8 @@ public class TestWtCacheAsyncOpSingleThread extends ZkUnitTestBase {
 
     // init zkCacheDataAccessor
     String curStatePath =
-        PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
-    String extViewPath = PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName);
+        PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
+    String extViewPath = PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName);
 
     ZkBaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_gZkClient);
 
@@ -196,7 +194,7 @@ public class TestWtCacheAsyncOpSingleThread extends ZkUnitTestBase {
     List<ZNRecord> records = new ArrayList<ZNRecord>();
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
+          PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
               "session_1", "TestDB" + i);
       ZNRecord record = new ZNRecord("TestDB" + i);
 

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestWtCacheSyncOpSingleThread.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestWtCacheSyncOpSingleThread.java
@@ -24,14 +24,12 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.helix.AccessOption;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.ZNRecordUpdater;
 import org.apache.helix.ZkUnitTestBase;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.manager.zk.ZkCacheBaseDataAccessor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -47,8 +45,8 @@ public class TestWtCacheSyncOpSingleThread extends ZkUnitTestBase {
 
     // init zkCacheDataAccessor
     String curStatePath =
-        PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
-    String extViewPath = PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName);
+        PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
+    String extViewPath = PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName);
 
     ZkBaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_gZkClient);
 
@@ -94,7 +92,7 @@ public class TestWtCacheSyncOpSingleThread extends ZkUnitTestBase {
     // set 10 external views
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
+          PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
       boolean success = accessor.set(path, new ZNRecord("TestDB" + i), AccessOption.PERSISTENT);
       Assert.assertTrue(success, "Should succeed in set: " + path);
     }
@@ -107,7 +105,7 @@ public class TestWtCacheSyncOpSingleThread extends ZkUnitTestBase {
     // get 10 external views
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
+          PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
       ZNRecord record = accessor.get(path, null, 0);
       Assert.assertEquals(record.getId(), "TestDB" + i);
     }
@@ -123,7 +121,7 @@ public class TestWtCacheSyncOpSingleThread extends ZkUnitTestBase {
     // exists
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
+          PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
               "session_0", "TestDB" + i);
 
       Assert.assertTrue(accessor.exists(path, 0));
@@ -141,7 +139,7 @@ public class TestWtCacheSyncOpSingleThread extends ZkUnitTestBase {
 
     // init zkCacheDataAccessor
     String curStatePath =
-        PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
+        PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
 
     ZkBaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_gZkClient);
 
@@ -151,7 +149,7 @@ public class TestWtCacheSyncOpSingleThread extends ZkUnitTestBase {
     // create 10 current states
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
+          PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
               "session_1", "TestDB" + i);
       boolean success = accessor.create(path, new ZNRecord("TestDB" + i), AccessOption.PERSISTENT);
       Assert.assertTrue(success, "Should succeed in create: " + path);
@@ -160,7 +158,7 @@ public class TestWtCacheSyncOpSingleThread extends ZkUnitTestBase {
     // create same 10 current states again, should fail
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
+          PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
               "session_1", "TestDB" + i);
       boolean success = accessor.create(path, new ZNRecord("TestDB" + i), AccessOption.PERSISTENT);
       Assert.assertFalse(success, "Should fail in create due to NodeExists: " + path);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKUtil.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
@@ -80,7 +80,7 @@ public class TestZKUtil extends ZkUnitTestBase {
     list.add(new ZNRecord("id1"));
     list.add(new ZNRecord("id2"));
     String path =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString());
     ZKUtil.createChildren(_zkClient, path, list);
     list = ZKUtil.getChildren(_zkClient, path);
@@ -97,7 +97,7 @@ public class TestZKUtil extends ZkUnitTestBase {
   @Test()
   public void testUpdateIfExists() {
     String path =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString(), "id3");
     ZNRecord record = new ZNRecord("id4");
     ZKUtil.updateIfExists(_zkClient, path, record, false);
@@ -112,7 +112,7 @@ public class TestZKUtil extends ZkUnitTestBase {
   @Test()
   public void testSubtract() {
     String path =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString(), "id5");
     ZNRecord record = new ZNRecord("id5");
     record.setSimpleField("key1", "value1");
@@ -125,7 +125,7 @@ public class TestZKUtil extends ZkUnitTestBase {
   @Test()
   public void testNullChildren() {
     String path =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString(), "id6");
     ZKUtil.createChildren(_zkClient, path, (List<ZNRecord>) null);
   }
@@ -133,7 +133,7 @@ public class TestZKUtil extends ZkUnitTestBase {
   @Test()
   public void testCreateOrUpdate() {
     String path =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString(), "id7");
     ZNRecord record = new ZNRecord("id7");
     ZKUtil.createOrUpdate(_zkClient, path, record, true, true);
@@ -144,7 +144,7 @@ public class TestZKUtil extends ZkUnitTestBase {
   @Test()
   public void testCreateOrReplace() {
     String path =
-        PropertyPathConfig.getPath(PropertyType.CONFIGS, clusterName,
+        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
             ConfigScopeProperty.PARTICIPANT.toString(), "id8");
     ZNRecord record = new ZNRecord("id8");
     ZKUtil.createOrReplace(_zkClient, path, record, true);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -26,17 +26,14 @@ import java.util.List;
 import org.I0Itec.zkclient.DataUpdater;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.ZNRecordUpdater;
 import org.apache.helix.ZkUnitTestBase;
-import org.apache.helix.manager.zk.ZNRecordSerializer;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor.AccessResult;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor.RetCode;
-import org.apache.helix.manager.zk.ZkClient;
 import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -374,12 +371,12 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     ZkBaseDataAccessor<ZNRecord> accessor = new ZkBaseDataAccessor<ZNRecord>(zkClient);
 
     // test async createChildren
-    String parentPath = PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1");
+    String parentPath = PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1");
     List<ZNRecord> records = new ArrayList<ZNRecord>();
     List<String> paths = new ArrayList<String>();
     for (int i = 0; i < 10; i++) {
       String msgId = "msg_" + i;
-      paths.add(PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1", msgId));
+      paths.add(PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1", msgId));
       records.add(new ZNRecord(msgId));
     }
     boolean[] success = accessor.createChildren(paths, records, AccessOption.PERSISTENT);
@@ -391,18 +388,18 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     // test get what we created
     for (int i = 0; i < 10; i++) {
       String msgId = "msg_" + i;
-      String path = PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1", msgId);
+      String path = PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1", msgId);
       ZNRecord record = zkClient.readData(path);
       Assert.assertEquals(record.getId(), msgId, "Should get what we created");
     }
 
     // test async setChildren
-    parentPath = PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1");
+    parentPath = PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1");
     records = new ArrayList<ZNRecord>();
     paths = new ArrayList<String>();
     for (int i = 0; i < 10; i++) {
       String msgId = "msg_" + i;
-      paths.add(PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1", msgId));
+      paths.add(PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1", msgId));
       ZNRecord newRecord = new ZNRecord(msgId);
       newRecord.setSimpleField("key1", "value1");
       records.add(newRecord);
@@ -416,20 +413,20 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     // test get what we set
     for (int i = 0; i < 10; i++) {
       String msgId = "msg_" + i;
-      String path = PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1", msgId);
+      String path = PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1", msgId);
       ZNRecord record = zkClient.readData(path);
       Assert.assertEquals(record.getSimpleFields().size(), 1, "Should have 1 simple field set");
       Assert.assertEquals(record.getSimpleField("key1"), "value1", "Should have value1 set");
     }
 
     // test async updateChildren
-    parentPath = PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1");
+    parentPath = PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1");
     // records = new ArrayList<ZNRecord>();
     List<DataUpdater<ZNRecord>> znrecordUpdaters = new ArrayList<DataUpdater<ZNRecord>>();
     paths = new ArrayList<String>();
     for (int i = 0; i < 10; i++) {
       String msgId = "msg_" + i;
-      paths.add(PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1", msgId));
+      paths.add(PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1", msgId));
       ZNRecord newRecord = new ZNRecord(msgId);
       newRecord.setSimpleField("key2", "value2");
       // records.add(newRecord);
@@ -444,14 +441,14 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     // test get what we updated
     for (int i = 0; i < 10; i++) {
       String msgId = "msg_" + i;
-      String path = PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1", msgId);
+      String path = PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1", msgId);
       ZNRecord record = zkClient.readData(path);
       Assert.assertEquals(record.getSimpleFields().size(), 2, "Should have 2 simple fields set");
       Assert.assertEquals(record.getSimpleField("key2"), "value2", "Should have value2 set");
     }
 
     // test async getChildren
-    parentPath = PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1");
+    parentPath = PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1");
     records = accessor.getChildren(parentPath, null, 0);
     for (int i = 0; i < 10; i++) {
       String msgId = "msg_" + i;
@@ -462,11 +459,11 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     }
 
     // test async exists
-    parentPath = PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1");
+    parentPath = PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1");
     paths = new ArrayList<String>();
     for (int i = 0; i < 10; i++) {
       String msgId = "msg_" + i;
-      paths.add(PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1", msgId));
+      paths.add(PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1", msgId));
     }
     boolean[] exists = accessor.exists(paths, 0);
     for (int i = 0; i < 10; i++) {
@@ -475,11 +472,11 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     }
 
     // test async getStats
-    parentPath = PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1");
+    parentPath = PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1");
     paths = new ArrayList<String>();
     for (int i = 0; i < 10; i++) {
       String msgId = "msg_" + i;
-      paths.add(PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1", msgId));
+      paths.add(PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1", msgId));
     }
     Stat[] stats = accessor.getStats(paths, 0);
     for (int i = 0; i < 10; i++) {
@@ -490,11 +487,11 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     }
 
     // test async remove
-    parentPath = PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1");
+    parentPath = PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1");
     paths = new ArrayList<String>();
     for (int i = 0; i < 10; i++) {
       String msgId = "msg_" + i;
-      paths.add(PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1", msgId));
+      paths.add(PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1", msgId));
     }
     success = accessor.remove(paths, 0);
     for (int i = 0; i < 10; i++) {
@@ -505,7 +502,7 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     // test get what we removed
     for (int i = 0; i < 10; i++) {
       String msgId = "msg_" + i;
-      String path = PropertyPathConfig.getPath(PropertyType.MESSAGES, root, "host_1", msgId);
+      String path = PropertyPathBuilder.getPath(PropertyType.MESSAGES, root, "host_1", msgId);
       boolean pathExists = zkClient.exists(path);
       Assert.assertFalse(pathExists, "Should be removed " + msgId);
     }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkCacheAsyncOpSingleThread.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkCacheAsyncOpSingleThread.java
@@ -26,16 +26,12 @@ import java.util.List;
 
 import org.I0Itec.zkclient.DataUpdater;
 import org.apache.helix.AccessOption;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.ZNRecordUpdater;
 import org.apache.helix.ZkUnitTestBase;
-import org.apache.helix.manager.zk.ZNRecordSerializer;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.manager.zk.ZkCacheBaseDataAccessor;
-import org.apache.helix.manager.zk.ZkClient;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -54,8 +50,8 @@ public class TestZkCacheAsyncOpSingleThread extends ZkUnitTestBase {
 
     // init zkCacheBaseDataAccessor
     String curStatePath =
-        PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
-    String extViewPath = PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName);
+        PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
+    String extViewPath = PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName);
 
     ZkBaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_gZkClient);
 
@@ -75,7 +71,7 @@ public class TestZkCacheAsyncOpSingleThread extends ZkUnitTestBase {
     List<ZNRecord> records = new ArrayList<ZNRecord>();
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
+          PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
               "session_0", "TestDB" + i);
       ZNRecord record = new ZNRecord("TestDB" + i);
 
@@ -134,7 +130,7 @@ public class TestZkCacheAsyncOpSingleThread extends ZkUnitTestBase {
     records.clear();
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
+          PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
       ZNRecord record = new ZNRecord("TestDB" + i);
 
       paths.add(path);
@@ -157,7 +153,7 @@ public class TestZkCacheAsyncOpSingleThread extends ZkUnitTestBase {
     paths.clear();
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
+          PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
 
       paths.add(path);
     }
@@ -189,8 +185,8 @@ public class TestZkCacheAsyncOpSingleThread extends ZkUnitTestBase {
 
     // init zkCacheDataAccessor
     String curStatePath =
-        PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
-    String extViewPath = PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName);
+        PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
+    String extViewPath = PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName);
 
     ZkBaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_gZkClient);
 
@@ -210,7 +206,7 @@ public class TestZkCacheAsyncOpSingleThread extends ZkUnitTestBase {
     List<ZNRecord> records = new ArrayList<ZNRecord>();
     for (int i = 0; i < 10; i++) {
       String path =
-          PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
+          PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901",
               "session_0", "TestDB" + i);
       ZNRecord record = new ZNRecord("TestDB" + i);
 
@@ -263,7 +259,7 @@ public class TestZkCacheAsyncOpSingleThread extends ZkUnitTestBase {
     for (int j = 0; j < 10; j++) {
       for (int i = 0; i < 10; i++) {
         String path =
-            PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
+            PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName, "TestDB" + i);
         ZNRecord record = new ZNRecord("TestDB" + i);
         record.setSimpleField("setKey", "" + j);
 
@@ -306,7 +302,7 @@ public class TestZkCacheAsyncOpSingleThread extends ZkUnitTestBase {
     paths.clear();
     for (int i = 0; i < 10; i++) {
       String path = curStatePath + "/session_0/TestDB" + i;
-      // // PropertyPathConfig.getPath(PropertyType.CURRENTSTATES,
+      // // PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES,
       // // clusterName,
       // // "localhost_8901",
       // // "session_0",

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkCacheSyncOpSingleThread.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkCacheSyncOpSingleThread.java
@@ -29,16 +29,12 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.apache.helix.AccessOption;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.ZNRecordUpdater;
 import org.apache.helix.ZkUnitTestBase;
-import org.apache.helix.manager.zk.ZNRecordSerializer;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.manager.zk.ZkCacheBaseDataAccessor;
-import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.store.HelixPropertyListener;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -88,8 +84,8 @@ public class TestZkCacheSyncOpSingleThread extends ZkUnitTestBase {
 
     // init zkCacheDataAccessor
     String curStatePath =
-        PropertyPathConfig.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
-    String extViewPath = PropertyPathConfig.getPath(PropertyType.EXTERNALVIEW, clusterName);
+        PropertyPathBuilder.getPath(PropertyType.CURRENTSTATES, clusterName, "localhost_8901");
+    String extViewPath = PropertyPathBuilder.getPath(PropertyType.EXTERNALVIEW, clusterName);
 
     ZkBaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_gZkClient);
 

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -29,7 +29,7 @@ import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.PropertyKey;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
@@ -96,7 +96,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     config.getRecord().setListField("dummy", dummyList);
     tool.addInstance(clusterName, config);
     tool.enableInstance(clusterName, instanceName, true);
-    String path = PropertyPathConfig.getPath(PropertyType.INSTANCES, clusterName, instanceName);
+    String path = PropertyPathBuilder.getPath(PropertyType.INSTANCES, clusterName, instanceName);
     AssertJUnit.assertTrue(_gZkClient.exists(path));
 
     try {
@@ -163,7 +163,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     ZNRecord stateModelRecord = new ZNRecord("id1");
     try {
       tool.addStateModelDef(clusterName, "id1", new StateModelDefinition(stateModelRecord));
-      path = PropertyPathConfig.getPath(PropertyType.STATEMODELDEFS, clusterName, "id1");
+      path = PropertyPathBuilder.getPath(PropertyType.STATEMODELDEFS, clusterName, "id1");
       AssertJUnit.assertTrue(_gZkClient.exists(path));
       Assert.fail("should fail");
     } catch (HelixException e) {
@@ -384,7 +384,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
       }
       tool.addInstance(clusterName, config);
       tool.enableInstance(clusterName, instanceName, true);
-      String path = PropertyPathConfig.getPath(PropertyType.INSTANCES, clusterName, instanceName);
+      String path = PropertyPathBuilder.getPath(PropertyType.INSTANCES, clusterName, instanceName);
       AssertJUnit.assertTrue(_gZkClient.exists(path));
     }
 

--- a/helix-core/src/test/java/org/apache/helix/mock/controller/MockController.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/controller/MockController.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
 
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.PropertyKey.Builder;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
@@ -40,7 +41,6 @@ import org.apache.helix.model.IdealState.IdealStateProperty;
 import org.apache.helix.model.LiveInstance.LiveInstanceProperty;
 import org.apache.helix.model.Message.MessageState;
 import org.apache.helix.model.Message.MessageType;
-import org.apache.helix.util.HelixUtil;
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -70,7 +70,7 @@ public class MockController {
     // message.setPartitionId(partitionId);
     message.setPartitionName(partitionKey);
 
-    String path = HelixUtil.getMessagePath(clusterName, instanceName) + "/" + message.getId();
+    String path = PropertyPathBuilder.instanceMessage(clusterName, instanceName, message.getId());
     ObjectMapper mapper = new ObjectMapper();
     StringWriter sw = new StringWriter();
     mapper.writeValueUsingView(sw, message, Message.class);
@@ -78,7 +78,7 @@ public class MockController {
     client.delete(path);
 
     Thread.sleep(10000);
-    ZNRecord record = client.readData(HelixUtil.getLiveInstancePath(clusterName, instanceName));
+    ZNRecord record = client.readData(PropertyPathBuilder.liveInstance(clusterName, instanceName));
     message.setTgtSessionId(record.getSimpleField(LiveInstanceProperty.SESSION_ID.toString())
         .toString());
     client.createPersistent(path, message);

--- a/helix-core/src/test/java/org/apache/helix/mock/spectator/MockSpectatorProcess.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/spectator/MockSpectatorProcess.java
@@ -26,12 +26,13 @@ import org.I0Itec.zkclient.ZkServer;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.spectator.RoutingTableProvider;
 import org.apache.helix.tools.ClusterSetup;
-import org.apache.helix.util.HelixUtil;
+
 
 /**
  * A MockSpectatorProcess to demonstrate the integration with cluster manager.
@@ -58,10 +59,8 @@ public class MockSpectatorProcess {
   public static void main(String[] args) throws Exception {
     setup();
     zkServer.getZkClient().setZkSerializer(new ZNRecordSerializer());
-    ZNRecord record =
-        zkServer.getZkClient().readData(HelixUtil.getIdealStatePath(clusterName, "TestDB"));
-
-    String externalViewPath = HelixUtil.getExternalViewPath(clusterName, "TestDB");
+    ZNRecord record = zkServer.getZkClient().readData(PropertyPathBuilder.idealState(clusterName, "TestDB"));
+    String externalViewPath = PropertyPathBuilder.externalView(clusterName, "TestDB");
 
     MockSpectatorProcess process = new MockSpectatorProcess();
     process.start();

--- a/helix-core/src/test/java/org/apache/helix/participant/TestDistControllerElection.java
+++ b/helix-core/src/test/java/org/apache/helix/participant/TestDistControllerElection.java
@@ -28,7 +28,7 @@ import org.apache.helix.HelixTimerTask;
 import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.PropertyKey.Builder;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
@@ -75,7 +75,7 @@ public class TestDistControllerElection extends ZkUnitTestBase {
     context.setType(NotificationContext.Type.INIT);
     election.onControllerChange(context);
 
-    // path = PropertyPathConfig.getPath(PropertyType.LEADER, clusterName);
+    // path = PropertyPathBuilder.getPath(PropertyType.LEADER, clusterName);
     // ZNRecord leaderRecord = _gZkClient.<ZNRecord> readData(path);
     LiveInstance liveInstance = accessor.getProperty(keyBuilder.controllerLeader());
     AssertJUnit.assertEquals(controllerName, liveInstance.getInstanceName());
@@ -132,7 +132,7 @@ public class TestDistControllerElection extends ZkUnitTestBase {
     LiveInstance liveInstance = accessor.getProperty(keyBuilder.controllerLeader());
     AssertJUnit.assertEquals(controllerName, liveInstance.getInstanceName());
 
-    // path = PropertyPathConfig.getPath(PropertyType.LEADER, clusterName);
+    // path = PropertyPathBuilder.getPath(PropertyType.LEADER, clusterName);
     // ZNRecord leaderRecord = _gZkClient.<ZNRecord> readData(path);
     // AssertJUnit.assertEquals(controllerName, leaderRecord.getSimpleField("LEADER"));
     // AssertJUnit.assertNotNull(election.getController());
@@ -182,7 +182,7 @@ public class TestDistControllerElection extends ZkUnitTestBase {
     context.setType(NotificationContext.Type.INIT);
     election.onControllerChange(context);
 
-    path = PropertyPathConfig.getPath(PropertyType.LEADER, clusterName);
+    path = PropertyPathBuilder.getPath(PropertyType.LEADER, clusterName);
     ZNRecord leaderRecord = _gZkClient.<ZNRecord> readData(path, true);
     AssertJUnit.assertNull(leaderRecord);
     // AssertJUnit.assertNull(election.getController());

--- a/helix-core/src/test/java/org/apache/helix/tools/TestClusterSetup.java
+++ b/helix-core/src/test/java/org/apache/helix/tools/TestClusterSetup.java
@@ -27,7 +27,7 @@ import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.PropertyKey;
-import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
@@ -41,7 +41,6 @@ import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
-import org.apache.helix.tools.ClusterSetup;
 import org.apache.log4j.Logger;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
@@ -435,7 +434,7 @@ public class TestClusterSetup extends ZkUnitTestBase {
 
     Assert.assertNull(accessor.getProperty(keyBuilder.instanceConfig("localhost_12918")),
         "Instance config should be dropped");
-    Assert.assertFalse(_gZkClient.exists(PropertyPathConfig.getPath(PropertyType.INSTANCES,
+    Assert.assertFalse(_gZkClient.exists(PropertyPathBuilder.getPath(PropertyType.INSTANCES,
         clusterName, "localhost_12918")), "Instance/host should be dropped");
 
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));


### PR DESCRIPTION
1. Make synchronized for AsyncCallback.startTimer to avoid race condition
2. Add test for SEMI_AUTO
3. More specific log message when verification is in progress
5. Assign orders for tests in TestSchedulerMessage
6. Rename PropertyPathConfig to PropertyPathBuilder
7. Move HelixUtil.get*Path to PropertyPathBuilder
8. Replace HelixDataAccessor.createProperty with more specific methods
9. Refactor isClusterSetup log structure for debugging purpose