### PR TITLE
[TASK] Make AssignableInstanceManager listen on data changes to update AssignableInstances

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/common/caches/TaskDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/TaskDataCache.java
@@ -72,7 +72,6 @@ public class TaskDataCache extends AbstractDataCache {
   public synchronized boolean refresh(HelixDataAccessor accessor,
       Map<String, ResourceConfig> resourceConfigMap) {
     refreshJobContexts(accessor);
-
     // update workflow and job configs.
     _workflowConfigMap.clear();
     _jobConfigMap.clear();
@@ -85,30 +84,7 @@ public class TaskDataCache extends AbstractDataCache {
         _jobConfigMap.put(entry.getKey(), new JobConfig(entry.getValue()));
       }
     }
-
     return true;
-  }
-
-  /**
-   * Refreshes Task Framework contexts and configs from ZooKeeper. This method also re-instantiates
-   * AssignableInstanceManager.
-   * @param accessor
-   * @param resourceConfigMap
-   * @param liveInstanceMap
-   * @param instanceConfigMap
-   * @return
-   */
-  public synchronized boolean refresh(HelixDataAccessor accessor,
-      Map<String, ResourceConfig> resourceConfigMap, ClusterConfig clusterConfig,
-      Map<String, LiveInstance> liveInstanceMap, Map<String, InstanceConfig> instanceConfigMap) {
-    // First, call the original refresh for contexts and configs
-    if (refresh(accessor, resourceConfigMap)) {
-      // Upon refresh success, re-instantiate AssignableInstanceManager from scratch
-      _assignableInstanceManager.buildAssignableInstances(clusterConfig, this, liveInstanceMap,
-          instanceConfigMap);
-      return true;
-    }
-    return false;
   }
 
   private void refreshJobContexts(HelixDataAccessor accessor) {


### PR DESCRIPTION
…update AssignableInstances

Previously, although AssignableInstanceManager provided an API for updating its AssignableInstances, this API was not being called at all. This RB fixes this.

Changelist:
1. Add a boolean flag in ClusterDataCache for LiveInstance, ClusterConfig, InstanceConfig changes
2. If the ClusterDataCache is a taskDataCache, call AssignableInstanceManager.updateAssignableInstances() when the said boolean flag is true
3. Use thread-safe map in AssignableInstanceManager
4. Address the issue of targeted tasks having null taskIds (use pName convention instead)
5. Address the issue of LiveInstanceChange not notifying the caches by explicitly using setLiveInstance() function
6. Fix bug in restoreTaskAssignResult where tasks with null quota type were not being restored properly