### PR TITLE
Refactor ClusterDataCache, break it into small cache components, 

### DIFF
--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -189,6 +189,7 @@ under the License.
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>appassembler-maven-plugin</artifactId>
         <configuration>
+          <extraJvmArguments>-Dlog4j.configuration=file://"$BASEDIR"/conf/log4j.properties</extraJvmArguments>
           <programs>
             <program>
               <mainClass>org.apache.helix.controller.HelixControllerMain</mainClass>

--- a/helix-core/src/main/config/log4j.properties
+++ b/helix-core/src/main/config/log4j.properties
@@ -16,16 +16,15 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# Set root logger level to INFO and its only appender to A1.
+log4j.rootLogger=INFO, console
 
-# Set root logger level to DEBUG and its only appender to A1.
-log4j.rootLogger=ERROR,A1
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+log4j.appender.console.threshold=INFO
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=[%d] [%-5p] [%t] [%c:%L] - %m%n
 
-# A1 is set to be a ConsoleAppender.
-log4j.appender.A1=org.apache.log4j.ConsoleAppender
-
-# A1 uses PatternLayout.
-log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
-
-log4j.logger.org.I0Itec=ERROR
-log4j.logger.org.apache=ERROR
+log4j.logger.org.I0Itec=INFO
+log4j.logger.org.apache=INFO
+log4j.logger.org.apache.helix=INFO

--- a/helix-core/src/main/java/org/apache/helix/common/caches/BasicClusterDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/BasicClusterDataCache.java
@@ -1,4 +1,4 @@
-package org.apache.helix.common;
+package org.apache.helix.common.caches;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixDataAccessor;
-import org.apache.helix.HelixException;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyType;
 import org.apache.helix.model.ExternalView;
