### PR TITLE
[HELIX-718] implement ThreadCountBasedTaskAssigner

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/assigner/TaskAssignResult.java
+++ b/helix-core/src/main/java/org/apache/helix/task/assigner/TaskAssignResult.java
@@ -77,7 +77,7 @@ public class TaskAssignResult implements Comparable<TaskAssignResult> {
    * @return instance name. Null if assignment was not successful
    */
   public String getInstanceName() {
-    return _node.getInstanceName();
+    return _node == null ? null : _node.getInstanceName();
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/task/assigner/AssignerTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/task/assigner/AssignerTestBase.java
@@ -1,0 +1,69 @@
+package org.apache.helix.task.assigner;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.task.TaskConfig;
+
+/* package */ class AssignerTestBase {
+
+  private static final String testClusterName = "testCluster";
+  static final String testInstanceName = "testInstance";
+
+  static final String[] testResourceTypes = new String[] {"Resource1", "Resource2", "Resource3"};
+  static final String[] testResourceCapacity = new String[] {"20", "50", "100"};
+
+  static final String[] testQuotaTypes = new String[] {"Type1", "Type2", "Type3"};
+  static final String[] testQuotaRatio = new String[] {"50", "30", "20"};
+  private static final String defaultQuotaRatio = "100";
+
+  /* package */ LiveInstance createLiveInstance(String[] resourceTypes, String[] resourceCapacity) {
+    return createLiveInstance(resourceTypes, resourceCapacity, testInstanceName);
+  }
+
+  /* package */ LiveInstance createLiveInstance(String[] resourceTypes, String[] resourceCapacity, String instancename) {
+    LiveInstance li = new LiveInstance(instancename);
+    if (resourceCapacity != null && resourceTypes != null) {
+      Map<String, String> resMap = new HashMap<>();
+      for (int i = 0; i < resourceCapacity.length; i++) {
+        resMap.put(resourceTypes[i], resourceCapacity[i]);
+      }
+      li.setResourceCapacityMap(resMap);
+    }
+    return li;
+  }
+
+  /* package */ ClusterConfig createClusterConfig(String[] quotaTypes, String[] quotaRatio,
+      boolean addDefaultQuota) {
+    ClusterConfig clusterConfig = new ClusterConfig(testClusterName);
+    if (quotaTypes != null && quotaRatio != null) {
+      for (int i = 0; i < quotaTypes.length; i++) {
+        clusterConfig.setTaskQuotaRatio(quotaTypes[i], quotaRatio[i]);
+      }
+    }
+    if (addDefaultQuota) {
+      clusterConfig.setTaskQuotaRatio(TaskConfig.DEFAULT_QUOTA_TYPE, defaultQuotaRatio);
+    }
+    return clusterConfig;
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/task/assigner/TestAssignableInstance.java
+++ b/helix-core/src/test/java/org/apache/helix/task/assigner/TestAssignableInstance.java
@@ -29,17 +29,7 @@ import org.apache.helix.task.TaskStateModelFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-public class TestAssignableInstance {
-  private static final String testClusterName = "testCluster";
-  private static final String testInstanceName = "testInstance";
-
-  private static final String[] testResourceTypes = new String[] {"Resource1", "Resource2", "Resource3"};
-  private static final String[] testResourceCapacity = new String[] {"20", "50", "100"};
-
-  private static final String[] testQuotaTypes = new String[] {"Type1", "Type2", "Type3"};
-  private static final String[] testQuotaRatio = new String[] {"50", "30", "20"};
-  private static final String defaultQuotaRatio = "100";
-
+public class TestAssignableInstance extends AssignerTestBase {
 
   @Test
   public void testInvalidInitialization() {
@@ -329,31 +319,5 @@ public class TestAssignableInstance {
               / totalQuota));
     }
     return expectedQuotaPerType;
-  }
-
-  private LiveInstance createLiveInstance(String[] resourceTypes, String[] resourceCapacity) {
-    LiveInstance li = new LiveInstance(testInstanceName);
-    if (resourceCapacity != null && resourceTypes != null) {
-      Map<String, String> resMap = new HashMap<>();
-      for (int i = 0; i < resourceCapacity.length; i++) {
-        resMap.put(resourceTypes[i], resourceCapacity[i]);
-      }
-      li.setResourceCapacityMap(resMap);
-    }
-    return li;
-  }
-
-  private ClusterConfig createClusterConfig(String[] quotaTypes, String[] quotaRatio,
-      boolean addDefaultQuota) {
-    ClusterConfig clusterConfig = new ClusterConfig(testClusterName);
-    if (quotaTypes != null && quotaRatio != null) {
-      for (int i = 0; i < quotaTypes.length; i++) {
-        clusterConfig.setTaskQuotaRatio(quotaTypes[i], quotaRatio[i]);
-      }
-    }
-    if (addDefaultQuota) {
-      clusterConfig.setTaskQuotaRatio(TaskConfig.DEFAULT_QUOTA_TYPE, defaultQuotaRatio);
-    }
-    return clusterConfig;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/task/assigner/TestThreadCountBasedTaskAssigner.java
+++ b/helix-core/src/test/java/org/apache/helix/task/assigner/TestThreadCountBasedTaskAssigner.java
@@ -1,0 +1,206 @@
+package org.apache.helix.task.assigner;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.task.TaskConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestThreadCountBasedTaskAssigner extends AssignerTestBase {
+
+  @Test
+  public void testSuccessfulAssignment() {
+    TaskAssigner assigner = new ThreadCountBasedTaskAssigner();
+    int taskCountPerType = 150;
+    int instanceCount = 20;
+    int threadCount = 50;
+    List<AssignableInstance> instances = createAssignableInstances(instanceCount, threadCount);
+
+    for (String quotaType : testQuotaTypes) {
+      // Create tasks
+      List<TaskConfig> tasks = createTaskConfigs(taskCountPerType, quotaType);
+
+      // Assign
+      Map<String, TaskAssignResult> results = assigner.assignTasks(instances, tasks);
+
+      // Check success
+      assertAssignmentResults(results.values(), true);
+
+      // Check evenness
+      for (AssignableInstance instance : instances) {
+        int assignedCount = instance.getUsedCapacity()
+            .get(LiveInstance.InstanceResourceType.TASK_EXEC_THREAD.name()).get(quotaType);
+        Assert.assertTrue(assignedCount <= taskCountPerType / instanceCount + 1
+            && assignedCount >= taskCountPerType / instanceCount);
+      }
+    }
+  }
+
+  @Test
+  public void testAssignmentFailureNoInstance() {
+    TaskAssigner assigner = new ThreadCountBasedTaskAssigner();
+    int taskCount = 10;
+    List<TaskConfig> tasks = createTaskConfigs(taskCount, "Dummy");
+    Map<String, TaskAssignResult> results =
+        assigner.assignTasks(Collections.<AssignableInstance>emptyList(), tasks);
+    Assert.assertEquals(results.size(), taskCount);
+    for (TaskAssignResult result : results.values()) {
+      Assert.assertFalse(result.isSuccessful());
+      Assert.assertNull(result.getAssignableInstance());
+      Assert.assertEquals(result.getFailureReason(),
+          TaskAssignResult.FailureReason.INSUFFICIENT_QUOTA);
+    }
+  }
+
+  @Test
+  public void testAssignmentFailureNoTask() {
+    TaskAssigner assigner = new ThreadCountBasedTaskAssigner();
+    List<AssignableInstance> instances = createAssignableInstances(1, 10);
+    Map<String, TaskAssignResult> results =
+        assigner.assignTasks(instances, Collections.<TaskConfig>emptyList());
+    Assert.assertTrue(results.isEmpty());
+  }
+
+  @Test
+  public void testAssignmentFailureInsufficientQuota() {
+    TaskAssigner assigner = new ThreadCountBasedTaskAssigner();
+
+    // 10 * Type1 quota
+    List<AssignableInstance> instances = createAssignableInstances(2, 10);
+    List<TaskConfig> tasks = createTaskConfigs(20, testQuotaTypes[0]);
+
+    Map<String, TaskAssignResult> results = assigner.assignTasks(instances, tasks);
+    int successCnt = 0;
+    int failCnt = 0;
+    for (TaskAssignResult rst : results.values()) {
+      if (rst.isSuccessful()) {
+        successCnt += 1;
+      } else {
+        failCnt += 1;
+        Assert.assertEquals(rst.getFailureReason(),
+            TaskAssignResult.FailureReason.INSUFFICIENT_QUOTA);
+      }
+    }
+    Assert.assertEquals(successCnt, 10);
+    Assert.assertEquals(failCnt, 10);
+  }
+
+  @Test
+  public void testAssignmentFailureDuplicatedTask() {
+    TaskAssigner assigner = new ThreadCountBasedTaskAssigner();
+    List<AssignableInstance> instances = createAssignableInstances(1, 20);
+    List<TaskConfig> tasks = createTaskConfigs(10, testQuotaTypes[0], false);
+
+    // Duplicate all tasks
+    tasks.addAll(createTaskConfigs(10, testQuotaTypes[0], false));
+    Collections.shuffle(tasks);
+
+    Map<String, TaskAssignResult> results = assigner.assignTasks(instances, tasks);
+    Assert.assertEquals(results.size(), 10);
+    assertAssignmentResults(results.values(), true);
+  }
+
+  @Test(enabled = false, description = "Not enabling profiling tests")
+  public void testAssignerProfiling() {
+    int instanceCount = 1000;
+    int taskCount = 50000;
+    for (int batchSize : new int[] {10000, 5000, 2000, 1000, 500, 100}) {
+      System.out.println("testing batch size: " + batchSize);
+      profileAssigner(batchSize, instanceCount, taskCount);
+    }
+  }
+
+  private void profileAssigner(int assignBatchSize, int instanceCount, int taskCount) {
+    int trail = 100;
+    long totalTime = 0;
+    for (int i = 0; i < trail; i++) {
+      TaskAssigner assigner = new ThreadCountBasedTaskAssigner();
+
+      // 50 * instanceCount number of tasks
+      List<AssignableInstance> instances = createAssignableInstances(instanceCount, 100);
+      List<TaskConfig> tasks = createTaskConfigs(taskCount, testQuotaTypes[0]);
+      List<Map<String, TaskAssignResult>> allResults = new ArrayList<>();
+
+      // Assign
+      long start = System.currentTimeMillis();
+      for (int j = 0; j < taskCount / assignBatchSize; j++) {
+        allResults.add(assigner
+            .assignTasks(instances, tasks.subList(j * assignBatchSize, (j + 1) * assignBatchSize)));
+      }
+      long duration = System.currentTimeMillis() - start;
+      totalTime += duration;
+
+      // Validate
+      for (Map<String, TaskAssignResult> results : allResults) {
+        for (TaskAssignResult rst : results.values()) {
+          Assert.assertTrue(rst.isSuccessful());
+        }
+      }
+    }
+    System.out.println("Average time: " + totalTime / trail + "ms");
+  }
+
+  private void assertAssignmentResults(Iterable<TaskAssignResult> results, boolean expected) {
+    for (TaskAssignResult rst : results) {
+      Assert.assertEquals(rst.isSuccessful(), expected);
+    }
+  }
+
+  private List<TaskConfig> createTaskConfigs(int count, String quotaType) {
+    return createTaskConfigs(count, quotaType, true);
+  }
+
+  private List<TaskConfig> createTaskConfigs(int count, String quotaType, boolean randomID) {
+    List<TaskConfig> tasks = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      TaskConfig task =
+          new TaskConfig(null, null, randomID ? UUID.randomUUID().toString() : "task-" + i, null);
+      task.setQuotaType(quotaType);
+      tasks.add(task);
+    }
+    return tasks;
+  }
+
+  private List<AssignableInstance> createAssignableInstances(int count, int threadCount) {
+    List<AssignableInstance> instances = new ArrayList<>();
+    String instanceNameFormat = "instance-%s";
+    for (int i = 0; i < count; i++) {
+      String instanceName = String.format(instanceNameFormat, i);
+      instances.add(
+          new AssignableInstance(
+              createClusterConfig(testQuotaTypes, testQuotaRatio, false),
+              new InstanceConfig(instanceName),
+              createLiveInstance(
+                  new String[] { LiveInstance.InstanceResourceType.TASK_EXEC_THREAD.name() },
+                  new String[] { Integer.toString(threadCount) },
+                  instanceName)
+          )
+      );
+    }
+    return instances;
+  }
+}


### PR DESCRIPTION
In this RB, I implemented a thread count based task assigner that is optimized for short-term use cases. It assumes:
- All tasks to assign have same quota type
- All tasks to assign requires only 1 thread


The algorithms did best effort that tasks with same type / same job are spread out: i.e.
- if there are 3 nodes, each has 10 threads for each quota type A, B, and C
- node1 is empty, node2 and node3 each has 5 typeB tasks and 5 typeC tasks running
=> when 3 typeA tasks are to be assigned, it will assign 1 typeA task to each node rather than squeeze all 3 typeA tasks to node1.



Added tests for the assigner. Below is the profiling results, each result takes average of 100 trails:


Assign 50K tasks onto 1K nodes:

testing batch size: 10000
Average time: 118ms
testing batch size: 5000
Average time: 114ms
testing batch size: 2000
Average time: 117ms
testing batch size: 1000
Average time: 119ms
testing batch size: 500
Average time: 123ms
testing batch size: 100
Average time: 182ms



Assign 10K tasks onto 1K nodes:

testing batch size: 10000
Average time: 25ms
testing batch size: 5000
Average time: 21ms
testing batch size: 2000
Average time: 22ms
testing batch size: 1000
Average time: 25ms
testing batch size: 500
Average time: 22ms
testing batch size: 100
Average time: 34ms