### PR TITLE
Ignore instances with no instance configuration

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -602,7 +602,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     for (String instanceName : instances) {
       InstanceConfig config = accessor.getProperty(keyBuilder.instanceConfig(instanceName));
-      if (config.containsTag(tag)) {
+      if (config != null && config.containsTag(tag)) {
         result.add(instanceName);
       }
     }


### PR DESCRIPTION
Ignore instances with no instance configuration when fetching the list
of instances that have a specific tag.

The deletion order in ZKHelixAdmin#dropInstance deletes the instance
configuration before deleting the instance itself. If this is
interrupted midway, the instance configuration is deleted but the
instance is present in the list of instances.

When fetching the list of instances with a given tag, this means that
if an instance has its configuration missing, the instance
configuration will be null and the loop will exit with NPE. This patch
adds a null check to avoid aborting the loop.