### PR TITLE
Fix race-condition issue that could block ZkClient event thread in CallbackHandler.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/common/DedupEventProcessor.java
+++ b/helix-core/src/main/java/org/apache/helix/common/DedupEventProcessor.java
@@ -52,7 +52,7 @@ public abstract class DedupEventProcessor<T, E> extends Thread {
         logger.error(_processorName + " thread failed while running the controller pipeline", t);
       }
     }
-    logger.info("END " + _processorName + " thread");
+    logger.info("END " + _processorName + " thread for cluster " + _clusterName);
   }
 
   protected abstract void handleEvent(E event);
@@ -62,7 +62,7 @@ public abstract class DedupEventProcessor<T, E> extends Thread {
   }
 
   public void shutdown() {
-    _eventQueue.clear();
     this.interrupt();
+    _eventQueue.clear();
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkEventThread.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkEventThread.java
@@ -82,6 +82,8 @@ public class ZkEventThread extends Thread {
     } catch (InterruptedException e) {
       LOG.info("Terminate ZkClient event thread.");
     }
+
+    LOG.info("Terminate ZkClient event thread.");
   }
 
   public void send(ZkEvent event) {


### PR DESCRIPTION
1) Replace native batch callback handling thread with DedupEventCallbackProcessor, so the queue is deduplicated when event gets enqueued, instead of at the time of dequeue.

2) Shutdown and clean up the processor properly when CallbackHanlder is reset().

3) Add a flag to indicated whether the CallbackHandler is reset. If reset, do not enqueue further event into the batch callback queue.