### PR TITLE
[HELIX-691] Allow users to update InstanceConfig

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -735,7 +735,7 @@ public class ConfigAccessor {
   }
 
   /**
-   * Update ResourceConfig of the given resource. The value of field in current config will be
+   * Update InstanceConfig of the given resource. The value of field in current config will be
    * replaced with the value of the same field in given config if it presents. If there is new field
    * in given config but not in current config, the field will be added into the current config..
    * The list fields and map fields will be replaced as a single entry.

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -34,13 +34,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.I0Itec.zkclient.DataUpdater;
 import org.I0Itec.zkclient.exception.ZkNoNodeException;
-import org.apache.commons.math.stat.clustering.Cluster;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import org.I0Itec.zkclient.DataUpdater;
 import org.apache.helix.BaseDataAccessor;
-import org.apache.helix.HelixException;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.ZNRecord;

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAccessor.java
@@ -240,22 +240,22 @@ public class ResourceAccessor extends AbstractHelixResource {
     HelixAdmin admin = getHelixAdmin();
     try {
       switch (cmd) {
-        case enable:
-          admin.enableResource(clusterId, resourceName, true);
-          break;
-        case disable:
-          admin.enableResource(clusterId, resourceName, false);
-          break;
-        case rebalance:
-          if (replicas == -1) {
-            return badRequest("Number of replicas is needed for rebalancing!");
-          }
-          keyPrefix = keyPrefix.length() == 0 ? resourceName : keyPrefix;
-          admin.rebalance(clusterId, resourceName, replicas, keyPrefix, group);
-          break;
-        default:
-          _logger.error("Unsupported command :" + command);
-          return badRequest("Unsupported command :" + command);
+      case enable:
+        admin.enableResource(clusterId, resourceName, true);
+        break;
+      case disable:
+        admin.enableResource(clusterId, resourceName, false);
+        break;
+      case rebalance:
+        if (replicas == -1) {
+          return badRequest("Number of replicas is needed for rebalancing!");
+        }
+        keyPrefix = keyPrefix.length() == 0 ? resourceName : keyPrefix;
+        admin.rebalance(clusterId, resourceName, replicas, keyPrefix, group);
+        break;
+      default:
+        _logger.error("Unsupported command :" + command);
+        return badRequest("Unsupported command :" + command);
       }
     } catch (Exception e) {
       _logger.error("Failed in updating resource : " + resourceName, e);
@@ -309,9 +309,7 @@ public class ResourceAccessor extends AbstractHelixResource {
     } catch (HelixException ex) {
       return notFound(ex.getMessage());
     } catch (Exception ex) {
-      _logger.error(
-          "Failed to update cluster config, cluster " + clusterId + " new config: " + content
-              + ", Exception: " + ex);
+      _logger.error(String.format("Error in update resource config for resource: %s", resourceName), ex);
       return serverError(ex);
     }
     return OK();

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstanceAccessor.java
@@ -213,7 +213,7 @@ public class TestInstanceAccessor extends AbstractTestClass {
 
     Entity entity =
         Entity.entity(OBJECT_MAPPER.writeValueAsString(record), MediaType.APPLICATION_JSON_TYPE);
-    put("clusters/" + CLUSTER_NAME + "/instances/" + instanceName + "/configs", null, entity,
+    post("clusters/" + CLUSTER_NAME + "/instances/" + instanceName + "/configs", null, entity,
         Response.Status.OK.getStatusCode());
     Assert.assertEquals(record.getSimpleFields(),
         _configAccessor.getInstanceConfig(CLUSTER_NAME, instanceName).getRecord()


### PR DESCRIPTION
In helix-rest, we provide a method in InstanceAccessor, updateInstanceConfig, that updates the instance's config through a POST call.