### PR TITLE
[HELIX-752] Add missing shutdown for RoutingTableProvider

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
@@ -127,6 +127,7 @@ public class TestRoutingTableProvider extends ZkTestBase {
     _controller.syncStop();
     _routingTableProvider_default.shutdown();
     _routingTableProvider_ev.shutdown();
+    _routingTableProvider_cs.shutdown();
     _spectator.disconnect();
     deleteCluster(CLUSTER_NAME);
   }


### PR DESCRIPTION
Changelist:
1. Add a missing shutdown() call to avoid having a background thread keep printing out error messages