### PR TITLE
[HELIX-695] add helix manager listener for new connection notification

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -661,6 +661,9 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     try {
       createClient();
       _messagingService.onConnected();
+      if (_stateListener != null) {
+        _stateListener.onConnected(this);
+      }
     } catch (Exception e) {
       LOG.error("fail to connect " + _instanceName, e);
       disconnect();


### PR DESCRIPTION
In this PR I added invocation and related tests of `stateListener.onConnected()` method in ZkHelixManager when it is connected.