### PR TITLE
[HELIX-753] Record top state handoff finished in single cluster data cache refresh

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/AttributeName.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/AttributeName.java
@@ -37,5 +37,6 @@ public enum AttributeName {
   instanceName,
   eventData,
   AsyncFIFOWorkerPool,
-  PipelineType
+  PipelineType,
+  LastRebalanceFinishTimeStamp
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEvent.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEvent.java
@@ -93,11 +93,13 @@ public class ClusterEvent {
 
   @SuppressWarnings("unchecked")
   public <T extends Object> T getAttribute(String attrName) {
+    return getAttributeWithDefault(attrName, null);
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends Object> T getAttributeWithDefault(String attrName, T defaultVal) {
     Object ret = _eventAttributeMap.get(attrName);
-    if (ret != null) {
-      return (T) ret;
-    }
-    return null;
+    return ret == null ? defaultVal : (T) ret;
   }
 
   @Override

--- a/helix-core/src/test/resources/TestTopStateHandoffMetrics.json
+++ b/helix-core/src/test/resources/TestTopStateHandoffMetrics.json
@@ -254,5 +254,53 @@
       },
       "expectedDuration": "0"
     }
+  ],
+  "fast": [
+    {
+      "initialCurrentStates": {
+        "localhost_0": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "1000",
+          "EndTime": "2000"
+        },
+        "localhost_1": {
+          "CurrentState": "MASTER",
+          "PreviousState": "SLAVE",
+          "StartTime": "2500",
+          "EndTime": "5000"
+        },
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "1000",
+          "EndTime": "2000"
+        }
+      },
+      "MissingTopStates": {
+        "localhost_0": {
+          "CurrentState": "MASTER",
+          "PreviousState": "SLAVE",
+          "StartTime": "8000",
+          "EndTime": "9000"
+        },
+        "localhost_1": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": "6000",
+          "EndTime": "7000"
+        },
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": "1000",
+          "EndTime": "2000"
+        }
+      },
+      "handoffCurrentStates": {
+
+      },
+      "expectedDuration": "3000"
+    }
   ]
 }


### PR DESCRIPTION
This PR adds top state handoff reporting when a single pipeline refresh catches the entire handoff process, which we missed before. Here is the rough procedure:


- retrieve cached last top state instance for a partition
- retrieve current top state instance for a partition
- if there is no missing top state record of that partition, and top state instance changed, we record the number

Current top state end time is easy to find from current state in cluster data cache, for handoff start time, if we cannot find it, we use last pipeline run's end time for best guess. Detailed reason is explained in code comment.


Added test case to verify such top state handoff, and consolidated common part in TestTopStateHandoffMetrics for avoiding code replication