### PR TITLE
[HELIX-681] don't fail state transition task if we fail to remove message or send out relay message

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -69,6 +69,7 @@ import org.apache.helix.monitoring.mbeans.ParticipantMessageMonitor.ProcessedMes
 import org.apache.helix.participant.HelixStateMachineEngine;
 import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelFactory;
+import org.apache.helix.util.HelixUtil;
 import org.apache.helix.util.StatusUpdateUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1059,9 +1060,10 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
 
   private void removeMessageFromZK(HelixDataAccessor accessor, Message message,
       String instanceName) {
-    boolean success = accessor.removeProperty(message.getKey(accessor.keyBuilder(), instanceName));
-    if (!success) {
-      LOG.warn("Failed to remove message " + message.getId() + " from zk!");
+    if (HelixUtil.removeMessageFromZK(accessor, message, instanceName)) {
+      LOG.info("Successfully removed message {} from ZK.", message.getMsgId());
+    } else {
+      LOG.warn("Failed to remove message {} from ZK.", message.getMsgId());
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-
+import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyType;
 import org.apache.helix.controller.rebalancer.AbstractRebalancer;
 import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
@@ -37,6 +37,7 @@ import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.Message;
 import org.apache.helix.model.StateModelDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -218,5 +219,23 @@ public final class HelixUtil {
     }
 
     return idealStateMap;
+  }
+
+  /**
+   * Remove the given message from ZK using the given accessor. This function will
+   * not throw exception
+   * @param accessor HelixDataAccessor
+   * @param msg message to remove
+   * @param instanceName name of the instance on which the message sits
+   * @return true if success else false
+   */
+  public static boolean removeMessageFromZK(HelixDataAccessor accessor, Message msg,
+      String instanceName) {
+    try {
+      return accessor.removeProperty(msg.getKey(accessor.keyBuilder(), instanceName));
+    } catch (Exception e) {
+      LOG.error("Caught exception while removing message {}.", msg, e);
+    }
+    return false;
   }
 }


### PR DESCRIPTION
This PR includes fix on participant side:
1. Consolidated message deletion logic to HelixUtil, as we currently have duplicated logics in various places
2. When we fail to delete message, we don't throw exception to fail task
3. When we fail to send out relay message, we don't throw exception to fail task