### PR TITLE
[Helix 678] Clear controller event queue when it is shutdown or no longer the leader

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -607,8 +607,6 @@ public class GenericHelixController implements IdealStateChangeListener,
       enableClusterStatusMonitor(true);
       _clusterStatusMonitor.setEnabled(!_paused);
     } else {
-      _eventQueue.clear();
-      _taskEventQueue.clear();
       enableClusterStatusMonitor(false);
     }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -607,6 +607,8 @@ public class GenericHelixController implements IdealStateChangeListener,
       enableClusterStatusMonitor(true);
       _clusterStatusMonitor.setEnabled(!_paused);
     } else {
+      _eventQueue.clear();
+      _taskEventQueue.clear();
       enableClusterStatusMonitor(false);
     }
 
@@ -694,6 +696,9 @@ public class GenericHelixController implements IdealStateChangeListener,
 
     terminateEventThread(_eventThread);
     terminateEventThread(_taskEventThread);
+
+    _eventQueue.clear();
+    _taskEventQueue.clear();
 
     // shutdown asycTasksThreadpool and wait for terminate.
     _asyncTasksThreadPool.shutdownNow();


### PR DESCRIPTION
 Clear controller event queue when it is shutdown or no longer the leader