### PR TITLE
[helix-front] Fix building issue caused by version mismatching

### DIFF
--- a/helix-front/package.json
+++ b/helix-front/package.json
@@ -18,7 +18,7 @@
     "@angular/common": "^4.3.2",
     "@angular/compiler": "^4.3.2",
     "@angular/core": "^4.3.2",
-    "@angular/flex-layout": "^2.0.0-beta.8",
+    "@angular/flex-layout": "2.0.0-beta.8",
     "@angular/forms": "^4.3.2",
     "@angular/http": "^4.3.2",
     "@angular/material": "2.0.0-beta.6",


### PR DESCRIPTION
The wrong version descriptor will cause [helix-front] building failure. Need to force `@angular/flex-layout` to stick on version `2.0.0-beta.8` or `2.0.0-beta.12` will be installed instead.