### PR TITLE
[HELIX-692] use map instead of list to avoid deleting redundant message during cleanup

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -64,7 +64,7 @@ public class MessageGenerationPhase extends AbstractBaseStage {
     HelixManager manager = event.getAttribute(AttributeName.helixmanager.name());
     ClusterDataCache cache = event.getAttribute(AttributeName.ClusterDataCache.name());
     Map<String, Resource> resourceMap = event.getAttribute(AttributeName.RESOURCES_TO_REBALANCE.name());
-    Map<String, List<Message>> pendingMessagesToCleanUp = new HashMap<>();
+    Map<String, Map<String, Message>> pendingMessagesToCleanUp = new HashMap<>();
     CurrentStateOutput currentStateOutput =
         event.getAttribute(AttributeName.CURRENT_STATE.name());
     IntermediateStateOutput intermediateStateOutput =
@@ -138,9 +138,10 @@ public class MessageGenerationPhase extends AbstractBaseStage {
                 pendingMessage.getMsgId(), instanceName, pendingMessage.getFromState(),
                 pendingMessage.getToState(), resourceName, partition, currentState);
             if (!pendingMessagesToCleanUp.containsKey(instanceName)) {
-              pendingMessagesToCleanUp.put(instanceName, new ArrayList<Message>());
+                pendingMessagesToCleanUp.put(instanceName, new HashMap<String, Message>());
             }
-            pendingMessagesToCleanUp.get(instanceName).add(pendingMessage);
+            pendingMessagesToCleanUp.get(instanceName)
+                .put(pendingMessage.getMsgId(), pendingMessage);
           }
 
           if (desiredState.equals(NO_DESIRED_STATE) || desiredState.equalsIgnoreCase(currentState)) {
@@ -248,14 +249,14 @@ public class MessageGenerationPhase extends AbstractBaseStage {
    * @param accessor Data accessor used to clean up message
    */
   private void schedulePendingMessageCleanUp(
-      final Map<String, List<Message>> pendingMessagesToPurge, ExecutorService workerPool,
+      final Map<String, Map<String, Message>> pendingMessagesToPurge, ExecutorService workerPool,
       final HelixDataAccessor accessor) {
     workerPool.submit(new Callable<Object>() {
         @Override
         public Object call() {
-          for (Map.Entry<String, List<Message>> entry : pendingMessagesToPurge.entrySet()) {
+          for (Map.Entry<String, Map<String, Message>> entry : pendingMessagesToPurge.entrySet()) {
             String instanceName = entry.getKey();
-            for (Message msg : entry.getValue()) {
+            for (Message msg : entry.getValue().values()) {
               if (accessor.removeProperty(msg.getKey(accessor.keyBuilder(), instanceName))) {
                 logger.info("Deleted message {} from instance {}", msg.getMsgId(), instanceName);
               } else {


### PR DESCRIPTION
Currently in MessageGenerationPhase, we are using list to store messages to GC. However, pending message is stored per resource/partition/instance, and under batch message mode, same message is stored once for each partition in the batch, which lead to the fact that we are cleaning up same message a lot of times.


This RB changes list to map to avoid redundant cleanup