### PR TITLE
Allow downward state transition during recovery and add recovery threshold

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/api/config/StateTransitionThrottleConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/api/config/StateTransitionThrottleConfig.java
@@ -48,9 +48,9 @@ public class StateTransitionThrottleConfig {
   }
 
   public enum RebalanceType {
-    LOAD_BALANCE,
+    LOAD_BALANCE, // A rebalance type for load balance excluding dropping a replica
     RECOVERY_BALANCE,
-    ANY, // A type used for general throttling (to account for all types of rebalance)
+    ANY, // A rebalance type used for general throttling (to account for all types of rebalance)
     NONE
   }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
@@ -29,8 +29,10 @@ import org.testng.annotations.Test;
 import java.util.*;
 
 public class TestIntermediateStateCalcStage extends BaseStageTest {
+  private ClusterConfig _clusterConfig;
 
-  @Test public void testNoStateMissing() {
+  @Test
+  public void testNoStateMissing() {
     String resourcePrefix = "resource";
     int nResource = 4;
     int nPartition = 2;
@@ -43,12 +45,12 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
 
     preSetup(StateTransitionThrottleConfig.RebalanceType.RECOVERY_BALANCE, resourceSet, nReplica,
         nReplica);
-    event.addAttribute(AttributeName.RESOURCES.name(),
-        getResourceMap(resourceSet.toArray(new String[resourceSet.size()]), nPartition,
-            "OnlineOffline"));
-    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(),
-        getResourceMap(resourceSet.toArray(new String[resourceSet.size()]), nPartition,
-            "OnlineOffline"));
+    event.addAttribute(AttributeName.RESOURCES.name(), getResourceMap(
+        resourceSet.toArray(new String[resourceSet.size()]), nPartition, "OnlineOffline"));
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), getResourceMap(
+        resourceSet.toArray(new String[resourceSet.size()]), nPartition, "OnlineOffline"));
+
+
 
     // Initialize bestpossible state and current state
     BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
@@ -56,11 +58,14 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
 
     IntermediateStateOutput expectedResult = new IntermediateStateOutput();
 
+    _clusterConfig.setErrorOrRecoveryPartitionThresholdForLoadBalance(1);
+    setClusterConfig(_clusterConfig);
+
     for (String resource : resourceSet) {
       IdealState is = accessor.getProperty(accessor.keyBuilder().idealStates(resource));
       setSingleIdealState(is);
 
-      Map<String, List<String>> partitionMap = new HashMap<String, List<String>>();
+      Map<String, List<String>> partitionMap = new HashMap<>();
       for (int p = 0; p < nPartition; p++) {
         Partition partition = new Partition(resource + "_" + p);
         for (int r = 0; r < nReplica; r++) {
@@ -101,11 +106,50 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
               }
             } else {
               currentStateOutput.setCurrentState(resource, partition, instanceName, "ONLINE");
-              currentStateOutput
-                  .setCurrentState(resource, partition, instanceName + "-1", "OFFLINE");
+              currentStateOutput.setCurrentState(resource, partition, instanceName + "-1",
+                  "OFFLINE");
               // load balance is throttled, so keep all current states
               expectedResult.setState(resource, partition, instanceName, "ONLINE");
-              expectedResult.setState(resource, partition, instanceName + "-1", "OFFLINE");
+              // The following must be removed because now downward state transitions are allowed
+              // expectedResult.setState(resource, partition, instanceName + "-1", "OFFLINE");
+            }
+          } else if (resource.endsWith("4")) {
+            // Test that partitions with replicas to drop are dropping them when recovery is
+            // happening for other partitions
+            if (p == 0) {
+              // This partition requires recovery
+              currentStateOutput.setCurrentState(resource, partition, instanceName, "OFFLINE");
+              bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
+              // After recovery, it should be back ONLINE
+              expectedResult.setState(resource, partition, instanceName, "ONLINE");
+            } else {
+              // Other partitions require dropping of replicas
+              currentStateOutput.setCurrentState(resource, partition, instanceName, "ONLINE");
+              currentStateOutput.setCurrentState(resource, partition, instanceName + "-1",
+                  "OFFLINE");
+              // BestPossibleState dictates that we only need one ONLINE replica
+              bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
+              bestPossibleStateOutput.setState(resource, partition, instanceName + "-1", "DROPPED");
+              // So instanceName-1 will NOT be expected to show up in expectedResult
+              expectedResult.setState(resource, partition, instanceName, "ONLINE");
+              expectedResult.setState(resource, partition, instanceName + "-1", "DROPPED");
+            }
+          } else if (resource.endsWith("5")) {
+            // Test that load balance bringing up a new replica does NOT happen with a recovery
+            // partition
+            if (p == 0) {
+              // Set up a partition requiring recovery
+              currentStateOutput.setCurrentState(resource, partition, instanceName, "OFFLINE");
+              bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
+              // After recovery, it should be back ONLINE
+              expectedResult.setState(resource, partition, instanceName, "ONLINE");
+            } else {
+              currentStateOutput.setCurrentState(resource, partition, instanceName, "ONLINE");
+              bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
+              // Check that load balance (bringing up a new node) did not take place
+              bestPossibleStateOutput.setState(resource, partition, instanceName + "-1", "ONLINE");
+              expectedResult.setState(resource, partition, instanceName, "ONLINE");
+
             }
           }
         }
