### PR TITLE
helix manager should support getting metadata store connection string

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManager.java
@@ -289,6 +289,13 @@ public interface HelixManager {
   String getClusterName();
 
   /**
+   * Returns a string that can be used to connect to metadata store for this HelixManager instance
+   * i.e. for ZkHelixManager, this will have format "{zookeeper-address}:{port}"
+   * @return a string used to connect to metadata store
+   */
+  String getMetadataStoreConnectionString();
+
+  /**
    * Returns the instanceName used to connect to the cluster
    * @return the associated instance name
    */

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -560,6 +560,16 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     return _clusterName;
   }
 
+  /**
+   * Returns a string that can be used to connect to metadata store for this HelixManager instance
+   * i.e. for ZkHelixManager, this will have format "{zookeeper-address}:{port}"
+   * @return a string used to connect to metadata store
+   */
+  @Override
+  public String getMetadataStoreConnectionString() {
+    return _zkAddress;
+  }
+
   @Override
   public String getInstanceName() {
     return _instanceName;

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/DummyClusterManager.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/DummyClusterManager.java
@@ -155,6 +155,11 @@ public class DummyClusterManager implements HelixManager {
   }
 
   @Override
+  public String getMetadataStoreConnectionString() {
+    return null;
+  }
+
+  @Override
   public String getInstanceName() {
     // TODO Auto-generated method stub
     return null;

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkReconnect.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkReconnect.java
@@ -84,6 +84,8 @@ public class TestZkReconnect {
               }
             });
 
+    Assert.assertEquals(controller.getMetadataStoreConnectionString(), zkAddr);
+
     try {
       controller.connect();
       // check onConnected() is triggered
@@ -112,6 +114,7 @@ public class TestZkReconnect {
       // Inject expire to test handler
       // onDisconnectedFlag should be set within onDisconnected handler
       controller.handleSessionEstablishmentError(new Exception("For testing"));
+      Thread.sleep(10);
       Assert.assertTrue(onDisconnectedFlag.get());
       Assert.assertFalse(onConnectedFlag.get());
       Assert.assertFalse(controller.isConnected());

--- a/helix-core/src/test/java/org/apache/helix/mock/MockManager.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockManager.java
@@ -164,6 +164,11 @@ public class MockManager implements HelixManager {
   }
 
   @Override
+  public String getMetadataStoreConnectionString() {
+    return null;
+  }
+
+  @Override
   public String getInstanceName() {
     return _instanceName;
   }

--- a/helix-core/src/test/java/org/apache/helix/participant/MockZKHelixManager.java
+++ b/helix-core/src/test/java/org/apache/helix/participant/MockZKHelixManager.java
@@ -181,6 +181,11 @@ public class MockZKHelixManager implements HelixManager {
   }
 
   @Override
+  public String getMetadataStoreConnectionString() {
+    return null;
+  }
+
+  @Override
   public String getInstanceName() {
     return _instanceName;
   }


### PR DESCRIPTION
We have a request here that it would be handy to retrieve zk address from ZkHelixManager for user components to perform some customized operations in ZooKeeper.

To make it more general (also to introduce less code change), I'm adding an interface in HelixManager for such functionality and use a more generic name "metadata store" in HelixManager interface.