### PR TITLE
[HELIX-677] Change error log to info/warning when replica count canno…

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -215,11 +215,14 @@ public class ResourceMonitor extends DynamicMBeanProvider {
 
     _numOfPartitions.updateValue(partitions.size());
 
-    int replica = -1;
+    int replica;
     try {
       replica = Integer.valueOf(idealState.getReplicas());
     } catch (NumberFormatException e) {
-      _logger.error("Invalid replica count for " + _resourceName + ", failed to update its ResourceMonitor Mbean!");
+      _logger.info("Unspecified replica count for " + _resourceName + ", skip updating the ResourceMonitor Mbean: " + idealState.getReplicas());
+      return;
+    } catch (Exception ex) {
+      _logger.warn("Failed to get replica count for " + _resourceName + ", cannot update the ResourceMonitor Mbean.");
       return;
     }
 


### PR DESCRIPTION
…t be read in ResourceMonitor.

Some string such as ALL_LIVEINSTANCES in the replica field cannot be processed by the monitor. And those resources are not expected to be monitoring.
Currently error log on this case drags too much attention. Lower the log level to info/warning according to the Exception type.