### PR TITLE
Add Test for Batch Message ThreadPool

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -119,11 +119,11 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
   final ConcurrentHashMap<String, MsgHandlerFactoryRegistryItem> _hdlrFtyRegistry;
 
   final ConcurrentHashMap<String, ExecutorService> _executorMap;
-  
+
   /**
    * separate executor for executing batch messages
    */
-  private final ExecutorService _batchMessageExecutorService;
+  final ExecutorService _batchMessageExecutorService;
 
 
   /* Resources whose configuration for dedicate thread pool has been checked.*/


### PR DESCRIPTION
Add Test for Batch Message ThreadPool. For easy testing, change the private type to default type.