### PR TITLE
bump ivy file versions and disable helix-front build

### DIFF
--- a/helix-admin-webapp/helix-admin-webapp-0.8.3-SNAPSHOT.ivy
+++ b/helix-admin-webapp/helix-admin-webapp-0.8.3-SNAPSHOT.ivy
@@ -20,7 +20,7 @@ under the License.
 <ivy-module version="1.0">
 	<info organisation="org.apache.helix"
 		module="helix-admin-webapp"
-		revision="0.8.2-SNAPSHOT"
+		revision="0.8.3-SNAPSHOT"
 		status="integration"
 		publication="20120315141623"
 	/>
@@ -43,7 +43,7 @@ under the License.
     <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.7.14" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)">
         <artifact name="slf4j-log4j12" ext="jar"/>
     </dependency>
-		<dependency org="org.apache.helix" name="helix-core" rev="0.8.2-SNAPSHOT" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="org.apache.helix" name="helix-core" rev="0.8.3-SNAPSHOT" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.restlet.jse" name="org.restlet" rev="2.2.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.8.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.8.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>

--- a/helix-agent/helix-agent-0.8.3-SNAPSHOT.ivy
+++ b/helix-agent/helix-agent-0.8.3-SNAPSHOT.ivy
@@ -21,7 +21,7 @@ under the License.
 <ivy-module version="2.0" xmlns:m="http://ant.apache.org/ivy/maven">
 	<info organisation="org.apache.helix"
 		module="helix-agent"
-		revision="0.8.2-SNAPSHOT"
+		revision="0.8.3-SNAPSHOT"
 		status="integration"
 		publication="20141020152553"
 	>
@@ -31,7 +31,7 @@ under the License.
 		<m:properties__osgi.export>org.apache.helix.agent*;version=&quot;${project.version};-noimport:=true</m:properties__osgi.export>
 		<m:properties__svnImpl>svn</m:properties__svnImpl>
 		<m:properties__scmSkipDeletedFiles>false</m:properties__scmSkipDeletedFiles>
-		<m:properties__currentRelease>0.8.2-SNAPSHOT</m:properties__currentRelease>
+		<m:properties__currentRelease>0.8.3-SNAPSHOT</m:properties__currentRelease>
 		<m:properties__osgi.import>
       org.apache.helix*,
       org.apache.commons.cli;version=&quot;[1.2,2)&quot;,
@@ -46,7 +46,7 @@ under the License.
 		<m:properties__distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</m:properties__distMgmtSnapshotsUrl>
 		<m:properties__SKIP_INTEGRATION_TESTS>true</m:properties__SKIP_INTEGRATION_TESTS>
 		<m:properties__gpg.useagent>true</m:properties__gpg.useagent>
-		<m:dependency.management__org.apache.helix__helix-core__version>0.8.2-SNAPSHOT</m:dependency.management__org.apache.helix__helix-core__version>
+		<m:dependency.management__org.apache.helix__helix-core__version>0.8.3-SNAPSHOT</m:dependency.management__org.apache.helix__helix-core__version>
 		<m:properties__project.build.sourceEncoding>UTF-8</m:properties__project.build.sourceEncoding>
 		<m:dependency.management__org.testng__testng__version>6.0.1</m:dependency.management__org.testng__testng__version>
 		<m:properties__helix.release.preparationGoals>clean install</m:properties__helix.release.preparationGoals>
@@ -77,12 +77,12 @@ under the License.
 		<artifact name="helix-agent" type="source" ext="jar" conf="sources" m:classifier="sources"/>
 	</publications>
 	<dependencies>
-		<dependency org="org.apache.helix" name="helix-core" rev="0.8.2-SNAPSHOT" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="org.apache.helix" name="helix-core" rev="0.8.3-SNAPSHOT" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.restlet.jse" name="org.restlet" rev="2.2.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.testng" name="testng" rev="6.0.1" force="true" conf="test->runtime(*),master(*)">
 			<exclude org="junit" module="junit" name="*" type="*" ext="*" conf="" matcher="exact"/>
 		</dependency>
-		<dependency org="org.apache.helix" name="helix-core" rev="0.8.2-SNAPSHOT" force="true" conf="test->runtime(*),master(*)">
+		<dependency org="org.apache.helix" name="helix-core" rev="0.8.3-SNAPSHOT" force="true" conf="test->runtime(*),master(*)">
 			<artifact name="helix-core" type="test-jar" ext="jar" conf="" m:classifier="tests"/>
 		</dependency>
     <dependency org="org.slf4j" name="slf4j-api" rev="1.7.25" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)">
@@ -92,7 +92,7 @@ under the License.
         <artifact name="slf4j-log4j12" ext="jar"/>
     </dependency>
 		<override org="org.mockito" module="mockito-all" matcher="exact" rev="1.9.5"/>
-		<override org="org.apache.helix" module="helix-core" matcher="exact" rev="0.8.2-SNAPSHOT"/>
+		<override org="org.apache.helix" module="helix-core" matcher="exact" rev="0.8.3-SNAPSHOT"/>
 		<override org="org.restlet.jse" module="org.restlet" matcher="exact" rev="2.2.1"/>
 		<override org="junit" module="junit" matcher="exact" rev="4.11"/>
 		<override org="org.testng" module="testng" matcher="exact" rev="6.0.1"/>

--- a/helix-core/helix-core-0.8.3-SNAPSHOT.ivy
+++ b/helix-core/helix-core-0.8.3-SNAPSHOT.ivy
@@ -20,7 +20,7 @@ under the License.
 <ivy-module version="1.0" xmlns:m="http://ant.apache.org/ivy/maven">
 	<info organisation="org.apache.helix"
 		module="helix-core"
-		revision="0.8.2-SNAPSHOT"
+		revision="0.8.3-SNAPSHOT"
 		status="release"
 		publication="2011111505113547"
 	>

--- a/helix-rest/helix-rest-0.8.3-SNAPSHOT.ivy
+++ b/helix-rest/helix-rest-0.8.3-SNAPSHOT.ivy
@@ -20,7 +20,7 @@ under the License.
 <ivy-module version="1.0">
 	<info organisation="org.apache.helix"
 		module="helix-rest"
-		revision="0.8.2-SNAPSHOT"
+		revision="0.8.3-SNAPSHOT"
 		status="integration"
 		publication="20170128141623"
 	/>
@@ -46,7 +46,7 @@ under the License.
     <dependency org="org.yaml" name="snakeyaml" rev="1.17">
         <artifact name="snakeyaml" m:classifier="sources" ext="jar"/>
     </dependency>
-		<dependency org="org.apache.helix" name="helix-core" rev="0.8.2-SNAPSHOT" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="org.apache.helix" name="helix-core" rev="0.8.3-SNAPSHOT" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.8.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.8.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@ under the License.
     <module>helix-admin-webapp</module>
     <module>helix-rest</module>
     <module>helix-agent</module>
-    <module>helix-front</module>
+    <!-- <module>helix-front</module> -->
     <module>recipes</module>
   </modules>
 


### PR DESCRIPTION
After releasing open source 0.8.2 stable release, we need to modify all ivy files to match the version specified in pom file in root directory. Also disabled helix-front build for dev simplicity.

Tested build and it worked.