### PR TITLE
Retrieve cached idealMappings for all Rebalancers instead of recomputing it during every rebalance round.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
@@ -21,14 +21,12 @@ package org.apache.helix.controller.rebalancer;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.helix.HelixDefinedState;
 import org.apache.helix.HelixException;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.controller.stages.ClusterDataCache;
@@ -57,6 +55,15 @@ public class AutoRebalancer extends AbstractRebalancer {
   public IdealState computeNewIdealState(String resourceName,
       IdealState currentIdealState, CurrentStateOutput currentStateOutput,
       ClusterDataCache clusterData) {
+
+    IdealState cachedIdealState = getCachedIdealState(resourceName, clusterData);
+    if (cachedIdealState != null) {
+      LOG.debug("Use cached IdealState for " + resourceName);
+      return cachedIdealState;
+    }
+
+    LOG.info("Computing IdealState for " + resourceName);
+
     List<String> partitions = new ArrayList<String>(currentIdealState.getPartitionSet());
     String stateModelName = currentIdealState.getStateModelDefRef();
     StateModelDefinition stateModelDef = clusterData.getStateModelDef(stateModelName);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
@@ -65,6 +65,8 @@ public class CustomRebalancer extends AbstractRebalancer {
       return partitionMapping;
     }
 
+    LOG.info("Computing BestPossibleMapping for " + resource);
+
     String stateModelDefName = idealState.getStateModelDefRef();
     StateModelDefinition stateModelDef = cache.getStateModelDef(stateModelDefName);
     if (LOG.isDebugEnabled()) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/SemiAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/SemiAutoRebalancer.java
@@ -18,17 +18,9 @@ package org.apache.helix.controller.rebalancer;
  * specific language governing permissions and limitations
  * under the License.
  */
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.apache.helix.HelixDefinedState;
 import org.apache.helix.controller.stages.ClusterDataCache;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.IdealState;
-import org.apache.helix.model.StateModelDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Retrieve cached idealMappings for all Rebalancers (AutoRebalancer, DelayedRebalancer and CustomRebalancer) for any rebalance strategies. This will avoid recompute idealmapping (preference list) if there is no idealstate/instanceconfig/LiveInstances changes.