### PR TITLE
Change migration strategy to N -> N+1 -> N model

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/api/config/StateTransitionThrottleConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/api/config/StateTransitionThrottleConfig.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 public class StateTransitionThrottleConfig {
   private static final Logger logger =
       LoggerFactory.getLogger(StateTransitionThrottleConfig.class.getName());
+  public final static int DEFAULT_NUM_TRANSIT_REPLICAS = 1;
 
   private enum ConfigProperty {
     CONFIG_TYPE,
@@ -42,7 +43,8 @@ public class StateTransitionThrottleConfig {
   public enum ThrottleScope {
     CLUSTER,
     RESOURCE,
-    INSTANCE
+    INSTANCE,
+    PARTITION
   }
 
   public enum RebalanceType {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
@@ -34,7 +34,8 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer {
       Map<String, String> stateMap = currentStateMap.get(partition);
       List<String> preferenceList = new ArrayList<>(stateMap.keySet());
       Collections.sort(preferenceList, new PreferenceListNodeComparator(stateMap,
-          clusterData.getStateModelDef(currentIdealState.getStateModelDefRef())));
+          clusterData.getStateModelDef(currentIdealState.getStateModelDefRef()),
+          Collections.<String>emptyList()));
       currentIdealState.setPreferenceList(partition.getPartitionName(), preferenceList);
     }
     LOG.info("End computing ideal state for resource %s in maintenance mode.");

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -66,7 +66,7 @@ public class ClusterConfig extends HelixProperty {
   }
   private final static int DEFAULT_MAX_CONCURRENT_TASK_PER_INSTANCE = 40;
   private final static int DEFAULT_ERROR_PARTITION_THRESHOLD_FOR_LOAD_BALANCE = 0; // By default, no load balance if any error partition
-  private static final String IDEAL_STATE_RULE_PREFIX = "IdealStateRule!";
+  private final static String IDEAL_STATE_RULE_PREFIX = "IdealStateRule!";
 
   /**
    * Instantiate for a specific cluster

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestAbstractRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestAbstractRebalancer.java
@@ -22,8 +22,11 @@ package org.apache.helix.controller.rebalancer;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.model.Partition;
 import org.apache.helix.util.TestInputLoader;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -38,10 +41,17 @@ public class TestAbstractRebalancer {
       Map<String, String> expectedBestPossibleMap) {
     System.out.println("Test case comment: " + comment);
     AutoRebalancer rebalancer = new AutoRebalancer();
+    Partition partition = new Partition("testPartition");
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    for (String instance : currentStateMap.keySet()) {
+      currentStateOutput
+          .setCurrentState("test", partition, instance, currentStateMap.get(instance));
+    }
     Map<String, String> bestPossibleMap = rebalancer
         .computeBestPossibleStateForPartition(new HashSet<String>(liveInstances),
             BuiltInStateModelDefinitions.valueOf(stateModelName).getStateModelDefinition(),
-            preferenceList, currentStateMap, new HashSet<String>(disabledInstancesForPartition), new IdealState("test"));
+            preferenceList, currentStateOutput, new HashSet<String>(disabledInstancesForPartition),
+            new IdealState("test"), new ClusterConfig("TestCluster"), partition);
 
     Assert.assertTrue(bestPossibleMap.equals(expectedBestPossibleMap));
   }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestZeroReplicaAvoidance.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestZeroReplicaAvoidance.java
@@ -10,8 +10,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.helix.controller.stages.BaseStageTest;
+import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.model.Partition;
 import org.apache.helix.model.StateModelDefinition;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.ObjectReader;
@@ -56,11 +59,17 @@ public class TestZeroReplicaAvoidance extends BaseStageTest {
 
     IdealState is = new IdealState("test");
     is.setReplicas("3");
-
+    Partition partition = new Partition("testPartition");
     DelayedAutoRebalancer rebalancer = new DelayedAutoRebalancer();
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    for (String instance : currentStateMap.keySet()) {
+      currentStateOutput
+          .setCurrentState("test", partition, instance, currentStateMap.get(instance));
+    }
     Map<String, String> bestPossibleMap = rebalancer
-        .computeBestPossibleStateForPartition(liveInstances, stateModelDef, instancePreferenceList, currentStateMap,
-            Collections.<String>emptySet(), is);
+        .computeBestPossibleStateForPartition(liveInstances, stateModelDef, instancePreferenceList,
+            currentStateOutput, Collections.<String>emptySet(), is,
+            new ClusterConfig("TestCluster"), partition);
     Assert.assertEquals(bestPossibleMap, expectedBestPossibleMap,
         "Differs, get " + bestPossibleMap + "\nexpected: " + expectedBestPossibleMap
             + "\ncurrentState: " + currentStateMap + "\npreferenceList: " + instancePreferenceList);

--- a/helix-core/src/test/java/org/apache/helix/integration/common/ZkIntegrationTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/common/ZkIntegrationTestBase.java
@@ -293,6 +293,10 @@ public class ZkIntegrationTestBase {
         }
       }
 
+      if (activeReplica < minActiveReplica) {
+        int a = 0;
+      }
+
       Assert.assertTrue(hasTopState, String.format("%s missing %s replica", partition, topState));
       Assert.assertTrue(activeReplica >= minActiveReplica, String
           .format("%s has less active replica %d then required %d", partition, activeReplica,

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalance.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.helix.controller.rebalancer.strategy.CrushRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.util.RebalanceScheduler;
 import org.apache.helix.integration.common.ZkIntegrationTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
@@ -267,7 +268,7 @@ public class TestDelayedAutoRebalance extends ZkIntegrationTestBase {
     for (String stateModel : TestStateModels) {
       String db = "Test-DB-" + i++;
       createResourceWithDelayedRebalance(CLUSTER_NAME, db, stateModel, _PARTITIONS, _replica,
-          _minActiveReplica, delayTime);
+          _minActiveReplica, delayTime, CrushRebalanceStrategy.class.getName());
       _testDBs.add(db);
     }
     Thread.sleep(800);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalanceWithDisabledInstance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalanceWithDisabledInstance.java
@@ -120,7 +120,7 @@ public class TestDelayedAutoRebalanceWithDisabledInstance extends TestDelayedAut
 
     // disable another node, the minimal active replica for each partition should be maintained.
     enableInstance(_participants.get(3).getInstanceName(), false);
-    Thread.sleep(100);
+    Thread.sleep(1000);
     Assert.assertTrue(_clusterVerifier.verify());
 
     for (String db : _testDBs) {
@@ -193,7 +193,7 @@ public class TestDelayedAutoRebalanceWithDisabledInstance extends TestDelayedAut
           _participants.get(0).getInstanceName(), true);
     }
 
-    Thread.sleep(delay + 200);
+    Thread.sleep(delay + 500);
     // after delay time, it should maintain required number of replicas.
     for (String db : _testDBs) {
       ExternalView ev =
@@ -274,7 +274,7 @@ public class TestDelayedAutoRebalanceWithDisabledInstance extends TestDelayedAut
     enableDelayRebalanceInCluster(_gZkClient, CLUSTER_NAME, false);
     // TODO: remove this once controller is listening on cluster config change.
     RebalanceScheduler.invokeRebalance(_controller.getHelixDataAccessor(), _testDBs.get(0));
-    Thread.sleep(500);
+    Thread.sleep(2000);
     Assert.assertTrue(_clusterVerifier.verify());
     for (String db : _testDBs) {
       ExternalView ev =

--- a/helix-core/src/test/resources/TestDelayedAutoRebalancer.MasterSlave.json
+++ b/helix-core/src/test/resources/TestDelayedAutoRebalancer.MasterSlave.json
@@ -15,7 +15,6 @@
       "bestPossibleStates": {
         "localhost_2": "MASTER",
         "localhost_3": "SLAVE",
-        "localhost_4": "SLAVE",
         "localhost_0": "SLAVE",
         "localhost_1": "SLAVE"
       }
@@ -30,13 +29,11 @@
         "localhost_0": "SLAVE",
         "localhost_1": "SLAVE",
         "localhost_2": "SLAVE",
-        "localhost_3": "OFFLINE",
-        "localhost_4": "OFFLINE"
+        "localhost_3": "OFFLINE"
       },
       "bestPossibleStates": {
         "localhost_2": "MASTER",
         "localhost_3": "SLAVE",
-        "localhost_4": "SLAVE",
         "localhost_0": "SLAVE",
         "localhost_1": "SLAVE"
       }
@@ -51,15 +48,13 @@
         "localhost_0": "SLAVE",
         "localhost_1": "SLAVE",
         "localhost_2": "MASTER",
-        "localhost_3": "SLAVE",
-        "localhost_4": "SLAVE"
+        "localhost_3": "SLAVE"
       },
       "bestPossibleStates": {
+        "localhost_0": "SLAVE",
+        "localhost_1": "DROPPED",
         "localhost_2": "MASTER",
-        "localhost_3": "SLAVE",
-        "localhost_4": "SLAVE",
-        "localhost_0": "DROPPED",
-        "localhost_1": "DROPPED"
+        "localhost_3": "SLAVE"
       }
     },
     {
@@ -72,15 +67,13 @@
         "localhost_0": "OFFLINE",
         "localhost_1": "SLAVE",
         "localhost_2": "MASTER",
-        "localhost_3": "SLAVE",
-        "localhost_4": "SLAVE"
+        "localhost_3": "SLAVE"
       },
       "bestPossibleStates": {
-        "localhost_2": "MASTER",
-        "localhost_3": "SLAVE",
-        "localhost_4": "SLAVE",
         "localhost_0": "DROPPED",
-        "localhost_1": "DROPPED"
+        "localhost_1": "SLAVE",
+        "localhost_2": "MASTER",
+        "localhost_3": "SLAVE"
       }
     },
     {
@@ -96,11 +89,31 @@
         "localhost_3": "ERROR"
       },
       "bestPossibleStates": {
-        "localhost_2": "MASTER",
-        "localhost_4": "SLAVE",
-        "localhost_0": "DROPPED",
+        "localhost_0": "ERROR",
         "localhost_1": "SLAVE",
+        "localhost_2": "MASTER",
         "localhost_3": "ERROR"
+      }
+    },
+    {
+      "preferenceList": [
+        "localhost_3",
+        "localhost_4",
+        "localhost_5"
+      ],
+      "currentStates": {
+        "localhost_3": "OFFLINE",
+        "localhost_4": "OFFLINE",
+        "localhost_0": "MASTER",
+        "localhost_1": "OFFLINE",
+        "localhost_2": "OFFLINE"
+      },
+      "bestPossibleStates": {
+        "localhost_0": "MASTER",
+        "localhost_1": "SLAVE",
+        "localhost_2": "SLAVE",
+        "localhost_3": "SLAVE",
+        "localhost_4": "SLAVE"
       }
     }
   ]

--- a/helix-core/src/test/resources/TestDelayedAutoRebalancer.OnlineOffline.json
+++ b/helix-core/src/test/resources/TestDelayedAutoRebalancer.OnlineOffline.json
@@ -15,7 +15,6 @@
       "bestPossibleStates": {
         "localhost_2": "ONLINE",
         "localhost_3": "ONLINE",
-        "localhost_4": "ONLINE",
         "localhost_0": "ONLINE",
         "localhost_1": "ONLINE"
       }
@@ -30,14 +29,12 @@
         "localhost_0": "ONLINE",
         "localhost_1": "ONLINE",
         "localhost_2": "ONLINE",
-        "localhost_3": "ONLINE",
-        "localhost_4": "ONLINE"
+        "localhost_3": "ONLINE"
       },
       "bestPossibleStates": {
         "localhost_2": "ONLINE",
         "localhost_3": "ONLINE",
-        "localhost_4": "ONLINE",
-        "localhost_0": "DROPPED",
+        "localhost_0": "ONLINE",
         "localhost_1": "DROPPED"
       }
     },
@@ -56,7 +53,6 @@
       "bestPossibleStates": {
         "localhost_2": "ONLINE",
         "localhost_3": "ONLINE",
-        "localhost_4": "ONLINE",
         "localhost_0": "DROPPED",
         "localhost_1": "ONLINE"
       }
@@ -88,13 +84,11 @@
       "currentStates": {
         "localhost_2": "ERROR",
         "localhost_3": "ONLINE",
-        "localhost_4": "ONLINE",
         "localhost_0": "ONLINE",
         "localhost_1": "ONLINE"
       },
       "bestPossibleStates": {
         "localhost_3": "ONLINE",
-        "localhost_4": "ONLINE",
         "localhost_0": "ONLINE",
         "localhost_1": "ONLINE",
         "localhost_2": "ERROR"


### PR DESCRIPTION
    Currently Helix takes N->2N->N strategy when migrating a partition, where N equals to DB's replica count. When Helix decides to move a partition to N new instances, it brings up all replicas in new instances first before drop all replicas in old instances (so there will be 2N replica existing at certain period of time). This approach gurantees the availability during migration but may require bigger disk footprint. It may also cause a partition having more than 6 replicas if the cluster topology keeps changing during migration.
    What we proposed here is N -> N+1 -> N strategy, where Helix will bootstrap a new replica in one of new instance, then drop one from old instances. It then repeats the process until all replicas are moved to new instances. This will reduce disk usage, but meanwhile still maintain at least N active replica during the process. The new strategy can also avoid partition having excessive replicas even there is toplogy changes during the migration.