### PR TITLE
Make map in NotificationContext synchronized

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/NotificationContext.java
+++ b/helix-core/src/main/java/org/apache/helix/NotificationContext.java
@@ -21,6 +21,7 @@ package org.apache.helix;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Metadata associated with a notification event and the current state of the cluster
@@ -64,7 +65,7 @@ public class NotificationContext {
    */
   public NotificationContext(HelixManager manager) {
     _manager = manager;
-    _map = new HashMap<String, Object>();
+    _map = new ConcurrentHashMap<String, Object>();
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -35,7 +35,8 @@ public class ClusterConfig extends HelixProperty {
     PERSIST_BEST_POSSIBLE_ASSIGNMENT,
     FAULT_ZONE_TYPE, // the type in which isolation should be applied on when Helix places the replicas from same partition.
     DELAY_REBALANCE_DISABLED,  // enabled the delayed rebalaning in case node goes offline.
-    DELAY_REBALANCE_TIME     // delayed time in ms that the delay time Helix should hold until rebalancing.
+    DELAY_REBALANCE_TIME,     // delayed time in ms that the delay time Helix should hold until rebalancing.
+    BATCH_STATE_TRANSITION_MAX_THREADS
   }
 
   /**
@@ -81,6 +82,25 @@ public class ClusterConfig extends HelixProperty {
 
   public boolean isDelayRebalaceDisabled() {
     return _record.getBooleanField(ClusterConfigProperty.DELAY_REBALANCE_DISABLED.name(), false);
+  }
+
+  /**
+   * Set the customized batch message thread pool size
+   *
+   * @return
+   */
+  public void setBatchStateTransitionMaxThreads(int maxThreads) {
+    _record
+        .setIntField(ClusterConfigProperty.BATCH_STATE_TRANSITION_MAX_THREADS.name(), maxThreads);
+  }
+
+  /**
+   * Get the customized batch message thread pool size
+   *
+   * @return
+   */
+  public int getBatchStateTransitionMaxThreads() {
+    return _record.getIntField(ClusterConfigProperty.BATCH_STATE_TRANSITION_MAX_THREADS.name(), -1);
   }
 
   @Override

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestConfigThreadpoolSize.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestConfigThreadpoolSize.java
@@ -23,13 +23,16 @@ import java.util.HashSet;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.apache.helix.ConfigAccessor;
-import org.apache.helix.model.ConfigScope;
-import org.apache.helix.model.builder.ConfigScopeBuilder;
+import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.integration.ZkStandAloneCMTestBase;
+import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.messaging.DefaultMessagingService;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ConfigScope;
 import org.apache.helix.model.Message;
+import org.apache.helix.model.builder.ConfigScopeBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -118,5 +121,38 @@ public class TestConfigThreadpoolSize extends ZkStandAloneCMTestBase {
       }
       Assert.assertEquals(HelixTaskExecutor.DEFAULT_PARALLEL_TASKS, executor2.getMaximumPoolSize());
     }
+  }
+
+  @Test
+  public void testBatchMessageStateTransitionThreadPoolSize() throws InterruptedException {
+    int customizedThreads = 123;
+    for (MockParticipantManager participantManager : _participants) {
+      participantManager.syncStop();
+    }
+
+    HelixDataAccessor accessor = _manager.getHelixDataAccessor();
+    ClusterConfig clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+    clusterConfig.setBatchStateTransitionMaxThreads(customizedThreads);
+    accessor.setProperty(accessor.keyBuilder().clusterConfig(), clusterConfig);
+
+    // Since old participants already checked the threadpool, shutdown all of others
+    _setupTool.addInstanceToCluster(CLUSTER_NAME, "TestParticipant");
+    MockParticipantManager newParticipant =
+        new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, "TestParticipant");
+    newParticipant.syncStart();
+
+    // Let messsage trigger update thread pool
+    String dbName = "TestDBSubMessageThreadPool";
+    _setupTool.addResourceToCluster(CLUSTER_NAME, dbName, 5, "OnlineOffline");
+    _setupTool.rebalanceStorageCluster(CLUSTER_NAME, dbName, 1);
+
+    Thread.sleep(1000);
+
+    DefaultMessagingService svc = (DefaultMessagingService) (newParticipant.getMessagingService());
+    HelixTaskExecutor helixExecutor = svc.getExecutor();
+    Assert.assertEquals(
+        ((ThreadPoolExecutor) helixExecutor._batchMessageExecutorService).getMaximumPoolSize(),
+        customizedThreads);
+
   }
 }


### PR DESCRIPTION
One issue we observed is that when batch messages enabled, it will have NPE in ZNRecord merge record. Race condition could be the root cause. The only place can have race condition is the current state update map in NotificationContext, which is passed as input for multiple sub tasks in BatchMessageHandler.