### PR TITLE
Fix TestStateTransitionThrottle and comparison operator change

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -316,7 +316,7 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
             cache.getStateModelDef(resource.getStateModelDefRef()).getTopState());
 
     // Perform load balance upon checking conditions below
-    Set<Partition> loadbalanceThrottledPartitions = partitionsNeedLoadBalance;
+    Set<Partition> loadbalanceThrottledPartitions;
     ClusterConfig clusterConfig = cache.getClusterConfig();
 
     // If the threshold (ErrorOrRecovery) is set, then use it, if not, then check if the old
@@ -338,7 +338,7 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
 
     // Perform regular load balance only if the number of partitions in recovery and in error is
     // less than the threshold. Otherwise, only allow downward-transition load balance
-    boolean onlyDownwardLoadBalance = partitionCount >= threshold;
+    boolean onlyDownwardLoadBalance = partitionCount > threshold;
 
     loadbalanceThrottledPartitions = loadRebalance(resource, currentStateOutput,
         bestPossiblePartitionStateMap, throttleController, intermediatePartitionStateMap,


### PR DESCRIPTION
…hange

Due to the change made in relation to allowing downward state transitions to take place while error or recovery balance transitions are present, this test was failing due to the change in the assumption. Parameters were adjusted, and test conditions were modified such that it is testing the new assumptions correctly.

Changelist:
1. TestStateTransitionThrottle assert statements were modified so that it assumes downward load balance transitions taking place
2. Comparison operator in IntermediateStateCalcState to make it more strictly backward-compatible