### PR TITLE
Add instance support for CriteriaEvaluator

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/PropertyKey.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyKey.java
@@ -310,6 +310,14 @@ public class PropertyKey {
     public PropertyKey instances() {
       return new PropertyKey(PropertyType.INSTANCES, null, _clusterName);
     }
+    
+    /**
+     * Get a property key associated with specified instance
+     * @return {@link PropertyKey}
+     */
+    public PropertyKey instance(String instanceName) {
+      return new PropertyKey(PropertyType.INSTANCES, null, _clusterName, instanceName);
+    }
 
     /**
      * Get a property key associated with {@link Message} for an instance


### PR DESCRIPTION
To improve the performance of CriteriaEvaluator, add specified instance support instead of querying all the instances.