### PR TITLE
[TEST] Remove null statement from AssignableInstanceManagerControllerSwitch

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/task/TestAssignableInstanceManagerControllerSwitch.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestAssignableInstanceManagerControllerSwitch.java
@@ -83,12 +83,10 @@ public class TestAssignableInstanceManagerControllerSwitch extends TaskTestBase 
 
     // Stop the current controller
     _controller.syncStop();
-    _controller = null;
     // Start a new controller
     String newControllerName = CONTROLLER_PREFIX + "_1";
-    ClusterControllerManager newController =
-        new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, newControllerName);
-    newController.syncStart();
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, newControllerName);
+    _controller.syncStart();
 
     // Generate a new AssignableInstanceManager
     taskDataCache.refresh(accessor, resourceConfigMap);


### PR DESCRIPTION
…erControllerSwitch

Controller was set to null during development of the test and never got removed after finishing writing the test, which caused an NPE.

Changelist:
1. Remove an old null statement in the test