@@ -116,17 +160,92 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
     event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
     event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
     runStage(event, new ReadClusterDataStage());
-
-    // Keep update the current state.
-    for (int i = 0; i < resourceSet.size(); i++) {
-      runStage(event, new IntermediateStateCalcStage());
-    }
+    runStage(event, new IntermediateStateCalcStage());
 
     IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+
     for (String resource : resourceSet) {
-      // Note Assert.assertEquals won't work. If "actual" is an empty map, it won't compare anything.
-      Assert.assertTrue(output.getPartitionStateMap(resource).getStateMap().equals(
-          expectedResult.getPartitionStateMap(resource).getStateMap()));
+      // Note Assert.assertEquals won't work. If "actual" is an empty map, it won't compare
+      // anything.
+      Assert.assertTrue(output.getPartitionStateMap(resource).getStateMap()
+          .equals(expectedResult.getPartitionStateMap(resource).getStateMap()));
+    }
+  }
+
+  @Test
+  public void testWithClusterConfigChange() {
+    String resourcePrefix = "resource";
+    int nResource = 1;
+    int nPartition = 2;
+    int nReplica = 3;
+
+    Set<String> resourceSet = new HashSet<>();
+    for (int i = 0; i < nResource; i++) {
+      resourceSet.add(resourcePrefix + "_" + i);
+    }
+
+    preSetup(StateTransitionThrottleConfig.RebalanceType.RECOVERY_BALANCE, resourceSet,
+        nReplica, nReplica);
+    event.addAttribute(AttributeName.RESOURCES.name(), getResourceMap(
+        resourceSet.toArray(new String[resourceSet.size()]), nPartition, "OnlineOffline"));
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), getResourceMap(
+        resourceSet.toArray(new String[resourceSet.size()]), nPartition, "OnlineOffline"));
+
+    // Initialize best possible state and current state
+    BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    IntermediateStateOutput expectedResult = new IntermediateStateOutput();
+
+    for (String resource : resourceSet) {
+      IdealState is = accessor.getProperty(accessor.keyBuilder().idealStates(resource));
+      setSingleIdealState(is);
+
+      Map<String, List<String>> partitionMap = new HashMap<>();
+      for (int p = 0; p < nPartition; p++) {
+        Partition partition = new Partition(resource + "_" + p);
+        for (int r = 0; r < nReplica; r++) {
+          String instanceName = HOSTNAME_PREFIX + r;
+          partitionMap.put(partition.getPartitionName(), Collections.singletonList(instanceName));
+          if (resource.endsWith("0")) {
+            // Test that when the threshold is set at a number greater than the number of error and
+            // recovery partitions, load balance DOES take place
+            _clusterConfig.setErrorOrRecoveryPartitionThresholdForLoadBalance(Integer.MAX_VALUE);
+            setClusterConfig(_clusterConfig);
+            if (p == 0) {
+              // Set up a partition requiring recovery
+              currentStateOutput.setCurrentState(resource, partition, instanceName, "OFFLINE");
+              bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
+              // After recovery, it should be back ONLINE
+              expectedResult.setState(resource, partition, instanceName, "ONLINE");
+            } else {
+              // Ensure we have at least one ONLINE replica so that this partition does not need
+              // recovery
+              currentStateOutput.setCurrentState(resource, partition, instanceName, "ONLINE");
+              bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
+              expectedResult.setState(resource, partition, instanceName, "ONLINE");
+
+              // This partition to bring up a replica (load balance will happen)
+              bestPossibleStateOutput.setState(resource, partition, instanceName + "-1", "ONLINE");
+              expectedResult.setState(resource, partition, instanceName + "-1", "ONLINE");
+            }
+          }
+        }
+      }
+      bestPossibleStateOutput.setPreferenceLists(resource, partitionMap);
+    }
+
+    event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new IntermediateStateCalcStage());
+
+    IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+
+    for (String resource : resourceSet) {
+      // Note Assert.assertEquals won't work. If "actual" is an empty map, it won't compare
+      // anything.
+      Assert.assertTrue(output.getPartitionStateMap(resource).getStateMap()
+          .equals(expectedResult.getPartitionStateMap(resource).getStateMap()));
     }
   }
 
