### PR TITLE
add null check in DeplayedAutoRebalancerz#computeNewIdealState

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.helix.HelixDefinedState;
+import org.apache.helix.HelixException;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
@@ -136,6 +137,11 @@ public class DelayedAutoRebalancer extends AbstractRebalancer {
 
     StateModelDefinition stateModelDef =
         clusterData.getStateModelDef(currentIdealState.getStateModelDefRef());
+
+    if (stateModelDef == null) {
+        LOG.error("State Model Definition null for resource: " + resourceName);
+        throw new HelixException("State Model Definition null for resource: " + resourceName);
+    }
 
     int replicaCount = currentIdealState.getReplicaCount(activeNodes.size());
     if (replicaCount == 0) {

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowRebalancer.java
@@ -391,6 +391,10 @@ public class WorkflowRebalancer extends TaskRebalancer {
         if (!newWorkflowName.equals(lastScheduled)) {
           Workflow clonedWf =
               cloneWorkflow(_manager, workflow, newWorkflowName, new Date(timeToSchedule));
+          if (clonedWf == null) {
+              LOG.error("Failed to schedule cloned workflow" + newWorkflowName);
+              throw new RuntimeException("Failed to schedule cloned workflow" + newWorkflowName);
+          }
           TaskDriver driver = new TaskDriver(_manager);
           try {
             // Start the cloned workflow

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowRebalancer.java
@@ -148,6 +148,9 @@ public class WorkflowRebalancer extends TaskRebalancer {
     if (!isWorkflowReadyForSchedule(workflowCfg)) {
       LOG.info("Workflow " + workflow + " is not ready to schedule");
       // set the timer to trigger future schedule
+        if (workflowCfg.getStartTime() == null) {
+            throw new RuntimeException("Unparseable date " + workflowCfg.getSimpleConfig(WorkflowConfig.WorkflowConfigProperty.StartTime.name()));
+        }
       _rebalanceScheduler
           .scheduleRebalance(_manager, workflow, workflowCfg.getStartTime().getTime());
       return buildEmptyAssignment(workflow, currStateOutput);


### PR DESCRIPTION
We have developed a static analysis tool [NPEDetector](https://github.com/lujiefsi/NPEDetector) to find some potential NPE. Our analysis shows that some callees may return null in corner case(e.g. node crash , IO exception), some of their callers have  !=null check but some do not have. In this issue we post a patch which can add  !=null  based on existed !=null  check. For example:

Callee ClusterDataCache#getStateModelDef:
```
public StateModelDefinition getStateModelDef(String stateModelDefRef) {
  if (stateModelDefRef == null) {
    return null;
  }
  return _stateModelDefMap.get(stateModelDefRef);
}
```

Caller AutoRebalancer#computeNewIdealState have !=null:
```
StateModelDefinition stateModelDef = clusterData.getStateModelDef(stateModelName);
if (stateModelDef == null) {
  LOG.error("State Model Definition null for resource: " + resourceName);
  throw new HelixException("State Model Definition null for resource: " + resourceName);
}
```

but another caller DelayedAutoRebalancer#computeNewIdealState does not have !=null check:
```
StateModelDefinition stateModelDef =
    clusterData.getStateModelDef(currentIdealState.getStateModelDefRef());
LinkedHashMap<String, Integer> stateCountMap =
    stateModelDef.getStateCountMap(activeNodes.size(), replicaCount);
```

So we will add below code in non-(!=null) caller DelayedAutoRebalancer#computeNewIdealState
```
if (stateModelDef == null) {
    throw new HelixException("State Model Definition null for resource:" + resourceName);
}
```
But due to we are not very  familiar with HELIX, hope some expert can review it.

Thanks.