### PR TITLE
use _lastCurState instead of _initState when carry over session

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CurStateCarryOverUpdater.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CurStateCarryOverUpdater.java
@@ -19,6 +19,8 @@ package org.apache.helix.manager.zk;
  * under the License.
  */
 
+import java.util.Map;
+
 import org.I0Itec.zkclient.DataUpdater;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.CurrentState;
@@ -32,16 +34,14 @@ import org.apache.helix.model.CurrentState;
  */
 class CurStateCarryOverUpdater implements DataUpdater<ZNRecord> {
   final String _curSessionId;
-  final String _initState;
   final CurrentState _lastCurState;
 
-  public CurStateCarryOverUpdater(String curSessionId, String initState, CurrentState lastCurState) {
-    if (curSessionId == null || initState == null || lastCurState == null) {
+  public CurStateCarryOverUpdater(String curSessionId, CurrentState lastCurState) {
+    if (curSessionId == null || lastCurState == null) {
       throw new IllegalArgumentException(
           "missing curSessionId|initState|lastCurState for carry-over");
     }
     _curSessionId = curSessionId;
-    _initState = initState;
     _lastCurState = lastCurState;
   }
 
@@ -57,10 +57,11 @@ class CurStateCarryOverUpdater implements DataUpdater<ZNRecord> {
       curState = new CurrentState(currentData);
     }
 
-    for (String partitionName : _lastCurState.getPartitionStateMap().keySet()) {
+    Map <String, String> lastCurStatePartitionMap =  _lastCurState.getPartitionStateMap();
+    for (String partitionName : lastCurStatePartitionMap.keySet()) {
       // carry-over only when current-state not exist
       if (curState.getState(partitionName) == null) {
-        curState.setState(partitionName, _initState);
+        curState.setState(partitionName, lastCurStatePartitionMap.get(partitionName));
       }
     }
     return curState.getRecord();

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -289,7 +289,7 @@ public class ParticipantManager {
           ZNRecord metaRecord = new ZNRecord(lastCurState.getId());
           metaRecord.setSimpleFields(lastCurState.getRecord().getSimpleFields());
           DataUpdater<ZNRecord> metaRecordUpdater =
-              new CurStateCarryOverUpdater(_sessionId, initState, new CurrentState(metaRecord));
+              new CurStateCarryOverUpdater(_sessionId, new CurrentState(metaRecord));
           boolean success =
               baseAccessor.update(curStatePath, metaRecordUpdater, AccessOption.PERSISTENT);
           if (success) {
@@ -301,7 +301,7 @@ public class ParticipantManager {
             List<DataUpdater<ZNRecord>> updaters = new ArrayList<DataUpdater<ZNRecord>>();
             for (String bucketName : map.keySet()) {
               paths.add(curStatePath + "/" + bucketName);
-              updaters.add(new CurStateCarryOverUpdater(_sessionId, initState, new CurrentState(map
+              updaters.add(new CurStateCarryOverUpdater(_sessionId, new CurrentState(map
                   .get(bucketName))));
             }
 
@@ -310,7 +310,7 @@ public class ParticipantManager {
 
         } else {
           _dataAccessor.getBaseDataAccessor().update(curStatePath,
-              new CurStateCarryOverUpdater(_sessionId, initState, lastCurState),
+              new CurStateCarryOverUpdater(_sessionId, lastCurState),
               AccessOption.PERSISTENT);
         }
       }


### PR DESCRIPTION
Although the current approach can work, it would very likely to trigger `HelixStateMismatchException`.  I am not sure why `initialState` is used here.

Let me know if I miss anything.