@@ -138,10 +257,10 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
     setupLiveInstances(numOfLiveInstances);
 
     // Set up cluster configs
-    ClusterConfig clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+    _clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
     StateTransitionThrottleConfig throttleConfig = new StateTransitionThrottleConfig(rebalanceType,
         StateTransitionThrottleConfig.ThrottleScope.CLUSTER, Integer.MAX_VALUE);
-    clusterConfig.setStateTransitionThrottleConfigs(Collections.singletonList(throttleConfig));
-    setClusterConfig(clusterConfig);
+    _clusterConfig.setStateTransitionThrottleConfigs(Collections.singletonList(throttleConfig));
+    setClusterConfig(_clusterConfig);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestRecoveryLoadBalance.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestRecoveryLoadBalance.java
@@ -1,0 +1,199 @@
+package org.apache.helix.controller.stages;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.api.config.StateTransitionThrottleConfig;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.Partition;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.ObjectReader;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestRecoveryLoadBalance extends BaseStageTest {
+
+  private final String INPUT = "inputs";
+  private final String CURRENT_STATE = "currentStates";
+  private final String BEST_POSSIBLE_STATE = "bestPossibleStates";
+  private final String EXPECTED_STATE = "expectedStates";
+  private final String ERROR_OR_RECOVERY_PARTITION_THRESHOLD =
+      "errorOrRecoveryPartitionThresholdForLoadBalance";
+  private final String STATE_MODEL = "statemodel";
+  private ClusterConfig _clusterConfig;
+
+  @Test(dataProvider = "recoveryLoadBalanceInput")
+  public void testRecoveryAndLoadBalance(String stateModelDef,
+      int errorOrRecoveryPartitionThresholdForLoadBalance,
+      Map<String, Map<String, Map<String, String>>> stateMapping) {
+    System.out.println("START TestRecoveryLoadBalance at " + new Date(System.currentTimeMillis()));
+
+    String resourcePrefix = "resource";
+    int nResource = 1;
+    int nPartition = 2;
+    int nReplica = 3;
+
+    Set<String> resourceSet = new HashSet<>();
+    for (int i = 0; i < nResource; i++) {
+      resourceSet.add(resourcePrefix + "_" + i);
+    }
+
+    preSetup(StateTransitionThrottleConfig.RebalanceType.RECOVERY_BALANCE, resourceSet, nReplica,
+        nReplica, stateModelDef);
+
+    _clusterConfig.setErrorOrRecoveryPartitionThresholdForLoadBalance(
+        errorOrRecoveryPartitionThresholdForLoadBalance);
+    setClusterConfig(_clusterConfig);
+
+    event.addAttribute(AttributeName.RESOURCES.name(), getResourceMap(
+        resourceSet.toArray(new String[resourceSet.size()]), nPartition, stateModelDef));
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), getResourceMap(
+        resourceSet.toArray(new String[resourceSet.size()]), nPartition, stateModelDef));
+
+    // Initialize bestpossible state and current state
+    BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    IntermediateStateOutput expectedResult = new IntermediateStateOutput();
+
+    for (String resource : resourceSet) {
+      IdealState is = accessor.getProperty(accessor.keyBuilder().idealStates(resource));
+      setSingleIdealState(is);
+
+      Map<String, List<String>> partitionMap = new HashMap<>();
+      for (int p = 0; p < nPartition; p++) {
+        Partition partition = new Partition(resource + "_" + p);
+
+        // Set input
+        for (int r = 0; r < stateMapping.get(partition.toString()).get(CURRENT_STATE).size(); r++) {
+          String instanceName = HOSTNAME_PREFIX + r;
+          currentStateOutput.setCurrentState(resource, partition, instanceName,
+              stateMapping.get(partition.toString()).get(CURRENT_STATE).get(instanceName));
+        }
+        for (int r = 0; r < stateMapping.get(partition.toString()).get(BEST_POSSIBLE_STATE)
+            .size(); r++) {
+          String instanceName = HOSTNAME_PREFIX + r;
+          bestPossibleStateOutput.setState(resource, partition, instanceName,
+              stateMapping.get(partition.toString()).get(BEST_POSSIBLE_STATE).get(instanceName));
+        }
+        for (int r = 0; r < stateMapping.get(partition.toString()).get(EXPECTED_STATE)
+            .size(); r++) {
+          String instanceName = HOSTNAME_PREFIX + r;
+          expectedResult.setState(resource, partition, instanceName,
+              stateMapping.get(partition.toString()).get(EXPECTED_STATE).get(instanceName));
+        }
+
+        // Set partitionMap
+        for (int r = 0; r < nReplica; r++) {
+          String instanceName = HOSTNAME_PREFIX + r;
+          partitionMap.put(partition.getPartitionName(), Collections.singletonList(instanceName));
+        }
+      }
+      bestPossibleStateOutput.setPreferenceLists(resource, partitionMap);
+    }
+
+    event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new IntermediateStateCalcStage());
+
+    IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+
+    for (String resource : resourceSet) {
+      // For debugging purposes
+      // Object map1 = output.getPartitionStateMap(resource).getStateMap();
+      // Object map2 = expectedResult.getPartitionStateMap(resource).getStateMap();
+
+      // Note Assert.assertEquals won't work. If "actual" is an empty map, it won't compare
+      // anything.
+      Assert.assertTrue(output.getPartitionStateMap(resource).getStateMap()
+          .equals(expectedResult.getPartitionStateMap(resource).getStateMap()));
+    }
+
+    System.out.println("END TestRecoveryLoadBalance at " + new Date(System.currentTimeMillis()));
+  }
+
+  @DataProvider(name = "recoveryLoadBalanceInput")
+  public Object[][] rebalanceStrategies() {
+
+    try {
+      List<Object[]> data = new ArrayList<>();
+      // Add data
+      data.addAll(loadTestInputs("TestRecoveryLoadBalance.OnlineOffline.json"));
+      data.addAll(loadTestInputs("TestRecoveryLoadBalance.MasterSlave.json"));
+
+      Object[][] ret = new Object[data.size()][];
+      for (int i = 0; i < data.size(); i++) {
+        ret[i] = data.get(i);
+      }
+      return ret;
+    } catch (Throwable e) {
+      return new Object[][] {
+          {}
+      };
+    }
+  }
+
+  public List<Object[]> loadTestInputs(String fileName) {
+    List<Object[]> ret = new ArrayList<>();
+    InputStream inputStream = getClass().getClassLoader().getResourceAsStream(fileName);
+    try {
+      ObjectReader mapReader = new ObjectMapper().reader(List.class);
+      List<Map<String, Object>> inputList = mapReader.readValue(inputStream);
+      for (Map<String, Object> inputMap : inputList) {
+        String stateModelName = (String) inputMap.get(STATE_MODEL);
+        int threshold = (int) inputMap.get(ERROR_OR_RECOVERY_PARTITION_THRESHOLD);
+        Map<String, Map<String, Map<String, String>>> stateMapping =
+            (Map<String, Map<String, Map<String, String>>>) inputMap.get(INPUT);
+        ret.add(new Object[] {
+            stateModelName, threshold, stateMapping
+        });
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return ret;
+  }
+
+  private void preSetup(StateTransitionThrottleConfig.RebalanceType rebalanceType,
+      Set<String> resourceSet, int numOfLiveInstances, int numOfReplicas, String stateModelName) {
+    setupIdealState(numOfLiveInstances, resourceSet.toArray(new String[resourceSet.size()]),
+        numOfLiveInstances, numOfReplicas, IdealState.RebalanceMode.FULL_AUTO, stateModelName);
+    setupStateModel();
+    setupLiveInstances(numOfLiveInstances);
+
+    // Set up cluster configs
+    _clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+    StateTransitionThrottleConfig throttleConfig = new StateTransitionThrottleConfig(rebalanceType,
+        StateTransitionThrottleConfig.ThrottleScope.CLUSTER, Integer.MAX_VALUE);
+    _clusterConfig.setStateTransitionThrottleConfigs(Collections.singletonList(throttleConfig));
+    setClusterConfig(_clusterConfig);
+  }
+}

--- a/helix-core/src/test/resources/TestRecoveryLoadBalance.MasterSlave.json
+++ b/helix-core/src/test/resources/TestRecoveryLoadBalance.MasterSlave.json
@@ -1,0 +1,257 @@
+[
+  {
+    "statemodel": "MasterSlave",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE",
+          "localhost_3": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE",
+          "localhost_3": "DROPPED"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE",
+          "localhost_3": "DROPPED"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        }
+      }
+    }
+  },
+  {
+    "statemodel": "MasterSlave",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 2,
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "ERROR",
+          "localhost_2": "SLAVE",
+          "localhost_3": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "ERROR",
+          "localhost_2": "SLAVE",
+          "localhost_3": "DROPPED"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "ERROR",
+          "localhost_2": "SLAVE",
+          "localhost_3": "DROPPED"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        }
+      }
+    }
+  },
+  {
+    "statemodel": "MasterSlave",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "ERROR",
+          "localhost_2": "SLAVE",
+          "localhost_3": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "ERROR",
+          "localhost_2": "SLAVE",
+          "localhost_3": "DROPPED"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "ERROR",
+          "localhost_2": "SLAVE",
+          "localhost_3": "DROPPED"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        }
+      }
+    }
+  },
+  {
+    "statemodel": "MasterSlave",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "OFFLINE",
+          "localhost_2": "OFFLINE",
+          "localhost_3": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE",
+          "localhost_3": "DROPPED"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE",
+          "localhost_3": "DROPPED"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        }
+      }
+    }
+  },
+  {
+    "statemodel": "MasterSlave",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "SLAVE",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        }
+      }
+    }
+  },
+  {
+    "statemodel": "MasterSlave",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "SLAVE",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE",
+          "localhost_3": "OFFLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE",
+          "localhost_3": "SLAVE"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE",
+          "localhost_3": "OFFLINE"
+        }
+      }
+    }
+  }
+]

