### PR TITLE
Fix test TestSwapInstance.

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/TestSwapInstance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestSwapInstance.java
@@ -46,6 +46,9 @@ public class TestSwapInstance extends ZkStandAloneCMTestBase {
     IdealState is2 = helixAccessor.getProperty(helixAccessor.keyBuilder().idealStates("MyDB"));
     idealStateOld2.merge(is2.getRecord());
 
+    Assert.assertTrue(ClusterStateVerifier
+        .verifyByPolling(new ClusterStateVerifier.BestPossAndExtViewZkVerifier(ZK_ADDR, CLUSTER_NAME)));
+
     String instanceName = PARTICIPANT_PREFIX + "_" + (START_PORT + 0);
     ZKHelixAdmin tool = new ZKHelixAdmin(_gZkClient);
     _setupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, instanceName, false);


### PR DESCRIPTION
Ensure resources have normal state before disabling an instance in the test.
This can avoid possible unpredictable resource partition assignment if the node is disabled when the assignment is not finished.