### PR TITLE
Improvements to Helix's Callback handling.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/GroupCommit.java
+++ b/helix-core/src/main/java/org/apache/helix/GroupCommit.java
@@ -92,7 +92,7 @@ public class GroupCommit {
 
     while (!entry._sent.get()) {
       if (queue._running.compareAndSet(null, Thread.currentThread())) {
-        ArrayList<Entry> processed = new ArrayList<Entry>();
+        ArrayList<Entry> processed = new ArrayList<>();
         try {
           if (queue._pending.peek() == null)
             return true;
@@ -136,13 +136,14 @@ public class GroupCommit {
           while (++retry <= MAX_RETRY && !success) {
             if (removeIfEmpty && merged.getMapFields().isEmpty()) {
               success = accessor.remove(mergedKey, options);
+              if (!success) {
+                LOG.error("Fails to remove " + mergedKey + " from ZK, retry it!");
+              }
             } else {
               success = accessor.set(mergedKey, merged, options);
-            }
-            if (!success) {
-              LOG.error(
-                  "Fails to update " + mergedKey + " to ZK, retry it! remove: " + (removeIfEmpty
-                      && merged.getMapFields().isEmpty()));
+              if (!success) {
+                LOG.error("Fails to update " + mergedKey + " to ZK, retry it! ");
+              }
             }
           }
         } finally {

--- a/helix-core/src/main/java/org/apache/helix/common/ClusterEventProcessor.java
+++ b/helix-core/src/main/java/org/apache/helix/common/ClusterEventProcessor.java
@@ -1,62 +1,26 @@
 package org.apache.helix.common;
 
-import org.I0Itec.zkclient.exception.ZkInterruptedException;
 import org.apache.helix.controller.stages.ClusterEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import org.apache.helix.controller.stages.ClusterEventType;
 /**
  * A generic extended single-thread class to handle ClusterEvent (multiple-producer/single consumer
  * style).
+ *
+ * This class is deprecated, please use {@link org.apache.helix.common.DedupEventProcessor}.
  */
-public abstract class ClusterEventProcessor extends Thread {
-  private static final Logger logger = LoggerFactory.getLogger(ClusterEventProcessor.class);
-
-  protected final ClusterEventBlockingQueue _eventQueue;
-  protected final String _clusterName;
-  protected final String _processorName;
+@Deprecated
+public abstract class ClusterEventProcessor
+    extends DedupEventProcessor<ClusterEventType, ClusterEvent> {
 
   public ClusterEventProcessor(String clusterName) {
     this(clusterName, "Helix-ClusterEventProcessor");
   }
 
   public ClusterEventProcessor(String clusterName, String processorName) {
-    super(processorName + "-" + clusterName);
-    _processorName = processorName;
-    _eventQueue = new ClusterEventBlockingQueue();
-    _clusterName = clusterName;
+    super(clusterName, processorName);
   }
-
-  @Override
-  public void run() {
-    logger.info("START " + _processorName + " thread for cluster " + _clusterName);
-    while (!isInterrupted()) {
-      try {
-        ClusterEvent event = _eventQueue.take();
-        handleEvent(event);
-      } catch (InterruptedException e) {
-        logger.warn(_processorName + " thread interrupted", e);
-        interrupt();
-      } catch (ZkInterruptedException e) {
-        logger.warn(_processorName + " thread caught a ZK connection interrupt", e);
-        interrupt();
-      } catch (ThreadDeath death) {
-        throw death;
-      } catch (Throwable t) {
-        logger.error(_processorName + " thread failed while running the controller pipeline", t);
-      }
-    }
-    logger.info("END " + _processorName + " thread");
-  }
-
-  protected abstract void handleEvent(ClusterEvent event);
 
   public void queueEvent(ClusterEvent event) {
-    _eventQueue.put(event);
-  }
-
-  public void shutdown() {
-    _eventQueue.clear();
-    this.interrupt();
+    _eventQueue.put(event.getEventType(), event);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/common/DedupEventBlockingQueue.java
+++ b/helix-core/src/main/java/org/apache/helix/common/DedupEventBlockingQueue.java
@@ -1,0 +1,139 @@
+package org.apache.helix.common;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * A blocking queue of events, which automatically deduplicate events with the same "type" within
+ * the queue, i.e, when putting an event into the queue, if there is already an event with the
+ * same type existing in the queue, the new event won't be inserted into the queue.
+ * This class is meant to be a limited implementation of the {@link BlockingQueue} interface.
+ *
+ * T -- the Type of an event.
+ * E -- the event itself.
+ */
+public class DedupEventBlockingQueue<T, E> {
+  private final Map<T, Entry<T, E>> _eventMap;
+  private final Queue<Entry> _eventQueue;
+
+  class Entry <T, E> {
+    private T _type;
+    private E _event;
+
+    Entry (T type, E event) {
+      _type = type;
+      _event = event;
+    }
+
+    T getType() {
+      return _type;
+    }
+
+    E getEvent() {
+      return _event;
+    }
+  }
+
+  /**
+   * Instantiate the queue
+   */
+  public DedupEventBlockingQueue() {
+    _eventMap = Maps.newHashMap();
+    _eventQueue = Lists.newLinkedList();
+  }
+
+  /**
+   * Remove all events from the queue
+   */
+  public synchronized void clear() {
+    _eventMap.clear();
+    _eventQueue.clear();
+  }
+
+  /**
+   * Add a single event to the queue, overwriting events with the same name
+   */
+  public synchronized void put(T type, E event) {
+    Entry entry = new Entry(type, event);
+
+    if (!_eventMap.containsKey(entry.getType())) {
+      // only insert to the queue if there isn't a same-typed event already present
+      boolean result = _eventQueue.offer(entry);
+      if (!result) {
+        return;
+      }
+    }
+    // always overwrite the existing entry in the map in case the entry is different
+    _eventMap.put((T) entry.getType(), entry);
+    notify();
+  }
+
+  /**
+   * Remove an element from the front of the queue, blocking if none is available. This method
+   * will return the most recent event seen with the oldest enqueued event name.
+   * @return ClusterEvent at the front of the queue
+   * @throws InterruptedException if the wait for elements was interrupted
+   */
+  public synchronized E take() throws InterruptedException {
+    while (_eventQueue.isEmpty()) {
+      wait();
+    }
+    Entry entry = _eventQueue.poll();
+    if (entry != null) {
+      entry = _eventMap.remove(entry.getType());
+      return (E) entry.getEvent();
+    }
+    return null;
+  }
+
+  /**
+   * Get at the head of the queue without removing it
+   * @return ClusterEvent at the front of the queue, or null if none available
+   */
+  public synchronized E peek() {
+    Entry entry = _eventQueue.peek();
+    if (entry != null) {
+      entry = _eventMap.get(entry.getType());
+      return (E) entry.getEvent();
+    }
+    return null;
+  }
+
+  /**
+   * Get the queue size
+   * @return integer size of the queue
+   */
+  public int size() {
+    return _eventQueue.size();
+  }
+
+  /**
+   * Check if the queue is empty
+   * @return true if events are not present, false otherwise
+   */
+  public boolean isEmpty() {
+    return _eventQueue.isEmpty();
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/common/DedupEventProcessor.java
+++ b/helix-core/src/main/java/org/apache/helix/common/DedupEventProcessor.java
@@ -1,0 +1,68 @@
+package org.apache.helix.common;
+
+import org.I0Itec.zkclient.exception.ZkInterruptedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A generic extended single-thread class to handle event with events with the same type de-duplicated (multiple-producer/single consumer
+ * style).
+ *
+ * T -- Type of the event.
+ * E -- The event itself.
+ */
+public abstract class DedupEventProcessor<T, E> extends Thread {
+  private static final Logger logger = LoggerFactory.getLogger(DedupEventProcessor.class);
+
+  protected final DedupEventBlockingQueue<T, E> _eventQueue;
+  protected final String _clusterName;
+  protected final String _processorName;
+
+  public DedupEventProcessor(String processorName) {
+    this(new String(), processorName);
+  }
+
+  public DedupEventProcessor(String clusterName, String processorName) {
+    super(processorName + "-" + clusterName);
+    _processorName = processorName;
+    _eventQueue = new DedupEventBlockingQueue<>();
+    _clusterName = clusterName;
+  }
+
+  public DedupEventProcessor() {
+    this(new String(), "Default-DedupEventProcessor");
+  }
+
+  @Override
+  public void run() {
+    logger.info("START " + _processorName + " thread for cluster " + _clusterName);
+    while (!isInterrupted()) {
+      try {
+        E event = _eventQueue.take();
+        handleEvent(event);
+      } catch (InterruptedException e) {
+        logger.warn(_processorName + " thread interrupted", e);
+        interrupt();
+      } catch (ZkInterruptedException e) {
+        logger.warn(_processorName + " thread caught a ZK connection interrupt", e);
+        interrupt();
+      } catch (ThreadDeath death) {
+        throw death;
+      } catch (Throwable t) {
+        logger.error(_processorName + " thread failed while running the controller pipeline", t);
+      }
+    }
+    logger.info("END " + _processorName + " thread");
+  }
+
+  protected abstract void handleEvent(E event);
+
+  public void queueEvent(T eventType, E event) {
+    _eventQueue.put(eventType, event);
+  }
+
+  public void shutdown() {
+    _eventQueue.clear();
+    this.interrupt();
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -73,6 +72,7 @@ import org.apache.zookeeper.Watcher.Event.EventType;
 
 import static org.apache.helix.HelixConstants.ChangeType.*;
 
+@PreFetch (enabled = false)
 public class CallbackHandler implements IZkChildListener, IZkDataListener {
   private static Logger logger = LoggerFactory.getLogger(CallbackHandler.class);
 
@@ -407,13 +407,11 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
     NotificationContext.Type type = context.getType();
     if (type == NotificationContext.Type.INIT || type == NotificationContext.Type.CALLBACK) {
       logger.info(
-          _manager.getInstanceName() + " subscribes child-change. path: " + path + ", listener: "
-              + _listener);
+          _manager.getInstanceName() + " subscribes child-change. path: " + path + ", listener: " + _listener);
       _zkClient.subscribeChildChanges(path, this);
     } else if (type == NotificationContext.Type.FINALIZE) {
       logger.info(
-          _manager.getInstanceName() + " unsubscribe child-change. path: " + path + ", listener: "
-              + _listener);
+          _manager.getInstanceName() + " unsubscribe child-change. path: " + path + ", listener: " + _listener);
 
       _zkClient.unsubscribeChildChanges(path, this);
     }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -168,41 +168,41 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
 
     Class listenerClass = null;
     switch (_changeType) {
-    case IDEAL_STATE:
-      listenerClass = IdealStateChangeListener.class;
-      break;
-    case INSTANCE_CONFIG:
-      if (_listener instanceof ConfigChangeListener) {
+      case IDEAL_STATE:
+        listenerClass = IdealStateChangeListener.class;
+        break;
+      case INSTANCE_CONFIG:
+        if (_listener instanceof ConfigChangeListener) {
+          listenerClass = ConfigChangeListener.class;
+        } else if (_listener instanceof InstanceConfigChangeListener) {
+          listenerClass = InstanceConfigChangeListener.class;
+        }
+        break;
+      case CLUSTER_CONFIG:
+        listenerClass = ClusterConfigChangeListener.class;
+        break;
+      case RESOURCE_CONFIG:
+        listenerClass = ResourceConfigChangeListener.class;
+        break;
+      case CONFIG:
         listenerClass = ConfigChangeListener.class;
-      } else if (_listener instanceof InstanceConfigChangeListener) {
-        listenerClass = InstanceConfigChangeListener.class;
-      }
-      break;
-    case CLUSTER_CONFIG:
-      listenerClass = ClusterConfigChangeListener.class;
-      break;
-    case RESOURCE_CONFIG:
-      listenerClass = ResourceConfigChangeListener.class;
-      break;
-    case CONFIG:
-      listenerClass = ConfigChangeListener.class;
-      break;
-    case LIVE_INSTANCE:
-      listenerClass = LiveInstanceChangeListener.class;
-      break;
-    case CURRENT_STATE:
-      listenerClass = CurrentStateChangeListener.class;        ;
-      break;
-    case MESSAGE:
-    case MESSAGES_CONTROLLER:
-      listenerClass = MessageListener.class;
-      break;
-    case EXTERNAL_VIEW:
-    case TARGET_EXTERNAL_VIEW:
-      listenerClass = ExternalViewChangeListener.class;
-      break;
-    case CONTROLLER:
-      listenerClass = ControllerChangeListener.class;
+        break;
+      case LIVE_INSTANCE:
+        listenerClass = LiveInstanceChangeListener.class;
+        break;
+      case CURRENT_STATE:
+        listenerClass = CurrentStateChangeListener.class;        ;
+        break;
+      case MESSAGE:
+      case MESSAGES_CONTROLLER:
+        listenerClass = MessageListener.class;
+        break;
+      case EXTERNAL_VIEW:
+      case TARGET_EXTERNAL_VIEW:
+        listenerClass = ExternalViewChangeListener.class;
+        break;
+      case CONTROLLER:
+        listenerClass = ControllerChangeListener.class;
     }
 
     Method callbackMethod = listenerClass.getMethods()[0];
@@ -464,7 +464,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
           case CURRENT_STATE:
           case IDEAL_STATE:
           case EXTERNAL_VIEW:
-          case TARGET_EXTERNAL_VIEW:{
+            case TARGET_EXTERNAL_VIEW:{
             // check if bucketized
             BaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_zkClient);
             List<ZNRecord> records = baseAccessor.getChildren(path, null, 0);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
@@ -876,6 +876,7 @@ public class ZkClient implements Watcher {
     try {
       delete(path);
     } catch (Exception e) {
+      LOG.error("Failed to delete " + path, e);
       throw new HelixException("Failed to delete " + path, e);
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkEventThread.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkEventThread.java
@@ -31,6 +31,9 @@ public class ZkEventThread extends Thread {
 
   private BlockingQueue<ZkEvent> _events = new LinkedBlockingQueue<>();
 
+  private long _totalEventCount = 0L;
+  private long _totalEventCountHandled = 0L;
+
   private static AtomicInteger _eventId = new AtomicInteger(0);
 
   public static abstract class ZkEvent {
@@ -62,6 +65,7 @@ public class ZkEventThread extends Thread {
         LOG.debug("Delivering event #" + eventId + " " + zkEvent);
         try {
           zkEvent.run();
+          _totalEventCountHandled ++;
         } catch (InterruptedException e) {
           interrupt();
         } catch (ZkInterruptedException e) {
@@ -80,10 +84,15 @@ public class ZkEventThread extends Thread {
     if (!isInterrupted()) {
       LOG.debug("New event: " + event);
       _events.add(event);
+      _totalEventCount ++;
     }
   }
 
-  public int getPendingEventsCount() {
+  public long getPendingEventsCount() {
     return _events.size();
   }
+
+  public long getTotalEventCount() { return _totalEventCount; }
+
+  public long getTotalHandledEventCount() { return _totalEventCountHandled; }
 }

--- a/helix-core/src/main/java/org/apache/helix/model/IdealState.java
+++ b/helix-core/src/main/java/org/apache/helix/model/IdealState.java
@@ -651,20 +651,20 @@ public class IdealState extends HelixProperty {
   @Override
   public boolean isValid() {
     if (getNumPartitions() < 0) {
-      logger.error("idealState:" + _record + " does not have number of partitions (was "
+      logger.error("idealState:" + _record.getId() + " does not have number of partitions (was "
           + getNumPartitions() + ").");
       return false;
     }
 
     if (getStateModelDefRef() == null) {
-      logger.error("idealStates:" + _record + " does not have state model definition.");
+      logger.error("idealStates:" + _record.getId() + " does not have state model definition.");
       return false;
     }
 
     if (getRebalanceMode() == RebalanceMode.SEMI_AUTO) {
       String replicaStr = getReplicas();
       if (replicaStr == null) {
-        logger.error("invalid ideal-state. missing replicas in auto mode. record was: " + _record);
+        logger.error("invalid ideal-state. missing replicas in auto mode. record was: " + _record.getId());
         return false;
       }
 
@@ -679,7 +679,7 @@ public class IdealState extends HelixProperty {
                     + replica
                     + ", preference-list size: "
                     + preferenceList.size()
-                    + ", record was: " + _record);
+                    + ", record was: " + _record.getId());
             return false;
           }
         }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientMonitor.java
@@ -124,6 +124,24 @@ public class ZkClientMonitor implements ZkClientMonitorMBean {
     return -1;
   }
 
+  @Override
+  public long getTotalCallbackCounter() {
+    if (_zkEventThread != null) {
+      return _zkEventThread.getTotalEventCount();
+    }
+
+    return -1;
+  }
+
+  @Override
+  public long getTotalCallbackHandledCounter() {
+    if (_zkEventThread != null) {
+      return _zkEventThread.getTotalHandledEventCount();
+    }
+
+    return -1;
+  }
+
   private void record(String path, int bytes, long latencyMilliSec, boolean isFailure,
       boolean isRead) {
     for (ZkClientPathMonitor.PredefinedPath predefinedPath : ZkClientPathMonitor.PredefinedPath

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientMonitorMBean.java
@@ -25,4 +25,6 @@ public interface ZkClientMonitorMBean extends SensorNameProvider {
   long getStateChangeEventCounter();
   long getDataChangeEventCounter();
   long getPendingCallbackGauge();
+  long getTotalCallbackCounter();
+  long getTotalCallbackHandledCounter();
 }

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -505,7 +505,7 @@ public class RoutingTableProvider implements ExternalViewChangeListener, Instanc
     private final RoutingDataCache _dataCache;
 
     public RouterUpdater(String clusterName, PropertyType sourceDataType) {
-      super("Helix-RouterUpdater-event_process");
+      super("Helix-RouterUpdater");
       _dataCache = new RoutingDataCache(clusterName, sourceDataType);
     }
 

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterStateVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterStateVerifier.java
@@ -45,6 +45,7 @@ import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyKey.Builder;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.ZNRecord;
+import org.apache.helix.api.listeners.PreFetch;
 import org.apache.helix.controller.pipeline.Stage;
 import org.apache.helix.controller.pipeline.StageContext;
 import org.apache.helix.controller.stages.AttributeName;
@@ -107,6 +108,7 @@ public class ClusterStateVerifier {
     }
 
     @Override
+    @PreFetch(enabled = false)
     public void handleDataChange(String dataPath, Object data) throws Exception {
       boolean result = _verifier.verify();
       if (result == true) {

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifier.java
@@ -24,6 +24,7 @@ import org.I0Itec.zkclient.IZkDataListener;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.ZNRecord;
+import org.apache.helix.api.listeners.PreFetch;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.manager.zk.ZkClient;
@@ -101,6 +102,7 @@ public abstract class ClusterVerifier implements IZkChildListener, IZkDataListen
   }
 
   @Override
+  @PreFetch(enabled = false)
   public void handleDataChange(String dataPath, Object data) throws Exception {
     boolean success = verify();
     if (success) {

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
@@ -27,6 +27,7 @@ import org.I0Itec.zkclient.IZkDataListener;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.ZNRecord;
+import org.apache.helix.api.listeners.PreFetch;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.manager.zk.ZkClient;
@@ -258,6 +259,7 @@ public abstract class ZkHelixClusterVerifier
   }
 
   @Override
+  @PreFetch (enabled = false)
   public void handleDataChange(String dataPath, Object data) throws Exception {
     if (!_verifyTaskThreadPool.isShutdown()) {
       _verifyTaskThreadPool.submit(new VerifyStateCallbackTask());

--- a/helix-core/src/test/java/org/apache/helix/TestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/TestHelper.java
@@ -770,7 +770,7 @@ public class TestHelper {
       if (result || (System.currentTimeMillis() - start) > timeout) {
         return result;
       }
-      Thread.sleep(100);
+      Thread.sleep(50);
     } while (true);
   }
 

--- a/helix-core/src/test/java/org/apache/helix/TestListenerCallbackBatchMode.java
+++ b/helix-core/src/test/java/org/apache/helix/TestListenerCallbackBatchMode.java
@@ -145,12 +145,22 @@ public class TestListenerCallbackBatchMode extends ZkUnitTestBase {
 
     System.setProperty("isAsyncBatchModeEnabled", "true");
 
-    final Listener listener = new Listener();
+    Listener listener = new Listener();
     addListeners(listener);
     updateConfigs();
     verifyBatchedListeners(listener);
 
     System.setProperty("isAsyncBatchModeEnabled", "false");
+    removeListeners(listener);
+
+    System.setProperty("helix.callbackhandler.isAsyncBatchModeEnabled", "true");
+
+    listener = new Listener();
+    addListeners(listener);
+    updateConfigs();
+    verifyBatchedListeners(listener);
+
+    System.setProperty("helix.callbackhandler.isAsyncBatchModeEnabled", "false");
     removeListeners(listener);
 
     System.out.println("END " + methodName + " at " + new Date(System.currentTimeMillis()));
@@ -221,8 +231,7 @@ public class TestListenerCallbackBatchMode extends ZkUnitTestBase {
     Thread.sleep(50);
     Assert.assertTrue(result,
         "instance callbacks: " + listener._instanceConfigChangedCount + ", idealstate callbacks "
-            + listener._idealStateChangedCount + "\ninstance count: " + _numNode
-            + ", idealstate counts: " + _numResource);
+            + listener._idealStateChangedCount + "\ninstance count: " + _numNode + ", idealstate counts: " + _numResource);
   }
 
   private void verifyBatchedListeners(Listener batchListener) throws InterruptedException {

--- a/helix-core/src/test/java/org/apache/helix/ZkTestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/ZkTestHelper.java
@@ -348,7 +348,7 @@ public class ZkTestHelper {
     Map<String, Set<String>> listenerMapByInstance = getListenersByZkPath(zkAddr);
 
     // convert to index by sessionId
-    Map<String, Set<String>> listenerMapBySession = new TreeMap<String, Set<String>>();
+    Map<String, Set<String>> listenerMapBySession = new TreeMap<>();
     for (String path : listenerMapByInstance.keySet()) {
       for (String sessionId : listenerMapByInstance.get(path)) {
         if (!listenerMapBySession.containsKey(sessionId)) {

--- a/helix-core/src/test/java/org/apache/helix/integration/DelayedTransitionBase.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/DelayedTransitionBase.java
@@ -19,17 +19,18 @@ package org.apache.helix.integration;
  * under the License.
  */
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.helix.NotificationContext;
 import org.apache.helix.mock.participant.MockTransition;
 import org.apache.helix.model.Message;
 
 public class DelayedTransitionBase extends MockTransition {
   protected static long _delay = 0;
+
+  public DelayedTransitionBase() {}
+
+  public DelayedTransitionBase(long delay) {
+    _delay = delay;
+  }
 
   public static void setDelay(long delay) {
     _delay = delay;

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestDistributedControllerManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestDistributedControllerManager.java
@@ -121,7 +121,7 @@ public class TestDistributedControllerManager extends ZkIntegrationTestBase {
 
     ZkTestHelper.expireSession(expireController.getZkClient());
     String newSessionId = expireController.getSessionId();
-    LOG.debug("Expried distributedController: " + expireController.getInstanceName()
+    LOG.debug("Expired distributedController: " + expireController.getInstanceName()
         + ", oldSessionId: " + oldSessionId + ", newSessionId: " + newSessionId);
 
     boolean result =

--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PMessageSemiAuto.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PMessageSemiAuto.java
@@ -21,29 +21,22 @@ package org.apache.helix.integration.messaging;
 
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
-import java.util.Set;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
-import org.apache.helix.NotificationContext;
-import org.apache.helix.PropertyKey;
 import org.apache.helix.api.config.HelixConfigProperty;
 import org.apache.helix.controller.stages.ClusterDataCache;
+import org.apache.helix.integration.DelayedTransitionBase;
 import org.apache.helix.integration.common.ZkIntegrationTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
-import org.apache.helix.mock.participant.MockTransition;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.CurrentState;
-import org.apache.helix.model.IdealState;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.MasterSlaveSMD;
-import org.apache.helix.model.Message;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.apache.helix.tools.ClusterVerifiers.HelixClusterVerifier;
@@ -91,6 +84,7 @@ public class TestP2PMessageSemiAuto extends ZkIntegrationTestBase {
     for (int i = 0; i < PARTICIPANT_NUMBER; i++) {
       MockParticipantManager participant =
           new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, _instances.get(i));
+      participant.setTransition(new DelayedTransitionBase(50));
       participant.syncStart();
       _participants.add(participant);
     }


### PR DESCRIPTION
- Improve CallbackHandler by avoiding unnessary re-subscripe to the data change event.Resubscribe to zk changes only when there is any child chanage, with async subscription to ensure not missing any new child paths.

- Add new config name for batch callback handing in CallbackHandler.

- Support configurable data prefetch in ZkClient during watch event callback.

- Add TotalEventCount and TotalHandledEventCount metrics into ZkClientMonitor Mbean.