### PR TITLE
Add support of setting/updating of cluster/resource/instance configs from ConfigAccessor.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ZNRecord.java
+++ b/helix-core/src/main/java/org/apache/helix/ZNRecord.java
@@ -512,7 +512,24 @@ public class ZNRecord {
   }
 
   /**
+   * Replace functionality is used to update this ZNRecord with the given ZNRecord. The value of a
+   * field in this record will be replaced with the value of the same field in given record if it
+   * presents. If there is new field in given ZNRecord but not in this record, add that field into
+   * this record. The list fields and map fields will be replaced as a single entry.
+   *
+   * @param record
+   */
+  public void update(ZNRecord record) {
+    if (record != null) {
+      simpleFields.putAll(record.simpleFields);
+      listFields.putAll(record.listFields);
+      mapFields.putAll(record.mapFields);
+    }
+  }
+
+  /**
    * Merge in a {@link ZNRecordDelta} corresponding to its merge policy
+   *
    * @param delta
    */
   void merge(ZNRecordDelta delta) {
@@ -520,6 +537,8 @@ public class ZNRecord {
       merge(delta.getRecord());
     } else if (delta.getMergeOperation() == MergeOperation.SUBTRACT) {
       subtract(delta.getRecord());
+    } else if (delta.getMergeOperation() == MergeOperation.UPDATE) {
+      update(delta.getRecord());
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/ZNRecordDelta.java
+++ b/helix-core/src/main/java/org/apache/helix/ZNRecordDelta.java
@@ -28,7 +28,8 @@ public class ZNRecordDelta {
    */
   public enum MergeOperation {
     ADD,
-    SUBTRACT
+    SUBTRACT,
+    UPDATE
   };
 
   /**
@@ -44,7 +45,7 @@ public class ZNRecordDelta {
   /**
    * Initialize the delta with a record and the update mode
    * @param record
-   * @param _mergeOperation
+   * @param mergeOperation
    */
   public ZNRecordDelta(ZNRecord record, MergeOperation mergeOperation) {
     _record = new ZNRecord(record);

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -127,6 +127,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
           rebalancer.init(manager);
           idealState =
               rebalancer.computeNewIdealState(resourceName, idealState, currentStateOutput, cache);
+          output.setPreferenceLists(resourceName, idealState.getPreferenceLists());
 
           // Use the internal MappingCalculator interface to compute the final assignment
           // The next release will support rebalancers that compute the mapping from start to finish
@@ -180,6 +181,8 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
       rebalancer = customizedRebalancer;
       break;
     default:
+      logger.error(
+          "Fail to find the rebalancer, invalid rebalance mode " + idealState.getRebalanceMode());
       break;
     }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateOutput.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateOutput.java
@@ -21,6 +21,7 @@ package org.apache.helix.controller.stages;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,6 +30,8 @@ import org.apache.helix.model.Partition;
 public class BestPossibleStateOutput {
   // Map of resource->partition->instance->state
   Map<String, Map<Partition, Map<String, String>>> _stateMap;
+  /* resource -> partition -> preference list */
+  private Map<String, Map<String, List<String>>> _preferenceLists;
 
   public BestPossibleStateOutput() {
     _stateMap = new HashMap<String, Map<Partition, Map<String, String>>>();
@@ -75,6 +78,45 @@ public class BestPossibleStateOutput {
 
   public Map<String, Map<Partition, Map<String, String>>> getStateMap() {
     return _stateMap;
+  }
+
+  public Map<String, Map<String, List<String>>> getPreferenceLists() {
+    return _preferenceLists;
+  }
+
+  public Map<String, List<String>> getPreferenceLists(String resource) {
+    if (_preferenceLists != null && _preferenceLists.containsKey(resource)) {
+      return _preferenceLists.get(resource);
+    }
+
+    return null;
+  }
+
+  public List<String> getPreferenceList(String resource, String partition) {
+    if (_preferenceLists != null && _preferenceLists.containsKey(resource) && _preferenceLists
+        .get(resource).containsKey(partition)) {
+      return _preferenceLists.get(resource).get(partition);
+    }
+
+    return null;
+  }
+
+  public void setPreferenceList(String resource, String partition, List<String> list) {
+    if (_preferenceLists == null) {
+      _preferenceLists = new HashMap<String, Map<String, List<String>>>();
+    }
+    if (!_preferenceLists.containsKey(resource)) {
+      _preferenceLists.put(resource, new HashMap<String, List<String>>());
+    }
+    _preferenceLists.get(resource).put(partition, list);
+  }
+
+  public void setPreferenceLists(String resource,
+      Map<String, List<String>> resourcePreferenceLists) {
+    if (_preferenceLists == null) {
+      _preferenceLists = new HashMap<String, Map<String, List<String>>>();
+    }
+    _preferenceLists.put(resource, resourcePreferenceLists);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/PersistAssignmentStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/PersistAssignmentStage.java
@@ -19,19 +19,16 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-
+import java.util.Set;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.controller.pipeline.AbstractBaseStage;
-import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.IdealState;
-import org.apache.helix.model.MasterSlaveSMD;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
 import org.apache.log4j.Logger;
@@ -49,56 +46,58 @@ public class PersistAssignmentStage extends AbstractBaseStage {
     ClusterDataCache cache = event.getAttribute("ClusterDataCache");
     ClusterConfig clusterConfig = cache.getClusterConfig();
 
-    if (clusterConfig.isPersistBestPossibleAssignment()) {
-      HelixManager helixManager = event.getAttribute("helixmanager");
-      HelixDataAccessor accessor = helixManager.getHelixDataAccessor();
-      PropertyKey.Builder keyBuilder = accessor.keyBuilder();
-      BestPossibleStateOutput bestPossibleAssignments =
-          event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.toString());
-      Map<String, Resource> resourceMap = event.getAttribute(AttributeName.RESOURCES.toString());
+    if (!clusterConfig.isPersistBestPossibleAssignment()) {
+      return;
+    }
 
-      for (String resourceId : bestPossibleAssignments.resourceSet()) {
-        Resource resource = resourceMap.get(resourceId);
-        if (resource != null) {
-          boolean changed = false;
-          Map<Partition, Map<String, String>> bestPossibleAssignment =
-              bestPossibleAssignments.getResourceMap(resourceId);
-          IdealState idealState = cache.getIdealState(resourceId);
-          if (idealState == null) {
-            LOG.warn("IdealState not found for resource " + resourceId);
-            continue;
-          }
-          IdealState.RebalanceMode mode = idealState.getRebalanceMode();
-          if (!mode.equals(IdealState.RebalanceMode.SEMI_AUTO) && !mode
-              .equals(IdealState.RebalanceMode.FULL_AUTO)) {
-            // do not persist assignment for resource in neither semi or full auto.
-            continue;
-          }
+    BestPossibleStateOutput bestPossibleAssignment =
+        event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.name());
 
-          //TODO: temporary solution for Espresso/Dbus backcompatible, should remove this.
-          Map<Partition, Map<String, String>> assignmentToPersist =
-              convertAssignmentPersisted(resource, idealState, bestPossibleAssignment);
+    HelixManager helixManager = event.getAttribute("helixmanager");
+    HelixDataAccessor accessor = helixManager.getHelixDataAccessor();
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    Map<String, Resource> resourceMap = event.getAttribute(AttributeName.RESOURCES.name());
 
-          for (Partition partition : resource.getPartitions()) {
-            Map<String, String> instanceMap = assignmentToPersist.get(partition);
-            Map<String, String> existInstanceMap =
-                idealState.getInstanceStateMap(partition.getPartitionName());
-            if (instanceMap == null && existInstanceMap == null) {
-              continue;
-            }
-            if (instanceMap == null || existInstanceMap == null || !instanceMap
-                .equals(existInstanceMap)) {
-              changed = true;
-              break;
-            }
+    for (String resourceId : bestPossibleAssignment.resourceSet()) {
+      Resource resource = resourceMap.get(resourceId);
+      if (resource != null) {
+        final IdealState idealState = cache.getIdealState(resourceId);
+        if (idealState == null) {
+          LOG.warn("IdealState not found for resource " + resourceId);
+          continue;
+        }
+        IdealState.RebalanceMode mode = idealState.getRebalanceMode();
+        if (!mode.equals(IdealState.RebalanceMode.SEMI_AUTO) && !mode
+            .equals(IdealState.RebalanceMode.FULL_AUTO)) {
+          // do not persist assignment for resource in neither semi or full auto.
+          continue;
+        }
+
+        boolean needPersist = false;
+        if (mode.equals(IdealState.RebalanceMode.FULL_AUTO)) {
+          // persist preference list in ful-auto mode.
+          Map<String, List<String>> newLists =
+              bestPossibleAssignment.getPreferenceLists(resourceId);
+          if (newLists != null && hasPreferenceListChanged(newLists, idealState)) {
+            idealState.setPreferenceLists(newLists);
+            needPersist = true;
           }
-          if (changed) {
-            for (Partition partition : assignmentToPersist.keySet()) {
-              Map<String, String> instanceMap = assignmentToPersist.get(partition);
-              idealState.setInstanceStateMap(partition.getPartitionName(), instanceMap);
-            }
-            accessor.setProperty(keyBuilder.idealStates(resourceId), idealState);
+        }
+
+        Map<Partition, Map<String, String>> bestPossibleAssignements =
+            bestPossibleAssignment.getResourceMap(resourceId);
+
+        if (bestPossibleAssignements != null && hasInstanceMapChanged(bestPossibleAssignements,
+            idealState)) {
+          for (Partition partition : bestPossibleAssignements.keySet()) {
+            Map<String, String> instanceMap = bestPossibleAssignements.get(partition);
+            idealState.setInstanceStateMap(partition.getPartitionName(), instanceMap);
           }
+          needPersist = true;
+        }
+
+        if (needPersist) {
+          accessor.setProperty(keyBuilder.idealStates(resourceId), idealState);
         }
       }
     }
@@ -108,47 +107,50 @@ public class PersistAssignmentStage extends AbstractBaseStage {
   }
 
   /**
-   * TODO: This is a temporary hacky for back-compatible support of Espresso and Databus,
-   * we should get rid of this conversion as soon as possible.
-   * --- Lei, 2016/9/9.
+   * has the preference list changed from the one persisted in current IdealState
    */
-  private Map<Partition, Map<String, String>> convertAssignmentPersisted(Resource resource,
-      IdealState idealState, Map<Partition, Map<String, String>> bestPossibleAssignment) {
-    String stateModelDef = idealState.getStateModelDefRef();
-    /** Only convert for MasterSlave resources */
-    if (!stateModelDef.equals(BuiltInStateModelDefinitions.MasterSlave.name())) {
-      return bestPossibleAssignment;
+  private boolean hasPreferenceListChanged(Map<String, List<String>> newLists,
+      IdealState idealState) {
+    Map<String, List<String>> existLists = idealState.getPreferenceLists();
+
+    Set<String> partitions = new HashSet<String>(newLists.keySet());
+    partitions.addAll(existLists.keySet());
+
+    for (String partition : partitions) {
+      List<String> assignedInstances = newLists.get(partition);
+      List<String> existingInstances = existLists.get(partition);
+      if (assignedInstances == null && existingInstances == null) {
+        continue;
+      }
+      if (assignedInstances == null || existingInstances == null || !assignedInstances
+          .equals(existingInstances)) {
+        return true;
+      }
     }
 
-    Map<Partition, Map<String, String>> assignmentToPersist =
-        new HashMap<Partition, Map<String, String>>();
+    return false;
+  }
 
-    for (Partition partition : resource.getPartitions()) {
-      Map<String, String> instanceMap = new HashMap<String, String>();
-      instanceMap.putAll(bestPossibleAssignment.get(partition));
-
-      List<String> preferenceList = idealState.getPreferenceList(partition.getPartitionName());
-      boolean hasMaster = false;
-      for (String ins : preferenceList) {
-        String state = instanceMap.get(ins);
-        if (state == null || (!state.equals(MasterSlaveSMD.States.SLAVE.name()) && !state
-            .equals(MasterSlaveSMD.States.MASTER.name()))) {
-          instanceMap.put(ins, MasterSlaveSMD.States.SLAVE.name());
-        }
-
-        if (state != null && state.equals(MasterSlaveSMD.States.MASTER.name())) {
-          hasMaster = true;
-        }
-      }
-
-      // if no master, just pick the first node in the preference list as the master.
-      if (!hasMaster && preferenceList.size() > 0) {
-        instanceMap.put(preferenceList.get(0), MasterSlaveSMD.States.MASTER.name());
-      }
-
-      assignmentToPersist.put(partition, instanceMap);
+  private boolean hasInstanceMapChanged(Map<Partition, Map<String, String>> newAssiments,
+      IdealState idealState) {
+    Set<Partition> partitions = new HashSet<Partition>(newAssiments.keySet());
+    for (String p : idealState.getPartitionSet()) {
+      partitions.add(new Partition(p));
     }
 
-    return assignmentToPersist;
+    for (Partition partition : partitions) {
+      Map<String, String> instanceMap = newAssiments.get(partition);
+      Map<String, String> existInstanceMap =
+          idealState.getInstanceStateMap(partition.getPartitionName());
+      if (instanceMap == null && existInstanceMap == null) {
+        continue;
+      }
+      if (instanceMap == null || existInstanceMap == null || !instanceMap
+          .equals(existInstanceMap)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -68,6 +68,21 @@ public class ClusterConfig extends HelixProperty {
   }
 
   /**
+   * Enable/Disable persist best possible assignment in a resource's idealstate.
+   *
+   * @return
+   */
+  public void setPersistBestPossibleAssignment(Boolean enable) {
+    if (enable == null) {
+      _record.getSimpleFields()
+          .remove(ClusterConfigProperty.PERSIST_BEST_POSSIBLE_ASSIGNMENT.toString());
+    } else {
+      _record.setBooleanField(ClusterConfigProperty.PERSIST_BEST_POSSIBLE_ASSIGNMENT.toString(),
+          enable);
+    }
+  }
+
+  /**
    *
    * @return
    */

--- a/helix-core/src/test/java/org/apache/helix/integration/ZkIntegrationTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/ZkIntegrationTestBase.java
@@ -104,15 +104,11 @@ public class ZkIntegrationTestBase {
   }
 
   protected void enablePersistBestPossibleAssignment(ZkClient zkClient, String clusterName,
-      Boolean enable) {
+      Boolean enabled) {
     ConfigAccessor configAccessor = new ConfigAccessor(zkClient);
-    HelixConfigScope clusterScope =
-        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER)
-            .forCluster(clusterName).build();
-
-    configAccessor.set(clusterScope,
-        ClusterConfig.ClusterConfigProperty.PERSIST_BEST_POSSIBLE_ASSIGNMENT.name(),
-        enable.toString());
+    ClusterConfig clusterConfig = configAccessor.getClusterConfig(clusterName);
+    clusterConfig.setPersistBestPossibleAssignment(enabled);
+    configAccessor.setClusterConfig(clusterName, clusterConfig);
   }
 
   protected void disableDelayRebalanceInCluster(ZkClient zkClient, String clusterName,

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKUtil.java
@@ -19,16 +19,15 @@ package org.apache.helix.manager.zk;
  * under the License.
  */
 
-import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
-
+import java.util.Map;
 import org.apache.helix.PropertyPathBuilder;
-import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.ZkUnitTestBase;
-import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
@@ -42,7 +41,7 @@ public class TestZKUtil extends ZkUnitTestBase {
   ZkClient _zkClient;
 
   @BeforeClass()
-  public void beforeClass() throws IOException, Exception {
+  public void beforeClass() throws Exception {
     _zkClient = new ZkClient(ZK_ADDR);
     _zkClient.setZkSerializer(new ZNRecordSerializer());
     if (_zkClient.exists("/" + clusterName)) {
@@ -79,9 +78,7 @@ public class TestZKUtil extends ZkUnitTestBase {
     List<ZNRecord> list = new ArrayList<ZNRecord>();
     list.add(new ZNRecord("id1"));
     list.add(new ZNRecord("id2"));
-    String path =
-        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
-            ConfigScopeProperty.PARTICIPANT.toString());
+    String path = PropertyPathBuilder.instanceConfig(clusterName);
     ZKUtil.createChildren(_zkClient, path, list);
     list = ZKUtil.getChildren(_zkClient, path);
     AssertJUnit.assertEquals(2, list.size());
@@ -96,63 +93,117 @@ public class TestZKUtil extends ZkUnitTestBase {
 
   @Test()
   public void testUpdateIfExists() {
-    String path =
-        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
-            ConfigScopeProperty.PARTICIPANT.toString(), "id3");
+    String path = PropertyPathBuilder.instanceConfig(clusterName, "id3");
     ZNRecord record = new ZNRecord("id4");
     ZKUtil.updateIfExists(_zkClient, path, record, false);
     AssertJUnit.assertFalse(_zkClient.exists(path));
     _zkClient.createPersistent(path);
     ZKUtil.updateIfExists(_zkClient, path, record, false);
     AssertJUnit.assertTrue(_zkClient.exists(path));
-    record = _zkClient.<ZNRecord> readData(path);
+    record = _zkClient.readData(path);
     AssertJUnit.assertEquals("id4", record.getId());
   }
 
   @Test()
   public void testSubtract() {
-    String path =
-        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
-            ConfigScopeProperty.PARTICIPANT.toString(), "id5");
+    String path = PropertyPathBuilder.instanceConfig(clusterName, "id5");
     ZNRecord record = new ZNRecord("id5");
     record.setSimpleField("key1", "value1");
     _zkClient.createPersistent(path, record);
     ZKUtil.subtract(_zkClient, path, record);
-    record = _zkClient.<ZNRecord> readData(path);
+    record = _zkClient.readData(path);
     AssertJUnit.assertNull(record.getSimpleField("key1"));
   }
 
   @Test()
   public void testNullChildren() {
-    String path =
-        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
-            ConfigScopeProperty.PARTICIPANT.toString(), "id6");
+    String path = PropertyPathBuilder.instanceConfig(clusterName, "id6");
     ZKUtil.createChildren(_zkClient, path, (List<ZNRecord>) null);
   }
 
   @Test()
-  public void testCreateOrUpdate() {
-    String path =
-        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
-            ConfigScopeProperty.PARTICIPANT.toString(), "id7");
+  public void testCreateOrMerge() {
+    String path = PropertyPathBuilder.instanceConfig(clusterName, "id7");
     ZNRecord record = new ZNRecord("id7");
-    ZKUtil.createOrUpdate(_zkClient, path, record, true, true);
-    record = _zkClient.<ZNRecord> readData(path);
-    AssertJUnit.assertEquals("id7", record.getId());
+    List<String> list = Arrays.asList("value1");
+    record.setListField("list", list);
+    ZKUtil.createOrMerge(_zkClient, path, record, true, true);
+    record = _zkClient.readData(path);
+    AssertJUnit.assertEquals(list, record.getListField("list"));
+
+    record = new ZNRecord("id7");
+    List<String> list2 = Arrays.asList("value2");
+    record.setListField("list", list2);
+    ZKUtil.createOrMerge(_zkClient, path, record, true, true);
+    record = _zkClient.readData(path);
+    AssertJUnit.assertEquals(Arrays.asList("value1", "value2"), record.getListField("list"));
+
+    Map<String, String> map = new HashMap<String, String>() {{put("k1", "v1");}};
+    record.setMapField("map", map);
+    ZKUtil.createOrMerge(_zkClient, path, record, true, true);
+    record = _zkClient.readData(path);
+    AssertJUnit.assertEquals(map, record.getMapField("map"));
+
+    record = new ZNRecord("id7");
+    Map<String, String> map2 = new HashMap<String, String>() {{put("k2", "v2");}};
+    record.setMapField("map", map2);
+    ZKUtil.createOrMerge(_zkClient, path, record, true, true);
+    record = _zkClient.readData(path);
+    AssertJUnit.assertEquals(new HashMap<String, String>() {{
+      put("k1", "v1");
+      put("k2", "v2");
+    }}, record.getMapField("map"));
   }
 
   @Test()
   public void testCreateOrReplace() {
-    String path =
-        PropertyPathBuilder.getPath(PropertyType.CONFIGS, clusterName,
-            ConfigScopeProperty.PARTICIPANT.toString(), "id8");
+    String path = PropertyPathBuilder.instanceConfig(clusterName, "id8");
     ZNRecord record = new ZNRecord("id8");
     ZKUtil.createOrReplace(_zkClient, path, record, true);
-    record = _zkClient.<ZNRecord> readData(path);
+    record = _zkClient.readData(path);
     AssertJUnit.assertEquals("id8", record.getId());
     record = new ZNRecord("id9");
     ZKUtil.createOrReplace(_zkClient, path, record, true);
-    record = _zkClient.<ZNRecord> readData(path);
+    record = _zkClient.readData(path);
     AssertJUnit.assertEquals("id9", record.getId());
+  }
+
+  @Test()
+  public void testCreateOrUpdate() {
+    String path = PropertyPathBuilder.instanceConfig(clusterName, "id7");
+    ZNRecord record = new ZNRecord("id7");
+    ZKUtil.createOrMerge(_zkClient, path, record, true, true);
+    record = _zkClient.readData(path);
+    AssertJUnit.assertEquals("id7", record.getId());
+
+    record = new ZNRecord("id7");
+    List<String> list = Arrays.asList("value1", "value2");
+    record.setListField("list", list);
+    ZKUtil.createOrUpdate(_zkClient, path, record, true, true);
+    record = _zkClient.readData(path);
+    AssertJUnit.assertEquals(list, record.getListField("list"));
+
+    record = new ZNRecord("id7");
+    List<String> list2 = Arrays.asList("value3", "value4");
+    record.setListField("list", list2);
+    ZKUtil.createOrUpdate(_zkClient, path, record, true, true);
+    record = _zkClient.readData(path);
+    AssertJUnit.assertEquals(list2, record.getListField("list"));
+
+
+    Map<String, String> map = new HashMap<String, String>() {{put("k1", "v1");}};
+    record.setMapField("map", map);
+    ZKUtil.createOrUpdate(_zkClient, path, record, true, true);
+    record = _zkClient.readData(path);
+    AssertJUnit.assertEquals(map, record.getMapField("map"));
+
+    record = new ZNRecord("id7");
+    Map<String, String> map2 = new HashMap<String, String>() {{put("k2", "v2");}};
+    record.setMapField("map", map2);
+    ZKUtil.createOrUpdate(_zkClient, path, record, true, true);
+    record = _zkClient.readData(path);
+    AssertJUnit.assertEquals(new HashMap<String, String>() {{
+      put("k2", "v2");
+    }}, record.getMapField("map"));
   }
 }


### PR DESCRIPTION
This pull requests contains two commits:

-     Add support of setting/updating Cluster/Resource/Instance configs in ConfigAccessor.
-     Allow user to enable persisting preference list and best possible state map into IdealState in full-auto mode.