--- a/helix-core/src/test/resources/TestRecoveryLoadBalance.OnlineOffline.json
+++ b/helix-core/src/test/resources/TestRecoveryLoadBalance.OnlineOffline.json
@@ -1,0 +1,206 @@
+[
+  {
+    "statemodel": "OnlineOffline",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "OFFLINE",
+          "localhost_1": "OFFLINE",
+          "localhost_2": "OFFLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        },
+        "expectedStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE",
+          "localhost_3": "ONLINE"
+        },
+        "expectedStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        }
+      }
+    }
+  },
+  {
+    "statemodel": "OnlineOffline",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "OFFLINE",
+          "localhost_1": "OFFLINE",
+          "localhost_2": "OFFLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        },
+        "expectedStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE",
+          "localhost_3": "ONLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE",
+          "localhost_3": "DROPPED"
+        },
+        "expectedStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE",
+          "localhost_3": "DROPPED"
+        }
+      }
+    }
+  },
+  {
+    "statemodel": "OnlineOffline",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 100,
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "OFFLINE",
+          "localhost_1": "OFFLINE",
+          "localhost_2": "OFFLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        },
+        "expectedStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE",
+          "localhost_3": "ONLINE"
+        },
+        "expectedStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE",
+          "localhost_3": "ONLINE"
+        }
+      }
+    }
+  },
+  {
+    "statemodel": "OnlineOffline",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "OFFLINE",
+          "localhost_1": "OFFLINE",
+          "localhost_2": "OFFLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        },
+        "expectedStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "OFFLINE",
+          "localhost_2": "ONLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "DROPPED",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        },
+        "expectedStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "OFFLINE",
+          "localhost_2": "ONLINE"
+        }
+      }
+    }
+  },
+  {
+    "statemodel": "OnlineOffline",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "DROPPED",
+          "localhost_1": "ONLINE",
+          "localhost_2": "OFFLINE"
+        },
+        "expectedStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "OFFLINE",
+          "localhost_1": "OFFLINE",
+          "localhost_2": "OFFLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        },
+        "expectedStates": {
+          "localhost_0": "ONLINE",
+          "localhost_1": "ONLINE",
+          "localhost_2": "ONLINE"
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
…recovery threshold

Previously, a single partition requiring recovery balance would block all types of load-balance. This commit allows all downward state transitions (load balance) to happen even when recovery balance is happening in the same cycle.
As for non-downward state transitions load-balance, a parameter, ErrorOrRecoveryPartitionThresholdForLoadBalance, was added to ClusterConfig. If the number of partitions requiring recovery is lower than the threshold, non-downward load-balance will take place in the same cycle as recovery balance; otherwise, non-downward load-balance will not take place in the same cycle.