### PR TITLE
[HELIX-669] State transition cancellation implementaion

### DIFF
--- a/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/SchedulerTasksResource.java
+++ b/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/SchedulerTasksResource.java
@@ -149,9 +149,9 @@ public class SchedulerTasksResource extends ServerResource {
 
       Map<String, String> resultMap = new HashMap<String, String>();
       resultMap.put("StatusUpdatePath", PropertyPathBuilder.getPath(
-          PropertyType.STATUSUPDATES_CONTROLLER, clusterName, MessageType.SCHEDULER_MSG.toString(),
+          PropertyType.STATUSUPDATES_CONTROLLER, clusterName, MessageType.SCHEDULER_MSG.name(),
           schedulerMessage.getMsgId()));
-      resultMap.put("MessageType", Message.MessageType.SCHEDULER_MSG.toString());
+      resultMap.put("MessageType", Message.MessageType.SCHEDULER_MSG.name());
       resultMap.put("MsgId", schedulerMessage.getMsgId());
 
       // Assemble the rest URL for task status update

--- a/helix-core/src/main/java/org/apache/helix/ClusterMessagingService.java
+++ b/helix-core/src/main/java/org/apache/helix/ClusterMessagingService.java
@@ -121,10 +121,25 @@ public interface ClusterMessagingService {
    *          The message type that the factory will create handler for
    * @param factory
    *          The per-type message factory
-   * @param threadpoolSize
-   *          size of the execution threadpool that handles the message
    */
   public void registerMessageHandlerFactory(String type, MessageHandlerFactory factory);
+
+
+  /**
+   * This will register a message handler factory to create handlers for
+   * message. In case client code defines its own message type, it can define a
+   * message handler factory to create handlers to process those messages.
+   * Messages are processed in a threadpool which is hosted by cluster manager,
+   * and cluster manager will call the factory to create handler, and the
+   * handler is called in the threadpool.
+   * Note that only one message handler factory can be registered with one
+   * message type.
+   * @param types
+   *          The different message types that the factory will create handler for
+   * @param factory
+   *          The per-type message factory
+   */
+  public void registerMessageHandlerFactory(List<String> types, MessageHandlerFactory factory);
 
   /**
    * This will generate all messages to be sent given the recipientCriteria and MessageTemplate,

--- a/helix-core/src/main/java/org/apache/helix/HelixRollbackException.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixRollbackException.java
@@ -1,0 +1,35 @@
+package org.apache.helix;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class HelixRollbackException extends HelixException {
+
+  public HelixRollbackException(String message) {
+    super(message);
+  }
+
+  public HelixRollbackException(Throwable cause) {
+    super(cause);
+  }
+
+  public HelixRollbackException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
@@ -27,17 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.helix.HelixException;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.controller.stages.ClusterDataCache;
 import org.apache.helix.controller.stages.CurrentStateOutput;
-import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
-import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.IdealState.RebalanceMode;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.StateModelDefinition;
-import org.apache.helix.util.HelixUtil;
 import org.apache.log4j.Logger;
 
 /**
@@ -53,9 +49,9 @@ import org.apache.log4j.Logger;
 public class AutoRebalancer extends AbstractRebalancer {
   private static final Logger LOG = Logger.getLogger(AutoRebalancer.class);
 
-  @Override
-  public IdealState computeNewIdealState(String resourceName, IdealState currentIdealState,
-      CurrentStateOutput currentStateOutput, ClusterDataCache clusterData) {
+  @Override public IdealState computeNewIdealState(String resourceName,
+      IdealState currentIdealState, CurrentStateOutput currentStateOutput,
+      ClusterDataCache clusterData) {
     List<String> partitions = new ArrayList<String>(currentIdealState.getPartitionSet());
     String stateModelName = currentIdealState.getStateModelDefRef();
     StateModelDefinition stateModelDef = clusterData.getStateModelDef(stateModelName);

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
@@ -58,7 +58,7 @@ import com.google.common.collect.Sets;
 public class ClusterDataCache {
 
   private static final String IDEAL_STATE_RULE_PREFIX = "IdealStateRule!";
-  private ClusterConfig _clusterConfig;
+  ClusterConfig _clusterConfig;
   Map<String, LiveInstance> _liveInstanceMap;
   Map<String, LiveInstance> _liveInstanceCacheMap;
   Map<String, IdealState> _idealStateMap;

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -54,7 +54,7 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
       String instanceName = instance.getInstanceName();
       Map<String, Message> instanceMessages = cache.getMessages(instanceName);
       for (Message message : instanceMessages.values()) {
-        if (!MessageType.STATE_TRANSITION.toString().equalsIgnoreCase(message.getMsgType())) {
+        if (!MessageType.STATE_TRANSITION.name().equalsIgnoreCase(message.getMsgType())) {
           continue;
         }
         if (!instance.getSessionId().equals(message.getTgtSessionId())) {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ExternalViewComputeStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ExternalViewComputeStage.java
@@ -241,7 +241,7 @@ public class ExternalViewComputeStage extends AbstractBaseStage {
     if (controllerMsgUpdates.size() > 0) {
       for (String controllerMsgId : controllerMsgUpdates.keySet()) {
         PropertyKey controllerStatusUpdateKey =
-            keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(), controllerMsgId);
+            keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(), controllerMsgId);
         StatusUpdate controllerStatusUpdate = accessor.getProperty(controllerStatusUpdateKey);
         for (String taskPartitionName : controllerMsgUpdates.get(controllerMsgId).keySet()) {
           Map<String, String> result = new HashMap<String, String>();

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageSelectionStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageSelectionStage.java
@@ -172,6 +172,10 @@ public class MessageSelectionStage extends AbstractBaseStage {
     Map<Integer, List<Message>> messagesGroupByStateTransitPriority =
         new TreeMap<Integer, List<Message>>();
     for (Message message : messages) {
+      if (message.getMsgType().equals(Message.MessageType.STATE_TRANSITION_CANCELLATION.name())) {
+        selectedMessages.add(message);
+        continue;
+      }
       String fromState = message.getFromState();
       String toState = message.getToState();
       String transition = fromState + "-" + toState;

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TaskAssignmentStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TaskAssignmentStage.java
@@ -144,7 +144,7 @@ public class TaskAssignmentStage extends AbstractBaseStage {
           "Sending Message " + message.getMsgId() + " to " + message.getTgtName() + " transit "
               + message.getResourceName() + "." + message.getPartitionName() + "|" + message
               .getPartitionNames() + " from:" + message.getFromState() + " to:" + message
-              .getToState());
+              .getToState() + ", Message type ");
 
       keys.add(keyBuilder.message(message.getTgtName(), message.getId()));
     }

--- a/helix-core/src/main/java/org/apache/helix/examples/BootstrapProcess.java
+++ b/helix-core/src/main/java/org/apache/helix/examples/BootstrapProcess.java
@@ -21,6 +21,7 @@ package org.apache.helix.examples;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Date;
+import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -44,6 +45,8 @@ import org.apache.helix.model.Message.MessageType;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelFactory;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * This process does little more than handling the state transition messages.
@@ -109,7 +112,7 @@ public class BootstrapProcess {
     manager.getMessagingService().registerMessageHandlerFactory(
         MessageType.STATE_TRANSITION.name(), stateMach);
     manager.getMessagingService().registerMessageHandlerFactory(
-        MessageType.USER_DEFINE_MSG.toString(), new CustomMessageHandlerFactory());
+        MessageType.USER_DEFINE_MSG.name(), new CustomMessageHandlerFactory());
     manager.connect();
   }
 
@@ -121,9 +124,15 @@ public class BootstrapProcess {
       return new CustomMessageHandler(message, context);
     }
 
+    @Deprecated
     @Override
     public String getMessageType() {
-      return MessageType.USER_DEFINE_MSG.toString();
+      return MessageType.USER_DEFINE_MSG.name();
+    }
+
+    @Override
+    public List<String> getMessageTypes() {
+      return ImmutableList.of(MessageType.USER_DEFINE_MSG.name());
     }
 
     @Override

--- a/helix-core/src/main/java/org/apache/helix/examples/BootstrapProcess.java
+++ b/helix-core/src/main/java/org/apache/helix/examples/BootstrapProcess.java
@@ -107,7 +107,7 @@ public class BootstrapProcess {
     stateMach.registerStateModelFactory("MasterSlave", stateModelFactory);
 
     manager.getMessagingService().registerMessageHandlerFactory(
-        MessageType.STATE_TRANSITION.toString(), stateMach);
+        MessageType.STATE_TRANSITION.name(), stateMach);
     manager.getMessagingService().registerMessageHandlerFactory(
         MessageType.USER_DEFINE_MSG.toString(), new CustomMessageHandlerFactory());
     manager.connect();

--- a/helix-core/src/main/java/org/apache/helix/examples/ExampleProcess.java
+++ b/helix-core/src/main/java/org/apache/helix/examples/ExampleProcess.java
@@ -91,7 +91,7 @@ public class ExampleProcess {
     stateMach.registerStateModelFactory(stateModelType, stateModelFactory);
     manager.connect();
     manager.getMessagingService().registerMessageHandlerFactory(
-        MessageType.STATE_TRANSITION.toString(), stateMach);
+        MessageType.STATE_TRANSITION.name(), stateMach);
   }
 
   public void stop() {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ControllerManagerHelper.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ControllerManagerHelper.java
@@ -54,20 +54,25 @@ public class ControllerManagerHelper {
       _manager.addControllerMessageListener(_messagingService.getExecutor());
       MessageHandlerFactory defaultControllerMsgHandlerFactory =
           new DefaultControllerMessageHandlerFactory();
-      _messagingService.getExecutor().registerMessageHandlerFactory(
-          defaultControllerMsgHandlerFactory.getMessageType(), defaultControllerMsgHandlerFactory);
+      for (String type : defaultControllerMsgHandlerFactory.getMessageTypes()) {
+        _messagingService.getExecutor()
+            .registerMessageHandlerFactory(type, defaultControllerMsgHandlerFactory);
+      }
 
       MessageHandlerFactory defaultSchedulerMsgHandlerFactory =
           new DefaultSchedulerMessageHandlerFactory(_manager);
-      _messagingService.getExecutor().registerMessageHandlerFactory(
-          defaultSchedulerMsgHandlerFactory.getMessageType(), defaultSchedulerMsgHandlerFactory);
+      for (String type : defaultSchedulerMsgHandlerFactory.getMessageTypes()) {
+        _messagingService.getExecutor()
+            .registerMessageHandlerFactory(type, defaultSchedulerMsgHandlerFactory);
+      }
 
       MessageHandlerFactory defaultParticipantErrorMessageHandlerFactory =
           new DefaultParticipantErrorMessageHandlerFactory(_manager);
-      _messagingService.getExecutor().registerMessageHandlerFactory(
-          defaultParticipantErrorMessageHandlerFactory.getMessageType(),
 
-          defaultParticipantErrorMessageHandlerFactory);
+      for (String type : defaultParticipantErrorMessageHandlerFactory.getMessageTypes()) {
+        _messagingService.getExecutor()
+            .registerMessageHandlerFactory(type, defaultParticipantErrorMessageHandlerFactory);
+      }
 
       /**
        * setup generic-controller

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/DefaultControllerMessageHandlerFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/DefaultControllerMessageHandlerFactory.java
@@ -19,6 +19,8 @@ package org.apache.helix.manager.zk;
  * under the License.
  */
 
+import java.util.List;
+
 import org.apache.helix.HelixException;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.messaging.handling.HelixTaskResult;
@@ -27,6 +29,8 @@ import org.apache.helix.messaging.handling.MessageHandlerFactory;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Message.MessageType;
 import org.apache.log4j.Logger;
+
+import com.google.common.collect.ImmutableList;
 
 public class DefaultControllerMessageHandlerFactory implements MessageHandlerFactory {
   private static Logger _logger = Logger.getLogger(DefaultControllerMessageHandlerFactory.class);
@@ -45,7 +49,12 @@ public class DefaultControllerMessageHandlerFactory implements MessageHandlerFac
 
   @Override
   public String getMessageType() {
-    return MessageType.CONTROLLER_MSG.toString();
+    return MessageType.CONTROLLER_MSG.name();
+  }
+
+  @Override
+  public List<String> getMessageTypes() {
+    return ImmutableList.of(MessageType.CONTROLLER_MSG.name());
   }
 
   @Override
@@ -62,7 +71,7 @@ public class DefaultControllerMessageHandlerFactory implements MessageHandlerFac
     public HelixTaskResult handleMessage() throws InterruptedException {
       String type = _message.getMsgType();
       HelixTaskResult result = new HelixTaskResult();
-      if (!type.equals(MessageType.CONTROLLER_MSG.toString())) {
+      if (!type.equals(MessageType.CONTROLLER_MSG.name())) {
         throw new HelixException("Unexpected msg type for message " + _message.getMsgId()
             + " type:" + _message.getMsgType());
       }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/DefaultParticipantErrorMessageHandlerFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/DefaultParticipantErrorMessageHandlerFactory.java
@@ -20,6 +20,7 @@ package org.apache.helix.manager.zk;
  */
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
@@ -29,6 +30,8 @@ import org.apache.helix.messaging.handling.MessageHandler;
 import org.apache.helix.messaging.handling.MessageHandlerFactory;
 import org.apache.helix.model.Message;
 import org.apache.log4j.Logger;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * DefaultParticipantErrorMessageHandlerFactory works on controller side.
@@ -118,7 +121,12 @@ public class DefaultParticipantErrorMessageHandlerFactory implements MessageHand
 
   @Override
   public String getMessageType() {
-    return Message.MessageType.PARTICIPANT_ERROR_REPORT.toString();
+    return Message.MessageType.PARTICIPANT_ERROR_REPORT.name();
+  }
+
+  @Override
+  public List<String> getMessageTypes() {
+    return ImmutableList.of(Message.MessageType.PARTICIPANT_ERROR_REPORT.name());
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/DefaultSchedulerMessageHandlerFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/DefaultSchedulerMessageHandlerFactory.java
@@ -48,6 +48,8 @@ import org.apache.helix.util.StatusUpdateUtil;
 import org.apache.log4j.Logger;
 import org.codehaus.jackson.map.ObjectMapper;
 
+import com.google.common.collect.ImmutableList;
+
 /*
  * The current implementation supports throttling on STATE-TRANSITION type of message, transition SCHEDULED-COMPLETED.
  *
@@ -107,12 +109,12 @@ public class DefaultSchedulerMessageHandlerFactory implements MessageHandlerFact
       Builder keyBuilder = accessor.keyBuilder();
       ZNRecord statusUpdate =
           accessor.getProperty(
-              keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(),
+              keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(),
                   originalMessage.getMsgId())).getRecord();
 
       statusUpdate.getMapFields().putAll(_resultSummaryMap);
       accessor.setProperty(
-          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(),
+          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(),
               originalMessage.getMsgId()), new StatusUpdate(statusUpdate));
 
     }
@@ -139,7 +141,12 @@ public class DefaultSchedulerMessageHandlerFactory implements MessageHandlerFact
 
   @Override
   public String getMessageType() {
-    return MessageType.SCHEDULER_MSG.toString();
+    return MessageType.SCHEDULER_MSG.name();
+  }
+
+  @Override
+  public List<String> getMessageTypes() {
+    return ImmutableList.of(MessageType.SCHEDULER_MSG.name());
   }
 
   @Override
@@ -219,11 +226,11 @@ public class DefaultSchedulerMessageHandlerFactory implements MessageHandlerFact
 
       ZNRecord statusUpdate =
           accessor.getProperty(
-              keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(),
+              keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(),
                   _message.getMsgId())).getRecord();
 
       statusUpdate.getMapFields().put("SentMessageCount", sendSummary);
-      accessor.updateProperty(keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(),
+      accessor.updateProperty(keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(),
           _message.getMsgId()), new StatusUpdate(statusUpdate));
     }
 
@@ -247,7 +254,7 @@ public class DefaultSchedulerMessageHandlerFactory implements MessageHandlerFact
     public HelixTaskResult handleMessage() throws InterruptedException {
       String type = _message.getMsgType();
       HelixTaskResult result = new HelixTaskResult();
-      if (!type.equals(MessageType.SCHEDULER_MSG.toString())) {
+      if (!type.equals(MessageType.SCHEDULER_MSG.name())) {
         throw new HelixException("Unexpected msg type for message " + _message.getMsgId()
             + " type:" + _message.getMsgType());
       }
@@ -324,12 +331,12 @@ public class DefaultSchedulerMessageHandlerFactory implements MessageHandlerFact
 
       ZNRecord statusUpdate =
           accessor.getProperty(
-              keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(),
+              keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(),
                   _message.getMsgId())).getRecord();
 
       statusUpdate.getMapFields().put("SentMessageCount", sendSummary);
 
-      accessor.setProperty(keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(),
+      accessor.setProperty(keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(),
           _message.getMsgId()), new StatusUpdate(statusUpdate));
 
       result.getTaskResultMap().put("ControllerResult",

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -331,7 +331,7 @@ public class ParticipantManager {
   }
 
   private void setupMsgHandler() throws Exception {
-    _messagingService.registerMessageHandlerFactory(MessageType.STATE_TRANSITION.toString(),
+    _messagingService.registerMessageHandlerFactory(MessageType.STATE_TRANSITION.name(),
         _stateMachineEngine);
     _manager.addMessageListener(_messagingService.getExecutor(), _instanceName);
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -331,7 +331,7 @@ public class ParticipantManager {
   }
 
   private void setupMsgHandler() throws Exception {
-    _messagingService.registerMessageHandlerFactory(MessageType.STATE_TRANSITION.name(),
+    _messagingService.registerMessageHandlerFactory(_stateMachineEngine.getMessageTypes(),
         _stateMachineEngine);
     _manager.addMessageListener(_messagingService.getExecutor(), _instanceName);
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -386,7 +386,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     // check there is no pending messages for the partitions exist
     List<Message> messages = accessor.getChildValues(keyBuilder.messages(instanceName));
     for (Message message : messages) {
-      if (!MessageType.STATE_TRANSITION.toString().equalsIgnoreCase(message.getMsgType())
+      if (!MessageType.STATE_TRANSITION.name().equalsIgnoreCase(message.getMsgType())
           || !sessionId.equals(message.getTgtSessionId())
           || !resourceName.equals(message.getResourceName())
           || !resetPartitionNames.contains(message.getPartitionName())) {

--- a/helix-core/src/main/java/org/apache/helix/messaging/DefaultMessagingService.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/DefaultMessagingService.java
@@ -20,6 +20,7 @@ package org.apache.helix.messaging;
  */
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +69,7 @@ public class DefaultMessagingService implements ClusterMessagingService {
 
     _taskExecutor = new HelixTaskExecutor(_participantStatusMonitor);
     _asyncCallbackService = new AsyncCallbackService();
-    _taskExecutor.registerMessageHandlerFactory(MessageType.TASK_REPLY.toString(),
+    _taskExecutor.registerMessageHandlerFactory(MessageType.TASK_REPLY.name(),
         _asyncCallbackService);
   }
 
@@ -207,11 +208,22 @@ public class DefaultMessagingService implements ClusterMessagingService {
   }
 
   @Override
-  public synchronized void registerMessageHandlerFactory(String type, MessageHandlerFactory factory) {
+  public synchronized void registerMessageHandlerFactory(String type,
+      MessageHandlerFactory factory) {
+    registerMessageHandlerFactory(Collections.singletonList(type), factory);
+  }
+
+  @Override
+  public synchronized void registerMessageHandlerFactory(List<String> types,
+      MessageHandlerFactory factory) {
     if (_manager.isConnected()) {
-      registerMessageHandlerFactoryInternal(type, factory);
+      for (String type : types) {
+        registerMessageHandlerFactoryInternal(type, factory);
+      }
     } else {
-      _messageHandlerFactoriestobeAdded.put(type, factory);
+      for (String type : types) {
+        _messageHandlerFactoriestobeAdded.put(type, factory);
+      }
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/AsyncCallbackService.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/AsyncCallbackService.java
@@ -19,6 +19,7 @@ package org.apache.helix.messaging.handling;
  * under the License.
  */
 
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.helix.HelixException;
@@ -27,6 +28,8 @@ import org.apache.helix.messaging.AsyncCallback;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Message.MessageType;
 import org.apache.log4j.Logger;
+
+import com.google.common.collect.ImmutableList;
 
 public class AsyncCallbackService implements MessageHandlerFactory {
   private final ConcurrentHashMap<String, AsyncCallback> _callbackMap =
@@ -45,7 +48,7 @@ public class AsyncCallbackService implements MessageHandlerFactory {
   }
 
   void verifyMessage(Message message) {
-    if (!message.getMsgType().toString().equalsIgnoreCase(MessageType.TASK_REPLY.toString())) {
+    if (!message.getMsgType().toString().equalsIgnoreCase(MessageType.TASK_REPLY.name())) {
       String errorMsg =
           "Unexpected msg type for message " + message.getMsgId() + " type:" + message.getMsgType()
               + " Expected : " + MessageType.TASK_REPLY;
@@ -79,7 +82,12 @@ public class AsyncCallbackService implements MessageHandlerFactory {
 
   @Override
   public String getMessageType() {
-    return MessageType.TASK_REPLY.toString();
+    return MessageType.TASK_REPLY.name();
+  }
+
+  @Override
+  public List<String> getMessageTypes() {
+    return ImmutableList.of(MessageType.TASK_REPLY.name());
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixBatchMessageTask.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixBatchMessageTask.java
@@ -114,4 +114,10 @@ public class HelixBatchMessageTask implements MessageTask {
       }
     }
   }
+
+  @Override
+  public boolean cancel() {
+    // TODO: implement this method if need for batch message cancel
+    return false;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionCancellationHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionCancellationHandler.java
@@ -40,20 +40,15 @@ public class HelixStateTransitionCancellationHandler extends MessageHandler {
   @Override
   public HelixTaskResult handleMessage() throws InterruptedException {
     HelixTaskResult taskResult = new HelixTaskResult();
-    synchronized (_stateModel) {
-      try {
-        _stateModel.cancel();
-        taskResult.setSuccess(true);
-      } catch (Exception e) {
-        taskResult.setSuccess(false);
-        taskResult.setMessage(e.toString());
-        taskResult.setException(e);
-      }
-
-      if (taskResult.isSuccess()) {
-        throw new HelixRollbackException("Cancellation success for " + _message.getMsgId());
-      }
+    try {
+      _stateModel.cancel();
+      taskResult.setSuccess(true);
+    } catch (Exception e) {
+      taskResult.setSuccess(false);
+      taskResult.setMessage(e.toString());
+      taskResult.setException(e);
     }
+
     return taskResult;
   }
 

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -303,6 +303,10 @@ public class HelixStateTransitionHandler extends MessageHandler {
         if (e.getCause() != null && e.getCause() instanceof InterruptedException) {
           e = (InterruptedException) e.getCause();
         }
+
+        if (e.getCause() != null && e.getCause() instanceof HelixRollbackException) {
+          throw new HelixRollbackException(e.getCause());
+        }
         _statusUpdateUtil.logError(message, HelixStateTransitionHandler.class, e, errorMessage,
             accessor);
         taskResult.setSuccess(false);
@@ -321,7 +325,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
 
   private void invoke(HelixDataAccessor accessor, NotificationContext context,
       HelixTaskResult taskResult, Message message) throws IllegalAccessException,
-      InvocationTargetException, InterruptedException {
+      InvocationTargetException, InterruptedException, HelixRollbackException {
     _statusUpdateUtil.logInfo(message, HelixStateTransitionHandler.class,
         "Message handling invoking", accessor);
 

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -28,11 +28,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
+import org.apache.helix.HelixRollbackException;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.NotificationContext.MapKey;
 import org.apache.helix.PropertyKey;
@@ -340,6 +342,13 @@ public class HelixStateTransitionHandler extends MessageHandler {
                                 message.getFromState(),
                                 message.getToState(),
                                 message.getTgtSessionId()));
+
+      if (_cancelled) {
+        throw new HelixRollbackException(String.format(
+            "Instance %s, partition %s state transition from %s to %s on session %s has been cancelled",
+            message.getTgtName(), message.getPartitionName(), message.getFromState(),
+            message.getToState(), message.getTgtSessionId()));
+      }
 
       Object result = methodToInvoke.invoke(_stateModel, new Object[] { message, context });
       taskResult.setSuccess(true);

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTask.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTask.java
@@ -95,14 +95,6 @@ public class HelixTask implements MessageTask {
       _statusUpdateUtil.logError(_message, HelixTask.class, e,
           "State transition interrupted, timeout:" + _isTimeout, accessor);
       logger.info("Message " + _message.getMsgId() + " is interrupted");
-    } catch (HelixRollbackException e) {
-      // TODO : Support cancel to any state
-      logger.info(
-          "Rollback happened of state transition on resource \"" + _message.getResourceName()
-              + "\" partition \"" + _message.getPartitionName() + "\" from \"" + _message
-              .getFromState() + "\" to \"" + _message.getToState() + "\"");
-      taskResult = new HelixTaskResult();
-      taskResult.setCancelled(true);
     } catch (Exception e) {
       taskResult = new HelixTaskResult();
       taskResult.setException(e);

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskResult.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskResult.java
@@ -25,6 +25,7 @@ import java.util.Map;
 public class HelixTaskResult {
 
   private boolean _success;
+  private boolean _cancelled;
   private String _message = "";
   private String _info = "";
   private Map<String, String> _taskResultMap = new HashMap<String, String>();
@@ -41,6 +42,14 @@ public class HelixTaskResult {
 
   public void setInterrupted(boolean interrupted) {
     _interrupted = interrupted;
+  }
+
+  public boolean isCancelled() {
+    return _cancelled;
+  }
+
+  public void setCancelled(boolean cancelled) {
+    _cancelled = cancelled;
   }
 
   public void setSuccess(boolean success) {

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/MessageHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/MessageHandler.java
@@ -41,6 +41,7 @@ public abstract class MessageHandler {
    * The message to be handled
    */
   protected final Message _message;
+  protected boolean _cancelled;
 
   /**
    * The context for handling the message. The cluster manager interface can be
@@ -55,6 +56,7 @@ public abstract class MessageHandler {
   public MessageHandler(Message message, NotificationContext context) {
     _message = message;
     _notificationContext = context;
+    _cancelled = false;
   }
 
   /**
@@ -87,5 +89,9 @@ public abstract class MessageHandler {
    */
   public Message getMessage() {
     return _message;
+  }
+
+  public void cancel() {
+    _cancelled = true;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/MessageHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/MessageHandler.java
@@ -80,4 +80,12 @@ public abstract class MessageHandler {
   public void onTimeout() {
 
   }
+
+  /**
+   * Get message for this message handler
+   * @return
+   */
+  public Message getMessage() {
+    return _message;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/MessageHandlerFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/MessageHandlerFactory.java
@@ -19,13 +19,18 @@ package org.apache.helix.messaging.handling;
  * under the License.
  */
 
+import java.util.List;
+
 import org.apache.helix.NotificationContext;
 import org.apache.helix.model.Message;
 
 public interface MessageHandlerFactory {
   MessageHandler createHandler(Message message, NotificationContext context);
 
+  @Deprecated
   String getMessageType();
+
+  List<String> getMessageTypes();
 
   void reset();
 }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/MessageTask.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/MessageTask.java
@@ -33,4 +33,5 @@ public interface MessageTask extends Callable<HelixTaskResult> {
 
   void onTimeout();
 
+  boolean cancel();
 }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/MessageTaskInfo.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/MessageTaskInfo.java
@@ -37,4 +37,8 @@ public class MessageTaskInfo {
     return _future;
   }
 
+  public MessageTask getTask(){
+    return _task;
+  }
+
 }

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -43,6 +43,7 @@ public class ClusterConfig extends HelixProperty {
     DELAY_REBALANCE_DISABLED,  // enabled the delayed rebalaning in case node goes offline.
     DELAY_REBALANCE_TIME,     // delayed time in ms that the delay time Helix should hold until rebalancing.
     STATE_TRANSITION_THROTTLE_CONFIGS,
+    STATE_TRANSITION_CANCELLATION_ENABLED,
     BATCH_STATE_TRANSITION_MAX_THREADS,
     MAX_CONCURRENT_TASK_PER_INSTANCE
   }
@@ -154,6 +155,24 @@ public class ClusterConfig extends HelixProperty {
   public int getMaxConcurrentTaskPerInstance() {
     return _record.getIntField(ClusterConfigProperty.MAX_CONCURRENT_TASK_PER_INSTANCE.name(),
         DEFAULT_MAX_CONCURRENT_TASK_PER_INSTANCE);
+  }
+  /**
+   * Enable/Disable state transition cancellation for the cluster
+   * @param enable
+   */
+  public void stateTransitionCancelEnabled(Boolean enable) {
+    if (enable == null) {
+      _record.getSimpleFields()
+          .remove(ClusterConfigProperty.STATE_TRANSITION_CANCELLATION_ENABLED.name());
+    } else {
+      _record.setBooleanField(ClusterConfigProperty.STATE_TRANSITION_CANCELLATION_ENABLED.name(),
+          enable);
+    }
+  }
+
+  public boolean isStateTransitionCancelEnabled() {
+    return _record
+        .getBooleanField(ClusterConfigProperty.STATE_TRANSITION_CANCELLATION_ENABLED.name(), false);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConstraints.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConstraints.java
@@ -164,7 +164,7 @@ public class ClusterConstraints extends HelixProperty {
     Map<ConstraintAttribute, String> attributes = new TreeMap<ConstraintAttribute, String>();
     String msgType = msg.getMsgType();
     attributes.put(ConstraintAttribute.MESSAGE_TYPE, msgType);
-    if (MessageType.STATE_TRANSITION.toString().equals(msgType)) {
+    if (MessageType.STATE_TRANSITION.name().equals(msgType)) {
       if (msg.getFromState() != null && msg.getToState() != null) {
         attributes.put(ConstraintAttribute.TRANSITION, msg.getFromState() + "-" + msg.getToState());
       }

--- a/helix-core/src/main/java/org/apache/helix/model/Message.java
+++ b/helix-core/src/main/java/org/apache/helix/model/Message.java
@@ -43,6 +43,7 @@ public class Message extends HelixProperty {
    */
   public enum MessageType {
     STATE_TRANSITION,
+    STATE_TRANSITION_CANCELLATION,
     SCHEDULER_MSG,
     USER_DEFINE_MSG,
     CONTROLLER_MSG,
@@ -50,7 +51,7 @@ public class Message extends HelixProperty {
     NO_OP,
     PARTICIPANT_ERROR_REPORT,
     PARTICIPANT_SESSION_CHANGE
-  };
+  }
 
   /**
    * Properties attached to Messages
@@ -696,7 +697,7 @@ public class Message extends HelixProperty {
     // TODO: refactor message to state transition message and task-message and
     // implement this function separately
 
-    if (getMsgType().equals(MessageType.STATE_TRANSITION.toString())) {
+    if (getMsgType().equals(MessageType.STATE_TRANSITION.name())) {
       boolean isNotValid =
           isNullOrEmpty(getTgtName()) || isNullOrEmpty(getPartitionName())
               || isNullOrEmpty(getResourceName()) || isNullOrEmpty(getStateModelDef())

--- a/helix-core/src/main/java/org/apache/helix/model/Message.java
+++ b/helix-core/src/main/java/org/apache/helix/model/Message.java
@@ -116,7 +116,7 @@ public class Message extends HelixProperty {
    * @param msgId unique message identifier
    */
   public Message(MessageType type, String msgId) {
-    this(type.toString(), msgId);
+    this(type.name(), msgId);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/participant/HelixStateMachineEngine.java
+++ b/helix-core/src/main/java/org/apache/helix/participant/HelixStateMachineEngine.java
@@ -19,6 +19,7 @@ package org.apache.helix.participant;
  * under the License.
  */
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -45,6 +46,8 @@ import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelFactory;
 import org.apache.helix.participant.statemachine.StateModelParser;
 import org.apache.log4j.Logger;
+
+import com.google.common.collect.ImmutableList;
 
 public class HelixStateMachineEngine implements StateMachineEngine {
   private static Logger logger = Logger.getLogger(HelixStateMachineEngine.class);
@@ -162,7 +165,8 @@ public class HelixStateMachineEngine implements StateMachineEngine {
   public MessageHandler createHandler(Message message, NotificationContext context) {
     String type = message.getMsgType();
 
-    if (!type.equals(MessageType.STATE_TRANSITION.name())) {
+    if (!type.equals(MessageType.STATE_TRANSITION.name()) && !type
+        .equals(MessageType.STATE_TRANSITION_CANCELLATION.name())) {
       throw new HelixException("Expect state-transition message type, but was "
           + message.getMsgType() + ", msgId: " + message.getMsgId());
     }
@@ -253,6 +257,11 @@ public class HelixStateMachineEngine implements StateMachineEngine {
   @Override
   public String getMessageType() {
     return MessageType.STATE_TRANSITION.name();
+  }
+
+  @Override public List<String> getMessageTypes() {
+    return ImmutableList
+        .of(MessageType.STATE_TRANSITION.name(), MessageType.STATE_TRANSITION_CANCELLATION.name());
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/participant/statemachine/StateModel.java
+++ b/helix-core/src/main/java/org/apache/helix/participant/statemachine/StateModel.java
@@ -25,6 +25,7 @@ import org.apache.log4j.Logger;
 
 public abstract class StateModel {
   static final String DEFAULT_INITIAL_STATE = "OFFLINE";
+  private boolean _cancelled;
   Logger logger = Logger.getLogger(StateModel.class);
 
   // TODO Get default state from implementation or from state model annotation
@@ -80,4 +81,10 @@ public abstract class StateModel {
     logger.info("Default ERROR->DROPPED transition invoked.");
   }
 
+  /**
+   * Default implementation for cancelling state transition
+   */
+  public void cancel() {
+    _cancelled = true;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/participant/statemachine/StateModel.java
+++ b/helix-core/src/main/java/org/apache/helix/participant/statemachine/StateModel.java
@@ -25,7 +25,7 @@ import org.apache.log4j.Logger;
 
 public abstract class StateModel {
   static final String DEFAULT_INITIAL_STATE = "OFFLINE";
-  private boolean _cancelled;
+  protected boolean _cancelled;
   Logger logger = Logger.getLogger(StateModel.class);
 
   // TODO Get default state from implementation or from state model annotation
@@ -86,5 +86,13 @@ public abstract class StateModel {
    */
   public void cancel() {
     _cancelled = true;
+  }
+
+  /**
+   * Default implementation to check whether state transition has been cancelled or not
+   * @return
+   */
+  public boolean isCancelled() {
+    return _cancelled;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/participant/statemachine/StateModel.java
+++ b/helix-core/src/main/java/org/apache/helix/participant/statemachine/StateModel.java
@@ -83,6 +83,18 @@ public abstract class StateModel {
 
   /**
    * Default implementation for cancelling state transition
+   *
+   * IMPORTANT:
+   *
+   * 1. Be careful with the implementation of this method. There is no
+   * grantee that this method is called before user state transition method invoked.
+   * Please make sure the implemention contains logic for checking state transition already started.
+   * Similar to this situation, when this cancel method has been called. Helix does not grantee the
+   * state transition is still running. The state transition could be completed.
+   *
+   * 2. This cancel method should not throw HelixRollbackException. It is better to trigger the real
+   * state transition to throw HelixRollbackException if user would like to cancel the current
+   * running state transition.
    */
   public void cancel() {
     _cancelled = true;

--- a/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
@@ -435,7 +435,7 @@ public class StatusUpdateUtil {
   }
 
   private String getStatusUpdateKey(Message message) {
-    if (message.getMsgType().equalsIgnoreCase(MessageType.STATE_TRANSITION.toString())) {
+    if (message.getMsgType().equalsIgnoreCase(MessageType.STATE_TRANSITION.name())) {
       return message.getPartitionName();
     }
     return message.getMsgId();
@@ -445,7 +445,7 @@ public class StatusUpdateUtil {
    * Generate the sub-path under STATUSUPDATE or ERROR path for a status update
    */
   String getStatusUpdateSubPath(Message message) {
-    if (message.getMsgType().equalsIgnoreCase(MessageType.STATE_TRANSITION.toString())) {
+    if (message.getMsgType().equalsIgnoreCase(MessageType.STATE_TRANSITION.name())) {
       return message.getResourceName();
     } else {
       return message.getMsgType();
@@ -453,7 +453,7 @@ public class StatusUpdateUtil {
   }
 
   String getStatusUpdateRecordName(Message message) {
-    if (message.getMsgType().equalsIgnoreCase(MessageType.STATE_TRANSITION.toString())) {
+    if (message.getMsgType().equalsIgnoreCase(MessageType.STATE_TRANSITION.name())) {
       return message.getTgtSessionId() + "__" + message.getResourceName();
     }
     return message.getMsgId();

--- a/helix-core/src/test/java/org/apache/helix/Mocks.java
+++ b/helix-core/src/test/java/org/apache/helix/Mocks.java
@@ -678,6 +678,11 @@ public class Mocks {
 
     }
 
+    @Override public void registerMessageHandlerFactory(List<String> types,
+        MessageHandlerFactory factory) {
+      // TODO Auto-generated method stub
+    }
+
     @Override
     public int send(Criteria receipientCriteria, Message message, AsyncCallback callbackOnReply,
         int timeOut, int retryCount) {

--- a/helix-core/src/test/java/org/apache/helix/TestHelixTaskExecutor.java
+++ b/helix-core/src/test/java/org/apache/helix/TestHelixTaskExecutor.java
@@ -62,7 +62,7 @@ public class TestHelixTaskExecutor {
 
     MockHelixTaskExecutor executor = new MockHelixTaskExecutor();
     MockStateModel stateModel = new MockStateModel();
-    executor.registerMessageHandlerFactory(MessageType.TASK_REPLY.toString(),
+    executor.registerMessageHandlerFactory(MessageType.TASK_REPLY.name(),
         new AsyncCallbackService());
 
     NotificationContext context = new NotificationContext(manager);

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
@@ -34,6 +34,7 @@ import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.Message;
@@ -209,6 +210,7 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     event.addAttribute("helixmanager", manager);
 
     ClusterDataCache cache = new ClusterDataCache();
+    cache._clusterConfig = new ClusterConfig(clusterName);
     event.addAttribute("ClusterDataCache", cache);
 
     final String resourceName = "testResource_pending";
@@ -266,6 +268,8 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     cache.setIdealStates(idealStates);
 
     runPipeline(event, dataRefresh);
+    cache = event.getAttribute("ClusterDataCache");
+    cache._clusterConfig = new ClusterConfig(clusterName);
     runPipeline(event, rebalancePipeline);
     msgSelOutput = event.getAttribute(AttributeName.MESSAGES_SELECTED.name());
     messages = msgSelOutput.getMessages(resourceName, new Partition(resourceName + "_0"));

--- a/helix-core/src/test/java/org/apache/helix/integration/TestMessageThrottle.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestMessageThrottle.java
@@ -98,7 +98,7 @@ public class TestMessageThrottle extends ZkIntegrationTestBase {
             int transitionMsgCount = 0;
             for (ZNRecord record : records) {
               Message msg = new Message(record);
-              if (msg.getMsgType().equals(Message.MessageType.STATE_TRANSITION.toString())) {
+              if (msg.getMsgType().equals(Message.MessageType.STATE_TRANSITION.name())) {
                 transitionMsgCount++;
               }
             }

--- a/helix-core/src/test/java/org/apache/helix/integration/TestMessagingService.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestMessagingService.java
@@ -20,6 +20,7 @@ package org.apache.helix.integration;
  */
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.UUID;
 
 import org.apache.helix.Criteria;
@@ -36,6 +37,8 @@ import org.apache.helix.model.Message.MessageType;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
+
 public class TestMessagingService extends ZkStandAloneCMTestBase {
   public static class TestMessagingHandlerFactory implements MessageHandlerFactory {
     public static HashSet<String> _processedMsgIds = new HashSet<String>();
@@ -48,6 +51,11 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
     @Override
     public String getMessageType() {
       return "TestExtensibility";
+    }
+
+    @Override
+    public List<String> getMessageTypes() {
+      return ImmutableList.of("TestExtensibility");
     }
 
     @Override
@@ -87,11 +95,11 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
     String hostDest = "localhost_" + (START_PORT + 1);
 
     TestMessagingHandlerFactory factory = new TestMessagingHandlerFactory();
-    _participants[1].getMessagingService().registerMessageHandlerFactory(factory.getMessageType(),
+    _participants[1].getMessagingService().registerMessageHandlerFactory(factory.getMessageTypes(),
         factory);
 
     String msgId = new UUID(123, 456).toString();
-    Message msg = new Message(factory.getMessageType(), msgId);
+    Message msg = new Message(factory.getMessageTypes().get(0), msgId);
     msg.setMsgId(msgId);
     msg.setSrcName(hostSrc);
     msg.setTgtSessionId("*");
@@ -179,14 +187,14 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
     String hostDest = "localhost_" + (START_PORT + 1);
 
     TestMessagingHandlerFactory factory = new TestMessagingHandlerFactory();
-    _participants[1].getMessagingService().registerMessageHandlerFactory(factory.getMessageType(),
+    _participants[1].getMessagingService().registerMessageHandlerFactory(factory.getMessageTypes(),
         factory);
 
-    _participants[0].getMessagingService().registerMessageHandlerFactory(factory.getMessageType(),
+    _participants[0].getMessagingService().registerMessageHandlerFactory(factory.getMessageTypes(),
         factory);
 
     String msgId = new UUID(123, 456).toString();
-    Message msg = new Message(factory.getMessageType(), msgId);
+    Message msg = new Message(factory.getMessageTypes().get(0), msgId);
     msg.setMsgId(msgId);
     msg.setSrcName(hostSrc);
 
@@ -246,11 +254,11 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
     String hostDest = "localhost_" + (START_PORT + 1);
 
     TestMessagingHandlerFactory factory = new TestMessagingHandlerFactory();
-    _participants[1].getMessagingService().registerMessageHandlerFactory(factory.getMessageType(),
+    _participants[1].getMessagingService().registerMessageHandlerFactory(factory.getMessageTypes(),
         factory);
 
     String msgId = new UUID(123, 456).toString();
-    Message msg = new Message(factory.getMessageType(), msgId);
+    Message msg = new Message(factory.getMessageTypes().get(0), msgId);
     msg.setMsgId(msgId);
     msg.setSrcName(hostSrc);
 
@@ -287,11 +295,11 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
       TestMessagingHandlerFactory factory = new TestMessagingHandlerFactory();
       String hostDest = "localhost_" + (START_PORT + i);
       _participants[i].getMessagingService().registerMessageHandlerFactory(
-          factory.getMessageType(), factory);
+          factory.getMessageTypes(), factory);
 
     }
     String msgId = new UUID(123, 456).toString();
-    Message msg = new Message(new TestMessagingHandlerFactory().getMessageType(), msgId);
+    Message msg = new Message(new TestMessagingHandlerFactory().getMessageTypes().get(0), msgId);
     msg.setMsgId(msgId);
     msg.setSrcName(hostSrc);
 
@@ -351,11 +359,11 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
       TestMessagingHandlerFactory factory = new TestMessagingHandlerFactory();
       String hostDest = "localhost_" + (START_PORT + i);
       _participants[i].getMessagingService().registerMessageHandlerFactory(
-          factory.getMessageType(), factory);
+          factory.getMessageTypes(), factory);
 
     }
     String msgId = new UUID(123, 456).toString();
-    Message msg = new Message(new TestMessagingHandlerFactory().getMessageType(), msgId);
+    Message msg = new Message(new TestMessagingHandlerFactory().getMessageTypes().get(0), msgId);
     msg.setMsgId(msgId);
     msg.setSrcName(hostSrc);
 
@@ -387,7 +395,7 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
       TestMessagingHandlerFactory factory = new TestMessagingHandlerFactory();
       String hostDest = "localhost_" + (START_PORT + i);
       _participants[i].getMessagingService().registerMessageHandlerFactory(
-          factory.getMessageType(), factory);
+          factory.getMessageTypes(), factory);
 
     }
     String msgId = new UUID(123, 456).toString();

--- a/helix-core/src/test/java/org/apache/helix/integration/TestResourceGroupEndtoEnd.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestResourceGroupEndtoEnd.java
@@ -277,7 +277,7 @@ public class TestResourceGroupEndtoEnd extends ZkIntegrationTestBase {
       stateMach.registerStateModelFactory("OnlineOffline", stateModelFactory2);
 
       manager.connect();
-      //manager.getMessagingService().registerMessageHandlerFactory(MessageType.STATE_TRANSITION.toString(), genericStateMachineHandler);
+      //manager.getMessagingService().registerMessageHandlerFactory(MessageType.STATE_TRANSITION.name(), genericStateMachineHandler);
       return manager;
     }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMessage.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMessage.java
@@ -58,6 +58,7 @@ import org.codehaus.jackson.map.SerializationConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
 
 public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
 
@@ -92,6 +93,10 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     @Override
     public String getMessageType() {
       return "TestParticipant";
+    }
+
+    @Override public List<String> getMessageTypes() {
+      return ImmutableList.of("TestParticipant");
     }
 
     @Override
@@ -150,6 +155,10 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
       return "TestMessagingHandlerLatch";
     }
 
+    @Override public List<String> getMessageTypes() {
+      return ImmutableList.of("TestMessagingHandlerLatch");
+    }
+
     @Override
     public void reset() {
       // TODO Auto-generated method stub
@@ -192,7 +201,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     HelixManager manager = null;
     for (int i = 0; i < NODE_NR; i++) {
       _participants[i].getMessagingService().registerMessageHandlerFactory(
-          _factory.getMessageType(), _factory);
+          _factory.getMessageTypes(), _factory);
 
       manager = _participants[i]; // _startCMResultMap.get(hostDest)._manager;
     }
@@ -206,7 +215,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     // schedulerMessage.getRecord().setSimpleField(DefaultSchedulerMessageHandlerFactory.SCHEDULER_TASK_QUEUE,
     // "TestSchedulerMsg");
     // Template for the individual message sent to each participant
-    Message msg = new Message(_factory.getMessageType(), "Template");
+    Message msg = new Message(_factory.getMessageTypes().get(0), "Template");
     msg.setTgtSessionId("*");
     msg.setMsgState(MessageState.NEW);
 
@@ -244,7 +253,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
 
     Assert.assertEquals(_PARTITIONS, _factory._results.size());
     PropertyKey controllerTaskStatus =
-        keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(),
+        keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(),
             schedulerMessage.getMsgId());
 
     int messageResultCount = 0;
@@ -326,7 +335,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     HelixManager manager = null;
     for (int i = 0; i < NODE_NR; i++) {
       _participants[i].getMessagingService().registerMessageHandlerFactory(
-          _factory.getMessageType(), _factory);
+          _factory.getMessageTypes(), _factory);
 
       manager = _participants[i]; // _startCMResultMap.get(hostDest)._manager;
     }
@@ -339,7 +348,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     schedulerMessage.setSrcName("CONTROLLER");
 
     // Template for the individual message sent to each participant
-    Message msg = new Message(_factory.getMessageType(), "Template");
+    Message msg = new Message(_factory.getMessageTypes().get(0), "Template");
     msg.setTgtSessionId("*");
     msg.setMsgState(MessageState.NEW);
 
@@ -373,7 +382,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
 
     Assert.assertEquals(0, _factory._results.size());
     PropertyKey controllerTaskStatus =
-        keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(),
+        keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(),
             schedulerMessage.getMsgId());
     for (int i = 0; i < 10; i++) {
       StatusUpdate update = helixDataAccessor.getProperty(controllerTaskStatus);
@@ -397,10 +406,10 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     HelixManager manager = null;
     for (int i = 0; i < NODE_NR; i++) {
       _participants[i].getMessagingService().registerMessageHandlerFactory(
-          _factory.getMessageType(), _factory);
+          _factory.getMessageTypes(), _factory);
 
       _participants[i].getMessagingService().registerMessageHandlerFactory(
-          _factory.getMessageType(), _factory);
+          _factory.getMessageTypes(), _factory);
 
       manager = _participants[i]; // _startCMResultMap.get(hostDest)._manager;
     }
@@ -413,7 +422,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     schedulerMessage.setSrcName("CONTROLLER");
 
     // Template for the individual message sent to each participant
-    Message msg = new Message(_factory.getMessageType(), "Template");
+    Message msg = new Message(_factory.getMessageTypes().get(0), "Template");
     msg.setTgtSessionId("*");
     msg.setMsgState(MessageState.NEW);
 
@@ -481,7 +490,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
       for (int j = 0; j < 100; j++) {
         Thread.sleep(200);
         PropertyKey controllerTaskStatus =
-            keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(), msgId);
+            keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(), msgId);
         ZNRecord statusUpdate = helixDataAccessor.getProperty(controllerTaskStatus).getRecord();
         if (statusUpdate.getMapFields().containsKey("Summary")) {
           break;
@@ -489,7 +498,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
       }
 
       PropertyKey controllerTaskStatus =
-          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(), msgId);
+          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(), msgId);
       ZNRecord statusUpdate = helixDataAccessor.getProperty(controllerTaskStatus).getRecord();
       Assert.assertTrue(statusUpdate.getMapField("SentMessageCount").get("MessageCount")
           .equals("" + (_PARTITIONS * 3 / 5)));
@@ -518,10 +527,10 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     HelixManager manager = null;
     for (int i = 0; i < NODE_NR; i++) {
       _participants[i].getMessagingService().registerMessageHandlerFactory(
-          _factory.getMessageType(), _factory);
+          _factory.getMessageTypes(), _factory);
 
       _participants[i].getMessagingService().registerMessageHandlerFactory(
-          _factory.getMessageType(), _factory);
+          _factory.getMessageTypes(), _factory);
 
       manager = _participants[i]; // _startCMResultMap.get(hostDest)._manager;
     }
@@ -534,7 +543,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     schedulerMessage.setSrcName("CONTROLLER");
 
     // Template for the individual message sent to each participant
-    Message msg = new Message(_factory.getMessageType(), "Template");
+    Message msg = new Message(_factory.getMessageTypes().get(0), "Template");
     msg.setTgtSessionId("*");
     msg.setMsgState(MessageState.NEW);
 
@@ -617,7 +626,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
       for (int j = 0; j < 100; j++) {
         Thread.sleep(200);
         PropertyKey controllerTaskStatus =
-            keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(), msgId);
+            keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(), msgId);
         ZNRecord statusUpdate = helixDataAccessor.getProperty(controllerTaskStatus).getRecord();
         if (statusUpdate.getMapFields().containsKey("Summary")) {
           // System.err.println(msgId+" done");
@@ -626,7 +635,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
       }
 
       PropertyKey controllerTaskStatus =
-          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(), msgId);
+          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(), msgId);
       ZNRecord statusUpdate = helixDataAccessor.getProperty(controllerTaskStatus).getRecord();
       Assert.assertTrue(statusUpdate.getMapField("SentMessageCount").get("MessageCount")
           .equals("" + (_PARTITIONS * 3 / 5)));
@@ -646,7 +655,7 @@ public class TestSchedulerMessage extends ZkStandAloneCMTestBase {
     for (int j = 0; j < 100; j++) {
       Thread.sleep(200);
       PropertyKey controllerTaskStatus =
-          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(), msgIdPrime);
+          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(), msgIdPrime);
       ZNRecord statusUpdate = helixDataAccessor.getProperty(controllerTaskStatus).getRecord();
       if (statusUpdate.getMapFields().containsKey("Summary")) {
         break;

--- a/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMessage2.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMessage2.java
@@ -106,7 +106,7 @@ public class TestSchedulerMessage2 extends ZkStandAloneCMTestBase {
     for (int i = 0; i < 10; i++) {
       Thread.sleep(200);
       PropertyKey controllerTaskStatus =
-          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(), msgId);
+          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(), msgId);
       ZNRecord statusUpdate = helixDataAccessor.getProperty(controllerTaskStatus).getRecord();
       if (statusUpdate.getMapFields().containsKey("Summary")) {
         break;
@@ -115,7 +115,7 @@ public class TestSchedulerMessage2 extends ZkStandAloneCMTestBase {
 
     Assert.assertEquals(_PARTITIONS, _factory._results.size());
     PropertyKey controllerTaskStatus =
-        keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(), msgId);
+        keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(), msgId);
     ZNRecord statusUpdate = helixDataAccessor.getProperty(controllerTaskStatus).getRecord();
     Assert.assertTrue(statusUpdate.getMapField("SentMessageCount").get("MessageCount")
         .equals("" + (_PARTITIONS * 3)));

--- a/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMsgContraints.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMsgContraints.java
@@ -131,7 +131,7 @@ public class TestSchedulerMsgContraints extends ZkStandAloneCMTestBase {
     for (int j = 0; j < 10; j++) {
       Thread.sleep(200);
       PropertyKey controllerTaskStatus =
-          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(), msgId);
+          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(), msgId);
       ZNRecord statusUpdate = helixDataAccessor.getProperty(controllerTaskStatus).getRecord();
       if (statusUpdate.getMapFields().containsKey("SentMessageCount")) {
         Assert.assertEquals(
@@ -156,7 +156,7 @@ public class TestSchedulerMsgContraints extends ZkStandAloneCMTestBase {
     for (int j = 0; j < 10; j++) {
       Thread.sleep(200);
       PropertyKey controllerTaskStatus =
-          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(), msgId);
+          keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(), msgId);
       ZNRecord statusUpdate = helixDataAccessor.getProperty(controllerTaskStatus).getRecord();
       if (statusUpdate.getMapFields().containsKey("Summary")) {
         break;
@@ -165,7 +165,7 @@ public class TestSchedulerMsgContraints extends ZkStandAloneCMTestBase {
 
     Assert.assertEquals(_PARTITIONS, factory._results.size());
     PropertyKey controllerTaskStatus =
-        keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(), msgId);
+        keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(), msgId);
     ZNRecord statusUpdate = helixDataAccessor.getProperty(controllerTaskStatus).getRecord();
     Assert.assertTrue(statusUpdate.getMapField("SentMessageCount").get("MessageCount")
         .equals("" + (_PARTITIONS * 3)));

--- a/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMsgUsingQueue.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestSchedulerMsgUsingQueue.java
@@ -103,7 +103,7 @@ public class TestSchedulerMsgUsingQueue extends ZkStandAloneCMTestBase {
 
     Assert.assertEquals(_PARTITIONS, _factory._results.size());
     PropertyKey controllerTaskStatus =
-        keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.toString(),
+        keyBuilder.controllerTaskStatus(MessageType.SCHEDULER_MSG.name(),
             schedulerMessage.getMsgId());
 
     int messageResultCount = 0;

--- a/helix-core/src/test/java/org/apache/helix/integration/TestStateTransitionCancellation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestStateTransitionCancellation.java
@@ -1,0 +1,293 @@
+package org.apache.helix.integration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixRollbackException;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.MockTask;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.integration.task.WorkflowGenerator;
+import org.apache.helix.mock.participant.MockDelayMSStateModel;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.Message;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.participant.statemachine.StateModel;
+import org.apache.helix.participant.statemachine.StateModelFactory;
+import org.apache.helix.participant.statemachine.StateModelInfo;
+import org.apache.helix.participant.statemachine.Transition;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.tools.ClusterSetup;
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestStateTransitionCancellation extends TaskTestBase {
+  // TODO: Replace the thread sleep with synchronized condition check
+  private ConfigAccessor _configAccessor;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _numDbs = 1;
+    _numParitions = 20;
+    _numNodes = 2;
+    _numReplicas = 2;
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursive(namespace);
+    }
+
+    _setupTool = new ClusterSetup(ZK_ADDR);
+    _setupTool.addCluster(CLUSTER_NAME, true);
+    setupParticipants();
+    setupDBs();
+
+    registerParticipants(_participants, _numNodes, _startPort, 0, -3000000L);
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    createManagers();
+    _configAccessor = new ConfigAccessor(_gZkClient);
+  }
+
+  @Test
+  public void testCancellationWhenDisableResource() throws InterruptedException {
+    // Enable cancellation
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.stateTransitionCancelEnabled(true);
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    // Wait for assignment done
+    Thread.sleep(2000);
+
+    // Disable the resource
+    _setupTool.getClusterManagementTool()
+        .enableResource(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, false);
+
+    // Wait for pipeline reaching final stage
+    Thread.sleep(2000L);
+    ExternalView externalView = _setupTool.getClusterManagementTool()
+        .getResourceExternalView(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB);
+    for (String partition : externalView.getPartitionSet()) {
+      for (String currentState : externalView.getStateMap(partition).values()) {
+        Assert.assertEquals(currentState, "OFFLINE");
+      }
+    }
+  }
+
+  @Test
+  public void testDisableCancellationWhenDisableResource() throws InterruptedException {
+    // Disable cancellation
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.stateTransitionCancelEnabled(false);
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    // Reenable resource
+    stateCleanUp();
+    _setupTool.getClusterManagementTool()
+        .enableResource(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, true);
+
+    // Wait for assignment done
+    Thread.sleep(2000);
+
+    // Disable the resource
+    _setupTool.getClusterManagementTool()
+        .enableResource(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, false);
+
+    // Wait for pipeline reaching final stage
+    Thread.sleep(2000L);
+    ExternalView externalView = _setupTool.getClusterManagementTool()
+        .getResourceExternalView(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB);
+    for (String partition : externalView.getPartitionSet()) {
+      Assert.assertTrue(externalView.getStateMap(partition).values().contains("SLAVE"));
+    }
+  }
+
+  @Test
+  public void testRebalancingCauseCancellation() throws InterruptedException {
+    // Enable cancellation
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.stateTransitionCancelEnabled(true);
+    clusterConfig.setPersistBestPossibleAssignment(true);
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    // Reenable resource
+    stateCleanUp();
+    _setupTool.getClusterManagementTool()
+        .enableResource(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, true);
+
+    // Wait for assignment done
+    Thread.sleep(2000);
+    int numNodesToStart = 10;
+    for (int i = 0; i < numNodesToStart; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (_startPort + _numNodes + i);
+      _setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+    MockParticipantManager[] newParticipants = new MockParticipantManager[numNodesToStart];
+    registerParticipants(newParticipants, numNodesToStart, _startPort + _numNodes, 1000, -3000000L);
+
+    // Wait for pipeline reaching final stage
+    Thread.sleep(2000L);
+    int numOfMasters = 0;
+    ExternalView externalView = _setupTool.getClusterManagementTool()
+        .getResourceExternalView(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB);
+    for (String partition : externalView.getPartitionSet()) {
+      if (externalView.getStateMap(partition).values().contains("MASTER")) {
+        numOfMasters++;
+      }
+    }
+
+    for (MockParticipantManager participant : newParticipants) {
+      participant.syncStop();
+    }
+
+    // Only partial of state transition has been cancelled
+    Assert.assertTrue((numOfMasters > 0 && numOfMasters < _numParitions));
+  }
+
+  private void stateCleanUp() {
+    InternalMockDelayMSStateModel._cancelledFirstTime = true;
+    InternalMockDelayMSStateModel._cancelledStatic = false;
+  }
+
+  @StateModelInfo(initialState = "OFFLINE", states = { "MASTER", "SLAVE", "ERROR"
+  })
+  public static class InternalMockDelayMSStateModel extends StateModel {
+    private static Logger LOG = Logger.getLogger(MockDelayMSStateModel.class);
+    private long _delay;
+    public static boolean _cancelledStatic;
+    public static boolean _cancelledFirstTime;
+
+    public InternalMockDelayMSStateModel(long delay) {
+      _delay = delay;
+      _cancelledStatic = false;
+      _cancelledFirstTime = true;
+    }
+
+    @Transition(to = "SLAVE", from = "OFFLINE") public void onBecomeSlaveFromOffline(
+        Message message, NotificationContext context) {
+      if (_delay > 0) {
+        try {
+          Thread.sleep(_delay);
+        } catch (InterruptedException e) {
+          LOG.error("Failed to sleep for " + _delay);
+        }
+      }
+      LOG.info("Become SLAVE from OFFLINE");
+    }
+
+    @Transition(to = "MASTER", from = "SLAVE") public void onBecomeMasterFromSlave(Message message,
+        NotificationContext context) throws InterruptedException, HelixRollbackException {
+      if (_cancelledFirstTime && _delay < 0) {
+        while (!_cancelledStatic) {
+          Thread.sleep(Math.abs(1000L));
+        }
+        _cancelledFirstTime = false;
+        throw new HelixRollbackException("EX");
+      }
+      LOG.error("Become MASTER from SLAVE");
+    }
+
+    @Transition(to = "SLAVE", from = "MASTER") public void onBecomeSlaveFromMaster(Message message,
+        NotificationContext context) {
+      LOG.info("Become Slave from Master");
+    }
+
+    @Transition(to = "OFFLINE", from = "SLAVE") public void onBecomeOfflineFromSlave(
+        Message message, NotificationContext context) {
+      LOG.info("Become OFFLINE from SLAVE");
+    }
+
+    @Transition(to = "DROPPED", from = "OFFLINE") public void onBecomeDroppedFromOffline(
+        Message message, NotificationContext context) {
+      LOG.info("Become DROPPED FROM OFFLINE");
+    }
+
+    @Override
+    public void cancel() {
+      _cancelledStatic = true;
+    }
+
+    @Override
+    public boolean isCancelled() {
+      return _cancelledStatic;
+    }
+  }
+
+  public class InMockDelayMSStateModelFactory
+      extends StateModelFactory<InternalMockDelayMSStateModel> {
+    private long _delay;
+
+    @Override
+    public InternalMockDelayMSStateModel createNewStateModel(String resourceName,
+        String partitionKey) {
+      InternalMockDelayMSStateModel model = new InternalMockDelayMSStateModel(_delay);
+      return model;
+    }
+
+    public InMockDelayMSStateModelFactory setDelay(long delay) {
+      _delay = delay;
+      return this;
+    }
+  }
+
+  private void registerParticipants(MockParticipantManager[] participants, int numNodes,
+      int startPort, long sleepTime, long delay) throws InterruptedException {
+    Map<String, TaskFactory> taskFactoryReg = new HashMap<String, TaskFactory>();
+    taskFactoryReg.put(MockTask.TASK_COMMAND, new TaskFactory() {
+      @Override
+      public Task createNewTask(TaskCallbackContext context) {
+        return new MockTask(context);
+      }
+    });
+
+    for (int i = 0; i < numNodes; i++) {
+      String instanceName = PARTICIPANT_PREFIX + "_" + (startPort + i);
+      participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+
+      // add a state model with non-OFFLINE initial state
+      StateMachineEngine stateMach = participants[i].getStateMachineEngine();
+      stateMach.registerStateModelFactory("Task",
+          new TaskStateModelFactory(participants[i], taskFactoryReg));
+      InMockDelayMSStateModelFactory delayFactory =
+          new InMockDelayMSStateModelFactory().setDelay(delay);
+      stateMach.registerStateModelFactory(MASTER_SLAVE_STATE_MODEL, delayFactory);
+
+      participants[i].syncStart();
+
+      if (sleepTime > 0) {
+        Thread.sleep(sleepTime);
+      }
+    }
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/TestStateTransitionCancellation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestStateTransitionCancellation.java
@@ -59,6 +59,7 @@ public class TestStateTransitionCancellation extends TaskTestBase {
     _numParitions = 20;
     _numNodes = 2;
     _numReplicas = 2;
+    _participants = new MockParticipantManager[_numNodes];
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
       _gZkClient.deleteRecursive(namespace);
@@ -93,6 +94,7 @@ public class TestStateTransitionCancellation extends TaskTestBase {
     // Disable the resource
     _setupTool.getClusterManagementTool()
         .enableResource(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, false);
+
 
     // Wait for pipeline reaching final stage
     Thread.sleep(2000L);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestZkSessionExpiry.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestZkSessionExpiry.java
@@ -21,6 +21,7 @@ package org.apache.helix.integration;
 
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -40,6 +41,8 @@ import org.apache.helix.model.Message;
 import org.apache.helix.tools.ClusterVerifiers.ClusterStateVerifier;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
 
 public class TestZkSessionExpiry extends ZkUnitTestBase {
   final static String DUMMY_MSG_TYPE = "DUMMY";
@@ -83,6 +86,10 @@ public class TestZkSessionExpiry extends ZkUnitTestBase {
     @Override
     public String getMessageType() {
       return DUMMY_MSG_TYPE;
+    }
+
+    @Override public List<String> getMessageTypes() {
+      return ImmutableList.of(DUMMY_MSG_TYPE);
     }
 
     @Override
@@ -158,7 +165,7 @@ public class TestZkSessionExpiry extends ZkUnitTestBase {
   /**
    * trigger dummy message handler and verify it's invoked
    * @param manager
-   * @param handledMsgMap
+   * @param handledMsgSet
    * @throws Exception
    */
   private static void checkDummyMsgHandler(HelixManager manager,

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -56,9 +56,17 @@ import org.apache.helix.tools.StateModelConfigGenerator;
 import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class TestZkHelixAdmin extends ZkUnitTestBase {
+
+  @BeforeClass
+  public void beforeClass() {
+
+  }
+
+  @Test
   public void testZkHelixAdmin() {
     //TODO refactor this test into small test cases and use @before annotations
     System.out.println("START testZkHelixAdmin at " + new Date(System.currentTimeMillis()));

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestConfigThreadpoolSize.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestConfigThreadpoolSize.java
@@ -20,6 +20,7 @@ package org.apache.helix.messaging.handling;
  */
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.apache.helix.ConfigAccessor;
@@ -36,6 +37,8 @@ import org.apache.helix.model.builder.ConfigScopeBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
+
 public class TestConfigThreadpoolSize extends ZkStandAloneCMTestBase {
   public static class TestMessagingHandlerFactory implements MessageHandlerFactory {
     public static HashSet<String> _processedMsgIds = new HashSet<String>();
@@ -48,6 +51,10 @@ public class TestConfigThreadpoolSize extends ZkStandAloneCMTestBase {
     @Override
     public String getMessageType() {
       return "TestMsg";
+    }
+
+    @Override public List<String> getMessageTypes() {
+      return ImmutableList.of("TestMsg");
     }
 
     @Override
@@ -68,6 +75,10 @@ public class TestConfigThreadpoolSize extends ZkStandAloneCMTestBase {
     @Override
     public String getMessageType() {
       return "TestMsg2";
+    }
+
+    @Override public List<String> getMessageTypes() {
+      return ImmutableList.of("TestMsg2");
     }
 
     @Override

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
@@ -647,6 +647,8 @@ public class TestHelixTaskExecutor {
     msg1.setResourceName("R1");
     msg1.setTgtName("Localhost_1123");
     msg1.setSrcName("127.101.1.23_2234");
+    msg1.setFromState("SLAVE");
+    msg1.setToState("MASTER");
     msgList.add(msg1);
 
     Message msg2 = new Message(Message.MessageType.STATE_TRANSITION_CANCELLATION, UUID.randomUUID().toString());
@@ -655,6 +657,8 @@ public class TestHelixTaskExecutor {
     msg2.setResourceName("R1");
     msg2.setTgtName("Localhost_1123");
     msg2.setSrcName("127.101.1.23_2234");
+    msg2.setFromState("SLAVE");
+    msg2.setToState("MASTER");
     msgList.add(msg2);
 
     executor.onMessage("someInstance", msgList, changeContext);

--- a/helix-core/src/test/java/org/apache/helix/mock/participant/DummyProcess.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/participant/DummyProcess.java
@@ -102,7 +102,7 @@ public class DummyProcess {
     stateMach.registerStateModelFactory("OnlineOffline", stateModelFactory2);
 
     manager.connect();
-    // manager.getMessagingService().registerMessageHandlerFactory(MessageType.STATE_TRANSITION.toString(),
+    // manager.getMessagingService().registerMessageHandlerFactory(MessageType.STATE_TRANSITION.name(),
     // genericStateMachineHandler);
     return manager;
   }

--- a/helix-core/src/test/java/org/apache/helix/task/TaskSynchronizedTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TaskSynchronizedTestBase.java
@@ -102,8 +102,9 @@ public class TaskSynchronizedTestBase extends ZkIntegrationTestBase {
         idealState.setInstanceGroupTag("TESTTAG0");
         _setupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, idealState);
       } else {
-        _setupTool.addResourceToCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB,
-            _numParitions, MASTER_SLAVE_STATE_MODEL, IdealState.RebalanceMode.FULL_AUTO.name());
+        _setupTool
+            .addResourceToCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, _numParitions,
+                MASTER_SLAVE_STATE_MODEL, IdealState.RebalanceMode.FULL_AUTO.name());
       }
       _setupTool.rebalanceStorageCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, _numReplicas);
     }


### PR DESCRIPTION
State transition takes a vital part of Helix managing clusters. There are different reasons can cause state transition is not necessary, for example, the node of partition running state transition is down. Thus state transition cancellation would be a useful feature to have in Helix. It not only helps cancel the state transition to avoid invalid state but also benefits for reducing redundant state transitions.