### PR TITLE
Modify TestGetLastScheduledTaskTimestamp for increased stability

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/task/TestGetLastScheduledTaskTimestamp.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestGetLastScheduledTaskTimestamp.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 
 public class TestGetLastScheduledTaskTimestamp extends TaskTestBase {
   private final static String TASK_START_TIME_KEY = "START_TIME";
+  private final static long INVALID_TIMESTAMP = -1L;
 
   @BeforeClass
   public void beforeClass() throws Exception {
@@ -44,8 +45,8 @@ public class TestGetLastScheduledTaskTimestamp extends TaskTestBase {
   public void testGetLastScheduledTaskTimestamp() throws InterruptedException {
     List<Long> startTimesWithStuckTasks = setupTasks("TestWorkflow_2", 5, 99999999);
     // First two must be -1 (two tasks are stuck), and API call must return the last value (most recent timestamp)
-    Assert.assertEquals(startTimesWithStuckTasks.get(0).longValue(), 0);
-    Assert.assertEquals(startTimesWithStuckTasks.get(1).longValue(), 0);
+    Assert.assertEquals(startTimesWithStuckTasks.get(0).longValue(), INVALID_TIMESTAMP);
+    Assert.assertEquals(startTimesWithStuckTasks.get(1).longValue(), INVALID_TIMESTAMP);
     Assert.assertEquals(startTimesWithStuckTasks.get(3).longValue(),
         _driver.getLastScheduledTaskTimestamp("TestWorkflow_2"));
 
@@ -97,7 +98,7 @@ public class TestGetLastScheduledTaskTimestamp extends TaskTestBase {
       for (Integer partition : allPartitions) {
         String timestamp = jobContext.getMapField(partition).get(TASK_START_TIME_KEY);
         if (timestamp == null) {
-          startTimes.add(0L);
+          startTimes.add(INVALID_TIMESTAMP);
         } else {
           startTimes.add(Long.parseLong(timestamp));
         }


### PR DESCRIPTION
…ability

This test was experiencing an intermittent failure. No inherent faults of its own, but sometimes tasks were not being given enough resource/time to be scheduled and register the timestamp, which is expected depending on how fast the system is running. One area of improvement was that TestGetLastScheduledTaskTimestamp was using a long value 0 for invalid or unscheduled timestamps. It will use -1L from now on, which is the invalid flag TaskDriver uses.

Changlist:
1. Change the flag for invalid or unscheduled timestamps from 0 to -1L in TestGetLastScheduledTaskTimestamp