### PR TITLE
[HELIX-679] consolidate semantics of recursively delete path in ZkClient

### DIFF
--- a/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/ZkChildResource.java
+++ b/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/ZkChildResource.java
@@ -114,7 +114,7 @@ public class ZkChildResource extends ServerResource {
       if (childNames != null) {
         for (String childName : childNames) {
           String childPath = zkPath.equals("/") ? "/" + childName : zkPath + "/" + childName;
-          zkClient.deleteRecursive(childPath);
+          zkClient.deleteRecursively(childPath);
         }
       }
 

--- a/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/ZkPathResource.java
+++ b/helix-admin-webapp/src/main/java/org/apache/helix/webapp/resources/ZkPathResource.java
@@ -75,7 +75,7 @@ public class ZkPathResource extends ServerResource {
         if (childNames != null) {
           for (String childName : childNames) {
             String childPath = zkPath.equals("/") ? "/" + childName : zkPath + "/" + childName;
-            zkClient.deleteRecursive(childPath);
+            zkClient.deleteRecursively(childPath);
           }
         }
       } else {
@@ -148,7 +148,7 @@ public class ZkPathResource extends ServerResource {
     try {
       ZkClient zkClient =
           (ZkClient) getContext().getAttributes().get(RestAdminApplication.ZKCLIENT);
-      zkClient.deleteRecursive(zkPath);
+      zkClient.deleteRecursively(zkPath);
 
       getResponse().setStatus(Status.SUCCESS_OK);
     } catch (Exception e) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -327,7 +327,7 @@ public class ParticipantManager {
 
       String path = _keyBuilder.currentStates(_instanceName, session).getPath();
       LOG.info("Removing current states from previous sessions. path: " + path);
-      _zkclient.deleteRecursive(path);
+      _zkclient.deleteRecursively(path);
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -147,7 +147,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     ZKUtil.dropChildren(_zkClient, instanceConfigsPath, instanceConfig.getRecord());
 
     // delete instance path
-    _zkClient.deleteRecursive(instancePath);
+    _zkClient.deleteRecursively(instancePath);
   }
 
   @Override
@@ -553,7 +553,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     if (_zkClient.exists(root)) {
       if (recreateIfExists) {
         logger.warn("Root directory exists.Cleaning the root directory:" + root);
-        _zkClient.deleteRecursive(root);
+        _zkClient.deleteRecursively(root);
       } else {
         logger.info("Cluster " + clusterName + " already exists");
         return true;
@@ -807,7 +807,7 @@ public class ZKHelixAdmin implements HelixAdmin {
       if (recreateIfExists) {
         logger.info(
             "Operation.State Model directory exists:" + stateModelPath + ", remove and recreate.");
-        _zkClient.deleteRecursive(stateModelPath);
+        _zkClient.deleteRecursively(stateModelPath);
       } else {
         logger.info("Skip the operation. State Model directory exists:" + stateModelPath);
         return;
@@ -862,7 +862,7 @@ public class ZKHelixAdmin implements HelixAdmin {
       throw new HelixException("There are still LEADER in the cluster, shut them down first.");
     }
 
-    _zkClient.deleteRecursive(root);
+    _zkClient.deleteRecursively(root);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -150,7 +150,7 @@ public final class ZKUtil {
     // TODO: check if parentPath exists
     String id = nodeRecord.getId();
     String temp = parentPath + "/" + id;
-    client.deleteRecursive(temp);
+    client.deleteRecursively(temp);
   }
 
   public static List<ZNRecord> getChildren(ZkClient client, String path) {

--- a/helix-core/src/main/java/org/apache/helix/tools/ZKDumper.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ZKDumper.java
@@ -158,7 +158,7 @@ public class ZKDumper {
   }
 
   private void delete(String zkPath) {
-    client.deleteRecursive(zkPath);
+    client.deleteRecursively(zkPath);
 
   }
 

--- a/helix-core/src/test/java/org/apache/helix/TestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/TestHelper.java
@@ -265,7 +265,7 @@ public class TestHelper {
     ZkClient zkClient = new ZkClient(ZkAddr);
     if (zkClient.exists("/" + clusterName)) {
       LOG.warn("Cluster already exists:" + clusterName + ". Deleting it");
-      zkClient.deleteRecursive("/" + clusterName);
+      zkClient.deleteRecursively("/" + clusterName);
     }
 
     ClusterSetup setupTool = new ClusterSetup(ZkAddr);
@@ -290,7 +290,7 @@ public class TestHelper {
   public static void dropCluster(String clusterName, ZkClient zkClient) throws Exception {
     if (!zkClient.exists("/" + clusterName)) {
       LOG.warn("Cluster does not exist:" + clusterName + ". Deleting it");
-      zkClient.deleteRecursive("/" + clusterName);
+      zkClient.deleteRecursively("/" + clusterName);
     }
 
     ClusterSetup setupTool = new ClusterSetup(zkClient);

--- a/helix-core/src/test/java/org/apache/helix/TestHierarchicalDataStore.java
+++ b/helix-core/src/test/java/org/apache/helix/TestHierarchicalDataStore.java
@@ -38,7 +38,7 @@ public class TestHierarchicalDataStore extends ZkUnitTestBase {
     FileFilter filter = null;
     // _zkClient.setZkSerializer(new ZNRecordSerializer());
 
-    _zkClientString.deleteRecursive(path);
+    _zkClientString.deleteRecursively(path);
     HierarchicalDataHolder<ZNRecord> dataHolder =
         new HierarchicalDataHolder<ZNRecord>(_zkClientString, path, filter);
     dataHolder.print();

--- a/helix-core/src/test/java/org/apache/helix/TestZKCallback.java
+++ b/helix-core/src/test/java/org/apache/helix/TestZKCallback.java
@@ -210,7 +210,7 @@ public class TestZKCallback extends ZkUnitTestBase {
     _zkClient = new ZkClient(ZK_ADDR);
     _zkClient.setZkSerializer(new ZNRecordSerializer());
     if (_zkClient.exists("/" + clusterName)) {
-      _zkClient.deleteRecursive("/" + clusterName);
+      _zkClient.deleteRecursively("/" + clusterName);
     }
 
     ClusterSetup.processCommandLineArgs(createArgs("-zkSvr " + ZK_ADDR + " -addCluster "

--- a/helix-core/src/test/java/org/apache/helix/TestZnodeModify.java
+++ b/helix-core/src/test/java/org/apache/helix/TestZnodeModify.java
@@ -240,7 +240,7 @@ public class TestZnodeModify extends ZkUnitTestBase {
     _zkClient = new ZkClient(ZK_ADDR);
     _zkClient.setZkSerializer(new ZNRecordSerializer());
     if (_zkClient.exists(PREFIX)) {
-      _zkClient.deleteRecursive(PREFIX);
+      _zkClient.deleteRecursively(PREFIX);
     }
 
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/TestAddClusterV2.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestAddClusterV2.java
@@ -56,13 +56,13 @@ public class TestAddClusterV2 extends ZkIntegrationTestBase {
 
     String namespace = "/" + CONTROLLER_CLUSTER;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     for (int i = 0; i < CLUSTER_NR; i++) {
       namespace = "/" + CLUSTER_PREFIX + "_" + CLASS_NAME + "_" + i;
       if (_gZkClient.exists(namespace)) {
-        _gZkClient.deleteRecursive(namespace);
+        _gZkClient.deleteRecursively(namespace);
       }
     }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestAlertingRebalancerFailure.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestAlertingRebalancerFailure.java
@@ -70,7 +70,7 @@ public class TestAlertingRebalancerFailure extends ZkStandAloneCMTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(ZK_ADDR);
     // setup storage cluster

--- a/helix-core/src/test/java/org/apache/helix/integration/TestClusterStartsup.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestClusterStartsup.java
@@ -40,7 +40,7 @@ public class TestClusterStartsup extends ZkStandAloneCMTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(ZK_ADDR);
 
@@ -69,7 +69,7 @@ public class TestClusterStartsup extends ZkStandAloneCMTestBase {
   public void testParticipantStartUp() throws Exception {
     setupCluster();
     String controllerMsgPath = PropertyPathBuilder.controllerMessage(CLUSTER_NAME);
-    _gZkClient.deleteRecursive(controllerMsgPath);
+    _gZkClient.deleteRecursively(controllerMsgPath);
     HelixManager manager = null;
 
     try {
@@ -102,7 +102,7 @@ public class TestClusterStartsup extends ZkStandAloneCMTestBase {
 
     setupCluster();
     String stateModelPath = PropertyPathBuilder.stateModelDef(CLUSTER_NAME);
-    _gZkClient.deleteRecursive(stateModelPath);
+    _gZkClient.deleteRecursively(stateModelPath);
 
     try {
       manager =
@@ -120,7 +120,7 @@ public class TestClusterStartsup extends ZkStandAloneCMTestBase {
     setupCluster();
     String instanceStatusUpdatePath =
         PropertyPathBuilder.instanceStatusUpdate(CLUSTER_NAME, "localhost_" + (START_PORT + 1));
-    _gZkClient.deleteRecursive(instanceStatusUpdatePath);
+    _gZkClient.deleteRecursively(instanceStatusUpdatePath);
 
     try {
       manager =

--- a/helix-core/src/test/java/org/apache/helix/integration/TestDisableExternalView.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestDisableExternalView.java
@@ -69,7 +69,7 @@ public class TestDisableExternalView extends ZkIntegrationTestBase {
     _admin = new ZKHelixAdmin(_gZkClient);
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     // setup storage cluster

--- a/helix-core/src/test/java/org/apache/helix/integration/TestDriver.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestDriver.java
@@ -126,7 +126,7 @@ public class TestDriver {
     if (zkClient.exists("/" + clusterName)) {
       LOG.warn("test cluster already exists:" + clusterName + ", test name:" + uniqClusterName
           + " is not unique or test has been run without cleaning up zk; deleting it");
-      zkClient.deleteRecursive("/" + clusterName);
+      zkClient.deleteRecursively("/" + clusterName);
     }
 
     if (_testInfoMap.containsKey(uniqClusterName)) {

--- a/helix-core/src/test/java/org/apache/helix/integration/TestPartitionMovementThrottle.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestPartitionMovementThrottle.java
@@ -62,7 +62,7 @@ public class TestPartitionMovementThrottle extends ZkStandAloneCMTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(_gZkClient);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestRebalancerPersistAssignments.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestRebalancerPersistAssignments.java
@@ -52,7 +52,7 @@ public class TestRebalancerPersistAssignments extends ZkStandAloneCMTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(ZK_ADDR);
     // setup storage cluster

--- a/helix-core/src/test/java/org/apache/helix/integration/TestStateTransitionCancellation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestStateTransitionCancellation.java
@@ -63,7 +63,7 @@ public class TestStateTransitionCancellation extends TaskTestBase {
     _numReplicas = 2;
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     _setupTool = new ClusterSetup(ZK_ADDR);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestZkConnectionLost.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestZkConnectionLost.java
@@ -39,7 +39,7 @@ public class TestZkConnectionLost extends TaskTestBase {
     _participants =  new MockParticipantManager[_numNodes];
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     _setupTool = new ClusterSetup(ZK_ADDR);

--- a/helix-core/src/test/java/org/apache/helix/integration/common/ZkStandAloneCMTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/common/ZkStandAloneCMTestBase.java
@@ -67,7 +67,7 @@ public class ZkStandAloneCMTestBase extends ZkIntegrationTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(ZK_ADDR);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestNonOfflineInitState.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestNonOfflineInitState.java
@@ -90,7 +90,7 @@ public class TestNonOfflineInitState extends ZkIntegrationTestBase {
       int nodesNb, int replica, String stateModelDef, boolean doRebalance) throws Exception {
     if (_gZkClient.exists("/" + clusterName)) {
       LOG.warn("Cluster already exists:" + clusterName + ". Deleting it");
-      _gZkClient.deleteRecursive("/" + clusterName);
+      _gZkClient.deleteRecursively("/" + clusterName);
     }
 
     ClusterSetup setupTool = new ClusterSetup(ZkAddr);

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestStateTransitionTimeout.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestStateTransitionTimeout.java
@@ -62,7 +62,7 @@ public class TestStateTransitionTimeout extends ZkStandAloneCMTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(ZK_ADDR);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestStateTransitionTimeoutWithResource.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestStateTransitionTimeoutWithResource.java
@@ -72,7 +72,7 @@ public class TestStateTransitionTimeoutWithResource extends ZkStandAloneCMTestBa
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(ZK_ADDR);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/CrushRebalancers/TestCrushAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/CrushRebalancers/TestCrushAutoRebalance.java
@@ -74,7 +74,7 @@ public class TestCrushAutoRebalance extends ZkIntegrationTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(_gZkClient);
     _setupTool.addCluster(CLUSTER_NAME, true);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/CrushRebalancers/TestCrushAutoRebalanceNonRack.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/CrushRebalancers/TestCrushAutoRebalanceNonRack.java
@@ -65,7 +65,7 @@ public class TestCrushAutoRebalanceNonRack extends ZkStandAloneCMTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(_gZkClient);
     _setupTool.addCluster(CLUSTER_NAME, true);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/CrushRebalancers/TestCrushAutoRebalanceTopoplogyAwareDisabled.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/CrushRebalancers/TestCrushAutoRebalanceTopoplogyAwareDisabled.java
@@ -35,7 +35,7 @@ public class TestCrushAutoRebalanceTopoplogyAwareDisabled extends TestCrushAutoR
 
     String namespace = "/" + CLUSTER_NAME;
     if (ZkIntegrationTestBase._gZkClient.exists(namespace)) {
-      ZkIntegrationTestBase._gZkClient.deleteRecursive(namespace);
+      ZkIntegrationTestBase._gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(ZkIntegrationTestBase._gZkClient);
     _setupTool.addCluster(CLUSTER_NAME, true);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalance.java
@@ -66,7 +66,7 @@ public class TestDelayedAutoRebalance extends ZkIntegrationTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(_gZkClient);
     _setupTool.addCluster(CLUSTER_NAME, true);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalanceWithRackaware.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalanceWithRackaware.java
@@ -43,7 +43,7 @@ public class TestDelayedAutoRebalanceWithRackaware extends TestDelayedAutoRebala
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(_gZkClient);
     _setupTool.addCluster(CLUSTER_NAME, true);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
@@ -57,7 +57,7 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(_gZkClient);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalancePartitionLimit.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalancePartitionLimit.java
@@ -56,7 +56,7 @@ public class TestAutoRebalancePartitionLimit extends ZkStandAloneCMTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(ZK_ADDR);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingMaxPartition.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingMaxPartition.java
@@ -60,7 +60,7 @@ public class TestClusterInMaintenanceModeWhenReachingMaxPartition extends ZkInte
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _gSetupTool.addCluster(CLUSTER_NAME, true);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit.java
@@ -72,7 +72,7 @@ public class TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _gSetupTool.addCluster(CLUSTER_NAME, true);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestMixedModeAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestMixedModeAutoRebalance.java
@@ -84,7 +84,7 @@ public class TestMixedModeAutoRebalance extends ZkIntegrationTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _gSetupTool.addCluster(CLUSTER_NAME, true);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestSemiAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestSemiAutoRebalance.java
@@ -63,7 +63,7 @@ public class TestSemiAutoRebalance extends ZkIntegrationTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     // setup storage cluster

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestZeroReplicaAvoidance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestZeroReplicaAvoidance.java
@@ -64,7 +64,7 @@ public class TestZeroReplicaAvoidance extends ZkIntegrationTestBase implements
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
     _setupTool = new ClusterSetup(_gZkClient);
     _setupTool.addCluster(CLUSTER_NAME, true);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestGenericTaskAssignmentCalculator.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestGenericTaskAssignmentCalculator.java
@@ -62,7 +62,7 @@ public class TestGenericTaskAssignmentCalculator extends TaskTestBase {
     _participants = new MockParticipantManager[_numNodes];
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     // Setup cluster and instances

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestIndependentTaskRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestIndependentTaskRebalancer.java
@@ -66,7 +66,7 @@ public class TestIndependentTaskRebalancer extends TaskTestBase {
     _participants = new MockParticipantManager[_numNodes];
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     // Setup cluster and instances

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailure.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailure.java
@@ -60,7 +60,7 @@ public final class TestJobFailure extends TaskSynchronizedTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     _setupTool = new ClusterSetup(ZK_ADDR);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureHighThreshold.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureHighThreshold.java
@@ -56,7 +56,7 @@ public class TestJobFailureHighThreshold extends TaskSynchronizedTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     _setupTool = new ClusterSetup(ZK_ADDR);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureTaskNotStarted.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureTaskNotStarted.java
@@ -73,7 +73,7 @@ public class TestJobFailureTaskNotStarted extends TaskSynchronizedTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     _setupTool = new ClusterSetup(ZK_ADDR);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobTimeout.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobTimeout.java
@@ -53,7 +53,7 @@ public final class TestJobTimeout extends TaskSynchronizedTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     _setupTool = new ClusterSetup(ZK_ADDR);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobTimeoutTaskNotStarted.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobTimeoutTaskNotStarted.java
@@ -64,7 +64,7 @@ public class TestJobTimeoutTaskNotStarted extends TaskSynchronizedTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     _setupTool = new ClusterSetup(ZK_ADDR);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestRebalanceRunningTask.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestRebalanceRunningTask.java
@@ -59,7 +59,7 @@ public final class TestRebalanceRunningTask extends TaskSynchronizedTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     _setupTool = new ClusterSetup(ZK_ADDR);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestUserContentStore.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestUserContentStore.java
@@ -57,7 +57,7 @@ public class TestUserContentStore extends TaskTestBase {
     _participants = new MockParticipantManager[_numNodes];
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     // Setup cluster and instances

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKLiveInstanceData.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKLiveInstanceData.java
@@ -113,7 +113,7 @@ public class TestZKLiveInstanceData extends ZkUnitTestBase {
       zkClient = new ZkClient(ZK_ADDR);
       zkClient.setZkSerializer(new ZNRecordSerializer());
       if (zkClient.exists("/" + clusterName)) {
-        zkClient.deleteRecursive("/" + clusterName);
+        zkClient.deleteRecursively("/" + clusterName);
       }
     } finally {
       if (zkClient != null) {

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKUtil.java
@@ -47,7 +47,7 @@ public class TestZKUtil extends ZkUnitTestBase {
     _zkClient = new ZkClient(ZK_ADDR);
     _zkClient.setZkSerializer(new ZNRecordSerializer());
     if (_zkClient.exists("/" + clusterName)) {
-      _zkClient.deleteRecursive("/" + clusterName);
+      _zkClient.deleteRecursively("/" + clusterName);
     }
 
     boolean result = ZKUtil.isClusterSetup(clusterName, _zkClient);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -366,7 +366,7 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     String root = "TestZkBaseDataAccessor_asyn";
     ZkClient zkClient = new ZkClient(ZK_ADDR);
     zkClient.setZkSerializer(new ZNRecordSerializer());
-    zkClient.deleteRecursive("/" + root);
+    zkClient.deleteRecursively("/" + root);
 
     ZkBaseDataAccessor<ZNRecord> accessor = new ZkBaseDataAccessor<ZNRecord>(zkClient);
 

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkClient.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkClient.java
@@ -70,7 +70,7 @@ public class TestZkClient extends ZkUnitTestBase {
   @Test()
   void testGetStat() {
     String path = "/tmp/getStatTest";
-    _zkClient.deleteRecursive(path);
+    _zkClient.deleteRecursively(path);
 
     Stat stat, newStat;
     stat = _zkClient.getStat(path);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkClusterManager.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkClusterManager.java
@@ -60,7 +60,7 @@ public class TestZkClusterManager extends ZkUnitTestBase {
 
     // basic test
     if (_gZkClient.exists("/" + clusterName)) {
-      _gZkClient.deleteRecursive("/" + clusterName);
+      _gZkClient.deleteRecursively("/" + clusterName);
     }
 
     ZKHelixManager controller =
@@ -232,7 +232,7 @@ public class TestZkClusterManager extends ZkUnitTestBase {
 
     // basic test
     if (_gZkClient.exists("/" + clusterName)) {
-      _gZkClient.deleteRecursive("/" + clusterName);
+      _gZkClient.deleteRecursively("/" + clusterName);
     }
 
     ZKHelixManager admin =

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -75,7 +75,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     final String clusterName = getShortClassName();
     String rootPath = "/" + clusterName;
     if (_gZkClient.exists(rootPath)) {
-      _gZkClient.deleteRecursive(rootPath);
+      _gZkClient.deleteRecursively(rootPath);
     }
 
     HelixAdmin tool = new ZKHelixAdmin(_gZkClient);
@@ -414,7 +414,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     final String clusterName = getShortClassName();
     String rootPath = "/" + clusterName;
     if (_gZkClient.exists(rootPath)) {
-      _gZkClient.deleteRecursive(rootPath);
+      _gZkClient.deleteRecursively(rootPath);
     }
 
     HelixAdmin tool = new ZKHelixAdmin(_gZkClient);

--- a/helix-core/src/test/java/org/apache/helix/participant/TestDistControllerElection.java
+++ b/helix-core/src/test/java/org/apache/helix/participant/TestDistControllerElection.java
@@ -55,7 +55,7 @@ public class TestDistControllerElection extends ZkUnitTestBase {
     final String clusterName = CLUSTER_PREFIX + "_" + className + "_" + "testController";
     String path = "/" + clusterName;
     if (_gZkClient.exists(path)) {
-      _gZkClient.deleteRecursive(path);
+      _gZkClient.deleteRecursively(path);
     }
 
     ZKHelixDataAccessor accessor =
@@ -108,7 +108,7 @@ public class TestDistControllerElection extends ZkUnitTestBase {
         CONTROLLER_CLUSTER_PREFIX + "_" + className + "_" + "testControllerParticipant";
     String path = "/" + clusterName;
     if (_gZkClient.exists(path)) {
-      _gZkClient.deleteRecursive(path);
+      _gZkClient.deleteRecursively(path);
     }
 
     ZKHelixDataAccessor accessor =
@@ -167,7 +167,7 @@ public class TestDistControllerElection extends ZkUnitTestBase {
     final String clusterName = CLUSTER_PREFIX + "_" + className + "_" + "testParticipant";
     String path = "/" + clusterName;
     if (_gZkClient.exists(path)) {
-      _gZkClient.deleteRecursive(path);
+      _gZkClient.deleteRecursively(path);
     }
     TestHelper.setupEmptyCluster(_gZkClient, clusterName);
 

--- a/helix-core/src/test/java/org/apache/helix/participant/TestDistControllerStateModel.java
+++ b/helix-core/src/test/java/org/apache/helix/participant/TestDistControllerStateModel.java
@@ -40,7 +40,7 @@ public class TestDistControllerStateModel extends ZkUnitTestBase {
   public void beforeMethod() {
     stateModel = new DistClusterControllerStateModel(ZK_ADDR);
     if (_gZkClient.exists("/" + clusterName)) {
-      _gZkClient.deleteRecursive("/" + clusterName);
+      _gZkClient.deleteRecursively("/" + clusterName);
     }
     TestHelper.setupEmptyCluster(_gZkClient, clusterName);
   }

--- a/helix-core/src/test/java/org/apache/helix/store/zk/TestZkHelixPropertyStore.java
+++ b/helix-core/src/test/java/org/apache/helix/store/zk/TestZkHelixPropertyStore.java
@@ -246,7 +246,7 @@ public class TestZkHelixPropertyStore extends ZkUnitTestBase {
     // test delete callbacks
     listener.reset();
     int expectDeleteNodes = 1 + firstLevelNr + firstLevelNr * secondLevelNr;
-    _gZkClient.deleteRecursive(subRoot);
+    _gZkClient.deleteRecursively(subRoot);
     Thread.sleep(1000);
 
     System.out.println("createKey#:" + listener._createKeys.size() + ", changeKey#:"

--- a/helix-core/src/test/java/org/apache/helix/task/TaskSynchronizedTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TaskSynchronizedTestBase.java
@@ -63,7 +63,7 @@ public class TaskSynchronizedTestBase extends ZkIntegrationTestBase {
     _participants =  new MockParticipantManager[_numNodes];
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     _setupTool = new ClusterSetup(ZK_ADDR);

--- a/helix-core/src/test/java/org/apache/helix/task/TestSemiAutoStateTransition.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestSemiAutoStateTransition.java
@@ -49,7 +49,7 @@ public class TestSemiAutoStateTransition extends TaskTestBase {
 
     String namespace = "/" + CLUSTER_NAME;
     if (_gZkClient.exists(namespace)) {
-      _gZkClient.deleteRecursive(namespace);
+      _gZkClient.deleteRecursively(namespace);
     }
 
     _setupTool = new ClusterSetup(ZK_ADDR);

--- a/helix-core/src/test/java/org/apache/helix/tools/TestClusterSetup.java
+++ b/helix-core/src/test/java/org/apache/helix/tools/TestClusterSetup.java
@@ -86,7 +86,7 @@ public class TestClusterSetup extends ZkUnitTestBase {
   @BeforeMethod()
   public void setup() {
 
-    _zkClient.deleteRecursive("/" + CLUSTER_NAME);
+    _zkClient.deleteRecursively("/" + CLUSTER_NAME);
     _clusterSetup = new ClusterSetup(ZK_ADDR);
     _clusterSetup.addCluster(CLUSTER_NAME, true);
   }
@@ -240,14 +240,14 @@ public class TestClusterSetup extends ZkUnitTestBase {
     // .processCommandLineArgs(createArgs("-zkSvr "+ZK_ADDR+ " help"));
 
     // wipe ZK
-    _zkClient.deleteRecursive("/" + CLUSTER_NAME);
+    _zkClient.deleteRecursively("/" + CLUSTER_NAME);
     _clusterSetup = new ClusterSetup(ZK_ADDR);
 
     ClusterSetup.processCommandLineArgs(createArgs("-zkSvr " + ZK_ADDR + " --addCluster "
         + CLUSTER_NAME));
 
     // wipe again
-    _zkClient.deleteRecursive("/" + CLUSTER_NAME);
+    _zkClient.deleteRecursively("/" + CLUSTER_NAME);
     _clusterSetup = new ClusterSetup(ZK_ADDR);
 
     _clusterSetup.setupTestCluster(CLUSTER_NAME);


### PR DESCRIPTION
This change consolidates semantics of APIs in ZkClient that recursively deletes a path

* For backward compatibility, we keep `deleteRecursive()`, which will only return true/false, and will not throw exception.
* create a new method called deleteRecursively() that will only throw exception upon error.
* mark `deleteRecursive()` as deprecated as throwing exception can carry error information
* make all current usage of `deleteRecursive()` to `deleteRecursively()` 