### PR TITLE
[HELIX-779] do not clean list field in maintenance rebalancer for new resources

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
@@ -24,7 +24,12 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer {
     if (currentStateMap == null || currentStateMap.size() == 0) {
       LOG.warn(String
           .format("No new partition will be assigned for %s in maintenance mode", resourceName));
-      currentIdealState.setPreferenceLists(Collections.EMPTY_MAP);
+
+      // Clear all preference lists, if the resource has not yet been rebalanced,
+      // leave it as is
+      for (List<String> pList : currentIdealState.getPreferenceLists().values()) {
+        pList.clear();
+      }
       return currentIdealState;
     }
 


### PR DESCRIPTION
Setting list fields to empty map will prevent newly added and initially rebalanced resources during maintenance mode from getting re-balanced after cluster exists maintenance mode.
The right thing to do is to clear every preference list.


Also added test case to verify