### PR TITLE
[HELIX-682] controller should delete obsolete messages with timeout to unblock state transition

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.helix.controller.pipeline.AbstractBaseStage;
 import org.apache.helix.controller.pipeline.StageException;
 import org.apache.helix.model.CurrentState;
@@ -158,7 +157,10 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
               currentState.getState(partitionName));
           currentStateOutput.setRequestedState(resourceName, partition, instanceName,
               currentState.getRequestedState(partitionName));
-          currentStateOutput.setInfo(resourceName, partition, instanceName, currentState.getInfo(partitionName));
+          currentStateOutput
+              .setInfo(resourceName, partition, instanceName, currentState.getInfo(partitionName));
+          currentStateOutput.setEndTime(resourceName, partition, instanceName,
+              currentState.getEndTime(partitionName));
         }
       }
     }


### PR DESCRIPTION
This RB contains implementations and tests for controller: during MessageGenerationPhase, it checks if the pending message should be cleaned up on participant to unblock further state transition:

- If partition's current state is same as message's toState, and the 3sec timeout already passed, in this case, it's likely that participant failed to delete message and controller should proactively remove the message so further rebalance could be unblocked
- If partition's current state is same as message's fromState, this means the partition is undergoing state transition or the state transition has not started yet, in this case, we do nothing
- If partition's current state is neither message's fromState nor toState (almost impossible), this means this message is a problematic one, and it is safe to delete it immediately so participant would not undergo an unnecessary message handling

Message deletion on controller side is async