### PR TITLE
Fix test configs for TestRecoveryLoadBalance

### DIFF
--- a/helix-core/src/test/resources/TestRecoveryLoadBalance.MasterSlave.json
+++ b/helix-core/src/test/resources/TestRecoveryLoadBalance.MasterSlave.json
@@ -1,7 +1,7 @@
 [
   {
     "statemodel": "MasterSlave",
-    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 0,
     "inputs": {
       "resource_0_0": {
         "currentStates": {
@@ -19,49 +19,6 @@
         "expectedStates": {
           "localhost_0": "MASTER",
           "localhost_1": "SLAVE",
-          "localhost_2": "SLAVE",
-          "localhost_3": "DROPPED"
-        }
-      },
-      "resource_0_1": {
-        "currentStates": {
-          "localhost_0": "MASTER",
-          "localhost_1": "SLAVE",
-          "localhost_2": "SLAVE"
-        },
-        "bestPossibleStates": {
-          "localhost_0": "MASTER",
-          "localhost_1": "SLAVE",
-          "localhost_2": "SLAVE"
-        },
-        "expectedStates": {
-          "localhost_0": "MASTER",
-          "localhost_1": "SLAVE",
-          "localhost_2": "SLAVE"
-        }
-      }
-    }
-  },
-  {
-    "statemodel": "MasterSlave",
-    "errorOrRecoveryPartitionThresholdForLoadBalance": 2,
-    "inputs": {
-      "resource_0_0": {
-        "currentStates": {
-          "localhost_0": "MASTER",
-          "localhost_1": "ERROR",
-          "localhost_2": "SLAVE",
-          "localhost_3": "SLAVE"
-        },
-        "bestPossibleStates": {
-          "localhost_0": "MASTER",
-          "localhost_1": "ERROR",
-          "localhost_2": "SLAVE",
-          "localhost_3": "DROPPED"
-        },
-        "expectedStates": {
-          "localhost_0": "MASTER",
-          "localhost_1": "ERROR",
           "localhost_2": "SLAVE",
           "localhost_3": "DROPPED"
         }
@@ -130,7 +87,50 @@
   },
   {
     "statemodel": "MasterSlave",
-    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 0,
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "ERROR",
+          "localhost_2": "SLAVE",
+          "localhost_3": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "ERROR",
+          "localhost_2": "SLAVE",
+          "localhost_3": "DROPPED"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "ERROR",
+          "localhost_2": "SLAVE",
+          "localhost_3": "DROPPED"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        }
+      }
+    }
+  },
+  {
+    "statemodel": "MasterSlave",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 0,
     "inputs": {
       "resource_0_0": {
         "currentStates": {
@@ -173,7 +173,7 @@
   },
   {
     "statemodel": "MasterSlave",
-    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 0,
     "inputs": {
       "resource_0_0": {
         "currentStates": {
@@ -213,7 +213,7 @@
   },
   {
     "statemodel": "MasterSlave",
-    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 0,
     "inputs": {
       "resource_0_0": {
         "currentStates": {

--- a/helix-core/src/test/resources/TestRecoveryLoadBalance.OnlineOffline.json
+++ b/helix-core/src/test/resources/TestRecoveryLoadBalance.OnlineOffline.json
@@ -1,7 +1,7 @@
 [
   {
     "statemodel": "OnlineOffline",
-    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 0,
     "inputs": {
       "resource_0_0": {
         "currentStates": {
@@ -42,7 +42,7 @@
   },
   {
     "statemodel": "OnlineOffline",
-    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 0,
     "inputs": {
       "resource_0_0": {
         "currentStates": {
@@ -127,7 +127,7 @@
   },
   {
     "statemodel": "OnlineOffline",
-    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 0,
     "inputs": {
       "resource_0_0": {
         "currentStates": {
@@ -167,7 +167,7 @@
   },
   {
     "statemodel": "OnlineOffline",
-    "errorOrRecoveryPartitionThresholdForLoadBalance": 1,
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 0,
     "inputs": {
       "resource_0_0": {
         "currentStates": {


### PR DESCRIPTION
There was a fix checked in for NumberOfErrorOrRecoveryPartitionThreshold in IntermediateStateCalcStage from less than equal to to strictly less than. Because of this, we need to change the config parameters (mostly from 1 to 0). There is no other underlying logic change.

Changelist:
1. Change config parameters appropriately in test case JSON files from 1 to 0