### PR TITLE
[HELIX-785] Record helix latency instead of user latency in top state handoff metrics

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
@@ -287,13 +287,13 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
     }
 
     long duration = endTime - startTime;
-    long userLatency = fromTopStateUserLatency + toTopStateuserLatency;
+    long helixLatency = duration - fromTopStateUserLatency - toTopStateuserLatency;
     // We always treat such top state handoff as graceful as if top state handoff is triggered
     // by instance crash, we cannot observe the entire handoff process within 1 pipeline run
-    logMissingTopStateInfo(duration, userLatency, true, partition.getPartitionName());
+    logMissingTopStateInfo(duration, helixLatency, true, partition.getPartitionName());
     if (clusterStatusMonitor != null) {
       clusterStatusMonitor
-          .updateMissingTopStateDurationStats(resourceName, duration, userLatency, true, true);
+          .updateMissingTopStateDurationStats(resourceName, duration, helixLatency, true, true);
     }
   }
 
@@ -468,17 +468,17 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
 
     if (handOffStartTime > 0 && handOffEndTime - handOffStartTime <= threshold) {
       long duration = handOffEndTime - handOffStartTime;
-      long userLatency = fromTopStateUserLatency + toTopStateUserLatency;
+      long helixLatency = duration - fromTopStateUserLatency - toTopStateUserLatency;
       // It is possible that during controller leader switch, we lost previous master information
       // and use current time to approximate missing top state start time. If we see the actual
       // user latency is larger than the duration we estimated, we use user latency to start with
-      duration = Math.max(duration, userLatency);
+      duration = Math.max(duration, helixLatency);
       boolean isGraceful = record.isGracefulHandoff();
-      logMissingTopStateInfo(duration, userLatency, isGraceful, partition.getPartitionName());
+      logMissingTopStateInfo(duration, helixLatency, isGraceful, partition.getPartitionName());
 
       if (clusterStatusMonitor != null) {
         clusterStatusMonitor
-            .updateMissingTopStateDurationStats(resourceName, duration, userLatency, isGraceful,
+            .updateMissingTopStateDurationStats(resourceName, duration, helixLatency, isGraceful,
                 true);
       }
     }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -467,12 +467,12 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   }
 
   public synchronized void updateMissingTopStateDurationStats(String resourceName,
-      long totalDuration, long userLatency, boolean isGraceful, boolean succeeded) {
+      long totalDuration, long helixLatency, boolean isGraceful, boolean succeeded) {
     ResourceMonitor resourceMonitor = getOrCreateResourceMonitor(resourceName);
 
     if (resourceMonitor != null) {
       resourceMonitor.updateStateHandoffStats(ResourceMonitor.MonitorState.TOP_STATE, totalDuration,
-          userLatency, isGraceful, succeeded);
+          helixLatency, isGraceful, succeeded);
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -71,7 +71,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
 
   // Histograms
   private HistogramDynamicMetric _partitionTopStateHandoffDurationGauge;
-  private HistogramDynamicMetric _partitionTopStateHandoffUserLatencyGauge;
+  private HistogramDynamicMetric _partitionTopStateHandoffHelixLatencyGauge;
   private HistogramDynamicMetric _partitionTopStateNonGracefulHandoffDurationGauge;
 
   private SimpleDynamicMetric<String> _rebalanceState;
@@ -101,7 +101,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     attributeList.add(_failedTopStateHandoffCounter);
     attributeList.add(_maxSinglePartitionTopStateHandoffDuration);
     attributeList.add(_partitionTopStateHandoffDurationGauge);
-    attributeList.add(_partitionTopStateHandoffUserLatencyGauge);
+    attributeList.add(_partitionTopStateHandoffHelixLatencyGauge);
     attributeList.add(_partitionTopStateNonGracefulHandoffDurationGauge);
     attributeList.add(_totalMessageReceived);
     attributeList.add(_numPendingStateTransitions);
@@ -142,8 +142,8 @@ public class ResourceMonitor extends DynamicMBeanProvider {
         new HistogramDynamicMetric("PartitionTopStateHandoffDurationGauge", new Histogram(
             new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
 
-    _partitionTopStateHandoffUserLatencyGauge =
-        new HistogramDynamicMetric("PartitionTopStateHandoffUserLatencyGauge", new Histogram(
+    _partitionTopStateHandoffHelixLatencyGauge =
+        new HistogramDynamicMetric("PartitionTopStateHandoffHelixLatencyGauge", new Histogram(
             new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
     _partitionTopStateNonGracefulHandoffDurationGauge =
         new HistogramDynamicMetric("PartitionTopStateNonGracefulHandoffGauge", new Histogram(
@@ -202,8 +202,8 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     return _partitionTopStateNonGracefulHandoffDurationGauge;
   }
 
-  public HistogramDynamicMetric getPartitionTopStateHandoffUserLatencyGauge() {
-    return _partitionTopStateHandoffUserLatencyGauge;
+  public HistogramDynamicMetric getPartitionTopStateHandoffHelixLatencyGauge() {
+    return _partitionTopStateHandoffHelixLatencyGauge;
   }
 
   public long getFailedTopStateHandoffCounter() {
@@ -345,7 +345,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   }
 
   public void updateStateHandoffStats(MonitorState monitorState, long totalDuration,
-      long userLatency, boolean isGraceful, boolean succeeded) {
+      long helixLatency, boolean isGraceful, boolean succeeded) {
     switch (monitorState) {
     case TOP_STATE:
       if (succeeded) {
@@ -354,7 +354,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
             .updateValue(_successfulTopStateHandoffDurationCounter.getValue() + totalDuration);
         if (isGraceful) {
           _partitionTopStateHandoffDurationGauge.updateValue(totalDuration);
-          _partitionTopStateHandoffUserLatencyGauge.updateValue(userLatency);
+          _partitionTopStateHandoffHelixLatencyGauge.updateValue(helixLatency);
         } else {
           _partitionTopStateNonGracefulHandoffDurationGauge.updateValue(totalDuration);
         }

--- a/helix-core/src/test/resources/TestTopStateHandoffMetrics.json
+++ b/helix-core/src/test/resources/TestTopStateHandoffMetrics.json
@@ -62,7 +62,7 @@
         }
       },
       "Duration": 7000,
-      "UserLatency": 5000,
+      "HelixLatency": 2000,
       "IsGraceful": true
     },
     {
@@ -127,7 +127,7 @@
         }
       },
       "Duration": 14000,
-      "UserLatency": 4000,
+      "HelixLatency": 10000,
       "IsGraceful": true
     }
   ],
@@ -182,7 +182,7 @@
         }
       },
       "Duration": 7000,
-      "UserLatency": 5000,
+      "HelixLatency": 2000,
       "IsGraceful": false
     }
   ],
@@ -249,7 +249,7 @@
         }
       },
       "Duration": 0,
-      "UserLatency": 0,
+      "HelixLatency": 0,
       "IsGraceful": false
     },
     {
@@ -314,7 +314,7 @@
         }
       },
       "Duration": 0,
-      "UserLatency": 0,
+      "HelixLatency": 0,
       "IsGraceful": false
     }
   ],
@@ -364,7 +364,7 @@
 
       },
       "Duration": 3000,
-      "UserLatency": 2000,
+      "HelixLatency": 1000,
       "IsGraceful": true
     }
   ]


### PR DESCRIPTION
- top state handoff reports helix latency instead of user latency
- modified test cases