### PR TITLE
Refactor AssignableInstanceManager

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/JobRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobRebalancer.java
@@ -19,12 +19,10 @@ package org.apache.helix.task;
  * under the License.
  */
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -33,14 +31,11 @@ import java.util.TreeSet;
 
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixDataAccessor;
-import org.apache.helix.HelixException;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.ZNRecord;
-import org.apache.helix.controller.rebalancer.util.RebalanceScheduler;
 import org.apache.helix.controller.stages.ClusterDataCache;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.IdealState;
-import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
@@ -50,7 +45,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
 
 /**
  * Custom rebalancer implementation for the {@code Job} in task model.

--- a/helix-core/src/test/java/org/apache/helix/task/TestAssignableInstanceManager.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestAssignableInstanceManager.java
@@ -36,6 +36,7 @@ import org.apache.helix.task.assigner.TaskAssignResult;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import sun.security.jca.GetInstance;
 
 public class TestAssignableInstanceManager {
   private static final int NUM_PARTICIPANTS = 3;
@@ -100,8 +101,9 @@ public class TestAssignableInstanceManager {
       _taskIDs.clear();
     }
 
-    // Create an AssignableInstanceManager
-    _assignableInstanceManager = new AssignableInstanceManager(_clusterConfig, _taskDataCache,
+    // Create an AssignableInstanceManager and build
+    _assignableInstanceManager = new AssignableInstanceManager();
+    _assignableInstanceManager.buildAssignableInstances(_clusterConfig, _taskDataCache,
         _liveInstances, _instanceConfigs);
   }
 
@@ -141,9 +143,11 @@ public class TestAssignableInstanceManager {
     // Check that the assignable instance map contains new instances and there are no
     // TaskAssignResults due to previous live instances being removed
     Assert.assertEquals(_assignableInstanceManager.getTaskAssignResultMap().size(), 0);
-    Assert.assertEquals(_assignableInstanceManager.getAssignableInstanceMap().size(), newLiveInstances.size());
+    Assert.assertEquals(_assignableInstanceManager.getAssignableInstanceMap().size(),
+        newLiveInstances.size());
     for (String instance : newLiveInstances.keySet()) {
-      Assert.assertTrue(_assignableInstanceManager.getAssignableInstanceMap().containsKey(instance));
+      Assert
+          .assertTrue(_assignableInstanceManager.getAssignableInstanceMap().containsKey(instance));
     }
   }
 

--- a/helix-core/src/test/java/org/apache/helix/task/TestAssignableInstanceManagerControllerSwitch.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestAssignableInstanceManagerControllerSwitch.java
@@ -42,8 +42,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class TestAssignableInstanceManagerControllerSwitch extends TaskTestBase {
-  protected int numJobs = 2;
-  protected int numTasks = 3;
+  private int numJobs = 2;
+  private int numTasks = 3;
 
   @Test
   public void testControllerSwitch() throws InterruptedException {
@@ -74,8 +74,10 @@ public class TestAssignableInstanceManagerControllerSwitch extends TaskTestBase 
     Thread.sleep(2000);
     taskDataCache.refresh(accessor, resourceConfigMap);
 
-    AssignableInstanceManager prevAssignableInstanceManager = new AssignableInstanceManager(
-        clusterConfig, taskDataCache, liveInstanceMap, instanceConfigMap);
+    // Create prev manager and build
+    AssignableInstanceManager prevAssignableInstanceManager = new AssignableInstanceManager();
+    prevAssignableInstanceManager.buildAssignableInstances(clusterConfig, taskDataCache,
+        liveInstanceMap, instanceConfigMap);
     Map<String, AssignableInstance> prevAssignableInstanceMap =
         new HashMap<>(prevAssignableInstanceManager.getAssignableInstanceMap());
     Map<String, TaskAssignResult> prevTaskAssignResultMap =
@@ -90,8 +92,9 @@ public class TestAssignableInstanceManagerControllerSwitch extends TaskTestBase 
 
     // Generate a new AssignableInstanceManager
     taskDataCache.refresh(accessor, resourceConfigMap);
-    AssignableInstanceManager newAssignableInstanceManager = new AssignableInstanceManager(
-        clusterConfig, taskDataCache, liveInstanceMap, instanceConfigMap);
+    AssignableInstanceManager newAssignableInstanceManager = new AssignableInstanceManager();
+    newAssignableInstanceManager.buildAssignableInstances(clusterConfig, taskDataCache,
+        liveInstanceMap, instanceConfigMap);
     Map<String, AssignableInstance> newAssignableInstanceMap =
         new HashMap<>(newAssignableInstanceManager.getAssignableInstanceMap());
     Map<String, TaskAssignResult> newTaskAssignResultMap =


### PR DESCRIPTION
This RB refactors AssignableInstanceManager's constructor so that the actual building of AssignableInstances is separated into another public method. This allows the instantiation of AssignableInstanceManager in TaskDataCache without having to provide metadata for building AssignableInstances.

ChangeList:
1. Add an empty constructor
2. Put build logic in a separate method
3. A boolean flag was added for buildAssignableInstances() to prevent it from building AssignableInstance objects from scratch every time this method is called by TaskDataCache's refresh()