### PR TITLE
[HELIX-707] Fix topstate handoff metrics.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
@@ -85,6 +85,7 @@ public class ClusterDataCache {
   private Map<String, ClusterConstraints> _constraintMap;
   private Map<String, Map<String, String>> _idealStateRuleMap;
   private Map<String, Map<String, Long>> _missingTopStateMap = new HashMap<>();
+  private Map<String, Map<String, String>> _lastTopStateLocationMap = new HashMap<>();
   private Map<String, ExternalView> _targetExternalViewMap = new HashMap<>();
   private Map<String, ExternalView> _externalViewMap = new HashMap<>();
   private Map<String, Map<String, Set<String>>> _disabledInstanceForPartitionMap = new HashMap<>();
@@ -632,6 +633,10 @@ public class ClusterDataCache {
     return _missingTopStateMap;
   }
 
+  public Map<String, Map<String, String>> getLastTopStateLocationMap() {
+    return _lastTopStateLocationMap;
+  }
+
   public Integer getParticipantActiveTaskCount(String instance) {
     return _participantActiveTaskCount.get(instance);
   }
@@ -900,6 +905,7 @@ public class ClusterDataCache {
 
   public void clearMonitoringRecords() {
     _missingTopStateMap.clear();
+    _lastTopStateLocationMap.clear();
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestTopStateHandoffMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestTopStateHandoffMetrics.java
@@ -19,19 +19,10 @@ package org.apache.helix.monitoring.mbeans;
  * under the License.
  */
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.helix.controller.stages.AttributeName;
-import org.apache.helix.controller.stages.BaseStageTest;
-import org.apache.helix.controller.stages.CurrentStateComputationStage;
-import org.apache.helix.controller.stages.ReadClusterDataStage;
+import org.apache.helix.controller.stages.*;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.Message;
 import org.apache.helix.model.Resource;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.ObjectReader;
@@ -39,9 +30,14 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
 public class TestTopStateHandoffMetrics extends BaseStageTest {
   public final static String TEST_INPUT_FILE = "TestTopStateHandoffMetrics.json";
   public final static String INITIAL_CURRENT_STATES = "initialCurrentStates";
+  public final static String MISSING_TOP_STATES = "MissingTopStates";
   public final static String HANDOFF_CURRENT_STATES = "handoffCurrentStates";
   public final static String EXPECTED_DURATION = "expectedDuration";
   public final static String TEST_RESOURCE = "TestResource";
@@ -53,7 +49,8 @@ public class TestTopStateHandoffMetrics extends BaseStageTest {
     Resource resource = new Resource(TEST_RESOURCE);
     resource.setStateModelDefRef("MasterSlave");
     resource.addPartition(PARTITION);
-    event.addAttribute(AttributeName.RESOURCES.name(), Collections.singletonMap(TEST_RESOURCE, resource));
+    event.addAttribute(AttributeName.RESOURCES.name(),
+        Collections.singletonMap(TEST_RESOURCE, resource));
     ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestCluster");
     monitor.active();
     event.addAttribute(AttributeName.clusterStatusMonitor.name(), monitor);
@@ -61,37 +58,188 @@ public class TestTopStateHandoffMetrics extends BaseStageTest {
 
   @Test(dataProvider = "successCurrentStateInput")
   public void testTopStateSuccessHandoff(Map<String, Map<String, String>> initialCurrentStates,
+      Map<String, Map<String, String>> missingTopStates,
       Map<String, Map<String, String>> handOffCurrentStates, Long expectedDuration) {
     preSetup();
-    runCurrentStage(initialCurrentStates, handOffCurrentStates);
-    ClusterStatusMonitor clusterStatusMonitor = event.getAttribute(AttributeName.clusterStatusMonitor.name());
+    runCurrentStage(initialCurrentStates, missingTopStates, handOffCurrentStates, null);
+    ClusterStatusMonitor clusterStatusMonitor =
+        event.getAttribute(AttributeName.clusterStatusMonitor.name());
     ResourceMonitor monitor = clusterStatusMonitor.getResourceMonitor(TEST_RESOURCE);
 
     // Should have 1 transition succeeded due to threshold.
     Assert.assertEquals(monitor.getSucceededTopStateHandoffCounter(), 1);
+    Assert.assertEquals(monitor.getFailedTopStateHandoffCounter(), 0);
 
     // Duration should match the expected result
-    Assert.assertEquals(monitor.getSuccessfulTopStateHandoffDurationCounter(), (long) expectedDuration);
-    Assert.assertEquals(monitor.getMaxSinglePartitionTopStateHandoffDurationGauge(), (long) expectedDuration);
+    Assert.assertEquals(monitor.getSuccessfulTopStateHandoffDurationCounter(),
+        (long) expectedDuration);
+    Assert.assertEquals(monitor.getMaxSinglePartitionTopStateHandoffDurationGauge(),
+        (long) expectedDuration);
   }
 
   @Test(dataProvider = "failedCurrentStateInput")
   public void testTopStateFailedHandoff(Map<String, Map<String, String>> initialCurrentStates,
+      Map<String, Map<String, String>> missingTopStates,
       Map<String, Map<String, String>> handOffCurrentStates, Long expectedDuration) {
     preSetup();
     ClusterConfig clusterConfig = new ClusterConfig(_clusterName);
     clusterConfig.setMissTopStateDurationThreshold(5000L);
     setClusterConfig(clusterConfig);
-    runCurrentStage(initialCurrentStates, handOffCurrentStates);
-    ClusterStatusMonitor clusterStatusMonitor = event.getAttribute(AttributeName.clusterStatusMonitor.name());
+    runCurrentStage(initialCurrentStates, missingTopStates, handOffCurrentStates, null);
+    ClusterStatusMonitor clusterStatusMonitor =
+        event.getAttribute(AttributeName.clusterStatusMonitor.name());
     ResourceMonitor monitor = clusterStatusMonitor.getResourceMonitor(TEST_RESOURCE);
 
     // Should have 1 transition failed due to threshold.
+    Assert.assertEquals(monitor.getSucceededTopStateHandoffCounter(), 0);
     Assert.assertEquals(monitor.getFailedTopStateHandoffCounter(), 1);
 
     // No duration updated.
-    Assert.assertEquals(monitor.getSuccessfulTopStateHandoffDurationCounter(), (long)expectedDuration);
-    Assert.assertEquals(monitor.getMaxSinglePartitionTopStateHandoffDurationGauge(), (long) expectedDuration);
+    Assert.assertEquals(monitor.getSuccessfulTopStateHandoffDurationCounter(),
+        (long) expectedDuration);
+    Assert.assertEquals(monitor.getMaxSinglePartitionTopStateHandoffDurationGauge(),
+        (long) expectedDuration);
+  }
+
+  // Test handoff that are triggered by an offline master instance
+  @Test(dataProvider = "successCurrentStateInput", dependsOnMethods = "testTopStateSuccessHandoff")
+  public void testTopStateSuccessHandoffWithOfflineNode(
+      final Map<String, Map<String, String>> initialCurrentStates,
+      final Map<String, Map<String, String>> missingTopStates,
+      Map<String, Map<String, String>> handOffCurrentStates, Long expectedDuration) {
+    final long offlineTimeBeforeMasterless = 125;
+
+    preSetup();
+    runCurrentStage(initialCurrentStates, missingTopStates, handOffCurrentStates,
+        new MissingStatesDataCacheInject() {
+          @Override
+          public void doInject(ClusterDataCache cache) {
+            Set<String> topStateNodes = new HashSet<>();
+            for (String instance : initialCurrentStates.keySet()) {
+              if (initialCurrentStates.get(instance).get("CurrentState").equals("MASTER")) {
+                topStateNodes.add(instance);
+              }
+            }
+            // Simulate the previous top state instance goes offline
+            if (!topStateNodes.isEmpty()) {
+              cache.getLiveInstances().keySet().removeAll(topStateNodes);
+              for (String topStateNode : topStateNodes) {
+                long originalStartTime =
+                    Long.parseLong(missingTopStates.get(topStateNode).get("StartTime"));
+                cache.getInstanceOfflineTimeMap()
+                    .put(topStateNode, originalStartTime - offlineTimeBeforeMasterless);
+              }
+            }
+          }
+        });
+    ClusterStatusMonitor clusterStatusMonitor =
+        event.getAttribute(AttributeName.clusterStatusMonitor.name());
+    ResourceMonitor monitor = clusterStatusMonitor.getResourceMonitor(TEST_RESOURCE);
+
+    // Should have 1 transition succeeded due to threshold.
+    Assert.assertEquals(monitor.getSucceededTopStateHandoffCounter(), 1);
+    Assert.assertEquals(monitor.getFailedTopStateHandoffCounter(), 0);
+
+    // Duration should match the expected result
+    Assert.assertEquals(monitor.getSuccessfulTopStateHandoffDurationCounter(),
+        expectedDuration + offlineTimeBeforeMasterless);
+    Assert.assertEquals(monitor.getMaxSinglePartitionTopStateHandoffDurationGauge(),
+        expectedDuration + offlineTimeBeforeMasterless);
+  }
+
+  // Test success with no available clue about previous master.
+  // For example, controller is just changed to a new node.
+  @Test(dataProvider = "successCurrentStateInput", dependsOnMethods = "testTopStateSuccessHandoff")
+  public void testHandoffDurationWithDefaultStartTime(
+      Map<String, Map<String, String>> initialCurrentStates,
+      Map<String, Map<String, String>> missingTopStates,
+      Map<String, Map<String, String>> handOffCurrentStates, Long expectedDuration) {
+    preSetup();
+
+    // reset expectedDuration since current system time would be used
+    for (Map<String, String> states : handOffCurrentStates.values()) {
+      if (states.get("CurrentState").equals("MASTER")) {
+        expectedDuration = Long.parseLong(states.get("EndTime")) - System.currentTimeMillis();
+        break;
+      }
+    }
+
+    // No initialCurrentStates means no input can be used as the clue of the previous master.
+    runCurrentStage(Collections.EMPTY_MAP, missingTopStates, handOffCurrentStates, null);
+    ClusterStatusMonitor clusterStatusMonitor =
+        event.getAttribute(AttributeName.clusterStatusMonitor.name());
+    ResourceMonitor monitor = clusterStatusMonitor.getResourceMonitor(TEST_RESOURCE);
+
+    // Should have 1 transition succeeded due to threshold.
+    Assert.assertEquals(monitor.getSucceededTopStateHandoffCounter(), 1);
+    Assert.assertEquals(monitor.getFailedTopStateHandoffCounter(), 0);
+
+    // Duration should match the expected result.
+    // Note that the gap between expectedDuration calculated and monitor calculates the value should be allowed
+    Assert.assertTrue(
+        expectedDuration - monitor.getSuccessfulTopStateHandoffDurationCounter() < 1500);
+    Assert.assertTrue(
+        expectedDuration - monitor.getMaxSinglePartitionTopStateHandoffDurationGauge() < 1500);
+  }
+
+  /**
+   * Test success with only a pending message as the clue.
+   * For instance, if the master was dropped, there is no way to track the dropping time.
+   * So either use current system time.
+   *
+   * @see org.apache.helix.monitoring.mbeans.TestTopStateHandoffMetrics#testHandoffDurationWithDefaultStartTime
+   * Or we can check if any pending message to be used as the start time.
+   */
+  @Test(dataProvider = "successCurrentStateInput", dependsOnMethods = "testTopStateSuccessHandoff")
+  public void testHandoffDurationWithPendingMessage(
+      final Map<String, Map<String, String>> initialCurrentStates,
+      final Map<String, Map<String, String>> missingTopStates,
+      Map<String, Map<String, String>> handOffCurrentStates, Long expectedDuration) {
+    final long messageTimeBeforeMasterless = 145;
+    preSetup();
+    // No initialCurrentStates means no input can be used as the clue of the previous master.
+    runCurrentStage(Collections.EMPTY_MAP, missingTopStates, handOffCurrentStates,
+        new MissingStatesDataCacheInject() {
+          @Override
+          public void doInject(ClusterDataCache cache) {
+            String topStateNode = null;
+            for (String instance : initialCurrentStates.keySet()) {
+              if (initialCurrentStates.get(instance).get("CurrentState").equals("MASTER")) {
+                topStateNode = instance;
+                break;
+              }
+            }
+            // Simulate the previous top state instance goes offline
+            if (topStateNode != null) {
+              long originalStartTime =
+                  Long.parseLong(missingTopStates.get(topStateNode).get("StartTime"));
+              // Inject a message that fit expectedDuration
+              Message message =
+                  new Message(Message.MessageType.STATE_TRANSITION, "thisisafakemessage");
+              message.setTgtSessionId(SESSION_PREFIX + topStateNode.split("_")[1]);
+              message.setToState("MASTER");
+              message.setCreateTimeStamp(originalStartTime - messageTimeBeforeMasterless);
+              message.setTgtName(topStateNode);
+              message.setResourceName(TEST_RESOURCE);
+              message.setPartitionName(PARTITION);
+              cache.cacheMessages(Collections.singletonList(message));
+            }
+          }
+        });
+
+    ClusterStatusMonitor clusterStatusMonitor =
+        event.getAttribute(AttributeName.clusterStatusMonitor.name());
+    ResourceMonitor monitor = clusterStatusMonitor.getResourceMonitor(TEST_RESOURCE);
+
+    // Should have 1 transition succeeded due to threshold.
+    Assert.assertEquals(monitor.getSucceededTopStateHandoffCounter(), 1);
+    Assert.assertEquals(monitor.getFailedTopStateHandoffCounter(), 0);
+
+    // Duration should match the expected result
+    Assert.assertEquals(monitor.getSuccessfulTopStateHandoffDurationCounter(),
+        expectedDuration + messageTimeBeforeMasterless);
+    Assert.assertEquals(monitor.getMaxSinglePartitionTopStateHandoffDurationGauge(),
+        expectedDuration + messageTimeBeforeMasterless);
   }
 
   private final String CURRENT_STATE = "CurrentState";
@@ -103,6 +251,7 @@ public class TestTopStateHandoffMetrics extends BaseStageTest {
   public Object[][] successCurrentState() {
     return loadInputData("succeeded");
   }
+
   @DataProvider(name = "failedCurrentStateInput")
   public Object[][] failedCurrentState() {
     return loadInputData("failed");
@@ -118,14 +267,18 @@ public class TestTopStateHandoffMetrics extends BaseStageTest {
 
       List<Map<String, Object>> inputs = (List<Map<String, Object>>) inputMaps.get(inputEntry);
       inputData = new Object[inputs.size()][];
-      for (int i = 0; i < inputs.size(); i++) {
+      for (int i = 0; i < inputData.length; i++) {
         Map<String, Map<String, String>> intialCurrentStates =
             (Map<String, Map<String, String>>) inputs.get(i).get(INITIAL_CURRENT_STATES);
+        Map<String, Map<String, String>> missingTopStates =
+            (Map<String, Map<String, String>>) inputs.get(i).get(MISSING_TOP_STATES);
         Map<String, Map<String, String>> handoffCurrentStates =
             (Map<String, Map<String, String>>) inputs.get(i).get(HANDOFF_CURRENT_STATES);
         Long expectedDuration = Long.parseLong((String) inputs.get(i).get(EXPECTED_DURATION));
 
-        inputData[i] = new Object[] { intialCurrentStates, handoffCurrentStates, expectedDuration };
+        inputData[i] = new Object[] { intialCurrentStates, missingTopStates, handoffCurrentStates,
+            expectedDuration
+        };
       }
     } catch (IOException e) {
       e.printStackTrace();
@@ -151,12 +304,30 @@ public class TestTopStateHandoffMetrics extends BaseStageTest {
   }
 
   private void runCurrentStage(Map<String, Map<String, String>> initialCurrentStates,
-      Map<String, Map<String, String>> handOffCurrentStates) {
-    setupCurrentStates(generateCurrentStateMap(initialCurrentStates));
+      Map<String, Map<String, String>> missingTopStates,
+      Map<String, Map<String, String>> handOffCurrentStates,
+      MissingStatesDataCacheInject testInjection) {
+
+    if (initialCurrentStates != null && !initialCurrentStates.isEmpty()) {
+      setupCurrentStates(generateCurrentStateMap(initialCurrentStates));
+      runStage(event, new ReadClusterDataStage());
+      runStage(event, new CurrentStateComputationStage());
+    }
+
+    setupCurrentStates(generateCurrentStateMap(missingTopStates));
     runStage(event, new ReadClusterDataStage());
+    if (testInjection != null) {
+      ClusterDataCache cache = event.getAttribute(AttributeName.ClusterDataCache.name());
+      testInjection.doInject(cache);
+    }
     runStage(event, new CurrentStateComputationStage());
+
     setupCurrentStates(generateCurrentStateMap(handOffCurrentStates));
     runStage(event, new ReadClusterDataStage());
     runStage(event, new CurrentStateComputationStage());
+  }
+
+  interface MissingStatesDataCacheInject {
+    void doInject(ClusterDataCache cache);
   }
 }

--- a/helix-core/src/test/resources/TestTopStateHandoffMetrics.json
+++ b/helix-core/src/test/resources/TestTopStateHandoffMetrics.json
@@ -1,178 +1,258 @@
 {
-  "succeeded" : [
+  "succeeded": [
     {
       "initialCurrentStates": {
-        "localhost_0" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "MASTER",
-          "StartTime" : "15000",
-          "EndTime" : "18000"
+        "localhost_0": {
+          "CurrentState": "MASTER",
+          "PreviousState": "SLAVE",
+          "StartTime": "10000",
+          "EndTime": "11000"
         },
-        "localhost_1" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "OFFLINE",
-          "StartTime" : "8000",
-          "EndTime" : "10000"
+        "localhost_1": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
         },
-        "localhost_2" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "OFFLINE",
-          "StartTime" : "8000",
-          "EndTime" : "10000"
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
+        }
+      },
+      "MissingTopStates": {
+        "localhost_0": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "15000",
+          "EndTime": "18000"
+        },
+        "localhost_1": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
+        },
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
         }
       },
       "handoffCurrentStates": {
-        "localhost_0" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "MASTER",
-          "StartTime" : "15000",
-          "EndTime" : "18000"
+        "localhost_0": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "15000",
+          "EndTime": "18000"
         },
-        "localhost_1" : {
-          "CurrentState" : "MASTER",
-          "PreviousState" : "SLAVE",
-          "StartTime" : "20000",
-          "EndTime" : "22000"
+        "localhost_1": {
+          "CurrentState": "MASTER",
+          "PreviousState": "SLAVE",
+          "StartTime": "20000",
+          "EndTime": "22000"
         },
-        "localhost_2" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "OFFLINE",
-          "StartTime" : "8000",
-          "EndTime" : "10000"
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
         }
       },
-      "expectedDuration" : "7000"
+      "expectedDuration": "7000"
     },
     {
-    "initialCurrentStates": {
-      "localhost_0" : {
-        "CurrentState" : "SLAVE",
-        "PreviousState" : "MASTER",
-        "StartTime" : "1000",
-        "EndTime" : "2000"
+      "initialCurrentStates": {
+        "localhost_0": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "1000",
+          "EndTime": "2000"
+        },
+        "localhost_1": {
+          "CurrentState": "MASTER",
+          "PreviousState": "SLAVE",
+          "StartTime": "2500",
+          "EndTime": "5000"
+        },
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
+        }
       },
-      "localhost_1" : {
-        "CurrentState" : "SLAVE",
-        "PreviousState" : "MASTER",
-        "StartTime" : "8000",
-        "EndTime" : "10000"
+      "MissingTopStates": {
+        "localhost_0": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "1000",
+          "EndTime": "2000"
+        },
+        "localhost_1": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "8000",
+          "EndTime": "10000"
+        },
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
+        }
       },
-      "localhost_2" : {
-        "CurrentState" : "SLAVE",
-        "PreviousState" : "OFFLINE",
-        "StartTime" : "8000",
-        "EndTime" : "10000"
-      }
-    },
-    "handoffCurrentStates": {
-      "localhost_0" : {
-        "CurrentState" : "SLAVE",
-        "PreviousState" : "MASTER",
-        "StartTime" : "1000",
-        "EndTime" : "2000"
+      "handoffCurrentStates": {
+        "localhost_0": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "1000",
+          "EndTime": "2000"
+        },
+        "localhost_1": {
+          "CurrentState": "MASTER",
+          "PreviousState": "SLAVE",
+          "StartTime": "20000",
+          "EndTime": "22000"
+        },
+        "localhost_2": {
+          "CurrentState": "ERROR",
+          "PreviousState": "SLAVE",
+          "StartTime": "8000",
+          "EndTime": "10000"
+        }
       },
-      "localhost_1" : {
-        "CurrentState" : "MASTER",
-        "PreviousState" : "SLAVE",
-        "StartTime" : "20000",
-        "EndTime" : "22000"
-      },
-      "localhost_2" : {
-        "CurrentState" : "ERROR",
-        "PreviousState" : "SLAVE",
-        "StartTime" : "8000",
-        "EndTime" : "10000"
-      }
-    },
-    "expectedDuration" : "14000"
+      "expectedDuration": "14000"
     }
   ],
-  "failed" : [
+  "failed": [
     {
       "initialCurrentStates": {
-        "localhost_0" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "MASTER",
-          "StartTime" : "15000",
-          "EndTime" : "18000"
+        "localhost_0": {
+          "CurrentState": "MASTER",
+          "PreviousState": "SLAVE",
+          "StartTime": "10000",
+          "EndTime": "11000"
         },
-        "localhost_1" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "OFFLINE",
-          "StartTime" : "8000",
-          "EndTime" : "10000"
+        "localhost_1": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
         },
-        "localhost_2" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "OFFLINE",
-          "StartTime" : "8000",
-          "EndTime" : "10000"
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
+        }
+      },
+      "MissingTopStates": {
+        "localhost_0": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "15000",
+          "EndTime": "18000"
+        },
+        "localhost_1": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
+        },
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
         }
       },
       "handoffCurrentStates": {
-        "localhost_0" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "MASTER",
-          "StartTime" : "15000",
-          "EndTime" : "18000"
+        "localhost_0": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "15000",
+          "EndTime": "18000"
         },
