### PR TITLE
Expose ExternalViews in RoutingTable and RoutingTableSnap…

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTable.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTable.java
@@ -49,6 +49,7 @@ class RoutingTable {
   private final Map<String, ResourceGroupInfo> _resourceGroupInfoMap;
   private final Collection<LiveInstance> _liveInstances;
   private final Collection<InstanceConfig> _instanceConfigs;
+  private final Collection<ExternalView> _externalViews;
 
   public RoutingTable() {
     this(Collections.<ExternalView>emptyList(), Collections.<InstanceConfig>emptyList(),
@@ -57,6 +58,7 @@ class RoutingTable {
 
   public RoutingTable(Collection<ExternalView> externalViews, Collection<InstanceConfig> instanceConfigs,
       Collection<LiveInstance> liveInstances) {
+    _externalViews = externalViews;
     _resourceInfoMap = new HashMap<>();
     _resourceGroupInfoMap = new HashMap<>();
     _liveInstances = new HashSet<>(liveInstances);
@@ -66,6 +68,7 @@ class RoutingTable {
 
   public RoutingTable(Map<String, Map<String, Map<String, CurrentState>>> currentStateMap,
       Collection<InstanceConfig> instanceConfigs, Collection<LiveInstance> liveInstances) {
+    _externalViews = Collections.emptyList();
     _resourceInfoMap = new HashMap<>();
     _resourceGroupInfoMap = new HashMap<>();
     _liveInstances = liveInstances;
@@ -345,6 +348,14 @@ class RoutingTable {
   }
 
   /**
+   * Returns ExternalViews.
+   * @return a collection of ExternalViews
+   */
+  protected Collection<ExternalView> getExternalViews() {
+    return Collections.unmodifiableCollection(_externalViews);
+  }
+
+  /**
    * Class to store instances, partitions and their states for each resource.
    */
   class ResourceInfo {
@@ -474,7 +485,8 @@ class RoutingTable {
           if (config2 == null) {
             return 1;
           }
-          // IDs for InstanceConfigs are a concatenation of instance name, host, and port.
+          // HELIX-936: a NPE on the hostname; compare IDs instead. IDs for InstanceConfigs are
+          // concatenation of instance name, host, and port.
           return config1.getId().compareTo(config2.getId());
         }
       };

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -59,7 +59,7 @@ public class RoutingTableProvider
     implements ExternalViewChangeListener, InstanceConfigChangeListener, ConfigChangeListener,
                LiveInstanceChangeListener, CurrentStateChangeListener {
   private static final Logger logger = LoggerFactory.getLogger(RoutingTableProvider.class);
-  private static final long DEFAULT_PERIODIC_REFRESH_INTERVAL = 300000; // 5 minutes
+  private static final long DEFAULT_PERIODIC_REFRESH_INTERVAL = 300000L; // 5 minutes
   private final AtomicReference<RoutingTable> _routingTableRef;
   private final HelixManager _helixManager;
   private final RouterUpdater _routerUpdater;

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableSnapshot.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableSnapshot.java
@@ -22,6 +22,7 @@ package org.apache.helix.spectator;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 
@@ -147,5 +148,14 @@ public class RoutingTableSnapshot {
    */
   public Collection<String> getResources() {
     return _routingTable.getResources();
+  }
+
+  /**
+   * Returns a Collection of latest snapshot of ExternalViews. Note that if the RoutingTable is
+   * instantiated using CurrentStates, this Collection will be empty.
+   * @return
+   */
+  public Collection<ExternalView> getExternalViews() {
+    return _routingTable.getExternalViews();
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableSnapshot.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableSnapshot.java
@@ -91,6 +91,7 @@ public class TestRoutingTableSnapshot extends ZkTestBase {
       Assert.assertEquals(routingTableSnapshot.getInstanceConfigs().size(), NUM_NODES);
       Assert.assertEquals(routingTableSnapshot.getResources().size(), 1);
       Assert.assertEquals(routingTableSnapshot.getLiveInstances().size(), NUM_NODES);
+      Assert.assertEquals(routingTableSnapshot.getExternalViews().size(), 1); // 1 DB
 
       // add new DB and shutdown an instance
       String db2 = "TestDB-2";
@@ -112,6 +113,7 @@ public class TestRoutingTableSnapshot extends ZkTestBase {
       Assert.assertEquals(newRoutingTableSnapshot.getInstanceConfigs().size(), NUM_NODES);
       Assert.assertEquals(newRoutingTableSnapshot.getResources().size(), 2);
       Assert.assertEquals(newRoutingTableSnapshot.getLiveInstances().size(), NUM_NODES - 1);
+      Assert.assertEquals(newRoutingTableSnapshot.getExternalViews().size(), 2); // 2 DBs
     } finally {
       routingTableProvider.shutdown();
     }
@@ -131,4 +133,3 @@ public class TestRoutingTableSnapshot extends ZkTestBase {
     }
   }
 }
-


### PR DESCRIPTION
…shot

Exposing ExternalViews in RoutingTable allows users an easy access to ExternalViews to track resource/partition/replica status.

Changelist:
1. Add getExternalViews() in RoutingTable
2. Add getExternalViews() in RoutingTableProvider
3. Cache ExternalViews in RoutingTable
4. Add an ExternalView test in TestRoutingTableSnapshot