### PR TITLE
[HELIX-654] Running task rebalance

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/JobConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobConfig.java
@@ -142,7 +142,12 @@ public class JobConfig extends ResourceConfig {
     /**
      * The expiration time for the job
      */
-    Expiry
+    Expiry,
+
+    /**
+     * Whether or not enable running task rebalance
+     */
+    RebalanceRunningTask
   }
 
   //Default property values
@@ -157,6 +162,7 @@ public class JobConfig extends ResourceConfig {
   public static final int DEFAULT_NUMBER_OF_TASKS = 0;
   public static final long DEFAULT_JOB_EXECUTION_START_TIME = -1L;
   public static final long DEFAULT_Job_EXECUTION_DELAY_TIME = -1L;
+  public static final boolean DEFAULT_REBALANCE_RUNNING_TASK = false;
 
   public JobConfig(HelixProperty property) {
     super(property.getRecord());
@@ -171,7 +177,8 @@ public class JobConfig extends ResourceConfig {
         jobConfig.getTaskRetryDelay(), jobConfig.isDisableExternalView(),
         jobConfig.isIgnoreDependentJobFailure(), jobConfig.getTaskConfigMap(),
         jobConfig.getJobType(), jobConfig.getInstanceGroupTag(), jobConfig.getExecutionDelay(),
-        jobConfig.getExecutionStart(), jobId, jobConfig.getExpiry());
+        jobConfig.getExecutionStart(), jobId, jobConfig.getExpiry(),
+        jobConfig.isRebalanceRunningTask());
   }
 
   private JobConfig(String workflow, String targetResource, List<String> targetPartitions,
@@ -180,7 +187,8 @@ public class JobConfig extends ResourceConfig {
       int maxForcedReassignmentsPerTask, int failureThreshold, long retryDelay,
       boolean disableExternalView, boolean ignoreDependentJobFailure,
       Map<String, TaskConfig> taskConfigMap, String jobType, String instanceGroupTag,
-      long executionDelay, long executionStart, String jobId, long expiry) {
+      long executionDelay, long executionStart, String jobId, long expiry,
+      boolean rebalanceRunningTask) {
     super(jobId);
     putSimpleConfig(JobConfigProperty.WorkflowID.name(), workflow);
     putSimpleConfig(JobConfigProperty.JobID.name(), jobId);
@@ -239,6 +247,8 @@ public class JobConfig extends ResourceConfig {
     }
     putSimpleConfig(ResourceConfigProperty.MONITORING_DISABLED.toString(),
         String.valueOf(WorkflowConfig.DEFAULT_MONITOR_DISABLE));
+    getRecord().setBooleanField(JobConfigProperty.RebalanceRunningTask.name(),
+        rebalanceRunningTask);
   }
 
   public String getWorkflow() {
@@ -354,6 +364,11 @@ public class JobConfig extends ResourceConfig {
     return getRecord().getLongField(JobConfigProperty.Expiry.name(), WorkflowConfig.DEFAULT_EXPIRY);
   }
 
+  public boolean isRebalanceRunningTask() {
+    return getRecord().getBooleanField(JobConfigProperty.RebalanceRunningTask.name(),
+        DEFAULT_REBALANCE_RUNNING_TASK);
+  }
+
   public static JobConfig fromHelixProperty(HelixProperty property)
       throws IllegalArgumentException {
     Map<String, String> configs = property.getRecord().getSimpleFields();
@@ -386,6 +401,7 @@ public class JobConfig extends ResourceConfig {
     private boolean _disableExternalView = DEFAULT_DISABLE_EXTERNALVIEW;
     private boolean _ignoreDependentJobFailure = DEFAULT_IGNORE_DEPENDENT_JOB_FAILURE;
     private int _numberOfTasks = DEFAULT_NUMBER_OF_TASKS;
+    private boolean _rebalanceRunningTask = DEFAULT_REBALANCE_RUNNING_TASK;
 
     public JobConfig build() {
       if (_targetResource == null && _taskConfigMap.isEmpty()) {
@@ -404,7 +420,8 @@ public class JobConfig extends ResourceConfig {
           _command, _commandConfig, _timeoutPerTask, _numConcurrentTasksPerInstance,
           _maxAttemptsPerTask, _maxForcedReassignmentsPerTask, _failureThreshold, _retryDelay,
           _disableExternalView, _ignoreDependentJobFailure, _taskConfigMap, _jobType,
-          _instanceGroupTag, _executionDelay, _executionStart, _jobId, _expiry);
+          _instanceGroupTag, _executionDelay, _executionStart, _jobId, _expiry,
+          _rebalanceRunningTask);
     }
 
     /**
@@ -479,6 +496,10 @@ public class JobConfig extends ResourceConfig {
       }
       if (cfg.containsKey(JobConfigProperty.Expiry.name())) {
         b.setExpiry(Long.valueOf(cfg.get(JobConfigProperty.Expiry.name())));
+      }
+      if (cfg.containsKey(JobConfigProperty.RebalanceRunningTask.name())) {
+        b.setRebalanceRunningTask(
+            Boolean.valueOf(cfg.get(JobConfigProperty.RebalanceRunningTask.name())));
       }
       return b;
     }
@@ -604,6 +625,11 @@ public class JobConfig extends ResourceConfig {
       return this;
     }
 
+    public Builder setRebalanceRunningTask(boolean enabled) {
+      _rebalanceRunningTask = enabled;
+      return this;
+    }
+
     private void validate() {
       if (_taskConfigMap.isEmpty() && _targetResource == null) {
         throw new IllegalArgumentException(
@@ -675,7 +701,8 @@ public class JobConfig extends ResourceConfig {
           .setDisableExternalView(jobBean.disableExternalView)
           .setIgnoreDependentJobFailure(jobBean.ignoreDependentJobFailure)
           .setNumberOfTasks(jobBean.numberOfTasks).setExecutionDelay(jobBean.executionDelay)
-          .setExecutionStart(jobBean.executionStart);
+          .setExecutionStart(jobBean.executionStart)
+          .setRebalanceRunningTask(jobBean.rebalanceRunningTask);
 
       if (jobBean.jobCommandConfigMap != null) {
         b.setJobCommandConfigMap(jobBean.jobCommandConfigMap);

--- a/helix-core/src/main/java/org/apache/helix/task/beans/JobBean.java
+++ b/helix-core/src/main/java/org/apache/helix/task/beans/JobBean.java
@@ -48,4 +48,5 @@ public class JobBean {
   public boolean disableExternalView = JobConfig.DEFAULT_DISABLE_EXTERNALVIEW;
   public boolean ignoreDependentJobFailure = JobConfig.DEFAULT_IGNORE_DEPENDENT_JOB_FAILURE;
   public int numberOfTasks = JobConfig.DEFAULT_NUMBER_OF_TASKS;
+  public boolean rebalanceRunningTask = JobConfig.DEFAULT_REBALANCE_RUNNING_TASK;
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/MockTask.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/MockTask.java
@@ -46,6 +46,8 @@ public class MockTask extends UserContentStore implements Task {
   private int _numOfSuccessBeforeFail;
   private String _errorMsg;
 
+  public static boolean _signalFail;
+
   public MockTask(TaskCallbackContext context) {
     Map<String, String> cfg = context.getJobConfig().getJobCommandConfigMap();
     if (cfg == null) {
@@ -86,6 +88,9 @@ public class MockTask extends UserContentStore implements Task {
         timeLeft = expiry - System.currentTimeMillis();
         return new TaskResult(TaskResult.Status.CANCELED, String.valueOf(timeLeft < 0 ? 0
             : timeLeft));
+      }
+      if (_signalFail) {
+        return new TaskResult(TaskResult.Status.FAILED, "Signaled to fail.");
       }
       sleep(50);
     }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TaskTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TaskTestBase.java
@@ -20,6 +20,7 @@ package org.apache.helix.integration.task;
  */
 
 import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.task.TaskSynchronizedTestBase;
 import org.apache.helix.tools.ClusterSetup;
 import org.apache.helix.tools.ClusterVerifiers.ClusterStateVerifier;
@@ -32,23 +33,12 @@ public class TaskTestBase extends TaskSynchronizedTestBase {
 
   @BeforeClass
   public void beforeClass() throws Exception {
-    String namespace = "/" + CLUSTER_NAME;
-    if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
-    }
-
-    _setupTool = new ClusterSetup(ZK_ADDR);
-    _setupTool.addCluster(CLUSTER_NAME, true);
-    setupParticipants();
-    setupDBs();
-    startParticipants();
+    super.beforeClass();
 
     // start controller
     String controllerName = CONTROLLER_PREFIX + "_0";
     _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
     _controller.syncStart();
-
-    createManagers();
 
     boolean result = ClusterStateVerifier.verifyByZkCallback(
         new ClusterStateVerifier.BestPossAndExtViewZkVerifier(ZK_ADDR, CLUSTER_NAME));

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TaskTestUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TaskTestUtil.java
@@ -287,4 +287,33 @@ public class TaskTestUtil {
 
     return event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.toString());
   }
+
+  /**
+   * Implement this class to periodically check whether a defined condition is true,
+   * if timeout, check the condition for the last time and return the result.
+   */
+  public static abstract class Poller {
+    private static final long DEFAULT_TIME_OUT = 1000*10;
+
+    public boolean poll() {
+      return poll(DEFAULT_TIME_OUT);
+    }
+
+    public boolean poll(long timeOut) {
+      long startTime = System.currentTimeMillis();
+      while (System.currentTimeMillis() < startTime + timeOut) {
+        if (check()) {
+          break;
+        }
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException e) {
+          throw new IllegalStateException(e);
+        }
+      }
+      return check();
+    }
+
+    public abstract boolean check();
+  }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestGenericTaskAssignmentCalculator.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestGenericTaskAssignmentCalculator.java
@@ -56,6 +56,7 @@ public class TestGenericTaskAssignmentCalculator extends TaskTestBase {
 
   @BeforeClass
   public void beforeClass() throws Exception {
+    _participants =  new MockParticipantManager[_numNodes];
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
       _gZkClient.deleteRecursive(namespace);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestIndependentTaskRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestIndependentTaskRebalancer.java
@@ -19,17 +19,17 @@ package org.apache.helix.integration.task;
  * under the License.
  */
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.TestHelper;
-import org.apache.helix.integration.ZkIntegrationTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.participant.StateMachineEngine;
@@ -54,10 +54,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.collections.Sets;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
 public class TestIndependentTaskRebalancer extends TaskTestBase {
   private Set<String> _invokedClasses = Sets.newHashSet();
   private Map<String, Integer> _runCounts = Maps.newHashMap();
@@ -65,6 +61,7 @@ public class TestIndependentTaskRebalancer extends TaskTestBase {
 
   @BeforeClass
   public void beforeClass() throws Exception {
+    _participants = new MockParticipantManager[_numNodes];
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
       _gZkClient.deleteRecursive(namespace);
@@ -177,7 +174,6 @@ public class TestIndependentTaskRebalancer extends TaskTestBase {
     _driver.start(workflowBuilder.build());
 
     // Ensure the job completes
-    _driver.pollForWorkflowState(jobName, TaskState.IN_PROGRESS);
     _driver.pollForWorkflowState(jobName, TaskState.COMPLETED);
 
     // Ensure that each class was invoked

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestRebalanceRunningTask.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestRebalanceRunningTask.java
@@ -1,0 +1,320 @@
+package org.apache.helix.integration.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.MasterSlaveSMD;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.JobContext;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.TaskSynchronizedTestBase;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.tools.ClusterSetup;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.apache.helix.tools.ClusterVerifiers.HelixClusterVerifier;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public final class TestRebalanceRunningTask extends TaskSynchronizedTestBase {
+
+  private ClusterControllerManager _controller;
+  private final String JOB = "test_job";
+  private String WORKFLOW;
+  private final String DATABASE = WorkflowGenerator.DEFAULT_TGT_DB;
+  private final int _initialNumNodes = 1;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _numNodes = 2;
+    _numParitions = 2;
+    _numReplicas = 1; // only Master, no Slave
+    _numDbs = 1;
+
+    _participants =  new MockParticipantManager[_numNodes];
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursive(namespace);
+    }
+
+    _setupTool = new ClusterSetup(ZK_ADDR);
+    _setupTool.addCluster(CLUSTER_NAME, true);
+    setupParticipants();
+    setupDBs();
+
+    createManagers();
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, CONTROLLER_PREFIX);
+    _controller.syncStart();
+  }
+
+  @BeforeMethod
+  public void beforeMethod() throws InterruptedException {
+    startParticipants(_initialNumNodes);
+    Thread.sleep(1000);
+  }
+
+  @AfterMethod
+  public void afterMethod() {
+    stopParticipants();
+    MockTask._signalFail = false;
+  }
+
+  private boolean checkTasksOnDifferentInstances() {
+    return new TaskTestUtil.Poller() {
+      @Override
+      public boolean check() {
+        try {
+          return getNumOfInstances() > 1;
+        } catch (NullPointerException e) {
+          return false;
+        }
+      }
+    }.poll();
+  }
+
+  private boolean checkTasksOnSameInstances() {
+    return new TaskTestUtil.Poller() {
+      @Override
+      public boolean check() {
+        try {
+          return getNumOfInstances() == 1;
+        } catch (NullPointerException e) {
+          return false;
+        }
+      }
+    }.poll();
+  }
+
+  private int getNumOfInstances() {
+    JobContext jobContext = _driver.getJobContext(TaskUtil.getNamespacedJobName(WORKFLOW, JOB));
+    Set<String> instances = new HashSet<String>();
+    for (int pId : jobContext.getPartitionSet()) {
+      instances.add(jobContext.getAssignedParticipant(pId));
+    }
+    return instances.size();
+  }
+
+  /**
+   * Task type: generic
+   * Rebalance raunning task: disabled
+   * Story: 1 node is down
+   */
+  @Test
+  public void testGenericTaskAndDisabledRebalanceAndNodeDown() throws InterruptedException {
+    WORKFLOW = TestHelper.getTestMethodName();
+    startParticipant(_initialNumNodes);
+
+    JobConfig.Builder jobBuilder = new JobConfig.Builder()
+        .setWorkflow(WORKFLOW)
+        .setNumberOfTasks(10) // should be enough for consistent hashing to place tasks on
+                              // different instances
+        .setNumConcurrentTasksPerInstance(100)
+        .setCommand(MockTask.TASK_COMMAND)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.TIMEOUT_CONFIG, "99999999")); // task stuck
+
+    Workflow.Builder workflowBuilder = new Workflow.Builder(WORKFLOW)
+        .addJob(JOB, jobBuilder);
+
+    _driver.start(workflowBuilder.build());
+
+    Assert.assertTrue(checkTasksOnDifferentInstances());
+    // Stop a participant, tasks rebalanced to the same instance
+    stopParticipant(_initialNumNodes);
+    Assert.assertTrue(checkTasksOnSameInstances());
+  }
+
+  /**
+   * Task type: generic
+   * Rebalance raunning task: disabled
+   * Story: new node added, then current task fails
+   */
+  @Test
+  public void testGenericTaskAndDisabledRebalanceAndNodeAddedAndTaskFail() throws InterruptedException {
+    WORKFLOW = TestHelper.getTestMethodName();
+    JobConfig.Builder jobBuilder = new JobConfig.Builder()
+        .setWorkflow(WORKFLOW)
+        .setNumberOfTasks(10)
+        .setNumConcurrentTasksPerInstance(100)
+        .setCommand(MockTask.TASK_COMMAND)
+        .setFailureThreshold(10)
+        .setMaxAttemptsPerTask(2)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.TIMEOUT_CONFIG, "99999999")); // task stuck
+
+    Workflow.Builder workflowBuilder = new Workflow.Builder(WORKFLOW)
+        .addJob(JOB, jobBuilder);
+
+    _driver.start(workflowBuilder.build());
+
+    // All tasks stuck on the same instance
+    Assert.assertTrue(checkTasksOnSameInstances());
+    // Add a new instance
+    startParticipant(_initialNumNodes);
+    Thread.sleep(3000);
+    // All tasks still stuck on the same instance, because RebalanceRunningTask is disabled
+    Assert.assertTrue(checkTasksOnSameInstances());
+    // Signal to fail all tasks
+    MockTask._signalFail = true;
+    // After fail, some task will be re-assigned to the new node.
+    // This doesn't require RebalanceRunningTask to be enabled
+    Assert.assertTrue(checkTasksOnDifferentInstances());
+  }
+
+  /**
+   * Task type: generic
+   * Rebalance raunning task: enabled
+   * Story: new node added
+   */
+  @Test
+  public void testGenericTaskAndEnabledRebalanceAndNodeAdded() throws InterruptedException {
+    WORKFLOW = TestHelper.getTestMethodName();
+    JobConfig.Builder jobBuilder = new JobConfig.Builder()
+        .setWorkflow(WORKFLOW)
+        .setNumberOfTasks(10)
+        .setNumConcurrentTasksPerInstance(100)
+        .setCommand(MockTask.TASK_COMMAND)
+        .setRebalanceRunningTask(true)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.TIMEOUT_CONFIG, "99999999")); // task stuck
+
+    Workflow.Builder workflowBuilder = new Workflow.Builder(WORKFLOW)
+        .addJob(JOB, jobBuilder);
+
+    _driver.start(workflowBuilder.build());
+
+    // All tasks stuck on the same instance
+    Assert.assertTrue(checkTasksOnSameInstances());
+    // Add a new instance, and some running tasks will be rebalanced to the new node
+    startParticipant(_initialNumNodes);
+    Assert.assertTrue(checkTasksOnDifferentInstances());
+  }
+
+  /**
+   * Task type: fixed target
+   * Rebalance raunning task: disabled
+   * Story: 1 node is down
+   */
+  @Test
+  public void testFixedTargetTaskAndDisabledRebalanceAndNodeDown() throws InterruptedException {
+    WORKFLOW = TestHelper.getTestMethodName();
+    startParticipant(_initialNumNodes);
+
+    JobConfig.Builder jobBuilder = new JobConfig.Builder()
+        .setWorkflow(WORKFLOW)
+        .setTargetResource(DATABASE)
+        .setNumConcurrentTasksPerInstance(100)
+        .setCommand(MockTask.TASK_COMMAND)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.TIMEOUT_CONFIG, "99999999"));
+
+    Workflow.Builder workflowBuilder = new Workflow.Builder(WORKFLOW)
+        .addJob(JOB, jobBuilder);
+
+    _driver.start(workflowBuilder.build());
+
+    Assert.assertTrue(checkTasksOnDifferentInstances());
+    // Stop a participant and partitions will be moved to the same instance,
+    // and tasks rebalanced accordingly
+    stopParticipant(_initialNumNodes);
+    Assert.assertTrue(checkTasksOnSameInstances());
+  }
+
+  /**
+   * Task type: fixed target
+   * Rebalance raunning task: disabled
+   * Story: new node added
+   */
+  @Test
+  public void testFixedTargetTaskAndDisabledRebalanceAndNodeAdded() throws InterruptedException {
+    WORKFLOW = TestHelper.getTestMethodName();
+    JobConfig.Builder jobBuilder = new JobConfig.Builder()
+        .setWorkflow(WORKFLOW)
+        .setTargetResource(DATABASE)
+        .setTargetPartitionStates(Sets.newHashSet(MasterSlaveSMD.States.MASTER.name()))
+        .setNumConcurrentTasksPerInstance(100)
+        .setFailureThreshold(2)
+        .setMaxAttemptsPerTask(2)
+        .setCommand(MockTask.TASK_COMMAND)
+        .setJobCommandConfigMap(
+            ImmutableMap.of(MockTask.TIMEOUT_CONFIG, "99999999")); // task stuck
+
+    Workflow.Builder workflowBuilder = new Workflow.Builder(WORKFLOW).addJob(JOB, jobBuilder);
+
+    _driver.start(workflowBuilder.build());
+
+    // All tasks stuck on the same instance
+    Assert.assertTrue(checkTasksOnSameInstances());
+    // Add a new instance, partition is rebalanced
+    startParticipant(_initialNumNodes);
+    HelixClusterVerifier clusterVerifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setResources(Sets.newHashSet(DATABASE)).build();
+    Assert.assertTrue(clusterVerifier.verify(10*1000));
+    // Running tasks are also rebalanced, even though RebalanceRunningTask is disabled
+    Assert.assertTrue(checkTasksOnDifferentInstances());
+  }
+
+  /**
+   * Task type: fixed target
+   * Rebalance raunning task: enabled
+   * Story: new node added
+   */
+  @Test
+  public void testFixedTargetTaskAndEnabledRebalanceAndNodeAdded() throws InterruptedException {
+    WORKFLOW = TestHelper.getTestMethodName();
+    JobConfig.Builder jobBuilder = new JobConfig.Builder()
+        .setWorkflow(WORKFLOW)
+        .setTargetResource(DATABASE)
+        .setTargetPartitionStates(Sets.newHashSet(MasterSlaveSMD.States.MASTER.name()))
+        .setNumConcurrentTasksPerInstance(100)
+        .setRebalanceRunningTask(true)
+        .setCommand(MockTask.TASK_COMMAND)
+        .setJobCommandConfigMap(
+            ImmutableMap.of(MockTask.TIMEOUT_CONFIG, "99999999")); // task stuck
+
+    Workflow.Builder workflowBuilder = new Workflow.Builder(WORKFLOW).addJob(JOB, jobBuilder);
+
+    _driver.start(workflowBuilder.build());
+
+    // All tasks stuck on the same instance
+    Assert.assertTrue(checkTasksOnSameInstances());
+    // Add a new instance, partition is rebalanced
+    startParticipant(_initialNumNodes);
+    HelixClusterVerifier clusterVerifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setResources(Sets.newHashSet(DATABASE)).build();
+    Assert.assertTrue(clusterVerifier.verify(10*1000));
+    // Running tasks are also rebalanced
+    Assert.assertTrue(checkTasksOnDifferentInstances());
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestUserContentStore.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestUserContentStore.java
@@ -54,6 +54,7 @@ public class TestUserContentStore extends TaskTestBase {
 
   @BeforeClass
   public void beforeClass() throws Exception {
+    _participants =  new MockParticipantManager[_numNodes];
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
       _gZkClient.deleteRecursive(namespace);


### PR DESCRIPTION
Add a job config RebalanceRunningTask.

For generic task, if feature is enabled, Helix will drop running
tasks that are assigned differently from the previous assignment,
which will cause cancellation of that running task on participant.
The task will then be re-assigned to a new instance.

For fix target task, running task always follows the partition, so
tasks are always re-assigned as needed.

Add different test cases for this feature enabled/disabled.

Ticket:
https://issues.apache.org/jira/browse/HELIX-654

Test:
mvn test in helix-core