### PR TITLE
[HELIX-770] HELIX: Fix a possible NPE in loadBalance in IntermediateS…

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/StateModelDefinition.java
+++ b/helix-core/src/main/java/org/apache/helix/model/StateModelDefinition.java
@@ -70,7 +70,7 @@ public class StateModelDefinition extends HelixProperty {
 
   private final List<String> _stateTransitionPriorityList;
 
-  Map<String, Integer> _statesPriorityMap = new HashMap<String, Integer>();
+  private Map<String, Integer> _statesPriorityMap = new HashMap<>();
 
   /**
    * StateTransition which is used to find the nextState given StartState and
@@ -112,9 +112,17 @@ public class StateModelDefinition extends HelixProperty {
       }
     }
 
+    // add HelixDefinedStates to statesPriorityMap in case it hasn't been added already
+    for (HelixDefinedState state : HelixDefinedState.values()) {
+      if (!_statesPriorityMap.containsKey(state.name())) {
+        // Make it the lowest priority
+        _statesPriorityMap.put(state.name(), Integer.MAX_VALUE);
+      }
+    }
+
     // add transitions for helix-defined states
     for (HelixDefinedState state : HelixDefinedState.values()) {
-      if (!_statesPriorityList.contains(state.toString())) {
+      if (_statesPriorityList == null || !_statesPriorityList.contains(state.toString())) {
         _statesCountMap.put(state.toString(), "-1");
       }
     }


### PR DESCRIPTION
…tateCalcStage

In isLoadBalanceDownwardForAllReplicas() in IntermediateStateCalcStage, statePriorityMap was throwing a NPE because the partition contained a replica in ERROR state, and the map did not have an entry for it. To amend the issue, Venice added the ERROR state in the state model with a priority, and Helix added checks to prevent NPEs.
Changelist:
1. Add containsKey checks in isLoadBalanceDownwardForAllReplicas()
2. Make the Controller correctly log all partitions with ERROR state replicas
3. Add HelixDefinedStates in statePriorityList if not already added