### PR TITLE
[HELIX-675] Refactor controller start/cleanup logic to ensure monitor…

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -219,8 +219,9 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
         long startTime = missingTopStateMap.get(resourceName).get(partitionName);
         if (startTime > 0 && System.currentTimeMillis() - startTime > durationThreshold) {
           missingTopStateMap.get(resourceName).put(partitionName, TRANSITION_FAILED);
-          clusterStatusMonitor
-              .updateMissingTopStateDurationStats(resourceName, 0L, false);
+          if (clusterStatusMonitor != null) {
+            clusterStatusMonitor.updateMissingTopStateDurationStats(resourceName, 0L, false);
+          }
         }
       }
     }
@@ -294,8 +295,10 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
     if (handOffStartTime != TRANSITION_FAILED && handOffEndTime - handOffStartTime <= threshold) {
       LOG.info(String.format("Missing topstate duration is %d for partition %s",
           handOffEndTime - handOffStartTime, partition.getPartitionName()));
-      clusterStatusMonitor.updateMissingTopStateDurationStats(resource.getResourceName(),
-          handOffEndTime - handOffStartTime, true);
+      if (clusterStatusMonitor != null) {
+        clusterStatusMonitor.updateMissingTopStateDurationStats(resource.getResourceName(),
+            handOffEndTime - handOffStartTime, true);
+      }
     }
     removeFromStatsMap(missingTopStateMap, resource, partition);
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TaskAssignmentStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TaskAssignmentStage.java
@@ -77,7 +77,9 @@ public class TaskAssignmentStage extends AbstractBaseStage {
     if (!cache.isTaskCache()) {
       ClusterStatusMonitor clusterStatusMonitor =
           event.getAttribute(AttributeName.clusterStatusMonitor.name());
-      clusterStatusMonitor.increaseMessageReceived(outputMessages);
+      if (clusterStatusMonitor != null) {
+        clusterStatusMonitor.increaseMessageReceived(outputMessages);
+      }
     }
     long cacheStart = System.currentTimeMillis();
     cache.cacheMessages(outputMessages);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/DistributedLeaderElection.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/DistributedLeaderElection.java
@@ -22,7 +22,6 @@ package org.apache.helix.manager.zk;
 import java.lang.management.ManagementFactory;
 import java.util.List;
 
-import org.apache.helix.ControllerChangeListener;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixTimerTask;
@@ -30,6 +29,7 @@ import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.PropertyType;
 import org.apache.helix.PropertyKey.Builder;
+import org.apache.helix.api.listeners.ControllerChangeListener;
 import org.apache.helix.controller.GenericHelixController;
 import org.apache.helix.model.LeaderHistory;
 import org.apache.helix.model.LiveInstance;
@@ -97,11 +97,10 @@ public class DistributedLeaderElection implements ControllerChangeListener {
           }
         }
       } else if (changeContext.getType().equals(NotificationContext.Type.FINALIZE)) {
-        LOG.info(_manager.getInstanceName() + " reqlinquish leadership for cluster: "
+        LOG.info(_manager.getInstanceName() + " relinquish leadership for cluster: "
             + _manager.getClusterName());
         controllerHelper.stopControllerTimerTasks();
         controllerHelper.removeListenersFromController(_controller);
-        _controller.shutdownClusterStatusMonitor(_manager.getClusterName());
 
         /**
          * clear write-through cache

--- a/helix-core/src/main/java/org/apache/helix/task/TaskRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskRebalancer.java
@@ -78,13 +78,16 @@ public abstract class TaskRebalancer implements Rebalancer, MappingCalculator {
         failedJobs ++;
         if (!cfg.isJobQueue() && failedJobs > cfg.getFailureThreshold()) {
           ctx.setWorkflowState(TaskState.FAILED);
-          _clusterStatusMonitor.updateWorkflowCounters(cfg, TaskState.FAILED);
+          if (_clusterStatusMonitor != null) {
+            _clusterStatusMonitor.updateWorkflowCounters(cfg, TaskState.FAILED);
+          }
           for (String jobToFail : cfg.getJobDag().getAllNodes()) {
             if (ctx.getJobState(jobToFail) == TaskState.IN_PROGRESS) {
               ctx.setJobState(jobToFail, TaskState.ABORTED);
               // Skip aborted jobs latency since they are not accurate latency for job running time
-              _clusterStatusMonitor
-                  .updateJobCounters(jobConfigMap.get(jobToFail), TaskState.ABORTED);
+              if (_clusterStatusMonitor != null) {
+                _clusterStatusMonitor.updateJobCounters(jobConfigMap.get(jobToFail), TaskState.ABORTED);
+              }
             }
           }
           return true;
@@ -98,8 +101,9 @@ public abstract class TaskRebalancer implements Rebalancer, MappingCalculator {
 
     if (!incomplete && cfg.isTerminable()) {
       ctx.setWorkflowState(TaskState.COMPLETED);
-      _clusterStatusMonitor.updateWorkflowCounters(cfg, TaskState.COMPLETED,
-          ctx.getFinishTime() - ctx.getStartTime());
+      if (_clusterStatusMonitor != null) {
+        _clusterStatusMonitor.updateWorkflowCounters(cfg, TaskState.COMPLETED, ctx.getFinishTime() - ctx.getStartTime());
+      }
       return true;
     }
 

--- a/helix-core/src/test/java/org/apache/helix/monitoring/TestClusterEventStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/TestClusterEventStatusMonitor.java
@@ -47,6 +47,7 @@ public class TestClusterEventStatusMonitor {
   private class ClusterStatusMonitorForTest extends ClusterStatusMonitor {
     public ClusterStatusMonitorForTest(String clusterName) {
       super(clusterName);
+      active();
     }
     public ConcurrentHashMap<String, ClusterEventMonitor> getClusterEventMBean() {
       return _clusterEventMbeanMap;

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -54,6 +54,7 @@ public class TestClusterStatusMonitor {
     System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
 
     ClusterStatusMonitor monitor = new ClusterStatusMonitor(clusterName);
+    monitor.active();
     ObjectName clusterMonitorObjName = monitor.getObjectName(monitor.clusterBeanName());
     try {
       _server.getMBeanInfo(clusterMonitorObjName);

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestRebalancerMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestRebalancerMetrics.java
@@ -66,7 +66,9 @@ public class TestRebalancerMetrics extends BaseStageTest {
     event.addAttribute(AttributeName.RESOURCES.name(), resourceMap);
     event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), resourceMap);
     event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
-    event.addAttribute(AttributeName.clusterStatusMonitor.name(), new ClusterStatusMonitor(_clusterName));
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor(_clusterName);
+    monitor.active();
+    event.addAttribute(AttributeName.clusterStatusMonitor.name(), monitor);
 
     runStage(event, new ReadClusterDataStage());
     ClusterDataCache cache = event.getAttribute(AttributeName.ClusterDataCache.name());
@@ -110,7 +112,9 @@ public class TestRebalancerMetrics extends BaseStageTest {
     event.addAttribute(AttributeName.RESOURCES.name(), resourceMap);
     event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), resourceMap);
     event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
-    event.addAttribute(AttributeName.clusterStatusMonitor.name(), new ClusterStatusMonitor(_clusterName));
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor(_clusterName);
+    monitor.active();
+    event.addAttribute(AttributeName.clusterStatusMonitor.name(), monitor);
 
     runStage(event, new ReadClusterDataStage());
     runStage(event, new BestPossibleStateCalcStage());

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestTopStateHandoffMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestTopStateHandoffMetrics.java
@@ -54,7 +54,9 @@ public class TestTopStateHandoffMetrics extends BaseStageTest {
     resource.setStateModelDefRef("MasterSlave");
     resource.addPartition(PARTITION);
     event.addAttribute(AttributeName.RESOURCES.name(), Collections.singletonMap(TEST_RESOURCE, resource));
-    event.addAttribute(AttributeName.clusterStatusMonitor.name(), new ClusterStatusMonitor("TestCluster"));
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestCluster");
+    monitor.active();
+    event.addAttribute(AttributeName.clusterStatusMonitor.name(), monitor);
   }
 
   @Test(dataProvider = "successCurrentStateInput")


### PR DESCRIPTION
… register/reset is handled in any event orders.

Due to different possible event process order, controller init event might be processed later or earlier than expected.
This cause inconsistency when even handler thread process and record information in the cluster monitor.
This change ensures cluster monitor is off when the leadership changes to other node. So no extra metric data will be generated.

Also upgrade related test cases to verify MBean counts.