### PR TITLE
Make AssignmentCalculators non-static so that tests pass

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/JobRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobRebalancer.java
@@ -52,9 +52,6 @@ import com.google.common.collect.ImmutableMap;
  */
 public class JobRebalancer extends TaskRebalancer {
   private static final Logger LOG = LoggerFactory.getLogger(JobRebalancer.class);
-  private static TaskAssignmentCalculator _fixTaskAssignmentCal;
-  private static TaskAssignmentCalculator _threadCountBasedTaskAssignmentCal;
-
   private static final String PREV_RA_NODE = "PreviousResourceAssignment";
 
   @Override
@@ -434,14 +431,10 @@ public class JobRebalancer extends TaskRebalancer {
   private TaskAssignmentCalculator getAssignmentCalculator(JobConfig jobConfig,
       ClusterDataCache cache) {
     AssignableInstanceManager assignableInstanceManager = cache.getAssignableInstanceManager();
-    if (_threadCountBasedTaskAssignmentCal == null) {
-      _threadCountBasedTaskAssignmentCal = new ThreadCountBasedTaskAssignmentCalculator(
-          new ThreadCountBasedTaskAssigner(), assignableInstanceManager);
+    if (TaskUtil.isGenericTaskJob(jobConfig)) {
+      return new ThreadCountBasedTaskAssignmentCalculator(new ThreadCountBasedTaskAssigner(),
+          assignableInstanceManager);
     }
-    if (_fixTaskAssignmentCal == null) {
-      _fixTaskAssignmentCal = new FixedTargetTaskAssignmentCalculator(assignableInstanceManager);
-    }
-    return TaskUtil.isGenericTaskJob(jobConfig) ? _threadCountBasedTaskAssignmentCal
-        : _fixTaskAssignmentCal;
+    return new FixedTargetTaskAssignmentCalculator(assignableInstanceManager);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskThrottling.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskThrottling.java
@@ -63,7 +63,7 @@ public class TestTaskThrottling extends TaskTestBase {
     _driver.pollForJobState(flow.getName(), TaskUtil.getNamespacedJobName(flow.getName(), jobName1),
         TaskState.IN_PROGRESS);
     // Wait for tasks to be picked up
-    Thread.sleep(1500);
+    Thread.sleep(2000);
 
     Assert.assertEquals(countRunningPartition(flow, jobName1), numTasks);
 

--- a/helix-core/src/test/java/org/apache/helix/task/TestAssignableInstanceManagerControllerSwitch.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestAssignableInstanceManagerControllerSwitch.java
@@ -18,6 +18,7 @@ package org.apache.helix.task;
  * specific language governing permissions and limitations
  * under the License.
  */
+
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,6 +46,12 @@ public class TestAssignableInstanceManagerControllerSwitch extends TaskTestBase 
   private int numJobs = 2;
   private int numTasks = 3;
 
+  /**
+   * Tests the duality of two AssignableInstanceManager instances to model the
+   * situation where there is a Controller switch and AssignableInstanceManager is
+   * built back from scratch.
+   * @throws InterruptedException
+   */
   @Test
   public void testControllerSwitch() throws InterruptedException {
     setupAndRunJobs();
@@ -71,7 +78,7 @@ public class TestAssignableInstanceManagerControllerSwitch extends TaskTestBase 
         accessor.getChildValuesMap(accessor.keyBuilder().resourceConfigs(), true);
 
     // Wait for the job pipeline
-    Thread.sleep(100);
+    Thread.sleep(1000);
     taskDataCache.refresh(accessor, resourceConfigMap);
 
     // Create prev manager and build
@@ -82,13 +89,6 @@ public class TestAssignableInstanceManagerControllerSwitch extends TaskTestBase 
         new HashMap<>(prevAssignableInstanceManager.getAssignableInstanceMap());
     Map<String, TaskAssignResult> prevTaskAssignResultMap =
         new HashMap<>(prevAssignableInstanceManager.getTaskAssignResultMap());
-
-    // Stop the current controller
-    _controller.syncStop();
-    // Start a new controller
-    String newControllerName = CONTROLLER_PREFIX + "_2";
-    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, newControllerName);
-    _controller.syncStart();
 
     // Generate a new AssignableInstanceManager
     taskDataCache.refresh(accessor, resourceConfigMap);


### PR DESCRIPTION
With the introduction of quota-based scheduling, every task that gets scheduled takes up a thread. However, previously these AssignmentCalculators (both generic and fixed for generic jobs and targeted jobs) were stateless so they were instantiated statically. Since AssignmentCalculators now are stateful due to them operating on AssignableInstances' quota profile, they were made non-static so that they would be re-instantiated every pipeline.

This problem is specific to the testing environment where static variables live on from test to test, causing AssignmentCalculators to hold on to the very first reference to AssignableInstanceManager. Tasks were not being assigned and scheduled because the first set of AssignableInstances would get filled up and never get freed.

Changelist:
1. Make AssignmentCalculators non-static
2. Adjust sleep duration for some tests for stability