### PR TITLE
[HELIX-706] process tev and persist assignment asynchronously

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/common/DedupEventProcessor.java
+++ b/helix-core/src/main/java/org/apache/helix/common/DedupEventProcessor.java
@@ -58,6 +58,9 @@ public abstract class DedupEventProcessor<T, E> extends Thread {
   protected abstract void handleEvent(E event);
 
   public void queueEvent(T eventType, E event) {
+    if (isInterrupted()) {
+      return;
+    }
     _eventQueue.put(eventType, event);
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/AsyncWorkerType.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/AsyncWorkerType.java
@@ -19,22 +19,14 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
-public enum AttributeName {
-  RESOURCES,
-  RESOURCES_TO_REBALANCE,
-  BEST_POSSIBLE_STATE,
-  CURRENT_STATE,
-  INTERMEDIATE_STATE,
-  MESSAGES_ALL,
-  MESSAGES_SELECTED,
-  MESSAGES_THROTTLE,
-  LOCAL_STATE,
-  EVENT_CREATE_TIME,
-  ClusterDataCache,
-  helixmanager,
-  clusterStatusMonitor,
-  changeContext,
-  instanceName,
-  eventData,
-  AsyncFIFOWorkerPool
+/**
+ * There are bunch of stages, i.e. TargetExternalViewCalc, PersistAssignment, etc., that have
+ * the choice to submit its tasks to corresponding workers to do the job asynchronously.
+ *
+ * This class contains Async worker enums that corresponding stages can use
+ */
+
+public enum AsyncWorkerType {
+  TargetExternalViewCalcWorker,
+  PersistAssignmentWorker
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
@@ -154,7 +154,7 @@ public class ClusterDataCache {
       _liveInstanceCacheMap = accessor.getChildValuesMap(keyBuilder.liveInstances(), true);
       _updateInstanceOfflineTime = true;
       LOG.info("Refresh LiveInstances for cluster " + _clusterName + ", took " + (
-          System.currentTimeMillis() - startTime) + " ms");
+          System.currentTimeMillis() - start) + " ms");
     }
 
     if (_propertyDataChangedMap.get(ChangeType.INSTANCE_CONFIG)) {


### PR DESCRIPTION
Added async worker in generic helix controller to process persist assignment stage and tev generation state asynchronously. All current tests passed