-        "localhost_1" : {
-          "CurrentState" : "MASTER",
-          "PreviousState" : "SLAVE",
-          "StartTime" : "20000",
-          "EndTime" : "22000"
+        "localhost_1": {
+          "CurrentState": "MASTER",
+          "PreviousState": "SLAVE",
+          "StartTime": "20000",
+          "EndTime": "22000"
         },
-        "localhost_2" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "OFFLINE",
-          "StartTime" : "8000",
-          "EndTime" : "10000"
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
         }
       },
-      "expectedDuration" : "0"
+      "expectedDuration": "0"
     },
     {
       "initialCurrentStates": {
-        "localhost_0" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "MASTER",
-          "StartTime" : "15000",
-          "EndTime" : "18000"
+        "localhost_0": {
+          "CurrentState": "MASTER",
+          "PreviousState": "SLAVE",
+          "StartTime": "10000",
+          "EndTime": "11000"
         },
-        "localhost_1" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "OFFLINE",
-          "StartTime" : "8000",
-          "EndTime" : "10000"
+        "localhost_1": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
         },
-        "localhost_2" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "MASTER",
-          "StartTime" : "8000",
-          "EndTime" : "10000"
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "8000",
+          "EndTime": "10000"
+        }
+      },
+      "MissingTopStates": {
+        "localhost_0": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "15000",
+          "EndTime": "18000"
+        },
+        "localhost_1": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
+        },
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "8000",
+          "EndTime": "10000"
         }
       },
       "handoffCurrentStates": {
-        "localhost_0" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "MASTER",
-          "StartTime" : "15000",
-          "EndTime" : "18000"
+        "localhost_0": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "15000",
+          "EndTime": "18000"
         },
-        "localhost_1" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "OFFLINE",
-          "StartTime" : "20000",
-          "EndTime" : "22000"
+        "localhost_1": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "20000",
+          "EndTime": "22000"
         },
-        "localhost_2" : {
-          "CurrentState" : "SLAVE",
-          "PreviousState" : "OFFLINE",
-          "StartTime" : "8000",
-          "EndTime" : "10000"
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "8000",
+          "EndTime": "10000"
         }
       },
-      "expectedDuration" : "0"
+      "expectedDuration": "0"
     }
   ]
 }


### PR DESCRIPTION
We've confirmed a bug in the logic that calculates topstate handoff duration.
With this issue, if the previous master instance is offline, an older handoff start time could be used to calculate the duration.
This results in huge handoff duration in the Helix metrics.
This change will fix this bug. If the previous node that holds topstate replica goes to offline, the offline time will be used as the start time.