### PR TITLE
[HELIX-709] Move external view calculation to async stage and re-organize pipeline

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/pipeline/AsyncWorkerType.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/pipeline/AsyncWorkerType.java
@@ -28,5 +28,6 @@ package org.apache.helix.controller.pipeline;
 
 public enum AsyncWorkerType {
   TargetExternalViewCalcWorker,
-  PersistAssignmentWorker
+  PersistAssignmentWorker,
+  ExternalViewComputeWorker
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ExternalViewComputeStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ExternalViewComputeStage.java
@@ -22,7 +22,8 @@ package org.apache.helix.controller.stages;
 import org.apache.helix.*;
 import org.apache.helix.PropertyKey.Builder;
 import org.apache.helix.ZNRecordDelta.MergeOperation;
-import org.apache.helix.controller.pipeline.AbstractBaseStage;
+import org.apache.helix.controller.pipeline.AbstractAsyncBaseStage;
+import org.apache.helix.controller.pipeline.AsyncWorkerType;
 import org.apache.helix.controller.pipeline.StageException;
 import org.apache.helix.manager.zk.DefaultSchedulerMessageHandlerFactory;
 import org.apache.helix.model.*;
@@ -33,11 +34,16 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
-public class ExternalViewComputeStage extends AbstractBaseStage {
+public class ExternalViewComputeStage extends AbstractAsyncBaseStage {
   private static Logger LOG = LoggerFactory.getLogger(ExternalViewComputeStage.class);
 
   @Override
-  public void process(ClusterEvent event) throws Exception {
+  public AsyncWorkerType getAsyncWorkerType() {
+    return AsyncWorkerType.ExternalViewComputeWorker;
+  }
+
+  @Override
+  public void execute(final ClusterEvent event) throws Exception {
     HelixManager manager = event.getAttribute(AttributeName.helixmanager.name());
     Map<String, Resource> resourceMap = event.getAttribute(AttributeName.RESOURCES.name());
     ClusterDataCache cache = event.getAttribute(AttributeName.ClusterDataCache.name());

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -643,9 +643,8 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
   @Override
   public void handleChildChange(String parentPath, List<String> currentChilds) {
     if (logger.isDebugEnabled()) {
-      logger.debug(
-          "Data change callback: child changed, path: " + parentPath + ", current child count: "
-              + currentChilds.size());
+      logger.debug("Data change callback: child changed, path: {} , current child count: {}",
+          parentPath, currentChilds == null ? 0 : currentChilds.size());
     }
 
     try {

--- a/helix-core/src/test/java/org/apache/helix/ZkUnitTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/ZkUnitTestBase.java
@@ -28,6 +28,7 @@ import org.I0Itec.zkclient.IZkStateListener;
 import org.I0Itec.zkclient.ZkConnection;
 import org.I0Itec.zkclient.ZkServer;
 import org.apache.helix.PropertyKey.Builder;
+import org.apache.helix.controller.pipeline.AbstractAsyncBaseStage;
 import org.apache.helix.controller.pipeline.Pipeline;
 import org.apache.helix.controller.pipeline.Stage;
 import org.apache.helix.controller.pipeline.StageContext;
@@ -349,7 +350,16 @@ public class ZkUnitTestBase {
     StageContext context = new StageContext();
     stage.init(context);
     stage.preProcess();
-    stage.process(event);
+
+    // AbstractAsyncBaseStage will run asynchronously, and it's main logics are implemented in
+    // execute() function call
+    // TODO (harry): duplicated code in ZkIntegrationTestBase, consider moving runStage()
+    // to a shared library
+    if (stage instanceof AbstractAsyncBaseStage) {
+      ((AbstractAsyncBaseStage) stage).execute(event);
+    } else {
+      stage.process(event);
+    }
     stage.postProcess();
   }
 


### PR DESCRIPTION
- Separated controller pipeline to execute external view compute async and as early as possible
- renamed AbstractAsyncBaseStage
- fixed NPE in callback handler
- all tests passed