### PR TITLE
[HELIX-680] add system setting to unblock TestZkCallbackHandlerLeak test with zookeeper 3.4.11 upgrade

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/ZkUnitTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/ZkUnitTestBase.java
@@ -73,6 +73,9 @@ public class ZkUnitTestBase {
 
   @BeforeSuite(alwaysRun = true)
   public void beforeSuite() throws Exception {
+    // Due to ZOOKEEPER-2693 fix, we need to specify whitelist for execute zk commends
+    System.setProperty("zookeeper.4lw.commands.whitelist", "*");
+
     _zkServer = TestHelper.startZkServer(ZK_ADDR);
     AssertJUnit.assertTrue(_zkServer != null);
     ZKClientPool.reset();


### PR DESCRIPTION
By adding system property in ZkUnitTestBase `beforeSuite()`, `TestZkCallbackHandlerLeak` can pass now