@@ -35,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Cache the cluster data
+ * Cache the basic cluster data, including LiveInstances, InstanceConfigs and ExternalViews.
  */
 public class BasicClusterDataCache {
   protected final Logger LOG = LoggerFactory.getLogger(this.getClass().getName());
@@ -153,6 +152,26 @@ public class BasicClusterDataCache {
    */
   public synchronized void notifyDataChange(HelixConstants.ChangeType changeType) {
     _propertyDataChangedMap.put(changeType, Boolean.valueOf(true));
+  }
+
+  /**
+   * Clear the corresponding cache based on change type
+   * @param changeType
+   */
+  public synchronized void clearCache(HelixConstants.ChangeType changeType) {
+    switch (changeType) {
+    case LIVE_INSTANCE:
+      _liveInstanceMap.clear();
+      break;
+    case INSTANCE_CONFIG:
+      _instanceConfigMap.clear();
+      break;
+    case EXTERNAL_VIEW:
+      _externalViewMap.clear();
+      break;
+    default:
+      break;
+    }
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateCache.java
@@ -1,0 +1,206 @@
+package org.apache.helix.common.caches;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixProperty;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.LiveInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Cache to hold all CurrentStates of a cluster.
+ */
+public class CurrentStateCache {
+  private static final Logger LOG = LoggerFactory.getLogger(CurrentStateCache.class.getName());
+
+  private Map<String, Map<String, Map<String, CurrentState>>> _currentStateMap;
+  private Map<PropertyKey, CurrentState> _currentStateCache = Maps.newHashMap();
+
+  private String _clusterName;
+
+  public CurrentStateCache(String clusterName) {
+    _clusterName = clusterName;
+    _currentStateMap = Collections.emptyMap();
+  }
+
+  /**
+   * This refreshes the CurrentStates data by re-fetching the data from zookeeper in an efficient
+   * way
+   *
+   * @param accessor
+   * @param liveInstanceMap map of all liveInstances in cluster
+   *
+   * @return
+   */
+  public synchronized boolean refresh(HelixDataAccessor accessor,
+      Map<String, LiveInstance> liveInstanceMap) {
+    LOG.info("START: CurrentStateCache.refresh()");
+    long startTime = System.currentTimeMillis();
+
+    refreshCurrentStatesCache(accessor, liveInstanceMap);
+
+    Map<String, Map<String, Map<String, CurrentState>>> allCurStateMap = new HashMap<>();
+    for (PropertyKey key : _currentStateCache.keySet()) {
+      CurrentState currentState = _currentStateCache.get(key);
+      String[] params = key.getParams();
+      if (currentState != null && params.length >= 4) {
+        String instanceName = params[1];
+        String sessionId = params[2];
+        String stateName = params[3];
+        Map<String, Map<String, CurrentState>> instanceCurStateMap =
+            allCurStateMap.get(instanceName);
+        if (instanceCurStateMap == null) {
+          instanceCurStateMap = Maps.newHashMap();
+          allCurStateMap.put(instanceName, instanceCurStateMap);
+        }
+        Map<String, CurrentState> sessionCurStateMap = instanceCurStateMap.get(sessionId);
+        if (sessionCurStateMap == null) {
+          sessionCurStateMap = Maps.newHashMap();
+          instanceCurStateMap.put(sessionId, sessionCurStateMap);
+        }
+        sessionCurStateMap.put(stateName, currentState);
+      }
+    }
+
+    for (String instance : allCurStateMap.keySet()) {
+      allCurStateMap.put(instance, Collections.unmodifiableMap(allCurStateMap.get(instance)));
+    }
+    _currentStateMap = Collections.unmodifiableMap(allCurStateMap);
+
+    long endTime = System.currentTimeMillis();
+    LOG.info("END: CurrentStateCache.refresh() for cluster " + _clusterName + ", took " + (endTime
+        - startTime) + " ms");
+    return true;
+  }
+
+  // reload current states that has been changed from zk to local cache.
+  private void refreshCurrentStatesCache(HelixDataAccessor accessor,
+      Map<String, LiveInstance> liveInstanceMap) {
+    long start = System.currentTimeMillis();
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+
+    List<PropertyKey> currentStateKeys = Lists.newLinkedList();
+    for (String instanceName : liveInstanceMap.keySet()) {
+      LiveInstance liveInstance = liveInstanceMap.get(instanceName);
+      String sessionId = liveInstance.getSessionId();
+      List<String> currentStateNames =
+          accessor.getChildNames(keyBuilder.currentStates(instanceName, sessionId));
+      for (String currentStateName : currentStateNames) {
+        currentStateKeys.add(keyBuilder.currentState(instanceName, sessionId, currentStateName));
+      }
+    }
+
+    // All new entries from zk not cached locally yet should be read from ZK.
+    List<PropertyKey> reloadKeys = Lists.newLinkedList(currentStateKeys);
+    reloadKeys.removeAll(_currentStateCache.keySet());
+
+    List<PropertyKey> cachedKeys = Lists.newLinkedList(_currentStateCache.keySet());
+    cachedKeys.retainAll(currentStateKeys);
+
+    List<HelixProperty.Stat> stats = accessor.getPropertyStats(cachedKeys);
+    Map<PropertyKey, CurrentState> currentStatesMap = Maps.newHashMap();
+    for (int i = 0; i < cachedKeys.size(); i++) {
+      PropertyKey key = cachedKeys.get(i);
+      HelixProperty.Stat stat = stats.get(i);
+      if (stat != null) {
+        CurrentState property = _currentStateCache.get(key);
+        if (property != null && property.getBucketSize() == 0 && property.getStat().equals(stat)) {
+          currentStatesMap.put(key, property);
+        } else {
+          // need update from zk
+          reloadKeys.add(key);
+        }
+      } else {
+        LOG.debug("stat is null for key: " + key);
+        reloadKeys.add(key);
+      }
+    }
+
+    List<CurrentState> currentStates = accessor.getProperty(reloadKeys);
+    Iterator<PropertyKey> csKeyIter = reloadKeys.iterator();
+    for (CurrentState currentState : currentStates) {
+      PropertyKey key = csKeyIter.next();
+      if (currentState != null) {
+        currentStatesMap.put(key, currentState);
+      } else {
+        LOG.debug("CurrentState null for key: " + key);
+      }
+    }
+
+    _currentStateCache = Collections.unmodifiableMap(currentStatesMap);
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("# of CurrentState paths read from ZooKeeper " + reloadKeys.size());
+      LOG.debug("# of CurrentState paths skipped reading from ZK: " + (currentStateKeys.size()
+          - reloadKeys.size()));
+    }
+    LOG.info("Takes " + (System.currentTimeMillis() - start) + " ms to reload new current states!");
+  }
+
+  /**
+   * Return CurrentStates map for all instances.
+   *
+   * @return
+   */
+  public Map<String, Map<String, Map<String, CurrentState>>> getCurrentStatesMap() {
+    return Collections.unmodifiableMap(_currentStateMap);
+  }
+
+  /**
+   * Return all CurrentState on the given instance.
+   *
+   * @param instance
+   *
+   * @return
+   */
+  public Map<String, Map<String, CurrentState>> getCurrentStates(String instance) {
+    if (!_currentStateMap.containsKey(instance)) {
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(_currentStateMap.get(instance));
+  }
+
+  /**
+   * Provides the current state of the node for a given session id, the sessionid can be got from
+   * LiveInstance
+   *
+   * @param instance
+   * @param clientSessionId
+   *
+   * @return
+   */
+  public Map<String, CurrentState> getCurrentState(String instance, String clientSessionId) {
+    if (!_currentStateMap.containsKey(instance) || !_currentStateMap.get(instance)
+        .containsKey(clientSessionId)) {
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(_currentStateMap.get(instance).get(clientSessionId));
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/common/caches/InstanceMessagesCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/InstanceMessagesCache.java
@@ -1,0 +1,222 @@
+package org.apache.helix.common.caches;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Cache for holding pending messages in all instances in the given cluster.
+ */
+public class InstanceMessagesCache {
+  private static final Logger LOG = LoggerFactory.getLogger(InstanceMessagesCache.class.getName());
+  private Map<String, Map<String, Message>> _messageMap;
+
+  // maintain a cache of participant messages across pipeline runs
+  private Map<String, Map<String, Message>> _messageCache = Maps.newHashMap();
+  private String _clusterName;
+
+  public InstanceMessagesCache(String clusterName) {
+    _clusterName = clusterName;
+  }
+
+  /**
+   * This refreshes all pending messages in the cluster by re-fetching the data from zookeeper in an
+   * efficient way
+   * current state must be refreshed before refreshing relay messages because we need to use current
+   * state to validate all relay messages.
+   *
+   * @param accessor
+   * @param liveInstanceMap
+   *
+   * @return
+   */
+  public synchronized boolean refresh(HelixDataAccessor accessor,
+      Map<String, LiveInstance> liveInstanceMap) {
+    LOG.info("START: InstanceMessagesCache.refresh()");
+    long startTime = System.currentTimeMillis();
+
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    Map<String, Map<String, Message>> msgMap = new HashMap<>();
+    List<PropertyKey> newMessageKeys = Lists.newLinkedList();
+    long purgeSum = 0;
+    for (String instanceName : liveInstanceMap.keySet()) {
+      // get the cache
+      Map<String, Message> cachedMap = _messageCache.get(instanceName);
+      if (cachedMap == null) {
+        cachedMap = Maps.newHashMap();
+        _messageCache.put(instanceName, cachedMap);
+      }
+      msgMap.put(instanceName, cachedMap);
+
+      // get the current names
+      Set<String> messageNames =
+          Sets.newHashSet(accessor.getChildNames(keyBuilder.messages(instanceName)));
+
+      long purgeStart = System.currentTimeMillis();
+      // clear stale names
+      Iterator<String> cachedNamesIter = cachedMap.keySet().iterator();
+      while (cachedNamesIter.hasNext()) {
+        String messageName = cachedNamesIter.next();
+        if (!messageNames.contains(messageName)) {
+          cachedNamesIter.remove();
+        }
+      }
+      long purgeEnd = System.currentTimeMillis();
+      purgeSum += purgeEnd - purgeStart;
+
+      // get the keys for the new messages
+      for (String messageName : messageNames) {
+        if (!cachedMap.containsKey(messageName)) {
+          newMessageKeys.add(keyBuilder.message(instanceName, messageName));
+        }
+      }
+    }
+
+    // get the new messages
+    if (newMessageKeys.size() > 0) {
+      List<Message> newMessages = accessor.getProperty(newMessageKeys);
+      for (Message message : newMessages) {
+        if (message != null) {
+          Map<String, Message> cachedMap = _messageCache.get(message.getTgtName());
+          cachedMap.put(message.getId(), message);
+        }
+      }
+    }
+
+    _messageMap = Collections.unmodifiableMap(msgMap);
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Message purge took: " + purgeSum);
+      LOG.debug("# of Messages read from ZooKeeper " + newMessageKeys.size() + ". took " + (
+          System.currentTimeMillis() - startTime) + " ms.");
+    }
+
+    return true;
+  }
+
+  // update all valid relay messages attached to existing state transition messages into message map.
+  public void updateRelayMessages(Map<String, LiveInstance> liveInstanceMap,
+      Map<String, Map<String, Map<String, CurrentState>>> currentStateMap) {
+    List<Message> relayMessages = new ArrayList<>();
+    for (String instance : _messageMap.keySet()) {
+      Map<String, Message> instanceMessages = _messageMap.get(instance);
+      Map<String, Map<String, CurrentState>> instanceCurrentStateMap =
+          currentStateMap.get(instance);
+      if (instanceCurrentStateMap == null) {
+        continue;
+      }
+
+      for (Message message : instanceMessages.values()) {
+        if (message.hasRelayMessages()) {
+          String sessionId = message.getTgtSessionId();
+          String resourceName = message.getResourceName();
+          String partitionName = message.getPartitionName();
+          String targetState = message.getToState();
+          String instanceSessionId = liveInstanceMap.get(instance).getSessionId();
+
+          if (!instanceSessionId.equals(sessionId)) {
+            continue;
+          }
+
+          Map<String, CurrentState> sessionCurrentStateMap = instanceCurrentStateMap.get(sessionId);
+          if (sessionCurrentStateMap == null) {
+            continue;
+          }
+          CurrentState currentState = sessionCurrentStateMap.get(resourceName);
+          if (currentState == null || !targetState.equals(currentState.getState(partitionName))) {
+            continue;
+          }
+          long transitionCompleteTime = currentState.getEndTime(partitionName);
+
+          for (Message msg : message.getRelayMessages().values()) {
+            msg.setRelayTime(transitionCompleteTime);
+            if (!message.isExpired()) {
+              relayMessages.add(msg);
+            }
+          }
+        }
+      }
+    }
+
+    for (Message message : relayMessages) {
+      String instance = message.getTgtName();
+      Map<String, Message> instanceMessages = _messageMap.get(instance);
+      if (instanceMessages == null) {
+        instanceMessages = new HashMap<>();
+        _messageMap.put(instance, instanceMessages);
+      }
+      instanceMessages.put(message.getId(), message);
+    }
+  }
+
+  /**
+   * Provides a list of current outstanding transitions on a given instance.
+   *
+   * @param instanceName
+   *
+   * @return
+   */
+  public Map<String, Message> getMessages(String instanceName) {
+    Map<String, Message> map = _messageMap.get(instanceName);
+    if (map != null) {
+      return map;
+    } else {
+      return Collections.emptyMap();
+    }
+  }
+
+  public void cacheMessages(List<Message> messages) {
+    for (Message message : messages) {
+      String instanceName = message.getTgtName();
+      Map<String, Message> instMsgMap;
+      if (_messageCache.containsKey(instanceName)) {
+        instMsgMap = _messageCache.get(instanceName);
+      } else {
+        instMsgMap = Maps.newHashMap();
+        _messageCache.put(instanceName, instMsgMap);
+      }
+      instMsgMap.put(message.getId(), message);
+    }
+  }
+
+  @Override public String toString() {
+    return "InstanceMessagesCache{" +
+        "_messageMap=" + _messageMap +
+        ", _messageCache=" + _messageCache +
+        ", _clusterName='" + _clusterName + '\'' +
+        '}';
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/common/caches/TaskDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/TaskDataCache.java
@@ -1,0 +1,232 @@
+package org.apache.helix.common.caches;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.base.Joiner;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.AccessOption;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.PropertyType;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ResourceConfig;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.JobContext;
+import org.apache.helix.task.TaskConstants;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.task.WorkflowContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Cache for holding all task related cluster data, such as WorkflowConfig, JobConfig and Contexts.
+ */
+public class TaskDataCache {
+  private static final Logger LOG = LoggerFactory.getLogger(TaskDataCache.class.getName());
+  private static final String NAME = "NAME";
+
+  private Map<String, JobConfig> _jobConfigMap = new HashMap<>();
+  private Map<String, WorkflowConfig> _workflowConfigMap = new HashMap<>();
+  private Map<String, ZNRecord> _contextMap = new HashMap<>();
+
+  private String _clusterName;
+
+  public TaskDataCache(String clusterName) {
+    _clusterName = clusterName;
+  }
+
+  /**
+   * This refreshes the cluster data by re-fetching the data from zookeeper in an efficient way
+   *
+   * @param accessor
+   *
+   * @return
+   */
+  public synchronized boolean refresh(HelixDataAccessor accessor,
+      Map<String, ResourceConfig> resourceConfigMap) {
+    refreshJobContexts(accessor);
+
+    // update workflow and job configs.
+    _workflowConfigMap.clear();
+    _jobConfigMap.clear();
+    for (Map.Entry<String, ResourceConfig> entry : resourceConfigMap.entrySet()) {
+      if (entry.getValue().getRecord().getSimpleFields()
+          .containsKey(WorkflowConfig.WorkflowConfigProperty.Dag.name())) {
+        _workflowConfigMap.put(entry.getKey(), new WorkflowConfig(entry.getValue()));
+      } else if (entry.getValue().getRecord().getSimpleFields()
+          .containsKey(WorkflowConfig.WorkflowConfigProperty.WorkflowID.name())) {
+        _jobConfigMap.put(entry.getKey(), new JobConfig(entry.getValue()));
+      }
+    }
+
+    return true;
+  }
+
+  private void refreshJobContexts(HelixDataAccessor accessor) {
+    // TODO: Need an optimize for reading context only if the refresh is needed.
+    long start = System.currentTimeMillis();
+    _contextMap.clear();
+    if (_clusterName == null) {
+      return;
+    }
+    String path = String.format("/%s/%s%s", _clusterName, PropertyType.PROPERTYSTORE.name(),
+        TaskConstants.REBALANCER_CONTEXT_ROOT);
+    List<String> contextPaths = new ArrayList<>();
+    List<String> childNames = accessor.getBaseDataAccessor().getChildNames(path, 0);
+    if (childNames == null) {
+      return;
+    }
+    for (String context : childNames) {
+      contextPaths.add(Joiner.on("/").join(path, context, TaskConstants.CONTEXT_NODE));
+    }
+
+    List<ZNRecord> contexts = accessor.getBaseDataAccessor().get(contextPaths, null, 0);
+    for (int i = 0; i < contexts.size(); i++) {
+      ZNRecord context = contexts.get(i);
+      if (context != null && context.getSimpleField(NAME) != null) {
+        _contextMap.put(context.getSimpleField(NAME), context);
+      } else {
+        _contextMap.put(childNames.get(i), context);
+        LOG.debug(
+            String.format("Context for %s is null or miss the context NAME!", childNames.get((i))));
+      }
+    }
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("# of workflow/job context read from zk: " + _contextMap.size() + ". Take " + (
+          System.currentTimeMillis() - start) + " ms");
+    }
+  }
+
+  /**
+   * Returns job config map
+   *
+   * @return
+   */
+  public Map<String, JobConfig> getJobConfigMap() {
+    return _jobConfigMap;
+  }
+
+  /**
+   * Returns job config
+   *
+   * @param resource
+   *
+   * @return
+   */
+  public JobConfig getJobConfig(String resource) {
+    return _jobConfigMap.get(resource);
+  }
+
+  /**
+   * Returns workflow config map
+   *
+   * @return
+   */
+  public Map<String, WorkflowConfig> getWorkflowConfigMap() {
+    return _workflowConfigMap;
+  }
+
+  /**
+   * Returns workflow config
+   *
+   * @param resource
+   *
+   * @return
+   */
+  public WorkflowConfig getWorkflowConfig(String resource) {
+    return _workflowConfigMap.get(resource);
+  }
+
+  /**
+   * Return the JobContext by resource name
+   *
+   * @param resourceName
+   *
+   * @return
+   */
+  public JobContext getJobContext(String resourceName) {
+    if (_contextMap.containsKey(resourceName) && _contextMap.get(resourceName) != null) {
+      return new JobContext(_contextMap.get(resourceName));
+    }
+    return null;
+  }
+
+  /**
+   * Return the WorkflowContext by resource name
+   *
+   * @param resourceName
+   *
+   * @return
+   */
+  public WorkflowContext getWorkflowContext(String resourceName) {
+    if (_contextMap.containsKey(resourceName) && _contextMap.get(resourceName) != null) {
+      return new WorkflowContext(_contextMap.get(resourceName));
+    }
+    return null;
+  }
+
+  /**
+   * Update context of the Job
+   */
+  public void updateJobContext(String resourceName, JobContext jobContext,
+      HelixDataAccessor accessor) {
+    updateContext(resourceName, jobContext.getRecord(), accessor);
+  }
+
+  /**
+   * Update context of the Workflow
+   */
+  public void updateWorkflowContext(String resourceName, WorkflowContext workflowContext,
+      HelixDataAccessor accessor) {
+    updateContext(resourceName, workflowContext.getRecord(), accessor);
+  }
+
+  /**
+   * Update context of the Workflow or Job
+   */
+  private void updateContext(String resourceName, ZNRecord record, HelixDataAccessor accessor) {
+    String path = String.format("/%s/%s%s/%s/%s", _clusterName, PropertyType.PROPERTYSTORE.name(),
+        TaskConstants.REBALANCER_CONTEXT_ROOT, resourceName, TaskConstants.CONTEXT_NODE);
+    accessor.getBaseDataAccessor().set(path, record, AccessOption.PERSISTENT);
+    _contextMap.put(resourceName, record);
+  }
+
+  /**
+   * Return map of WorkflowContexts or JobContexts
+   *
+   * @return
+   */
+  public Map<String, ZNRecord> getContexts() {
+    return _contextMap;
+  }
+
+  @Override public String toString() {
+    return "TaskDataCache{" +
+        "_jobConfigMap=" + _jobConfigMap +
+        ", _workflowConfigMap=" + _workflowConfigMap +
+        ", _contextMap=" + _contextMap +
+        ", _clusterName='" + _clusterName + '\'' +
+        '}';
+  }
+}
+

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -21,7 +21,7 @@ package org.apache.helix.spectator;
 
 import org.apache.helix.HelixConstants;
 import org.apache.helix.PropertyType;
-import org.apache.helix.common.BasicClusterDataCache;
+import org.apache.helix.common.caches.BasicClusterDataCache;
 
 /**
  * Cache the cluster data that are needed by RoutingTableProvider.


### PR DESCRIPTION
1) Refactor ClusterDataCache, break it into small cache components, including CurrentStateCache, InstanceMessageCache and TaskDataCache, and put the refresh logic into each cache component itself.

2) Enable our helix-core admin scripts to be able to pump log lines into the console by default.