### PR TITLE
[HELIX-653] Fix enable/disable partition in instances for resource specific

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
@@ -88,7 +88,7 @@ public abstract class AbstractRebalancer implements Rebalancer, MappingCalculato
       Map<String, String> currentStateMap =
           currentStateOutput.getCurrentStateMap(resource.getResourceName(), partition);
       Set<String> disabledInstancesForPartition =
-          cache.getDisabledInstancesForPartition(partition.toString());
+          cache.getDisabledInstancesForPartition(resource.getResourceName(), partition.toString());
       List<String> preferenceList = ConstraintBasedAssignment
           .getPreferenceList(partition, idealState,
               Collections.unmodifiableSet(cache.getLiveInstances().keySet()));

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
@@ -65,7 +65,7 @@ public class CustomRebalancer extends AbstractRebalancer {
       Map<String, String> currentStateMap =
           currentStateOutput.getCurrentStateMap(resource.getResourceName(), partition);
       Set<String> disabledInstancesForPartition =
-          cache.getDisabledInstancesForPartition(partition.toString());
+          cache.getDisabledInstancesForPartition(resource.getResourceName(), partition.toString());
       Map<String, String> idealStateMap =
           idealState.getInstanceStateMap(partition.getPartitionName());
       Map<String, String> bestStateForPartition =

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -318,7 +318,7 @@ public class DelayedAutoRebalancer extends AbstractRebalancer {
       Map<String, String> currentStateMap =
           currentStateOutput.getCurrentStateMap(resource.getResourceName(), partition);
       Set<String> disabledInstancesForPartition =
-          cache.getDisabledInstancesForPartition(partition.toString());
+          cache.getDisabledInstancesForPartition(resource.getResourceName(), partition.toString());
       List<String> preferenceList =
           ConstraintBasedAssignment.getPreferenceList(partition, idealState, activeNodes);
       Map<String, String> bestStateForPartition = ConstraintBasedAssignment

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
@@ -487,12 +487,12 @@ public class ClusterDataCache {
    * @param partition
    * @return
    */
-  public Set<String> getDisabledInstancesForPartition(String partition) {
+  public Set<String> getDisabledInstancesForPartition(String resource, String partition) {
     Set<String> disabledInstancesSet = new HashSet<String>();
     for (String instance : _instanceConfigMap.keySet()) {
       InstanceConfig config = _instanceConfigMap.get(instance);
       if (config.getInstanceEnabled() == false
-          || config.getInstanceEnabledForPartition(partition) == false) {
+          || config.getInstanceEnabledForPartition(resource, partition) == false) {
         disabledInstancesSet.add(instance);
       }
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -67,7 +67,7 @@ public class ReadClusterDataStage extends AbstractBaseStage {
       Set<String> instanceSet = Sets.newHashSet();
       Set<String> liveInstanceSet = Sets.newHashSet();
       Set<String> disabledInstanceSet = Sets.newHashSet();
-      Map<String, Set<String>> disabledPartitions = Maps.newHashMap();
+      Map<String, Map<String, String>> disabledPartitions = Maps.newHashMap();
       Map<String, Set<String>> tags = Maps.newHashMap();
       Map<String, LiveInstance> liveInstanceMap = _cache.getLiveInstances();
       for (Map.Entry<String, InstanceConfig> e : _cache.getInstanceConfigMap().entrySet()) {
@@ -80,11 +80,7 @@ public class ReadClusterDataStage extends AbstractBaseStage {
         if (!config.getInstanceEnabled()) {
           disabledInstanceSet.add(instanceName);
         }
-        List<String> disabledPartitionsList = config.getDisabledPartitions();
-        Set<String> partitionNames =
-            disabledPartitionsList != null ? new HashSet<String>(config.getDisabledPartitions())
-                : new HashSet<String>();
-        disabledPartitions.put(instanceName, partitionNames);
+        disabledPartitions.put(instanceName, config.getDisabledPartitionsMap());
         Set<String> instanceTags = Sets.newHashSet(config.getTags());
         tags.put(instanceName, instanceTags);
       }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -70,6 +70,7 @@ import org.apache.helix.model.Message.MessageType;
 import org.apache.helix.model.PauseSignal;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.tools.DefaultIdealStateCalculator;
+import org.apache.helix.util.HelixUtil;
 import org.apache.helix.util.RebalanceUtil;
 import org.apache.log4j.Logger;
 
@@ -300,24 +301,12 @@ public class ZKHelixAdmin implements HelixAdmin {
               + ", participant config is null");
         }
 
-        // TODO: merge with InstanceConfig.setInstanceEnabledForPartition
-        List<String> list =
-            currentData.getListField(InstanceConfigProperty.HELIX_DISABLED_PARTITION.toString());
-        Set<String> disabledPartitions = new HashSet<String>();
-        if (list != null) {
-          disabledPartitions.addAll(list);
+        InstanceConfig instanceConfig = new InstanceConfig(currentData);
+        for (String partitionName : partitionNames) {
+          instanceConfig.setInstanceEnabledForPartition(resourceName, partitionName, enabled);
         }
 
-        if (enabled) {
-          disabledPartitions.removeAll(partitionNames);
-        } else {
-          disabledPartitions.addAll(partitionNames);
-        }
-
-        list = new ArrayList<String>(disabledPartitions);
-        Collections.sort(list);
-        currentData.setListField(InstanceConfigProperty.HELIX_DISABLED_PARTITION.toString(), list);
-        return currentData;
+        return instanceConfig.getRecord();
       }
     }, AccessOption.PERSISTENT);
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -46,6 +46,7 @@ import org.apache.helix.task.TaskState;
 import org.apache.helix.task.Workflow;
 import org.apache.helix.task.WorkflowConfig;
 import org.apache.helix.task.WorkflowContext;
+import org.apache.helix.util.HelixUtil;
 import org.apache.log4j.Logger;
 
 import com.google.common.collect.Maps;
@@ -74,7 +75,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   private Set<String> _liveInstances = Collections.emptySet();
   private Set<String> _instances = Collections.emptySet();
   private Set<String> _disabledInstances = Collections.emptySet();
-  private Map<String, Set<String>> _disabledPartitions = Collections.emptyMap();
+  private Map<String, Map<String, String>> _disabledPartitions = Collections.emptyMap();
   private Map<String, Long> _instanceMsgQueueSizes = Maps.newConcurrentMap();
 
   private final ConcurrentHashMap<String, ResourceMonitor> _resourceMbeanMap =
@@ -130,11 +131,14 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     return _disabledInstances.size();
   }
 
-  @Override
-  public long getDisabledPartitionsGauge() {
+  @Override public long getDisabledPartitionsGauge() {
     int numDisabled = 0;
-    for (String instance : _disabledPartitions.keySet()) {
-      numDisabled += _disabledPartitions.get(instance).size();
+    for (Map<String, String> perInstance : _disabledPartitions.values()) {
+      for (String partitions : perInstance.values()) {
+        if (partitions != null) {
+          numDisabled += HelixUtil.deserializeByComma(partitions).size();
+        }
+      }
     }
     return numDisabled;
   }
@@ -196,7 +200,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
    * @param tags a map of instance name to the set of tags on it
    */
   public void setClusterInstanceStatus(Set<String> liveInstanceSet, Set<String> instanceSet,
-      Set<String> disabledInstanceSet, Map<String, Set<String>> disabledPartitions,
+      Set<String> disabledInstanceSet, Map<String, Map<String, String>> disabledPartitions,
       Map<String, Set<String>> tags) {
     // Unregister beans for instances that are no longer configured
     Set<String> toUnregister = Sets.newHashSet(_instanceMbeanMap.keySet());

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitorMBean.java
@@ -42,4 +42,10 @@ public interface InstanceMonitorMBean extends SensorNameProvider {
    * @return The total number of messages sent to this instance
    */
   public long getTotalMessageReceived();
+
+  /**
+   * Get the total disabled partitions number for this instance
+   * @return The total number of disabled partitions
+   */
+  public long getDisabledPartitions();
 }

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -19,6 +19,9 @@ package org.apache.helix.util;
  * under the License.
  */
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -66,6 +69,17 @@ public final class HelixUtil {
    */
   public static String getZkName(String path) {
     return path.substring(path.lastIndexOf('/') + 1);
+  }
+
+  public static String serializeByComma(List<String> objects) {
+    return String.join(",", objects);
+  }
+
+  public static List<String> deserializeByComma(String object) {
+    if (object.length() == 0) {
+      return Collections.EMPTY_LIST;
+    }
+    return Arrays.asList(object.split(","));
   }
 
   /**


### PR DESCRIPTION
Helix currently enable/disable partition in instances across all the resources if partition is same. Fix it with resource associated partition enable/disable.