### PR TITLE
[TASK] Fix removeJob so its behavior is more consistent with removeWorkflow

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
@@ -662,26 +662,29 @@ public class TaskUtil {
     return expiredJobs;
   }
 
-  /* remove IS/EV, config and context of a job */
-  // Jobname is here should be NamespacedJobName.
+  /**
+   * Remove Job Config, IS/EV, and Context in order. Job name here must be a namespaced job name.
+   * @param accessor
+   * @param propertyStore
+   * @param job namespaced job name
+   * @return
+   */
   protected static boolean removeJob(HelixDataAccessor accessor, HelixPropertyStore propertyStore,
       String job) {
-    boolean success = true;
     if (!removeJobConfig(accessor, job)) {
       LOG.warn(String.format("Error occurred while trying to remove job config for %s.", job));
-      success = false;
+      return false;
     }
     if (!cleanupJobIdealStateExtView(accessor, job)) {
       LOG.warn(String.format(
           "Error occurred while trying to remove job idealstate/externalview for %s.", job));
-      success = false;
+      return false;
     }
     if (!removeJobContext(propertyStore, job)) {
       LOG.warn(String.format("Error occurred while trying to remove job context for %s.", job));
-      success = false;
+      return false;
     }
-
-    return success;
+    return true;
   }
 
   /** Remove the job name from the DAG from the queue configuration */


### PR DESCRIPTION
…oveWorkflow

Change the behavior of removeJob() so that it's more consistent with removeWorkflow(). This RB addresses the scenario: suppose config deletion failed (so config still exists) and context deletion succeeded. Then the Controller has no way of knowing whether this job has ever been scheduled or it was meant to be deleted (although failed due to partial deletion). Returning as soon as config deletion fails can prevent this scenario.

Changelist:
1. Make removeJob() return early as soon as a ZNode write failure is detected