### PR TITLE
[HELIX-690] batch message execution should not share same context

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/NotificationContext.java
+++ b/helix-core/src/main/java/org/apache/helix/NotificationContext.java
@@ -74,6 +74,24 @@ public class NotificationContext {
   }
 
   /**
+   * Clone a new Notification context from existing one. Map contents are
+   * not recursively deep copied.
+   *
+   * @return new copy of NotificationContext
+   */
+  public NotificationContext clone() {
+
+    NotificationContext copy = new NotificationContext(_manager);
+    copy.setType(_type);
+    copy.setChangeType(_changeType);
+    copy.setPathChanged(_pathChanged);
+    copy.setEventName(_eventName);
+    copy.setCreationTime(_creationTime);
+    copy._map.putAll(_map);
+    return copy;
+  }
+
+  /**
    * Get the HelixManager associated with this notification
    *
    * @return {@link HelixManager} object

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixBatchMessageTask.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixBatchMessageTask.java
@@ -48,7 +48,7 @@ public class HelixBatchMessageTask implements MessageTask {
     HelixTaskResult taskResult = null;
 
     long start = System.currentTimeMillis();
-    LOG.info("taskId:" + getTaskId() + " handling task begin, at: " + start);
+    LOG.info("BatchMsg task {} handling task begin, at: {}", getTaskId(), start);
 
     boolean isSucceed = true;
     try {
@@ -74,7 +74,9 @@ public class HelixBatchMessageTask implements MessageTask {
     }
 
     if (isSucceed) {
-      LOG.info("task: " + getTaskId() + " completed sucessfully");
+      LOG.info("BatchMsg task {} completed successfully", getTaskId());
+    } else {
+      LOG.warn("BatchMsg task {} failed.", getTaskId());
     }
 
     taskResult = new HelixTaskResult();

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTask.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTask.java
@@ -84,7 +84,7 @@ public class HelixTask implements MessageTask {
 
     // add a concurrent map to hold currentStateUpdates for sub-messages of a batch-message
     // partitionName -> csUpdate
-    if (_message.getBatchMessageMode() == true) {
+    if (_message.getBatchMessageMode()) {
       _notificationContext.add(MapKey.CURRENT_STATE_UPDATE.toString(),
           new ConcurrentHashMap<String, CurrentStateUpdate>());
     }


### PR DESCRIPTION
In this PR, I added deep copy methods to NotificationContext so when processing messages in batch, different thread would not share the same notification context.

This solves the problem that when processing BatchMessages, each thread will have their own current state delta to work on, so current states won't be messed up.

Also modified some logs to make it more useful when debugging