### PR TITLE
[HELIX-699] Compare InstanceConfigs using their IDs in RoutingTable

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTable.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTable.java
@@ -464,23 +464,18 @@ class RoutingTable {
   private static Comparator<InstanceConfig> INSTANCE_CONFIG_COMPARATOR =
       new Comparator<InstanceConfig>() {
         @Override
-        public int compare(InstanceConfig o1, InstanceConfig o2) {
-          if (o1 == o2) {
+        public int compare(InstanceConfig config1, InstanceConfig config2) {
+          if (config1 == config2) {
             return 0;
           }
-          if (o1 == null) {
+          if (config1 == null) {
             return -1;
           }
-          if (o2 == null) {
+          if (config2 == null) {
             return 1;
           }
-
-          int compareTo = o1.getHostName().compareTo(o2.getHostName());
-          if (compareTo == 0) {
-            return o1.getPort().compareTo(o2.getPort());
-          }
-
-          return compareTo;
+          // IDs for InstanceConfigs are a concatenation of instance name, host, and port.
+          return config1.getId().compareTo(config2.getId());
         }
       };
 }


### PR DESCRIPTION
A possible race condition was causing a NPE on InstanceConfig.getHostName(). Instead of comparing hostnames and ports, we compare IDs, which are supposed to be concatenation of instance name, hostname, and port anyways and should always be set.