### PR TITLE
[HELIX-682] delete duplicated message and log error in HelixTaskExecutor on participant

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -864,6 +864,15 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
         }
         if (message.getMsgType().equals(MessageType.STATE_TRANSITION.name()) || message.getMsgType()
             .equals(MessageType.STATE_TRANSITION_CANCELLATION.name())) {
+          String messageTarget =
+              getMessageTarget(message.getResourceName(), message.getPartitionName());
+          if (stateTransitionHandlers.containsKey(messageTarget)) {
+            Message duplicatedMessage = stateTransitionHandlers.get(messageTarget)._message;
+            throw new HelixException(String.format(
+                "Duplicated state transition message: %s. Existing: %s -> %s; New (Discarded): %s -> %s",
+                message.getMsgId(), duplicatedMessage.getFromState(),
+                duplicatedMessage.getToState(), message.getFromState(), message.getToState()));
+          }
           stateTransitionHandlers
               .put(getMessageTarget(message.getResourceName(), message.getPartitionName()),
                   createHandler);

--- a/helix-core/src/test/java/org/apache/helix/MockAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/MockAccessor.java
@@ -209,7 +209,7 @@ public class MockAccessor implements HelixDataAccessor {
   @Override
   public <T extends HelixProperty> boolean[] createChildren(List<PropertyKey> keys,
       List<T> children) {
-    throw new HelixException("Method not implemented!");
+    return setChildren(keys, children);
   }
 
   @Override


### PR DESCRIPTION
This PR is the second part of message dedup on participant side