### PR TITLE
[HELIX-775] add task driver support for helix rest to add/get task fr…

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -1029,6 +1029,41 @@ public class TaskDriver {
   }
 
   /**
+   * Return the full user content map for workflow
+   * @param workflowName workflow name
+   * @return user content map
+   */
+  public Map<String, String> getWorkflowUserContentMap(String workflowName) {
+    return TaskUtil.getWorkflowJobUserContentMap(_propertyStore, workflowName);
+  }
+
+  /**
+   * Return full user content map for job
+   * @param workflowName workflow name
+   * @param jobName Un-namespaced job name
+   * @return user content map
+   */
+  public Map<String, String> getJobUserContentMap(String workflowName, String jobName) {
+    String namespacedJobName = TaskUtil.getNamespacedJobName(workflowName, jobName);
+    return TaskUtil.getWorkflowJobUserContentMap(_propertyStore, namespacedJobName);
+  }
+
+  /**
+   * Return full user content map for task
+   * @param workflowName workflow name
+   * @param jobName Un-namespaced job name
+   * @param taskPartitionId task partition id
+   * @return user content map
+   */
+  public Map<String, String> getTaskContentMap(String workflowName, String jobName, String taskPartitionId) {
+    String namespacedJobName = TaskUtil.getNamespacedJobName(workflowName, jobName);
+    String namespacedTaskName = TaskUtil.getNamespacedTaskName(namespacedJobName, taskPartitionId);
+    return TaskUtil.getTaskUserContentMap(_propertyStore, namespacedJobName, namespacedTaskName);
+  }
+
+
+
+  /**
    * Set user content defined by the given key and string
    * @param key content key
    * @param value content value


### PR DESCRIPTION
…amework user content


consolidate user content related apis for task driver


To consolidate task driver user content related apis, and corresponding rest apis, I'm deprecating the general getUserContent() api, but instead, we now have the following apis for get / add / update user content.

```java
public void addOrUpdateWorkflowUserContentMap(String workflowName,
      final Map<String, String> contentToAddOrUpdate);

public void addOrUpdateJobUserContentMap(String workflowName, String jobName,
      final Map<String, String> contentToAddOrUpdate);

public void addOrUpdateTaskUserContentMap(String workflowName, String jobName,
      String taskPartitionId, final Map<String, String> contentToAddOrUpdate);


public Map<String, String> getWorkflowUserContentMap(String workflowName);


public Map<String, String> getJobUserContentMap(String workflowName, String jobName);

public Map<String, String> getTaskUserContentMap(String workflowName, String jobName,
      String taskPartitionId);
```

API for deleting user content is TBD but can use the same convension