### PR TITLE
[helix-core] _rebalanceTimerPeriod in RebalanceConfig should be in milliseconds 

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/api/config/RebalanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/api/config/RebalanceConfig.java
@@ -65,7 +65,7 @@ public class RebalanceConfig {
   private String _rebalancerClassName;
   private String _rebalanceStrategy;
   private Boolean _delayRebalanceDisabled;
-  private long _rebalanceTimerPeriod = -1;  /* in seconds */
+  private long _rebalanceTimerPeriod = -1;  /* in milliseconds */
 
   private static final Logger _logger = LoggerFactory.getLogger(RebalanceConfig.class.getName());
 


### PR DESCRIPTION
This left us some confusion since REBALANCE_TIMER_PERIOD in ResourceConfigProperty is not actually used.

However, REBALANCE_TIMER_PERIOD in IdealStateProperty & ClusterConfigProperty are used in GenericHelixController.java and they are in milliseconds.

Maybe there were some refactoring going on but set this in seconds would leave pp some confusions.