### PR TITLE
Fix TestAssignableInstanceManagerControllerSwitch

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/task/TestAssignableInstanceManagerControllerSwitch.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestAssignableInstanceManagerControllerSwitch.java
@@ -119,6 +119,9 @@ public class TestAssignableInstanceManagerControllerSwitch extends TaskTestBase 
       Assert.assertEquals(prevTaskAssignResultMap.get(taskID).toString(),
           taskAssignResultEntry.getValue().toString());
     }
+
+    // Shut down RoutingTableProvider so periodic update gets shut down
+    routingTableProvider.shutdown();
   }
 
   private void setupAndRunJobs() {


### PR DESCRIPTION
This test uses RoutingTableProvider. It was not being shut down, causing an ExecutorService thread to continue executing periodic updates. This RB makes it so that it is shut down at the end of the test.

Changelist:
1. Add shutdown() on RoutingTableProvider at the end of the test