### PR TITLE
Features and improvements to Helix RoutingTableProvider.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/api/listeners/RoutingTableChangeListener.java
+++ b/helix-core/src/main/java/org/apache/helix/api/listeners/RoutingTableChangeListener.java
@@ -1,0 +1,17 @@
+package org.apache.helix.api.listeners;
+
+import org.apache.helix.spectator.RoutingTableSnapshot;
+
+/**
+ * Interface to implement to listen for changes to RoutingTable on changes
+ */
+public interface RoutingTableChangeListener {
+
+  /**
+   * Invoked when RoutingTable on changes
+   *
+   * @param routingTableSnapshot
+   * @param context
+   */
+  void onRoutingTableChange(RoutingTableSnapshot routingTableSnapshot, Object context);
+}

--- a/helix-core/src/main/java/org/apache/helix/common/ClusterEventProcessor.java
+++ b/helix-core/src/main/java/org/apache/helix/common/ClusterEventProcessor.java
@@ -54,4 +54,9 @@ public abstract class ClusterEventProcessor extends Thread {
   public void queueEvent(ClusterEvent event) {
     _eventQueue.put(event);
   }
+
+  public void shutdown() {
+    _eventQueue.clear();
+    this.interrupt();
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEventType.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEventType.java
@@ -29,6 +29,7 @@ public enum ClusterEventType {
   LiveInstanceChange,
   MessageChange,
   ExternalViewChange,
+  TargetExternalViewChange,
   Resume,
   PeriodicalRebalance,
   StateVerifier,

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -276,7 +276,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
       throws Exception {
     //async mode only applicable to CALLBACK from ZK, During INIT and FINALIZE invoke the callback's immediately.
     if (_batchModeEnabled && changeContext.getType() == NotificationContext.Type.CALLBACK) {
-      logger.info("Enqueuing callback");
+      logger.debug("Enqueuing callback");
       _queue.put(changeContext);
     } else {
       invoke(changeContext);
@@ -442,15 +442,23 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
 
     if (_eventTypes.contains(EventType.NodeDataChanged) || _eventTypes
         .contains(EventType.NodeCreated) || _eventTypes.contains(EventType.NodeDeleted)) {
-      logger.debug("Subscribing data change listener to path:" + path);
+      if (logger.isDebugEnabled()) {
+        logger.debug("Subscribing data change listener to path:" + path);
+      }
       subscribeDataChange(path, context);
     }
 
     if (_eventTypes.contains(EventType.NodeChildrenChanged)) {
-      logger.debug("Subscribing child change listener to path:" + path);
+      if (logger.isDebugEnabled()) {
+        logger.debug("Subscribing child change listener to path:" + path);
+      }
+
       subscribeChildChange(path, context);
       if (watchChild) {
-        logger.debug("Subscribing data change listener to all children for path:" + path);
+        if (logger.isDebugEnabled()) {
+          logger.debug("Subscribing data change listener to all children for path:" + path);
+        }
+
         try {
           switch (_changeType) {
           case CURRENT_STATE:
@@ -504,7 +512,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
     }
 
     long end = System.currentTimeMillis();
-    logger.info("Subcribing to path:" + path + " took:" + (end - start));
+    logger.info("Subscribing to path:" + path + " took:" + (end - start));
   }
 
   public EventType[] getEventTypes() {
@@ -530,7 +538,9 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
 
   @Override
   public void handleDataChange(String dataPath, Object data) {
-    logger.info("Data change callback: paths changed: " + dataPath);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Data change callback: paths changed: " + dataPath);
+    }
 
     try {
       updateNotificationTime(System.nanoTime());
@@ -547,8 +557,11 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
     }
   }
 
-  @Override public void handleDataDeleted(String dataPath) {
-    logger.info("Data change callback: path deleted: " + dataPath);
+  @Override
+  public void handleDataDeleted(String dataPath) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Data change callback: path deleted: " + dataPath);
+    }
 
     try {
       updateNotificationTime(System.nanoTime());
@@ -573,8 +586,11 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
 
   @Override
   public void handleChildChange(String parentPath, List<String> currentChilds) {
-    logger.info("Data change callback: child changed, path: " + parentPath + ", current child count: "
-        + currentChilds.size());
+    if (logger.isDebugEnabled()) {
+      logger.debug(
+          "Data change callback: child changed, path: " + parentPath + ", current child count: "
+              + currentChilds.size());
+    }
 
     try {
       updateNotificationTime(System.nanoTime());

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
@@ -142,7 +142,9 @@ public class ZkClient implements Watcher {
       listeners.add(listener);
     }
     watchForData(path);
-    LOG.debug("Subscribed data changes for " + path);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Subscribed data changes for " + path);
+    }
   }
 
   public void unsubscribeDataChanges(String path, IZkDataListener dataListener) {
@@ -525,7 +527,9 @@ public class ZkClient implements Watcher {
 
   @Override
   public void process(WatchedEvent event) {
-    LOG.debug("Received event: " + event);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Received event: " + event);
+    }
     _zookeeperEventThread = Thread.currentThread();
 
     boolean stateChanged = event.getPath() == null;
@@ -540,8 +544,10 @@ public class ZkClient implements Watcher {
 
       // We might have to install child change event listener if a new node was created
       if (getShutdownTrigger()) {
-        LOG.debug("ignoring event '{" + event.getType() + " | " + event.getPath()
-            + "}' since shutdown triggered");
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("ignoring event '{" + event.getType() + " | " + event.getPath()
+              + "}' since shutdown triggered");
+        }
         return;
       }
       if (stateChanged) {
@@ -692,7 +698,7 @@ public class ZkClient implements Watcher {
         reconnect();
         fireNewSessionEvents();
       } catch (final Exception e) {
-        LOG.info(
+        LOG.warn(
             "Unable to re-establish connection. Notifying consumer of the following exception: ",
             e);
         fireSessionEstablishmentError(e);
@@ -855,7 +861,9 @@ public class ZkClient implements Watcher {
   public boolean waitUntilExists(String path, TimeUnit timeUnit, long time)
       throws ZkInterruptedException {
     Date timeout = new Date(System.currentTimeMillis() + timeUnit.toMillis(time));
-    LOG.debug("Waiting until znode '" + path + "' becomes available.");
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Waiting until znode '" + path + "' becomes available.");
+    }
     if (exists(path)) {
       return true;
     }

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -19,24 +19,99 @@ package org.apache.helix.spectator;
  * under the License.
  */
 
+import java.util.Collections;
+import java.util.Map;
 import org.apache.helix.HelixConstants;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyType;
 import org.apache.helix.common.caches.BasicClusterDataCache;
+import org.apache.helix.common.caches.CurrentStateCache;
+import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.LiveInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Cache the cluster data that are needed by RoutingTableProvider.
  */
 public class RoutingDataCache extends BasicClusterDataCache {
+  private static Logger LOG = LoggerFactory.getLogger(RoutingDataCache.class.getName());
+
+  private final PropertyType _sourceDataType;
+  private CurrentStateCache _currentStateCache;
+  private Map<String, ExternalView> _targetExternalViewMap;
+
   public RoutingDataCache(String clusterName, PropertyType sourceDataType) {
-    super(clusterName, sourceDataType);
+    super(clusterName);
+    _sourceDataType = sourceDataType;
+    _currentStateCache = new CurrentStateCache(clusterName);
+    _targetExternalViewMap = Collections.emptyMap();
     requireFullRefresh();
   }
 
   /**
-   * Notify the cache that some part of the cluster data has been changed.
+   * This refreshes the cluster data by re-fetching the data from zookeeper in an efficient way
+   *
+   * @param accessor
+   *
+   * @return
    */
-  public void notifyDataChange(HelixConstants.ChangeType changeType, String pathChanged) {
-    _propertyDataChangedMap.put(changeType, Boolean.valueOf(true));
+  @Override
+  public synchronized void refresh(HelixDataAccessor accessor) {
+    LOG.info("START: RoutingDataCache.refresh() for cluster " + _clusterName);
+    long startTime = System.currentTimeMillis();
+
+    super.refresh(accessor);
+
+    if (_sourceDataType.equals(PropertyType.TARGETEXTERNALVIEW) && _propertyDataChangedMap
+        .get(HelixConstants.ChangeType.TARGET_EXTERNAL_VIEW)) {
+      long start = System.currentTimeMillis();
+      PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+      _propertyDataChangedMap
+          .put(HelixConstants.ChangeType.TARGET_EXTERNAL_VIEW, Boolean.valueOf(false));
+      _targetExternalViewMap = accessor.getChildValuesMap(keyBuilder.targetExternalViews());
+      LOG.info("Reload TargetExternalViews: " + _targetExternalViewMap.keySet() + ". Takes " + (
+          System.currentTimeMillis() - start) + " ms");
+    }
+
+    if (_sourceDataType.equals(PropertyType.CURRENTSTATES) && _propertyDataChangedMap
+        .get(HelixConstants.ChangeType.CURRENT_STATE)) {
+      long start = System.currentTimeMillis();
+      Map<String, LiveInstance> liveInstanceMap = getLiveInstances();
+      _currentStateCache.refresh(accessor, liveInstanceMap);
+      LOG.info("Reload CurrentStates: " + _targetExternalViewMap.keySet() + ". Takes " + (
+          System.currentTimeMillis() - start) + " ms");
+    }
+
+    long endTime = System.currentTimeMillis();
+    LOG.info("END: RoutingDataCache.refresh() for cluster " + _clusterName + ", took " + (endTime
+        - startTime) + " ms");
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("CurrentStates: " + _currentStateCache);
+      LOG.debug("TargetExternalViews: " + _targetExternalViewMap);
+    }
+  }
+
+  /**
+   * Retrieves the TargetExternalView for all resources
+   *
+   * @return
+   */
+  public Map<String, ExternalView> getTargetExternalViews() {
+    return Collections.unmodifiableMap(_targetExternalViewMap);
+  }
+
+  /**
+   * Get map of current states in cluster. {InstanceName -> {SessionId -> {ResourceName ->
+   * CurrentState}}}
+   *
+   * @return
+   */
+  public Map<String, Map<String, Map<String, CurrentState>>> getCurrentStatesMap() {
+    return _currentStateCache.getCurrentStatesMap();
   }
 }
 

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Cache the cluster data that are needed by RoutingTableProvider.
  */
-public class RoutingDataCache extends BasicClusterDataCache {
+class RoutingDataCache extends BasicClusterDataCache {
   private static Logger LOG = LoggerFactory.getLogger(RoutingDataCache.class.getName());
 
   private final PropertyType _sourceDataType;

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTable.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTable.java
@@ -211,7 +211,7 @@ class RoutingTable {
     if (instanceList == null) {
       instanceList = Collections.emptyList();
     }
-    return instanceList;
+    return Collections.unmodifiableList(instanceList);
   }
 
   /**
@@ -219,7 +219,7 @@ class RoutingTable {
    * @return
    */
   protected Collection<LiveInstance> getLiveInstances() {
-    return _liveInstances;
+    return Collections.unmodifiableCollection(_liveInstances);
   }
 
   /**
@@ -227,7 +227,14 @@ class RoutingTable {
    * @return
    */
   protected Collection<InstanceConfig> getInstanceConfigs() {
-    return _instanceConfigs;
+    return Collections.unmodifiableCollection(_instanceConfigs);
+  }
+
+  /**
+   * Return names of all resources (shown in ExternalView) in this cluster.
+   */
+  protected Collection<String> getResources() {
+    return Collections.unmodifiableCollection(_resourceInfoMap.keySet());
   }
 
   /**
@@ -261,7 +268,7 @@ class RoutingTable {
       return Collections.emptyList();
     }
 
-    return instanceList;
+    return Collections.unmodifiableList(instanceList);
   }
 
   private void refresh(Collection<ExternalView> externalViewList,

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -60,7 +60,7 @@ public class RoutingTableProvider implements ExternalViewChangeListener, Instanc
   private final HelixManager _helixManager;
   private final RouterUpdater _routerUpdater;
   private final PropertyType _sourceDataType;
-  private final Map<RoutingTableChangeListener, Object> _routingTableChangeListenerMap;
+  private final Map<RoutingTableChangeListener, ListenerContext> _routingTableChangeListenerMap;
 
   public RoutingTableProvider() {
     this(null);
@@ -173,7 +173,7 @@ public class RoutingTableProvider implements ExternalViewChangeListener, Instanc
    */
   public void addRoutingTableChangeListener(final RoutingTableChangeListener routingTableChangeListener,
       Object context) {
-    _routingTableChangeListenerMap.put(routingTableChangeListener, context);
+    _routingTableChangeListenerMap.put(routingTableChangeListener, new ListenerContext(context));
   }
 
   /**
@@ -494,10 +494,10 @@ public class RoutingTableProvider implements ExternalViewChangeListener, Instanc
   }
 
   private void notifyRoutingTableChange() {
-    for (Map.Entry<RoutingTableChangeListener, Object> entry : _routingTableChangeListenerMap
+    for (Map.Entry<RoutingTableChangeListener, ListenerContext> entry : _routingTableChangeListenerMap
         .entrySet()) {
-      entry.getKey()
-          .onRoutingTableChange(new RoutingTableSnapshot(_routingTableRef.get()), entry.getValue());
+      entry.getKey().onRoutingTableChange(new RoutingTableSnapshot(_routingTableRef.get()),
+          entry.getValue().getContext());
     }
   }
 
@@ -559,6 +559,18 @@ public class RoutingTableProvider implements ExternalViewChangeListener, Instanc
       event.addAttribute(AttributeName.helixmanager.name(), context.getManager());
       event.addAttribute(AttributeName.changeContext.name(), context);
       queueEvent(event);
+    }
+  }
+
+  private class ListenerContext {
+    private Object _context;
+
+    public ListenerContext(Object context) {
+      _context = context;
+    }
+
+    public Object getContext() {
+      return _context;
     }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -20,6 +20,7 @@ package org.apache.helix.spectator;
  */
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -140,7 +141,8 @@ public class RoutingTableProvider implements ExternalViewChangeListener, Instanc
    */
   public List<InstanceConfig> getInstancesForResourceGroup(String resourceGroupName,
       String partitionName, String state) {
-    return _routingTableRef.get().getInstancesForResourceGroup(resourceGroupName, partitionName, state);
+    return _routingTableRef.get().getInstancesForResourceGroup(resourceGroupName, partitionName,
+        state);
   }
 
   /**
@@ -227,6 +229,13 @@ public class RoutingTableProvider implements ExternalViewChangeListener, Instanc
    */
   public Collection<InstanceConfig> getInstanceConfigs() {
     return _routingTableRef.get().getInstanceConfigs();
+  }
+
+  /**
+   * Return names of all resources (shown in ExternalView) in this cluster.
+   */
+  public Collection<String> getResources() {
+    return _routingTableRef.get().getResources();
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -152,6 +152,16 @@ public class RoutingTableProvider implements ExternalViewChangeListener, Instanc
   }
 
   /**
+   * Get an snapshot of current RoutingTable information. The snapshot is immutable, it reflects the
+   * routing table information at the time this method is called.
+   *
+   * @return snapshot of current routing table.
+   */
+  public RoutingTableSnapshot getRoutingTableSnapshot() {
+    return new RoutingTableSnapshot(_routingTableRef.get());
+  }
+
+  /**
    * returns the instances for {resource,partition} pair that are in a specific
    * {state}
    *

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableSnapshot.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableSnapshot.java
@@ -1,0 +1,151 @@
+package org.apache.helix.spectator;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+
+/**
+ * The snapshot of RoutingTable information.  It is immutable, it reflects the routing table
+ * information at the time it is generated.
+ */
+public class RoutingTableSnapshot {
+  private final RoutingTable _routingTable;
+
+  public RoutingTableSnapshot(RoutingTable routingTable) {
+    _routingTable = routingTable;
+  }
+
+  /**
+   * returns all instances for {resource} that are in a specific {state}.
+   *
+   * @param resourceName
+   * @param state
+   *
+   * @return empty list if there is no instance in a given state
+   */
+  public Set<InstanceConfig> getInstancesForResource(String resourceName, String state) {
+    return _routingTable.getInstancesForResource(resourceName, state);
+  }
+
+  /**
+   * returns the instances for {resource,partition} pair that are in a specific {state}
+   *
+   * @param resourceName
+   * @param partitionName
+   * @param state
+   *
+   * @return empty list if there is no instance in a given state
+   */
+  public List<InstanceConfig> getInstancesForResource(String resourceName, String partitionName,
+      String state) {
+    return _routingTable.getInstancesForResource(resourceName, partitionName, state);
+  }
+
+  /**
+   * returns all instances for resources contains any given tags in {resource group} that are in a
+   * specific {state}
+   *
+   * @param resourceGroupName
+   * @param state
+   *
+   * @return empty list if there is no instance in a given state
+   */
+  public Set<InstanceConfig> getInstancesForResourceGroup(String resourceGroupName, String state,
+      List<String> resourceTags) {
+    return _routingTable.getInstancesForResourceGroup(resourceGroupName, state, resourceTags);
+  }
+
+  /**
+   * returns all instances for all resources in {resource group} that are in a specific {state}
+   *
+   * @param resourceGroupName
+   * @param state
+   *
+   * @return empty set if there is no instance in a given state
+   */
+  public Set<InstanceConfig> getInstancesForResourceGroup(String resourceGroupName, String state) {
+    return _routingTable.getInstancesForResourceGroup(resourceGroupName, state);
+  }
+
+  /**
+   * returns the instances for {resource group,partition} pair in all resources belongs to the given
+   * resource group that are in a specific {state}.
+   * The return results aggregate all partition states from all the resources in the given resource
+   * group.
+   *
+   * @param resourceGroupName
+   * @param partitionName
+   * @param state
+   *
+   * @return empty list if there is no instance in a given state
+   */
+  public List<InstanceConfig> getInstancesForResourceGroup(String resourceGroupName,
+      String partitionName, String state) {
+    return _routingTable.getInstancesForResourceGroup(resourceGroupName, partitionName, state);
+  }
+
+  /**
+   * returns the instances for {resource group,partition} pair contains any of the given tags that
+   * are in a specific {state}.
+   * Find all resources belongs to the given resource group that have any of the given resource tags
+   * and return the aggregated partition states from all these resources.
+   *
+   * @param resourceGroupName
+   * @param partitionName
+   * @param state
+   * @param resourceTags
+   *
+   * @return empty list if there is no instance in a given state
+   */
+  public List<InstanceConfig> getInstancesForResourceGroup(String resourceGroupName,
+      String partitionName, String state, List<String> resourceTags) {
+    return _routingTable
+        .getInstancesForResourceGroup(resourceGroupName, partitionName, state, resourceTags);
+  }
+
+  /**
+   * Return all liveInstances in the cluster now.
+   *
+   * @return
+   */
+  public Collection<LiveInstance> getLiveInstances() {
+    return _routingTable.getLiveInstances();
+  }
+
+  /**
+   * Return all instance's config in this cluster.
+   *
+   * @return
+   */
+  public Collection<InstanceConfig> getInstanceConfigs() {
+    return _routingTable.getInstanceConfigs();
+  }
+
+  /**
+   * Return names of all resources (shown in ExternalView) in this cluster.
+   */
+  public Collection<String> getResources() {
+    return _routingTable.getResources();
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/MockAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/MockAccessor.java
@@ -205,8 +205,11 @@ public class MockAccessor implements HelixDataAccessor {
 
   @Override
   public <T extends HelixProperty> boolean[] setChildren(List<PropertyKey> keys, List<T> children) {
-    // TODO Auto-generated method stub
-    return null;
+    boolean[] results = new boolean[keys.size()];
+    for (int i = 0; i < keys.size(); i++) {
+      results[i] = setProperty(keys.get(i), children.get(i));
+    }
+    return results;
   }
 
   @Override

--- a/helix-core/src/test/java/org/apache/helix/integration/Spectator/TestRoutingTableProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/Spectator/TestRoutingTableProvider.java
@@ -2,6 +2,7 @@ package org.apache.helix.integration.Spectator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -112,6 +113,9 @@ public class TestRoutingTableProvider extends ZkIntegrationTestBase {
         Sets.newSet(_instances.get(1), _instances.get(2)));
     validateRoutingTable(_routingTableProvider2, Sets.newSet(_instances.get(0)),
         Sets.newSet(_instances.get(1), _instances.get(2)));
+
+    Collection<String> databases = _routingTableProvider.getResources();
+    Assert.assertEquals(databases.size(), 1);
   }
 
   @Test(dependsOnMethods = { "testRoutingTable" })

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
@@ -1,7 +1,6 @@
-package org.apache.helix.integration.Spectator;
+package org.apache.helix.integration.spectator;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
@@ -164,7 +164,7 @@ public class TestRoutingTableProvider extends ZkIntegrationTestBase {
     context.put("MASTER", Sets.newSet(_instances.get(0)));
     context.put("SLAVE", Sets.newSet(_instances.get(1), _instances.get(2)));
     _routingTableProvider.addRoutingTableChangeListener(routingTableChangeListener, context);
-
+    _routingTableProvider.addRoutingTableChangeListener(new MockRoutingTableChangeListener(), null);
     // reenable the master instance to cause change
     String prevMasterInstance = _instances.get(0);
     _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, prevMasterInstance, true);

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderFromCurrentStates.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderFromCurrentStates.java
@@ -1,0 +1,162 @@
+package org.apache.helix.integration.spectator;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixException;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.PropertyType;
+import org.apache.helix.integration.common.ZkIntegrationTestBase;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.spectator.RoutingTableProvider;
+import org.apache.helix.tools.ClusterSetup;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.apache.helix.tools.ClusterVerifiers.HelixClusterVerifier;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestRoutingTableProviderFromCurrentStates extends ZkIntegrationTestBase {
+  private HelixManager _manager;
+  private ClusterSetup _setupTool;
+  private final int NUM_NODES = 10;
+  protected int NUM_PARTITIONS = 20;
+  protected int NUM_REPLICAS = 3;
+  private final int START_PORT = 12918;
+  private final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + getShortClassName();
+  private MockParticipantManager[] _participants;
+  private ClusterControllerManager _controller;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    String namespace = "/" + CLUSTER_NAME;
+    _participants =  new MockParticipantManager[NUM_NODES];
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursively(namespace);
+    }
+
+    _setupTool = new ClusterSetup(ZK_ADDR);
+    _setupTool.addCluster(CLUSTER_NAME, true);
+
+    _participants = new MockParticipantManager[NUM_NODES];
+    for (int i = 0; i < NUM_NODES; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      _setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+
+    for (int i = 0; i < NUM_NODES; i++) {
+      String instanceName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+      _participants[i].syncStart();
+    }
+
+    _manager = HelixManagerFactory
+        .getZKHelixManager(CLUSTER_NAME, "Admin", InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    ConfigAccessor _configAccessor = _manager.getConfigAccessor();
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.enableTargetExternalView(true);
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+  }
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    _manager.disconnect();
+    for (int i = 0; i < NUM_NODES; i++) {
+      if (_participants[i] != null && _participants[i].isConnected()) {
+        _participants[i].reset();
+      }
+    }
+  }
+
+  @Test
+  public void testRoutingTableWithCurrentStates() throws InterruptedException {
+    RoutingTableProvider routingTableEV =
+        new RoutingTableProvider(_manager, PropertyType.EXTERNALVIEW);
+    RoutingTableProvider routingTableCurrentStates = new RoutingTableProvider(_manager, PropertyType.CURRENTSTATES);
+
+    String db1 = "TestDB-1";
+    _setupTool.addResourceToCluster(CLUSTER_NAME, db1, NUM_PARTITIONS, "MasterSlave",
+        IdealState.RebalanceMode.FULL_AUTO.name());
+    _setupTool.rebalanceStorageCluster(CLUSTER_NAME, db1, NUM_REPLICAS);
+
+    Thread.sleep(200);
+    HelixClusterVerifier clusterVerifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR).build();
+    Assert.assertTrue(clusterVerifier.verify());
+
+    IdealState idealState1 = _setupTool.getClusterManagementTool().getResourceIdealState(
+        CLUSTER_NAME, db1);
+    validate(idealState1, routingTableEV, routingTableCurrentStates);
+
+    // add new DB
+    String db2 = "TestDB-2";
+    _setupTool.addResourceToCluster(CLUSTER_NAME, db2, NUM_PARTITIONS, "MasterSlave",
+        IdealState.RebalanceMode.FULL_AUTO.name());
+    _setupTool.rebalanceStorageCluster(CLUSTER_NAME, db2, NUM_REPLICAS);
+
+    Thread.sleep(200);
+    Assert.assertTrue(clusterVerifier.verify());
+
+    IdealState idealState2 = _setupTool.getClusterManagementTool().getResourceIdealState(
+        CLUSTER_NAME, db2);
+    validate(idealState2, routingTableEV, routingTableCurrentStates);
+
+    // shutdown an instance
+    _participants[0].syncStop();
+    Thread.sleep(200);
+    Assert.assertTrue(clusterVerifier.verify());
+    validate(idealState1, routingTableEV, routingTableCurrentStates);
+    validate(idealState2, routingTableEV, routingTableCurrentStates);
+  }
+
+  @Test (dependsOnMethods = {"testRoutingTableWithCurrentStates"})
+  public void testWithSupportSourceDataType() {
+    new RoutingTableProvider(_manager, PropertyType.EXTERNALVIEW);
+    new RoutingTableProvider(_manager, PropertyType.TARGETEXTERNALVIEW);
+    new RoutingTableProvider(_manager, PropertyType.CURRENTSTATES);
+
+    try {
+      new RoutingTableProvider(_manager, PropertyType.IDEALSTATES);
+      Assert.fail();
+    } catch (HelixException ex) {
+      Assert.assertTrue(ex.getMessage().contains("Unsupported source data type"));
+    }
+  }
+
+  private void validate(IdealState idealState, RoutingTableProvider routingTableEV,
+      RoutingTableProvider routingTableCurrentStates) {
+    String db = idealState.getResourceName();
+    Set<String> partitions = idealState.getPartitionSet();
+    for (String partition : partitions) {
+      List<InstanceConfig> masterInsEv =
+          routingTableEV.getInstancesForResource(db, partition, "MASTER");
+      List<InstanceConfig> masterInsCs =
+          routingTableCurrentStates.getInstancesForResource(db, partition, "MASTER");
+      Assert.assertEquals(masterInsEv.size(), 1);
+      Assert.assertEquals(masterInsCs.size(), 1);
+      Assert.assertEquals(masterInsCs, masterInsEv);
+
+      List<InstanceConfig> slaveInsEv =
+          routingTableEV.getInstancesForResource(db, partition, "SLAVE");
+      List<InstanceConfig> slaveInsCs =
+          routingTableCurrentStates.getInstancesForResource(db, partition, "SLAVE");
+      Assert.assertEquals(slaveInsEv.size(), 2);
+      Assert.assertEquals(slaveInsCs.size(), 2);
+      Assert.assertEquals(new HashSet(slaveInsCs), new HashSet(slaveInsEv));
+    }
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderFromTargetEV.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderFromTargetEV.java
@@ -1,4 +1,4 @@
-package org.apache.helix.integration.Spectator;
+package org.apache.helix.integration.spectator;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -25,7 +25,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-public class TestRoutingTableProviderWithSourceType extends ZkIntegrationTestBase {
+public class TestRoutingTableProviderFromTargetEV extends ZkIntegrationTestBase {
   private HelixManager _manager;
   private ClusterSetup _setupTool;
   private final String MASTER_SLAVE_STATE_MODEL = "MasterSlave";

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableSnapshot.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableSnapshot.java
@@ -1,0 +1,140 @@
+package org.apache.helix.integration.spectator;
+
+import java.util.List;
+import java.util.Set;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.PropertyType;
+import org.apache.helix.integration.common.ZkIntegrationTestBase;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.spectator.RoutingTableProvider;
+import org.apache.helix.spectator.RoutingTableSnapshot;
+import org.apache.helix.tools.ClusterSetup;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.apache.helix.tools.ClusterVerifiers.HelixClusterVerifier;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestRoutingTableSnapshot extends ZkIntegrationTestBase {
+  private HelixManager _manager;
+  private ClusterSetup _setupTool;
+  private final int NUM_NODES = 10;
+  protected int NUM_PARTITIONS = 20;
+  protected int NUM_REPLICAS = 3;
+  private final int START_PORT = 12918;
+  private final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + getShortClassName();
+  private MockParticipantManager[] _participants;
+  private ClusterControllerManager _controller;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    String namespace = "/" + CLUSTER_NAME;
+    _participants =  new MockParticipantManager[NUM_NODES];
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursively(namespace);
+    }
+
+    _setupTool = new ClusterSetup(ZK_ADDR);
+    _setupTool.addCluster(CLUSTER_NAME, true);
+
+    _participants = new MockParticipantManager[NUM_NODES];
+    for (int i = 0; i < NUM_NODES; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      _setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+
+    for (int i = 0; i < NUM_NODES; i++) {
+      String instanceName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+      _participants[i].syncStart();
+    }
+
+    _manager = HelixManagerFactory
+        .getZKHelixManager(CLUSTER_NAME, "Admin", InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+  }
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    _manager.disconnect();
+    for (int i = 0; i < NUM_NODES; i++) {
+      if (_participants[i] != null && _participants[i].isConnected()) {
+        _participants[i].reset();
+      }
+    }
+  }
+
+  @Test
+  public void testRoutingTableSnapshot() throws InterruptedException {
+    RoutingTableProvider routingTableProvider =
+        new RoutingTableProvider(_manager, PropertyType.EXTERNALVIEW);
+
+    String db1 = "TestDB-1";
+    _setupTool.addResourceToCluster(CLUSTER_NAME, db1, NUM_PARTITIONS, "MasterSlave",
+        IdealState.RebalanceMode.FULL_AUTO.name());
+    _setupTool.rebalanceStorageCluster(CLUSTER_NAME, db1, NUM_REPLICAS);
+
+    Thread.sleep(200);
+    HelixClusterVerifier clusterVerifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR).build();
+    Assert.assertTrue(clusterVerifier.verify());
+
+    IdealState idealState1 = _setupTool.getClusterManagementTool().getResourceIdealState(
+        CLUSTER_NAME, db1);
+
+    RoutingTableSnapshot routingTableSnapshot = routingTableProvider.getRoutingTableSnapshot();
+    validateMapping(idealState1, routingTableSnapshot);
+
+    Assert.assertEquals(routingTableSnapshot.getInstanceConfigs().size(), NUM_NODES);
+    Assert.assertEquals(routingTableSnapshot.getResources().size(), 1);
+    Assert.assertEquals(routingTableSnapshot.getLiveInstances().size(), NUM_NODES);
+
+    // add new DB and shutdown an instance
+    String db2 = "TestDB-2";
+    _setupTool.addResourceToCluster(CLUSTER_NAME, db2, NUM_PARTITIONS, "MasterSlave",
+        IdealState.RebalanceMode.FULL_AUTO.name());
+    _setupTool.rebalanceStorageCluster(CLUSTER_NAME, db2, NUM_REPLICAS);
+
+    // shutdown an instance
+    _participants[0].syncStop();
+    Thread.sleep(200);
+    Assert.assertTrue(clusterVerifier.verify());
+
+    // the original snapshot should not change
+    Assert.assertEquals(routingTableSnapshot.getInstanceConfigs().size(), NUM_NODES);
+    Assert.assertEquals(routingTableSnapshot.getResources().size(), 1);
+    Assert.assertEquals(routingTableSnapshot.getLiveInstances().size(), NUM_NODES);
+
+    RoutingTableSnapshot newRoutingTableSnapshot = routingTableProvider.getRoutingTableSnapshot();
+
+    Assert.assertEquals(newRoutingTableSnapshot.getInstanceConfigs().size(), NUM_NODES);
+    Assert.assertEquals(newRoutingTableSnapshot.getResources().size(), 2);
+    Assert.assertEquals(newRoutingTableSnapshot.getLiveInstances().size(), NUM_NODES - 1);
+  }
+
+  private void validateMapping(IdealState idealState, RoutingTableSnapshot routingTableSnapshot) {
+    String db = idealState.getResourceName();
+    Set<String> partitions = idealState.getPartitionSet();
+    for (String partition : partitions) {
+      List<InstanceConfig> masterInsEv =
+          routingTableSnapshot.getInstancesForResource(db, partition, "MASTER");
+      Assert.assertEquals(masterInsEv.size(), 1);
+
+      List<InstanceConfig> slaveInsEv =
+          routingTableSnapshot.getInstancesForResource(db, partition, "SLAVE");
+      Assert.assertEquals(slaveInsEv.size(), 2);
+    }
+  }
+}
+


### PR DESCRIPTION
This PR includes a few of features and improvements to existing Helix's RoutingTableProvider interface and implements. There are:

1)   Add to getResources() into RoutingTableProvider.
2)   RoutingTableProvider to support direct aggregating routing information from CurrentStates in each liveinstance. When sourceDataType is set as CurrentState, RoutingTableProvider will listen on CurrentStateChanges and refresh routing table from CurrentStates upon changes.
3)   Add RoutingTableSnapshot class to hold a snapshot of routing table information and provide API to return RoutingTableSnapshot from RoutingTableProvider.
4)   Support RoutingTableChangeListener in RoutingTableProvider, which will be called when there is anything changed in the RoutingTable information.



