### PR TITLE
[HELIX-655] Helix per-participant concurrent task throttling

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -19,8 +19,10 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
+import java.util.Iterator;
 import java.util.Map;
 
+import java.util.PriorityQueue;
 import org.apache.helix.HelixManager;
 import org.apache.helix.controller.pipeline.AbstractBaseStage;
 import org.apache.helix.controller.pipeline.StageException;
@@ -34,7 +36,11 @@ import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
+import org.apache.helix.task.JobContext;
+import org.apache.helix.task.JobRebalancer;
+import org.apache.helix.task.TaskDriver;
 import org.apache.helix.task.TaskRebalancer;
+import org.apache.helix.task.WorkflowContext;
 import org.apache.helix.util.HelixUtil;
 import org.apache.log4j.Logger;
 
@@ -60,6 +66,9 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
           + ". Requires CURRENT_STATE|RESOURCES|DataCache");
     }
 
+    // Reset current INIT/RUNNING tasks on participants for throttling
+    cache.resetActiveTaskCount(currentStateOutput);
+
     BestPossibleStateOutput bestPossibleStateOutput =
         compute(event, resourceMap, currentStateOutput);
     event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
@@ -81,70 +90,85 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
 
   private BestPossibleStateOutput compute(ClusterEvent event, Map<String, Resource> resourceMap,
       CurrentStateOutput currentStateOutput) {
+    ClusterDataCache cache = event.getAttribute("ClusterDataCache");
+
+    BestPossibleStateOutput output = new BestPossibleStateOutput();
+
+    PriorityQueue<ResourcePriority> resourcePriorityQueue = new PriorityQueue<ResourcePriority>();
+    TaskDriver taskDriver = null;
+    HelixManager helixManager = event.getAttribute("helixmanager");
+    if (helixManager != null) {
+      taskDriver = new TaskDriver(helixManager);
+    }
+    for (Resource resource : resourceMap.values()) {
+      resourcePriorityQueue.add(new ResourcePriority(resource, cache.getIdealState(resource.getResourceName()),
+          taskDriver));
+    }
+
+    Iterator<ResourcePriority> itr = resourcePriorityQueue.iterator();
+    while (itr.hasNext()) {
+      computeResourceBestPossibleState(event, cache, currentStateOutput, itr.next().getResource(), output);
+    }
+
+    return output;
+  }
+
+  private void computeResourceBestPossibleState(ClusterEvent event, ClusterDataCache cache,
+      CurrentStateOutput currentStateOutput, Resource resource, BestPossibleStateOutput output) {
     // for each ideal state
     // read the state model def
     // for each resource
     // get the preference list
     // for each instanceName check if its alive then assign a state
-    ClusterDataCache cache = event.getAttribute("ClusterDataCache");
 
-    BestPossibleStateOutput output = new BestPossibleStateOutput();
+    String resourceName = resource.getResourceName();
+    logger.debug("Processing resource:" + resourceName);
+    // Ideal state may be gone. In that case we need to get the state model name
+    // from the current state
+    IdealState idealState = cache.getIdealState(resourceName);
 
-    for (String resourceName : resourceMap.keySet()) {
-      logger.debug("Processing resource:" + resourceName);
+    if (idealState == null) {
+      // if ideal state is deleted, use an empty one
+      logger.info("resource:" + resourceName + " does not exist anymore");
+      idealState = new IdealState(resourceName);
+      idealState.setStateModelDefRef(resource.getStateModelDefRef());
+    }
 
-      Resource resource = resourceMap.get(resourceName);
-      // Ideal state may be gone. In that case we need to get the state model name
-      // from the current state
-      IdealState idealState = cache.getIdealState(resourceName);
+    Rebalancer rebalancer = getRebalancer(idealState, resourceName);
+    MappingCalculator mappingCalculator = getMappingCalculator(rebalancer, resourceName);
 
-      if (idealState == null) {
-        // if ideal state is deleted, use an empty one
-        logger.info("resource:" + resourceName + " does not exist anymore");
-        idealState = new IdealState(resourceName);
-        idealState.setStateModelDefRef(resource.getStateModelDefRef());
+    if (rebalancer == null || mappingCalculator == null) {
+      logger.error("Error computing assignment for resource " + resourceName
+          + ". no rebalancer found. rebalancer: " + rebalancer + " mappingCaculator: "
+          + mappingCalculator);
+    }
+
+    if (rebalancer != null && mappingCalculator != null) {
+
+      if (rebalancer instanceof TaskRebalancer) {
+        TaskRebalancer taskRebalancer = TaskRebalancer.class.cast(rebalancer);
+        taskRebalancer.setClusterStatusMonitor(
+            (ClusterStatusMonitor) event.getAttribute("clusterStatusMonitor"));
       }
 
-      Rebalancer rebalancer = getRebalancer(idealState, resourceName);
-      MappingCalculator mappingCalculator = getMappingCalculator(rebalancer, resourceName);
+      try {
+        HelixManager manager = event.getAttribute("helixmanager");
+        rebalancer.init(manager);
+        idealState = rebalancer.computeNewIdealState(resourceName, idealState, currentStateOutput, cache);
+        output.setPreferenceLists(resourceName, idealState.getPreferenceLists());
 
-      if (rebalancer == null || mappingCalculator == null) {
-        logger.error("Error computing assignment for resource " + resourceName
-            + ". no rebalancer found. rebalancer: " + rebalancer + " mappingCaculator: "
-            + mappingCalculator);
-      }
-
-      if (rebalancer != null && mappingCalculator != null) {
-
-        if (rebalancer instanceof TaskRebalancer) {
-          TaskRebalancer taskRebalancer = TaskRebalancer.class.cast(rebalancer);
-          taskRebalancer.setClusterStatusMonitor(
-              (ClusterStatusMonitor) event.getAttribute("clusterStatusMonitor"));
+        // Use the internal MappingCalculator interface to compute the final assignment
+        // The next release will support rebalancers that compute the mapping from start to finish
+        ResourceAssignment partitionStateAssignment =
+            mappingCalculator.computeBestPossiblePartitionState(cache, idealState, resource, currentStateOutput);
+        for (Partition partition : resource.getPartitions()) {
+          Map<String, String> newStateMap = partitionStateAssignment.getReplicaMap(partition);
+          output.setState(resourceName, partition, newStateMap);
         }
-
-        try {
-          HelixManager manager = event.getAttribute("helixmanager");
-          rebalancer.init(manager);
-          idealState =
-              rebalancer.computeNewIdealState(resourceName, idealState, currentStateOutput, cache);
-          output.setPreferenceLists(resourceName, idealState.getPreferenceLists());
-
-          // Use the internal MappingCalculator interface to compute the final assignment
-          // The next release will support rebalancers that compute the mapping from start to finish
-          ResourceAssignment partitionStateAssignment =
-              mappingCalculator.computeBestPossiblePartitionState(cache, idealState, resource,
-                  currentStateOutput);
-          for (Partition partition : resource.getPartitions()) {
-            Map<String, String> newStateMap = partitionStateAssignment.getReplicaMap(partition);
-            output.setState(resourceName, partition, newStateMap);
-          }
-        } catch (Exception e) {
-          logger
-              .error("Error computing assignment for resource " + resourceName + ". Skipping.", e);
-        }
+      } catch (Exception e) {
+        logger.error("Error computing assignment for resource " + resourceName + ". Skipping.", e);
       }
     }
-    return output;
   }
 
   private Rebalancer getRebalancer(IdealState idealState, String resourceName) {
@@ -206,5 +230,34 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     }
 
     return mappingCalculator;
+  }
+
+  class ResourcePriority implements Comparable<ResourcePriority> {
+    final Resource _resource;
+    // By default, non-job resources and new jobs are assigned lowest priority
+    Long _priority = Long.MAX_VALUE;
+
+    Resource getResource() {
+      return _resource;
+    }
+
+    public ResourcePriority(Resource resource, IdealState idealState, TaskDriver taskDriver) {
+      _resource = resource;
+
+      if (taskDriver != null && idealState != null
+          && idealState.getRebalancerClassName() != null
+          && idealState.getRebalancerClassName().equals(JobRebalancer.class.getName())) {
+        // Update priority for job resources, note that older jobs will be processed earlier
+        JobContext jobContext = taskDriver.getJobContext(resource.getResourceName());
+        if (jobContext != null && jobContext.getStartTime() != WorkflowContext.UNSTARTED) {
+          _priority = jobContext.getStartTime();
+        }
+      }
+    }
+
+    @Override
+    public int compareTo(ResourcePriority otherJob) {
+      return _priority.compareTo(otherJob._priority);
+    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
@@ -20,6 +20,7 @@ package org.apache.helix.controller.stages;
  */
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,6 +43,8 @@ import org.apache.helix.model.Message;
 import org.apache.helix.model.ParticipantHistory;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
+import org.apache.helix.task.TaskConstants;
+import org.apache.helix.task.TaskPartitionState;
 import org.apache.log4j.Logger;
 
 import com.google.common.collect.Lists;
@@ -73,6 +76,8 @@ public class ClusterDataCache {
 
   // maintain a cache of participant messages across pipeline runs
   Map<String, Map<String, Message>> _messageCache = Maps.newHashMap();
+
+  Map<String, Integer> _participantActiveTaskCount = new HashMap<String, Integer>();
 
   boolean _init = true;
 
@@ -553,6 +558,39 @@ public class ClusterDataCache {
       return _constraintMap.get(type.toString());
     }
     return null;
+  }
+
+  public Integer getParticipantActiveTaskCount(String instance) {
+    return _participantActiveTaskCount.get(instance);
+  }
+
+  public void setParticipantActiveTaskCount(String instance, int taskCount) {
+    _participantActiveTaskCount.put(instance, taskCount);
+  }
+
+  /**
+   * Reset RUNNING/INIT tasks count based on current state output
+   */
+  public void resetActiveTaskCount(CurrentStateOutput currentStateOutput) {
+    // init participant map
+    for (String liveInstance : getLiveInstances().keySet()) {
+      _participantActiveTaskCount.put(liveInstance, 0);
+    }
+    // Active task == init and running tasks
+    fillActiveTaskCount(currentStateOutput.getPartitionCountWithPendingState(TaskConstants.STATE_MODEL_NAME,
+        TaskPartitionState.INIT.name()), _participantActiveTaskCount);
+    fillActiveTaskCount(currentStateOutput.getPartitionCountWithPendingState(TaskConstants.STATE_MODEL_NAME,
+        TaskPartitionState.RUNNING.name()), _participantActiveTaskCount);
+    fillActiveTaskCount(currentStateOutput.getPartitionCountWithCurrentState(TaskConstants.STATE_MODEL_NAME,
+        TaskPartitionState.INIT.name()), _participantActiveTaskCount);
+    fillActiveTaskCount(currentStateOutput.getPartitionCountWithCurrentState(TaskConstants.STATE_MODEL_NAME,
+        TaskPartitionState.RUNNING.name()), _participantActiveTaskCount);
+  }
+
+  private void fillActiveTaskCount(Map<String, Integer> additionPartitionMap, Map<String, Integer> partitionMap) {
+    for (String participant : additionPartitionMap.keySet()) {
+      partitionMap.put(participant, partitionMap.get(participant) + additionPartitionMap.get(participant));
+    }
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -36,8 +36,10 @@ public class ClusterConfig extends HelixProperty {
     FAULT_ZONE_TYPE, // the type in which isolation should be applied on when Helix places the replicas from same partition.
     DELAY_REBALANCE_DISABLED,  // enabled the delayed rebalaning in case node goes offline.
     DELAY_REBALANCE_TIME,     // delayed time in ms that the delay time Helix should hold until rebalancing.
-    BATCH_STATE_TRANSITION_MAX_THREADS
+    BATCH_STATE_TRANSITION_MAX_THREADS,
+    MAX_CONCURRENT_TASK_PER_INSTANCE
   }
+  private final static int DEFAULT_MAX_CONCURRENT_TASK_PER_INSTANCE = 40;
 
   /**
    * Instantiate for a specific cluster
@@ -116,6 +118,16 @@ public class ClusterConfig extends HelixProperty {
    */
   public int getBatchStateTransitionMaxThreads() {
     return _record.getIntField(ClusterConfigProperty.BATCH_STATE_TRANSITION_MAX_THREADS.name(), -1);
+  }
+
+  /**
+   * Get maximum allowed running task count on all instances in this cluster.
+   * Instance level configuration will override cluster configuration.
+   * @return the maximum task count
+   */
+  public int getMaxConcurrentTaskPerInstance() {
+    return _record.getIntField(ClusterConfigProperty.MAX_CONCURRENT_TASK_PER_INSTANCE.name(),
+        DEFAULT_MAX_CONCURRENT_TASK_PER_INSTANCE);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -47,9 +47,11 @@ public class InstanceConfig extends HelixProperty {
     HELIX_DISABLED_PARTITION,
     TAG_LIST,
     INSTANCE_WEIGHT,
-    DOMAIN
+    DOMAIN,
+    MAX_CONCURRENT_TASK
   }
   public static final int WEIGHT_NOT_SET = -1;
+  public static final int MAX_CONCURRENT_TASK_NOT_SET = -1;
 
   private static final Logger _logger = Logger.getLogger(InstanceConfig.class.getName());
 
@@ -406,6 +408,18 @@ public class InstanceConfig extends HelixProperty {
       _record.setListField(InstanceConfigProperty.HELIX_DISABLED_PARTITION.name(),
           oldDisabledPartitions);
     }
+  }
+
+  /**
+   * Get maximum allowed running task count on this instance
+   * @return the maximum task count
+   */
+  public int getMaxConcurrentTask() {
+    return _record.getIntField(InstanceConfigProperty.MAX_CONCURRENT_TASK.name(), MAX_CONCURRENT_TASK_NOT_SET);
+  }
+
+  public void setMaxConcurrentTask(int maxConcurrentTask) {
+    _record.setIntField(InstanceConfigProperty.MAX_CONCURRENT_TASK.name(), maxConcurrentTask);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowConfig.java
@@ -61,7 +61,9 @@ public class  WorkflowConfig extends ResourceConfig {
     capacity,
     WorkflowType,
     JobTypes,
-    IsJobQueue
+    IsJobQueue,
+    /* Allow multiple jobs in this workflow to be assigned to a same instance or not */
+    AllowOverlapJobAssignment
   }
 
   /* Default values */
@@ -74,6 +76,7 @@ public class  WorkflowConfig extends ResourceConfig {
   public static final boolean DEFAULT_TERMINABLE = true;
   public static final boolean DEFAULT_JOB_QUEUE = false;
   public static final boolean DEFAULT_MONITOR_DISABLE = true;
+  public static final boolean DEFAULT_ALLOW_OVERLAP_JOB_ASSIGNMENT = false;
 
   public WorkflowConfig(HelixProperty property) {
     super(property.getRecord());
@@ -82,7 +85,7 @@ public class  WorkflowConfig extends ResourceConfig {
   public WorkflowConfig(WorkflowConfig cfg, String workflowId) {
     this(workflowId, cfg.getJobDag(), cfg.getParallelJobs(), cfg.getTargetState(), cfg.getExpiry(),
         cfg.getFailureThreshold(), cfg.isTerminable(), cfg.getScheduleConfig(), cfg.getCapacity(),
-        cfg.getWorkflowType(), cfg.isJobQueue(), cfg.getJobTypes());
+        cfg.getWorkflowType(), cfg.isJobQueue(), cfg.getJobTypes(), cfg.isAllowOverlapJobAssignment());
   }
 
   /* Member variables */
@@ -91,7 +94,7 @@ public class  WorkflowConfig extends ResourceConfig {
   protected WorkflowConfig(String workflowId, JobDag jobDag, int parallelJobs,
       TargetState targetState, long expiry, int failureThreshold, boolean terminable,
       ScheduleConfig scheduleConfig, int capacity, String workflowType, boolean isJobQueue,
-      Map<String, String> jobTypes) {
+      Map<String, String> jobTypes, boolean allowOverlapJobAssignment) {
     super(workflowId);
 
     putSimpleConfig(WorkflowConfigProperty.WorkflowID.name(), workflowId);
@@ -105,8 +108,8 @@ public class  WorkflowConfig extends ResourceConfig {
     putSimpleConfig(WorkflowConfigProperty.TargetState.name(), targetState.name());
     putSimpleConfig(WorkflowConfigProperty.Terminable.name(), String.valueOf(terminable));
     putSimpleConfig(WorkflowConfigProperty.IsJobQueue.name(), String.valueOf(isJobQueue));
-    putSimpleConfig(WorkflowConfigProperty.FailureThreshold.name(),
-        String.valueOf(failureThreshold));
+    putSimpleConfig(WorkflowConfigProperty.FailureThreshold.name(), String.valueOf(failureThreshold));
+    putSimpleConfig(WorkflowConfigProperty.AllowOverlapJobAssignment.name(), String.valueOf(allowOverlapJobAssignment));
 
     if (capacity > 0) {
       putSimpleConfig(WorkflowConfigProperty.capacity.name(), String.valueOf(capacity));
@@ -210,6 +213,11 @@ public class  WorkflowConfig extends ResourceConfig {
         WorkflowConfigProperty.JobTypes.name()) : null;
   }
 
+  public boolean isAllowOverlapJobAssignment() {
+    return _record.getBooleanField(WorkflowConfigProperty.AllowOverlapJobAssignment.name(),
+        DEFAULT_ALLOW_OVERLAP_JOB_ASSIGNMENT);
+  }
+
   public static SimpleDateFormat getDefaultDateFormat() {
     SimpleDateFormat defaultDateFormat = new SimpleDateFormat(
         "MM-dd-yyyy HH:mm:ss");
@@ -295,13 +303,14 @@ public class  WorkflowConfig extends ResourceConfig {
     private String _workflowType;
     private boolean _isJobQueue = DEFAULT_JOB_QUEUE;
     private Map<String, String> _jobTypes;
+    private boolean _allowOverlapJobAssignment = DEFAULT_ALLOW_OVERLAP_JOB_ASSIGNMENT;
 
     public WorkflowConfig build() {
       validate();
 
       return new WorkflowConfig(_workflowId, _taskDag, _parallelJobs, _targetState, _expiry,
           _failureThreshold, _isTerminable, _scheduleConfig, _capacity, _workflowType, _isJobQueue,
-          _jobTypes);
+          _jobTypes, _allowOverlapJobAssignment);
     }
 
     public Builder() {}
@@ -319,6 +328,7 @@ public class  WorkflowConfig extends ResourceConfig {
       _workflowType = workflowConfig.getWorkflowType();
       _isJobQueue = workflowConfig.isJobQueue();
       _jobTypes = workflowConfig.getJobTypes();
+      _allowOverlapJobAssignment = workflowConfig.isAllowOverlapJobAssignment();
     }
 
     public Builder setWorkflowId(String v) {
@@ -391,6 +401,17 @@ public class  WorkflowConfig extends ResourceConfig {
       return this;
     }
 
+    /**
+     * Set if allow multiple jobs in one workflow to be assigned on one instance.
+     * If not set, default configuration is false.
+     * @param allowOverlapJobAssignment true if allow overlap assignment
+     * @return This builder
+     */
+    public Builder setAllowOverlapJobAssignment(boolean allowOverlapJobAssignment) {
+      _allowOverlapJobAssignment = allowOverlapJobAssignment;
+      return this;
+    }
+
     public static Builder fromMap(Map<String, String> cfg) {
       Builder builder = new Builder();
       builder.setConfigMap(cfg);
@@ -450,6 +471,12 @@ public class  WorkflowConfig extends ResourceConfig {
       if (cfg.containsKey(WorkflowConfigProperty.IsJobQueue.name())) {
         setJobQueue(Boolean.parseBoolean(cfg.get(WorkflowConfigProperty.IsJobQueue.name())));
       }
+
+      if (cfg.containsKey(WorkflowConfigProperty.AllowOverlapJobAssignment.name())) {
+        setAllowOverlapJobAssignment(
+            Boolean.parseBoolean(cfg.get(WorkflowConfigProperty.AllowOverlapJobAssignment.name())));
+      }
+
       return this;
     }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskThrottling.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskThrottling.java
@@ -1,0 +1,183 @@
+package org.apache.helix.integration.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.HelixConfigScope;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.builder.HelixConfigScopeBuilder;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.JobContext;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskPartitionState;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestTaskThrottling extends TaskTestBase {
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    setSingleTestEnvironment();
+    _numNodes = 2;
+    super.beforeClass();
+  }
+
+  @Test
+  public void testTaskThrottle() throws InterruptedException {
+    int numTasks = 30 * _numNodes;
+    int perNodeTaskLimitation = 5;
+
+    JobConfig.Builder jobConfig = generateLongRunJobConfig(numTasks);
+
+    // 1. Job executed in the participants with no limitation
+    String jobName1 = "Job1";
+    Workflow flow = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName1, jobConfig).build();
+    _driver.start(flow);
+    _driver.pollForJobState(flow.getName(), TaskUtil.getNamespacedJobName(flow.getName(), jobName1),
+        TaskState.IN_PROGRESS);
+    // Wait for tasks to be picked up
+    Thread.sleep(1500);
+
+    Assert.assertEquals(countRunningPartition(flow, jobName1), numTasks);
+
+    _driver.stop(flow.getName());
+    _driver.pollForWorkflowState(flow.getName(), TaskState.STOPPED);
+
+    // 2. Job executed in the participants with max task limitation
+
+    // Configuring cluster
+    HelixConfigScope scope =
+        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(CLUSTER_NAME).build();
+    Map<String, String> properties = new HashMap<String, String>();
+    properties.put(ClusterConfig.ClusterConfigProperty.MAX_CONCURRENT_TASK_PER_INSTANCE.name(),
+        new Integer(perNodeTaskLimitation).toString());
+    _setupTool.getClusterManagementTool().setConfig(scope, properties);
+
+    String jobName2 = "Job2";
+    flow = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName2, jobConfig).build();
+    _driver.start(flow);
+    _driver.pollForJobState(flow.getName(), TaskUtil.getNamespacedJobName(flow.getName(), jobName2),
+        TaskState.IN_PROGRESS);
+    // Wait for tasks to be picked up
+    Thread.sleep(1500);
+
+    Assert.assertEquals(countRunningPartition(flow, jobName2), _numNodes * perNodeTaskLimitation);
+
+    _driver.stop(flow.getName());
+    _driver.pollForWorkflowState(flow.getName(), TaskState.STOPPED);
+
+    // 3. Ensure job can finish normally
+    jobConfig.setJobCommandConfigMap(ImmutableMap.of(MockTask.TIMEOUT_CONFIG, "10"));
+    String jobName3 = "Job3";
+    flow = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName3, jobConfig).build();
+    _driver.start(flow);
+    _driver.pollForJobState(flow.getName(), TaskUtil.getNamespacedJobName(flow.getName(), jobName3),
+        TaskState.COMPLETED);
+  }
+
+  @Test(dependsOnMethods = {"testTaskThrottle"})
+  public void testJobPriority() throws InterruptedException {
+    int numTasks = 30 * _numNodes;
+    int perNodeTaskLimitation = 5;
+
+    JobConfig.Builder jobConfig = generateLongRunJobConfig(numTasks);
+
+    // Configuring participants
+    setParticipantsCapacity(perNodeTaskLimitation);
+
+    // schedule job1
+    String jobName1 = "PriorityJob1";
+    Workflow flow1 = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName1, jobConfig).build();
+    _driver.start(flow1);
+    _driver.pollForJobState(flow1.getName(), TaskUtil.getNamespacedJobName(flow1.getName(), jobName1),
+        TaskState.IN_PROGRESS);
+    // Wait for tasks to be picked up
+    Thread.sleep(1500);
+    Assert.assertEquals(countRunningPartition(flow1, jobName1), _numNodes * perNodeTaskLimitation);
+
+    // schedule job2
+    String jobName2 = "PriorityJob2";
+    Workflow flow2 = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName2, jobConfig).build();
+    _driver.start(flow2);
+    _driver.pollForJobState(flow2.getName(), TaskUtil.getNamespacedJobName(flow2.getName(), jobName2),
+        TaskState.IN_PROGRESS);
+    // Wait for tasks to be picked up
+    Thread.sleep(1500);
+    Assert.assertEquals(countRunningPartition(flow2, jobName2), 0);
+
+    // Increasing participants capacity
+    perNodeTaskLimitation = 2 * perNodeTaskLimitation;
+    setParticipantsCapacity(perNodeTaskLimitation);
+
+    Thread.sleep(1500);
+    // Additional capacity should all be used by job1
+    Assert.assertEquals(countRunningPartition(flow1, jobName1), _numNodes * perNodeTaskLimitation);
+    Assert.assertEquals(countRunningPartition(flow2, jobName2), 0);
+
+    _driver.stop(flow1.getName());
+    _driver.pollForWorkflowState(flow1.getName(), TaskState.STOPPED);
+    _driver.stop(flow2.getName());
+    _driver.pollForWorkflowState(flow2.getName(), TaskState.STOPPED);
+  }
+
+  private int countRunningPartition(Workflow flow, String jobName) {
+    int runningPartition = 0;
+    JobContext jobContext = _driver.getJobContext(TaskUtil.getNamespacedJobName(flow.getName(), jobName));
+    for (int partition : jobContext.getPartitionSet()) {
+      if (jobContext.getPartitionState(partition) != null && jobContext.getPartitionState(partition)
+          .equals(TaskPartitionState.RUNNING)) {
+        runningPartition++;
+      }
+    }
+    return runningPartition;
+  }
+
+  private JobConfig.Builder generateLongRunJobConfig(int numTasks) {
+    JobConfig.Builder jobConfig = new JobConfig.Builder();
+    List<TaskConfig> taskConfigs = new ArrayList<TaskConfig>();
+    for (int j = 0; j < numTasks; j++) {
+      taskConfigs.add(new TaskConfig.Builder().setTaskId("task_" + j).setCommand(MockTask.TASK_COMMAND).build());
+    }
+    jobConfig.addTaskConfigs(taskConfigs)
+        .setNumConcurrentTasksPerInstance(numTasks)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.TIMEOUT_CONFIG, "120000"));
+    return jobConfig;
+  }
+
+  private void setParticipantsCapacity(int perNodeTaskLimitation) {
+    for (int i = 0; i < _numNodes; i++) {
+      InstanceConfig instanceConfig = _setupTool.getClusterManagementTool()
+          .getInstanceConfig(CLUSTER_NAME, PARTICIPANT_PREFIX + "_" + (_startPort + i));
+      instanceConfig.setMaxConcurrentTask(perNodeTaskLimitation);
+      _setupTool.getClusterManagementTool()
+          .setInstanceConfig(CLUSTER_NAME, PARTICIPANT_PREFIX + "_" + (_startPort + i), instanceConfig);
+    }
+  }
+}


### PR DESCRIPTION
Add per participant concurrent task throttling.

Add a participant configuration item "MAX_CONCURRENT_TASK" for throttling.
New assigned task + existing running/init task <= MAX_CONCURRENT_TASK. Otherwise, new assignment won't be included in best possible state.
Tasks are assigned in the order of jobs' start time. Older jobs have higher priority than other jobs.
Add test case (TestTaskThrottling.java) for testing new throttling and priority.

Ticket:
https://issues.apache.org/jira/browse/HELIX-655

Test:
mvn test in helix-core

Please refer to previous discussions in another pull request:
https://github.com/apache/helix/pull/89