### PR TITLE
Implement view cluster aggregator

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -51,15 +51,15 @@ public interface HelixAdmin {
   InstanceConfig getInstanceConfig(String clusterName, String instanceName);
 
   /**
-   +   * Set the instance config of an existing instance under the given cluster.
-   +   *
-   +   * @param clusterName    the name of the cluster to which this instance belongs.
-   +   * @param instanceName   the name of this instance.
-   +   * @param instanceConfig the new {@link InstanceConfig} that will replace the current one
-   +   *                       associated with this instance.
-   +   *
-   +   * @return true if the operation was successful; false otherwise.
-   +   */
+   * Set the instance config of an existing instance under the given cluster.
+   *
+   * @param clusterName    the name of the cluster to which this instance belongs.
+   * @param instanceName   the name of this instance.
+   * @param instanceConfig the new {@link InstanceConfig} that will replace the current one
+   *                       associated with this instance.
+   *
+   * @return true if the operation was successful; false otherwise.
+   */
   boolean setInstanceConfig(String clusterName, String instanceName, InstanceConfig instanceConfig);
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/api/config/ViewClusterSourceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/api/config/ViewClusterSourceConfig.java
@@ -1,0 +1,118 @@
+package org.apache.helix.api.config;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.helix.PropertyType;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.ObjectMapper;
+
+/**
+ * Represents source physical cluster information for view cluster
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ViewClusterSourceConfig {
+  private static final List<PropertyType> _validPropertyTypes = Collections.unmodifiableList(
+      Arrays.asList(PropertyType.INSTANCES, PropertyType.EXTERNALVIEW, PropertyType.LIVEINSTANCES));
+  private static final ObjectMapper _objectMapper = new ObjectMapper();
+
+  private final String _name;
+  private final String _zkAddress;
+  private List<PropertyType> _properties;
+
+  @JsonCreator
+  public ViewClusterSourceConfig(
+      @JsonProperty("name") String name,
+      @JsonProperty("zkAddress") String zkAddress,
+      @JsonProperty("properties") List<PropertyType> properties
+  ) {
+    _name = name;
+    _zkAddress = zkAddress;
+    _properties = properties;
+  }
+
+  public ViewClusterSourceConfig(ViewClusterSourceConfig config) {
+    this(config.getName(), config.getZkAddress(), new ArrayList<>(config.getProperties()));
+  }
+
+  public void setProperties(List<PropertyType> properties) {
+    for (PropertyType p : properties) {
+      if (!_validPropertyTypes.contains(p)) {
+        throw new IllegalArgumentException(
+            String.format("Property %s is not support in ViewCluster yet.", p));
+      }
+    }
+    _properties = properties;
+  }
+
+  public String getName() {
+    return _name;
+  }
+
+  public String getZkAddress() {
+    return _zkAddress;
+  }
+
+  public List<PropertyType> getProperties() {
+    return _properties;
+  }
+
+  @JsonIgnore
+  public static List<PropertyType> getValidPropertyTypes() {
+    return _validPropertyTypes;
+  }
+
+  public String toJson() throws IOException {
+    return _objectMapper.writeValueAsString(this);
+  }
+
+  public String toString() {
+    return String.format("name=%s; zkAddr=%s; properties=%s", _name, _zkAddress, _properties);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == null || !(other instanceof ViewClusterSourceConfig)) {
+      return false;
+    }
+    ViewClusterSourceConfig otherConfig = (ViewClusterSourceConfig) other;
+
+    return _name.equals(otherConfig.getName()) && _zkAddress.equals(otherConfig.getZkAddress())
+        && _properties.containsAll(otherConfig.getProperties()) && otherConfig.getProperties()
+        .containsAll(_properties);
+
+  }
+
+  public static ViewClusterSourceConfig fromJson(String jsonString) {
+    try {
+      return _objectMapper.readValue(jsonString, ViewClusterSourceConfig.class);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          String.format("Invalid Json: %s, Exception: %s", jsonString, e.toString()));
+    }
+  }
+}

--- a/helix-view-aggregator/LICENSE
+++ b/helix-view-aggregator/LICENSE
@@ -1,0 +1,273 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
+For xstream:
+
+Copyright (c) 2003-2006, Joe Walnes
+Copyright (c) 2006-2009, 2011 XStream Committers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of
+conditions and the following disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of XStream nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+for jline:
+
+Copyright (c) 2002-2006, Marc Prud'hommeaux <mwp1@cornell.edu>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with
+the distribution.
+
+Neither the name of JLine nor the names of its contributors
+may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+

--- a/helix-view-aggregator/NOTICE
+++ b/helix-view-aggregator/NOTICE
@@ -1,0 +1,37 @@
+Apache Helix
+Copyright 2014 The Apache Software Foundation
+
+
+I. Included Software
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+Licensed under the Apache License 2.0.
+
+This product includes software developed at
+Codehaus (http://www.codehaus.org/).
+Licensed under the BSD License.
+
+This product includes software developed at
+jline (http://jline.sourceforge.net/).
+Licensed under the BSD License.
+
+This product includes software developed at
+restlet (http://www.restlet.org/about/legal).
+Licensed under the Apache License 2.0.
+
+This product includes software developed at
+Google (http://www.google.com/).
+Licensed under the Apache License 2.0.
+
+This product includes software developed at
+snakeyaml (http://www.snakeyaml.org/).
+Licensed under the Apache License 2.0.
+
+This product includes software developed at
+zkclient (https://github.com/sgroschupf/zkclient).
+Licensed under the Apache License 2.0.
+
+II. License Summary
+- Apache License 2.0
+- BSD License

--- a/helix-view-aggregator/helix-view-aggregator-0.8.1-SNAPSHOT.ivy
+++ b/helix-view-aggregator/helix-view-aggregator-0.8.1-SNAPSHOT.ivy
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<ivy-module version="1.0">
+	<info organisation="org.apache.helix"
+		module="helix-view-aggregator"
+		revision="0.8.1-SNAPSHOT"
+		status="integration"
+		publication="20170128141623"
+	/>
+	<configurations>
+		<conf name="default" visibility="public" description="runtime dependencies and master artifact can be used with this conf" extends="runtime,master"/>
+		<conf name="master" visibility="public" description="contains only the artifact published by this module itself, with no transitive dependencies"/>
+		<conf name="compile" visibility="public" description="this is the default scope, used if none is specified. Compile dependencies are available in all classpaths."/>
+		<conf name="provided" visibility="public" description="this is much like compile, but indicates you expect the JDK or a container to provide it. It is only available on the compilation classpath, and is not transitive."/>
+		<conf name="runtime" visibility="public" description="this scope indicates that the dependency is not required for compilation, but is for execution. It is in the runtime and test classpaths, but not the compile classpath." extends="compile"/>
+		<conf name="test" visibility="private" description="this scope indicates that the dependency is not required for normal use of the application, and is only available for the test compilation and execution phases."/>
+		<conf name="system" visibility="public" description="this scope is similar to provided except that you have to provide the JAR which contains it explicitly. The artifact is always available and is not looked up in a repository."/>
+	</configurations>
+	<publications>
+		<artifact name="helix-view-aggregator" type="jar" ext="jar" conf="master"/>
+	</publications>
+	<dependencies>
+	  <dependency org="org.slf4j" name="slf4j-api" rev="1.7.25" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)">
+        <artifact name="slf4j-api" ext="jar"/>
+    </dependency>
+    <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.7.14" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)">
+        <artifact name="slf4j-log4j12" ext="jar"/>
+    </dependency>
+		<dependency org="org.apache.helix" name="helix-core" rev="0.8.0-SNAPSHOT" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.8.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.8.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="commons-cli" name="commons-cli" rev="1.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="io.dropwizard.metrics" name="metrics-core" rev="3.2.3" conf="compile->compile(default);runtime->runtime(default);default->default"/>
+	</dependencies>
+</ivy-module>

--- a/helix-view-aggregator/pom.xml
+++ b/helix-view-aggregator/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.apache.helix</groupId>
+    <artifactId>helix</artifactId>
+    <version>0.8.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>helix-view-aggregator</artifactId>
+  <packaging>bundle</packaging>
+  <name>Apache Helix :: View Aggregator</name>
+
+  <properties>
+    <osgi.import>
+      org.apache.helix*,
+      org.codehaus.jackson*,
+      org.apache.commons.cli*,
+      org.slf4j*;version="[1.6,2)",
+      *
+    </osgi.import>
+    <osgi.export>org.apache.helix.view*;version="${project.version};-noimport:=true</osgi.export>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>3.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.14</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.helix</groupId>
+      <artifactId>helix-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <version>1.8.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>1.8.5</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.helix</groupId>
+      <artifactId>helix-core</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <resources>
+      <resource>
+        <directory>${basedir}</directory>
+        <includes>
+          <include>DISCLAIMER</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>appassembler-maven-plugin</artifactId>
+        <configuration>
+          <platforms>
+            <platform>windows</platform>
+            <platform>unix</platform>
+          </platforms>
+          <programs>
+            <program>
+              <mainClass>org.apache.helix.view.aggregator.HelixViewAggregatorMain</mainClass>
+              <name>run-view-aggregator</name>
+            </program>
+          </programs>
+        </configuration>
+
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptors>
+            <descriptor>src/assemble/assembly.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/helix-view-aggregator/src/assemble/assembly.xml
+++ b/helix-view-aggregator/src/assemble/assembly.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly>
+  <id>pkg</id>
+  <formats>
+    <format>tar</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>target/helix-view-aggregator-pkg/bin</directory>
+      <outputDirectory>bin</outputDirectory>
+      <lineEnding>unix</lineEnding>
+      <fileMode>0755</fileMode>
+      <directoryMode>0755</directoryMode>
+    </fileSet>
+    <fileSet>
+      <directory>target/helix-view-aggregator-pkg/repo/</directory>
+      <outputDirectory>repo</outputDirectory>
+      <fileMode>0755</fileMode>
+      <directoryMode>0755</directoryMode>
+      <excludes>
+        <exclude>**/*.xml</exclude>
+      </excludes>
+    </fileSet>
+   <fileSet>
+      <directory>target/helix-view-aggregator-pkg/conf</directory>
+      <outputDirectory>conf</outputDirectory>
+      <lineEnding>unix</lineEnding>
+      <fileMode>0755</fileMode>
+      <directoryMode>0755</directoryMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>LICENSE</include>
+        <include>NOTICE</include>
+        <include>DISCLAIMER</include>
+      </includes>
+      <fileMode>0755</fileMode>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/helix-view-aggregator/src/main/config/log4j.properties
+++ b/helix-view-aggregator/src/main/config/log4j.properties
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=WARN,A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+
+log4j.logger.org.I0Itec=ERROR
+log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.org.apache.helix=INFO

--- a/helix-view-aggregator/src/main/java/org/apache/helix/view/aggregator/HelixViewAggregator.java
+++ b/helix-view-aggregator/src/main/java/org/apache/helix/view/aggregator/HelixViewAggregator.java
@@ -1,0 +1,401 @@
+package org.apache.helix.view.aggregator;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.I0Itec.zkclient.exception.ZkInterruptedException;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixException;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.PropertyType;
+import org.apache.helix.api.config.ViewClusterSourceConfig;
+import org.apache.helix.api.listeners.ClusterConfigChangeListener;
+import org.apache.helix.api.listeners.PreFetch;
+import org.apache.helix.common.DedupEventProcessor;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.view.common.ClusterViewEvent;
+import org.apache.helix.view.dataprovider.SourceClusterDataProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Main logic for Helix view aggregator
+ */
+public class HelixViewAggregator implements ClusterConfigChangeListener {
+  private static final Logger logger = LoggerFactory.getLogger(HelixViewAggregator.class);
+  private static final long DEFAULT_INITIAL_EVENT_PROCESS_BACKOFF = 10;
+  private static final long DEFAULT_MAX_EVENT_PROCESS_BACKOFF = 5 * 1000;
+  private final String _viewClusterName;
+  private final HelixManager _viewClusterManager;
+  private final Map<String, SourceClusterDataProvider> _dataProviderMap;
+  private HelixDataAccessor _dataAccessor;
+
+  // Worker that processes source cluster events and refresh view cluster
+  private DedupEventProcessor<ClusterViewEvent.Type, ClusterViewEvent> _aggregator;
+  private AtomicBoolean _refreshViewCluster;
+
+  // Worker that processes view cluster config change
+  private DedupEventProcessor<ClusterViewEvent.Type, ClusterViewEvent> _viewConfigProcessor;
+
+  private ClusterConfig _curViewClusterConfig;
+  private Timer _viewClusterRefreshTimer;
+  private ViewClusterRefresher _viewClusterRefresher;
+
+  public HelixViewAggregator(String viewClusterName, String zkAddr) {
+    _viewClusterName = viewClusterName;
+    _dataProviderMap = new ConcurrentHashMap<>();
+    _viewClusterManager = HelixManagerFactory
+        .getZKHelixManager(_viewClusterName, generateHelixManagerInstanceName(_viewClusterName),
+            InstanceType.SPECTATOR, zkAddr);
+    _refreshViewCluster = new AtomicBoolean(false);
+    _aggregator = new DedupEventProcessor<ClusterViewEvent.Type, ClusterViewEvent>(_viewClusterName,
+        "Aggregator") {
+      @Override
+      public void handleEvent(ClusterViewEvent event) {
+        handleSourceClusterEvent(event);
+      }
+    };
+
+    _viewConfigProcessor = new DedupEventProcessor<ClusterViewEvent.Type, ClusterViewEvent>(_viewClusterName, "ViewConfigProcessor") {
+      @Override
+      public void handleEvent(ClusterViewEvent event) {
+        handleViewClusterConfigChange(event);
+      }
+    };
+  }
+
+  public String getAggregatorInstanceName() {
+    return String
+        .format("%s::%s", _viewClusterManager.getInstanceName(), hashCode());
+  }
+
+  /**
+   * Start controller main logic
+   * @throws Exception when HelixViewAggregator fails to start. Will try to shut it down before
+   *                   exception is thrown out
+   */
+  public void start() throws Exception {
+    // Start workers
+    _aggregator.start();
+    _viewConfigProcessor.start();
+
+    // Setup manager
+    try {
+      _viewClusterManager.connect();
+      _dataAccessor = _viewClusterManager.getHelixDataAccessor();
+      _viewClusterManager.addClusterfigChangeListener(this);
+    } catch (Exception e) {
+      shutdown();
+      throw new HelixException("Failed to connect view cluster helix manager", e);
+    }
+
+    // Set up view cluster refresher
+    _viewClusterRefresher =
+        new ViewClusterRefresher(_viewClusterName, _viewClusterManager.getHelixDataAccessor());
+  }
+
+  public void shutdown() {
+    boolean success = true;
+
+    // Stop all workers
+    _aggregator.interrupt();
+    _viewConfigProcessor.interrupt();
+
+    // Stop timer
+    if (_viewClusterRefreshTimer != null) {
+      logger.info("Shutting down view cluster refresh timer");
+      _viewClusterRefreshTimer.cancel();
+    }
+
+    // disconnect manager
+    if (_viewClusterManager != null && _viewClusterManager.isConnected()) {
+      logger.info("Shutting down view cluster helix manager");
+      try {
+        _viewClusterManager.disconnect();
+      } catch (ZkInterruptedException zkintr) {
+        logger.warn("ZK interrupted when disconnecting helix manager", zkintr);
+      } catch (Exception e) {
+        success = false;
+        logger.error(String
+            .format("Failed to disconnect helix manager for view cluster %s", _viewClusterName), e);
+      }
+    }
+
+    // Clean up all data providers
+    for (SourceClusterDataProvider provider : _dataProviderMap.values()) {
+      logger
+          .info(String.format("Shutting down data provider for source cluster %s", provider.getName()));
+      try {
+        provider.shutdown();
+      } catch (Exception e) {
+        success = false;
+        logger.error(String
+            .format("Failed to shutdown data provider %s for view cluster %s", provider.getName(),
+                _viewClusterName), e);
+      }
+    }
+
+    logger.info("HelixViewAggregator shutdown " + (success ? "cleanly" : "with error"));
+  }
+
+  @Override
+  @PreFetch(enabled = false)
+  public void onClusterConfigChange(ClusterConfig clusterConfig, NotificationContext context) {
+    if (context != null && context.getType() != NotificationContext.Type.FINALIZE) {
+      _viewConfigProcessor.queueEvent(ClusterViewEvent.Type.ConfigChange,
+          new ClusterViewEvent(_viewClusterName, ClusterViewEvent.Type.ConfigChange));
+    } else {
+      logger.info(String
+          .format("Skip processing view cluster config change with notification context type %s",
+              context == null ? "NoContext" : context.getType().name()));
+    }
+  }
+
+  private void handleSourceClusterEvent(ClusterViewEvent event) {
+    logger.info(String
+        .format("Processing event %s from source cluster %s.", event.getEventType().name(),
+            event.getClusterName()));
+    switch (event.getEventType()) {
+    case ExternalViewChange:
+    case InstanceConfigChange:
+    case LiveInstanceChange:
+      _refreshViewCluster.set(true);
+      break;
+    case PeriodicViewRefresh:
+      if (!_refreshViewCluster.get()) {
+        logger.info("Skip refresh: No event happened since last refresh, and no force refresh.");
+        return;
+      }
+      // mark source cluster as changed to trigger next refresh as we failed to refresh at
+      // least some of the elements in view cluster
+      logger.info("Refreshing cluster based on event " + event.getEventType().name());
+      refreshViewCluster();
+      break;
+    default:
+      logger.error(String.format("Unrecognized event type: %s", event.getEventType()));
+    }
+  }
+
+  private void handleViewClusterConfigChange(ClusterViewEvent event) {
+    logger.info(String
+        .format("Processing event %s for view cluster %s", event.getEventType().name(),
+            _viewClusterName));
+    switch (event.getEventType()) {
+    case ConfigChange:
+      // TODO: when DedupEventProcessor supports delayed scheduling,
+      // we should not have this head-of-line blocking but to have DedupEventProcessor do the work.
+      // Currently it's acceptable as we can endure delay in processing view cluster config change
+      try {
+        Thread.sleep(event.getEventProcessBackoff());
+      } catch (InterruptedException e) {
+        logger.warn("Interrupted when backing off during process view config change retry", e);
+        Thread.currentThread().interrupt();
+      }
+
+      // We always compare current cluster config with most up-to-date cluster config
+      boolean success;
+      ClusterConfig newClusterConfig =
+          _dataAccessor.getProperty(_dataAccessor.keyBuilder().clusterConfig());
+
+      if (newClusterConfig == null) {
+        logger.warn("Failed to read view cluster config");
+        success = false;
+      } else {
+        SourceClusterConfigChangeAction action =
+            new SourceClusterConfigChangeAction(_curViewClusterConfig, newClusterConfig);
+        action.computeAction();
+        success = processViewClusterConfigUpdate(action);
+      }
+
+      // If we fail to process action and should retry, re-queue event to retry
+      if (!success) {
+        long backoff = computeNextEventProcessBackoff(event.getEventProcessBackoff());
+        logger.info("Failed to process view cluster config change. Will retry in {} ms", backoff);
+        event.setEventProcessBackoff(backoff);
+        _viewConfigProcessor.queueEvent(event.getEventType(), event);
+      } else {
+        _curViewClusterConfig = newClusterConfig;
+      }
+      break;
+    default:
+      logger.error(String.format("Unrecognized event type: %s", event.getEventType()));
+    }
+  }
+
+  private long computeNextEventProcessBackoff(long currentBackoff) {
+    if (currentBackoff <= 0) {
+      return DEFAULT_INITIAL_EVENT_PROCESS_BACKOFF;
+    }
+
+    // Exponential backoff with ceiling
+    return currentBackoff * 2 > DEFAULT_MAX_EVENT_PROCESS_BACKOFF
+        ? DEFAULT_MAX_EVENT_PROCESS_BACKOFF
+        : currentBackoff * 2;
+  }
+
+  private class RefreshViewClusterTask extends TimerTask {
+    @Override
+    public void run() {
+      logger.info("Triggering view cluster refresh");
+      _aggregator.queueEvent(ClusterViewEvent.Type.PeriodicViewRefresh,
+          new ClusterViewEvent(_viewClusterName, ClusterViewEvent.Type.PeriodicViewRefresh));
+    }
+  }
+
+  /**
+   * Recreate timer that triggers RefreshViewClusterTask
+   */
+  private void resetTimer(long triggerIntervalMs) {
+    if (_viewClusterRefreshTimer != null) {
+      _viewClusterRefreshTimer.cancel();
+    }
+    RefreshViewClusterTask refreshTrigger = new RefreshViewClusterTask();
+    _viewClusterRefreshTimer = new Timer(true);
+    _viewClusterRefreshTimer.scheduleAtFixedRate(refreshTrigger, 0, triggerIntervalMs);
+  }
+
+  /**
+   * Use SourceClusterConfigChangeAction to reset timer (RefreshViewClusterTask),
+   * create/delete SourceClusterDataProvider in data provider map
+   *
+   * @return true if success else false
+   */
+  private boolean processViewClusterConfigUpdate(SourceClusterConfigChangeAction action) {
+    boolean success = true;
+    for (ViewClusterSourceConfig source : action.getConfigsToDelete()) {
+      String key = generateDataProviderMapKey(source);
+      logger.info("Deleting data provider " + key);
+      if (_dataProviderMap.containsKey(key)) {
+        try {
+          _dataProviderMap.get(key).shutdown();
+          synchronized (_dataProviderMap) {
+            _dataProviderMap.remove(key);
+            // upon successful removal of data provider, set refresh view cluster to true
+            // or if no event from source cluster happened before next refresh cycle, this
+            // removal will be missed.
+            _refreshViewCluster.set(true);
+          }
+        } catch (Exception e) {
+          success = false;
+          logger.warn(String.format("Failed to shutdown data provider %s, will retry", key));
+        }
+      }
+    }
+
+    for (ViewClusterSourceConfig source : action.getConfigsToAdd()) {
+      String key = generateDataProviderMapKey(source);
+      logger.info("Creating data provider " + key);
+      if (_dataProviderMap.containsKey(key)) {
+        // possibly due to a previous failure of shutting down, print warning and recreate for now
+        logger.warn(String.format("Add data provider %s which already exists. Recreating", key));
+        _dataProviderMap.remove(key);
+      }
+
+      try {
+        SourceClusterDataProvider provider = new SourceClusterDataProvider(source, _aggregator);
+        provider.setup();
+        _dataProviderMap.put(key, provider);
+      } catch (Exception e) {
+        success = false;
+        logger.warn(String.format("Failed to create data provider %s, will retry", key));
+      }
+    }
+
+
+    if (action.shouldResetTimer()) {
+      logger.info(
+          "Resetting view cluster refresh timer at interval " + action.getCurrentRefreshPeriodMs());
+      resetTimer(action.getCurrentRefreshPeriodMs());
+    }
+    return success;
+  }
+
+  /**
+   * Use ViewClusterRefresher to refresh ViewCluster.
+   */
+  private void refreshViewCluster() {
+    long startRefreshMs = System.currentTimeMillis();
+    logger.info(String.format("START RefreshViewCluster: Refresh view cluster %s at timestamp %s",
+        _viewClusterName, startRefreshMs));
+    boolean dataProviderFailure = false;
+
+    // Generate a view of providers so refresh won't block cluster config update
+    // When a data provider is shutdown while we are reloading cache / generating diff,
+    // Exception will be thrown out and we retry during next refresh cycle
+    Set<SourceClusterDataProvider> providerView;
+    synchronized (_dataProviderMap) {
+      _refreshViewCluster.set(false);
+      providerView = new HashSet<>(_dataProviderMap.values());
+    }
+
+    // Refresh data providers
+    // TODO: the following steps can be parallelized
+    for (SourceClusterDataProvider provider : providerView) {
+      try {
+        provider.refreshCache();
+      } catch (Exception e) {
+        logger.warn("Caught exception when refreshing source cluster cache. Abort refresh.", e);
+        _refreshViewCluster.set(true);
+        dataProviderFailure = true;
+
+        // Skip refresh view cluster when we cannot successfully refresh
+        // source cluster caches
+        break;
+      }
+    }
+
+    // Refresh properties in view cluster
+    if (!dataProviderFailure) {
+      _viewClusterRefresher.updateProviderView(providerView);
+      for (PropertyType propertyType : ViewClusterSourceConfig.getValidPropertyTypes()) {
+        logger.info(String
+            .format("Refreshing property %s in view cluster %s", propertyType, _viewClusterName));
+        try {
+          // We try to refresh all properties with best effort, and don't break when
+          // failed to refresh a particular property
+          if (!_viewClusterRefresher.refreshPropertiesInViewCluster(propertyType)) {
+            _refreshViewCluster.set(true);
+          }
+        } catch (IllegalArgumentException e) {
+          // Invalid property... not expected! Something wrong with code, should not retry
+          logger.error(String.format("Failed to refresh property in view cluster %s with exception",
+              _viewClusterName), e);
+        }
+      }
+    }
+  }
+
+  private static String generateHelixManagerInstanceName(String viewClusterName) {
+    return String.format("HelixViewAggregator-%s", viewClusterName);
+  }
+
+  private static String generateDataProviderMapKey(ViewClusterSourceConfig config) {
+    return String.format("%s-%s", config.getName(), config.getZkAddress());
+  }
+}

--- a/helix-view-aggregator/src/main/java/org/apache/helix/view/aggregator/HelixViewAggregatorMain.java
+++ b/helix-view-aggregator/src/main/java/org/apache/helix/view/aggregator/HelixViewAggregatorMain.java
@@ -1,0 +1,122 @@
+package org.apache.helix.view.aggregator;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.logging.Level;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HelixViewAggregatorMain {
+  private static Logger logger = LoggerFactory.getLogger(HelixViewAggregatorMain.class);
+  private static final String HELP = "help";
+  private static final String ZK_ADDR = "zookeeper-address";
+  private static final String VIEW_CLUSTER_NAME = "view-cluster-name";
+
+  private static void printUsage(Options cliOptions) {
+    HelpFormatter helpFormatter = new HelpFormatter();
+    helpFormatter.printHelp("java " + HelixViewAggregatorMain.class.getName(), cliOptions);
+  }
+
+  private static Options constructCommandLineOptions() {
+    Option helpOption =
+        OptionBuilder.withLongOpt(HELP).withDescription("Prints command-line options info")
+            .create();
+    helpOption.setArgs(0);
+    helpOption.setRequired(false);
+    helpOption.setArgName("print help message");
+
+    Option zkServerOption =
+        OptionBuilder.withLongOpt(ZK_ADDR).withDescription("Provide zookeeper address")
+            .create();
+    zkServerOption.setArgs(1);
+    zkServerOption.setRequired(true);
+    zkServerOption.setArgName("ZooKeeper server connection string (Required)");
+
+    Option portOption =
+        OptionBuilder.withLongOpt(VIEW_CLUSTER_NAME).withDescription("Name of the view cluster")
+            .create();
+    portOption.setArgs(1);
+    portOption.setRequired(true);
+    portOption.setArgName("Name of the view cluster");
+
+    Options options = new Options();
+    options.addOption(helpOption);
+    options.addOption(zkServerOption);
+    options.addOption(portOption);
+
+    return options;
+  }
+  /**
+   * @param args
+   * @throws Exception
+   */
+  public static void main(String[] args) throws Exception {
+    java.util.logging.Logger topJavaLogger = java.util.logging.Logger.getLogger("");
+    topJavaLogger.setLevel(Level.INFO);
+    CommandLineParser cliParser = new GnuParser();
+    Options cliOptions = constructCommandLineOptions();
+    CommandLine cmd = null;
+
+    try {
+      cmd = cliParser.parse(cliOptions, args);
+    } catch (ParseException pe) {
+      logger.error("HelixViewAggregatorMain: failed to parse command-line options.", pe);
+      printUsage(cliOptions);
+      System.exit(1);
+    }
+
+    String zkAddr, viewClusterName;
+    if (cmd.hasOption(HELP)) {
+      printUsage(cliOptions);
+      return;
+    } else {
+      zkAddr = String.valueOf(cmd.getOptionValue(ZK_ADDR));
+      viewClusterName = String.valueOf(cmd.getOptionValue(VIEW_CLUSTER_NAME));
+    }
+
+    final HelixViewAggregator aggregator = new HelixViewAggregator(viewClusterName, zkAddr);
+    Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+      @Override
+      public void run() {
+        aggregator.shutdown();
+      }
+    }));
+
+    try {
+      aggregator.start();
+      Thread.currentThread().join();
+    } catch (Exception e) {
+      logger.error("HelixViewAggregator caught exception.", e);
+    } finally {
+      aggregator.shutdown();
+    }
+
+    // Service should not exit successfully
+    System.exit(1);
+  }
+}

--- a/helix-view-aggregator/src/main/java/org/apache/helix/view/aggregator/SourceClusterConfigChangeAction.java
+++ b/helix-view-aggregator/src/main/java/org/apache/helix/view/aggregator/SourceClusterConfigChangeAction.java
@@ -1,0 +1,140 @@
+package org.apache.helix.view.aggregator;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.PropertyType;
+import org.apache.helix.api.config.ViewClusterSourceConfig;
+import org.apache.helix.model.ClusterConfig;
+
+/**
+ * This class takes an existing list of source cluster configs and generate lists of source
+ * cluster configs to add / delete / modify, and tell caller if ViewClusterRefreshTimer should
+ * be reset or not
+ */
+public class SourceClusterConfigChangeAction {
+  private ClusterConfig _oldConfig;
+  private ClusterConfig _newConfig;
+
+  private boolean _shouldResetTimer;
+  private List<ViewClusterSourceConfig> _toAdd;
+  private List<ViewClusterSourceConfig> _toDelete;
+
+  public SourceClusterConfigChangeAction(ClusterConfig oldConfig, ClusterConfig newConfig) {
+    _oldConfig = oldConfig;
+    _newConfig = newConfig;
+    _shouldResetTimer = false;
+    _toAdd = new ArrayList<>();
+    _toDelete = new ArrayList<>();
+    validate();
+  }
+
+  private void validate() {
+    StringBuilder allErrs = new StringBuilder();
+    if (_newConfig == null) {
+      allErrs.append("New config is null;");
+    }
+    if (_oldConfig != null && !_oldConfig.isViewCluster()) {
+      allErrs.append("Old config is not view cluster config;");
+    }
+    if (_newConfig != null && !_newConfig.isViewCluster()) {
+      allErrs.append("New config is not view cluster config;");
+    }
+    if (allErrs.length() > 0) {
+      throw new IllegalArgumentException(allErrs.toString());
+    }
+  }
+
+  /**
+   * Compute actions and generate toAdd, toDelete toModify, and refreshPeriodChanged.
+   */
+  public void computeAction() {
+    _shouldResetTimer = _oldConfig == null || _oldConfig.getViewClusterRefershPeriod() != _newConfig
+        .getViewClusterRefershPeriod();
+
+    Map<String, ViewClusterSourceConfig> oldConfigMap = new HashMap<>();
+    Map<String, ViewClusterSourceConfig> currentConfigMap = new HashMap<>();
+
+    if (_oldConfig != null) {
+      for (ViewClusterSourceConfig oldConfig : _oldConfig.getViewClusterSourceConfigs()) {
+        oldConfigMap
+            .put(generateConfigMapKey(oldConfig.getName(), oldConfig.getZkAddress()), oldConfig);
+      }
+    }
+
+    for (ViewClusterSourceConfig currentConfig : _newConfig.getViewClusterSourceConfigs()) {
+      currentConfigMap
+          .put(generateConfigMapKey(currentConfig.getName(), currentConfig.getZkAddress()),
+              currentConfig);
+    }
+
+    // Configs whose properties-to-aggregate got modified should have its data provider recreated
+    for (Map.Entry<String, ViewClusterSourceConfig> entry : currentConfigMap.entrySet()) {
+      if (oldConfigMap.containsKey(entry.getKey())) {
+        Set<PropertyType> oldPropertySet =
+            new HashSet<>(oldConfigMap.get(entry.getKey()).getProperties());
+        Set<PropertyType> currentPropertySet = new HashSet<>(entry.getValue().getProperties());
+        if (!oldPropertySet.equals(currentPropertySet)) {
+          _toAdd.add(new ViewClusterSourceConfig(entry.getValue()));
+          _toDelete.add(new ViewClusterSourceConfig(oldConfigMap.get(entry.getKey())));
+        }
+      }
+    }
+
+    // Generate toDelete. Use deep copy to avoid race conditions
+    Set<String> removedKeys = new HashSet<>(oldConfigMap.keySet());
+    removedKeys.removeAll(currentConfigMap.keySet());
+    for (String removedKey : removedKeys) {
+      _toDelete.add(new ViewClusterSourceConfig(oldConfigMap.get(removedKey)));
+    }
+
+    // Generate toAdd. Use deep copy to avoid race conditions
+    Set<String> addedKeys = new HashSet<>(currentConfigMap.keySet());
+    addedKeys.removeAll(oldConfigMap.keySet());
+    for (String addedKey : addedKeys) {
+      _toAdd.add(new ViewClusterSourceConfig(currentConfigMap.get(addedKey)));
+    }
+  }
+
+  public List<ViewClusterSourceConfig> getConfigsToAdd() {
+    return _toAdd;
+  }
+
+  public List<ViewClusterSourceConfig> getConfigsToDelete() {
+    return _toDelete;
+  }
+
+  public boolean shouldResetTimer() {
+    return _shouldResetTimer;
+  }
+
+  public long getCurrentRefreshPeriodMs() {
+    return _newConfig.getViewClusterRefershPeriod() * 1000;
+  }
+
+  private String generateConfigMapKey(String clusterName, String zkAddr) {
+    return String.format("%s%s", clusterName, zkAddr);
+  }
+}

--- a/helix-view-aggregator/src/main/java/org/apache/helix/view/aggregator/ViewClusterRefresher.java
+++ b/helix-view-aggregator/src/main/java/org/apache/helix/view/aggregator/ViewClusterRefresher.java
@@ -1,0 +1,424 @@
+package org.apache.helix.view.aggregator;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixProperty;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.PropertyType;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.view.dataprovider.SourceClusterDataProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class contains logics to refresh view cluster based on information from source cluster data
+ * providers.
+ * This class assumes SourceClusterDataProviders have its caches refreshed already.
+ */
+public class ViewClusterRefresher {
+  private static final Logger logger = LoggerFactory.getLogger(ViewClusterRefresher.class);
+  private String _viewClusterName;
+  private HelixDataAccessor _viewClusterDataAccessor;
+  private Set<SourceClusterDataProvider> _dataProviderView;
+
+  // These 3 caches stores objects that are pushed to view cluster (write-through) cache,
+  // thus we don't need to read from view cluster everytime we refresh it.
+  private Map<String, HelixProperty> _viewClusterLiveInstanceCache;
+  private Map<String, HelixProperty> _viewClusterInstanceConfigCache;
+  private Map<String, HelixProperty> _viewClusterExternalViewCache;
+
+  public ViewClusterRefresher(String viewClusterName, HelixDataAccessor viewClusterDataAccessor) {
+    _viewClusterName = viewClusterName;
+    _viewClusterDataAccessor = viewClusterDataAccessor;
+    _viewClusterLiveInstanceCache = new HashMap<>();
+    _viewClusterInstanceConfigCache = new HashMap<>();
+    _viewClusterExternalViewCache = new HashMap<>();
+  }
+
+  private class ClusterPropertyDiff {
+    /**
+     * List of names of objects to set (create or modify)
+     */
+    List<String> _keysToSet;
+
+    /**
+     * List of actual objects represented by _keysToSet
+     */
+    List<HelixProperty> _propertiesToSet;
+
+    /**
+     * List of names of objects to delete
+     */
+    List<String> _keysToDelete;
+
+    public ClusterPropertyDiff() {
+      _keysToSet = new ArrayList<>();
+      _propertiesToSet = new ArrayList<>();
+      _keysToDelete = new ArrayList<>();
+    }
+
+    public void addPropertyToSet(String key, HelixProperty obj) {
+      // batch setChildren API needs keys and objects to have corresponding order
+      _keysToSet.add(key);
+      _propertiesToSet.add(obj);
+    }
+
+    public void addPropertiesToDelete(Collection<? extends String> keys) {
+      _keysToDelete.addAll(keys);
+    }
+
+    public List<String> getKeysToSet() {
+      return Collections.unmodifiableList(_keysToSet);
+    }
+
+    public List<HelixProperty> getPropertiesToSet() {
+      return Collections.unmodifiableList(_propertiesToSet);
+    }
+
+    public List<String> getKeysToDelete() {
+      return Collections.unmodifiableList(_keysToDelete);
+    }
+  }
+
+  public void updateProviderView(Set<SourceClusterDataProvider> dataProviderView) {
+    _dataProviderView = dataProviderView;
+  }
+
+  /**
+   * Create / update / delete property of given type in view cluster, based on data change from
+   * source clusters.
+   *
+   * @param propertyType type of property to refresh in view cluster
+   * @return true if successfully refreshed all instances of the given property else false
+   * @throws IllegalArgumentException throws exception when give type is not supported
+   */
+  public boolean refreshPropertiesInViewCluster(PropertyType propertyType)
+      throws IllegalArgumentException {
+    boolean ok = false;
+    Set<String> listedNamesInView;
+    Set<String> listedNamesInSource = new HashSet<>();
+    Map<String, HelixProperty> sourceProperties = new HashMap<>();
+    Map<String, HelixProperty> viewClusterPropertyCache =
+        getViewClusterPropertyCache(propertyType);
+    if (viewClusterPropertyCache == null) {
+      throw new IllegalArgumentException(
+          "Cannot find view cluster property cache. Property: " + propertyType.name());
+    }
+
+    try {
+      listedNamesInView =
+          new HashSet<>(_viewClusterDataAccessor.getChildNames(getPropertyKey(propertyType, null)));
+      // Prepare data
+      for (SourceClusterDataProvider provider : _dataProviderView) {
+        if (!provider.getPropertiesToAggregate().contains(propertyType)) {
+          logger.info(String
+              .format("SourceCluster %s does not need to aggregate %s, skip.", provider.getName(),
+                  propertyType.name()));
+          continue;
+        }
+        switch (propertyType) {
+        case INSTANCES:
+          listedNamesInSource.addAll(provider.getInstanceConfigNames());
+          sourceProperties.putAll(provider.getInstanceConfigMap());
+          break;
+        case LIVEINSTANCES:
+          listedNamesInSource.addAll(provider.getLiveInstanceNames());
+          sourceProperties.putAll(provider.getLiveInstances());
+          break;
+        case EXTERNALVIEW:
+          listedNamesInSource.addAll(provider.getExternalViewNames());
+          for (Map.Entry<String, ExternalView> entry : provider.getExternalViews().entrySet()) {
+            String resourceName = entry.getKey();
+            if (!sourceProperties.containsKey(resourceName)) {
+              sourceProperties.put(resourceName, new ExternalView(resourceName));
+            }
+            mergeExternalViews((ExternalView) sourceProperties.get(resourceName), entry.getValue());
+          }
+          break;
+        default:
+          // Will NOT come here as for unsupported property type, exception will be thrown out
+          // earlier
+          break;
+        }
+      }
+
+      // Perform refresh
+      ok = doRefresh(propertyType, listedNamesInView, listedNamesInSource, sourceProperties,
+          viewClusterPropertyCache);
+    } catch (Exception e) {
+      logger.warn(String
+          .format("Caught exception during refreshing %s for view cluster %s", propertyType.name(),
+              _viewClusterName), e);
+    }
+    logRefreshResult(propertyType, ok);
+
+    return ok;
+  }
+
+  /**
+   * Merge external view "toMerge" into external view "source":
+   *  - if partition in toMerge does not exist in source, we add it into source
+   *  - if partition exist in both external views, we add all map fields from toMerge to source
+   *
+   * @param source
+   * @param toMerge
+   */
+  private static void mergeExternalViews(ExternalView source, ExternalView toMerge)
+      throws IllegalArgumentException {
+    if (!source.getId().equals(toMerge.getId())) {
+      throw new IllegalArgumentException(String
+          .format("Cannot merge ExternalViews with different ID. SourceID: %s; ToMergeID: %s",
+              source.getId(), toMerge.getId()));
+    }
+    for (String partitionName : toMerge.getPartitionSet()) {
+      // Deep copying state map to avoid modifying source cache
+      if (!source.getPartitionSet().contains(partitionName)) {
+        source.setStateMap(partitionName, new TreeMap<String, String>());
+      }
+      source.getStateMap(partitionName).putAll(toMerge.getStateMap(partitionName));
+    }
+  }
+
+  /**
+   * Based on property names in view cluster, property names in source clusters, and all cached
+   * properties in source clusters, generate ClusterPropertyDiff that contains information about
+   * what to add / update or delete
+   *
+   * @param viewPropertyNames names of all properties (i.e. liveInstances) in view cluster
+   * @param sourcePropertyNames names of all properties (i.e. liveInstances) in all source clusters
+   * @param cachedSourceProperties all cached properties from source clusters
+   * @param viewClusterPropertyCache all properties that are previously set successfully to view cluster
+   * @param <T> extends HelixProperty
+   * @return ClusterPropertyDiff object contains diff information
+   */
+  private <T extends HelixProperty> ClusterPropertyDiff calculatePropertyDiff(
+      Set<String> viewPropertyNames, Set<String> sourcePropertyNames,
+      Map<String, T> cachedSourceProperties, Map<String, T> viewClusterPropertyCache) {
+    ClusterPropertyDiff diff = new ClusterPropertyDiff();
+
+    // items whose names are in view cluster but not in source should be removed for sure
+    Set<String> toDelete = new HashSet<>(viewPropertyNames);
+    toDelete.removeAll(sourcePropertyNames);
+    diff.addPropertiesToDelete(toDelete);
+
+    for (Map.Entry<String, T> sourceProperty : cachedSourceProperties.entrySet()) {
+      String name = sourceProperty.getKey();
+      HelixProperty property = sourceProperty.getValue();
+
+      // cache refresh happens earlier than list curNames, so if cache is still in curNames,
+      // we confirm that this is a valid live instance. This is necessary because ZK
+      // can possibly not return all children content in a refresh, but list child names
+      // will reliably return all children names.
+      //
+      // Else, either this child is already deleted, or we fail to retrieve information
+      // from a cache refresh. either way, we will leave it to next ViewClusterRefresh cycle
+      // to confirm state
+      if (property != null && sourcePropertyNames.contains(name) && (
+          !viewClusterPropertyCache.containsKey(name) || !viewClusterPropertyCache.get(name)
+              .getRecord().equals(property.getRecord()))) {
+        diff.addPropertyToSet(name, property);
+      }
+    }
+    return diff;
+  }
+
+  /**
+   * Refresh view cluster regarding a particular property based given source of truths.
+   * Steps are:
+   *  - Calculate diff based on propertyNamesInView, propertyNamesInSource and
+   *    cachedSourceProperties
+   *  - Generate property keys for properties to set / delete
+   *  - Delete properties
+   *  - Set properties
+   *
+   * @param propertyType type of property to refresh
+   * @param viewPropertyNames all names of the target properties in view cluster
+   * @param sourcePropertyNames all names of the target properties in source clusters
+   * @param cachedSourceProperties all up-to-date cached properties in source cluster
+   * @param viewClusterPropertyCache view cluster cache
+   * @param <T> extends HelixProperty
+   * @return true if all required refreshes are successful, else false
+   */
+  private <T extends HelixProperty> boolean doRefresh(PropertyType propertyType,
+      Set<String> viewPropertyNames, Set<String> sourcePropertyNames,
+      Map<String, T> cachedSourceProperties, Map<String, T> viewClusterPropertyCache) {
+    boolean ok = true;
+    // Calculate diff
+    ClusterPropertyDiff diff =
+        calculatePropertyDiff(viewPropertyNames, sourcePropertyNames, cachedSourceProperties,
+            viewClusterPropertyCache);
+
+    // Generate property keys
+    List<PropertyKey> keysToSet = new ArrayList<>();
+    List<PropertyKey> keysToDelete = new ArrayList<>();
+    for (String name : diff.getKeysToSet()) {
+      PropertyKey key = getPropertyKey(propertyType, name);
+      if (key != null) {
+        keysToSet.add(key);
+      }
+    }
+
+    for (String name : diff.getKeysToDelete()) {
+      PropertyKey key = getPropertyKey(propertyType, name);
+      if (key != null) {
+        keysToDelete.add(key);
+      }
+    }
+
+    // Delete outdated properties
+    if (!deleteProperties(keysToDelete, viewClusterPropertyCache)) {
+      ok = false;
+    }
+
+    // Add or update changed properties
+    if (!addOrUpdateProperties(keysToSet, diff.getPropertiesToSet(), viewClusterPropertyCache)) {
+      ok = false;
+    }
+    return ok;
+  }
+
+  /**
+   * Based on type and property name, generate property key
+   * @param propertyType type of the property
+   * @param propertyName name of the property. If null, return key of the parent of
+   *                     all properties of given type
+   * @return property key
+   */
+  private PropertyKey getPropertyKey(PropertyType propertyType, String propertyName) {
+    switch (propertyType) {
+    case INSTANCES:
+      return propertyName == null
+          ? _viewClusterDataAccessor.keyBuilder().instanceConfigs()
+          : _viewClusterDataAccessor.keyBuilder().instanceConfig(propertyName);
+    case LIVEINSTANCES:
+      return propertyName == null
+          ? _viewClusterDataAccessor.keyBuilder().liveInstances()
+          : _viewClusterDataAccessor.keyBuilder().liveInstance(propertyName);
+    case EXTERNALVIEW:
+      return propertyName == null
+          ? _viewClusterDataAccessor.keyBuilder().externalViews()
+          : _viewClusterDataAccessor.keyBuilder().externalView(propertyName);
+    default:
+      return null;
+    }
+  }
+
+  private Map<String, HelixProperty> getViewClusterPropertyCache(PropertyType propertyType) {
+    switch (propertyType) {
+    case INSTANCES:
+      return _viewClusterInstanceConfigCache;
+    case LIVEINSTANCES:
+      return _viewClusterLiveInstanceCache;
+    case EXTERNALVIEW:
+      return _viewClusterExternalViewCache;
+    default:
+      return null;
+    }
+  }
+
+  /**
+   * Create or Update properties in ZK specified by a list of property keys. Update the given cache
+   * for the objects that got successfully created or updated in ZK
+   * @param keysToAddOrUpdate
+   * @param objects
+   * @param cache
+   * @param <T> HelixProperty
+   *
+   * @return true if all objects are successfully created or updated, else false
+   */
+  private <T extends HelixProperty> boolean addOrUpdateProperties(
+      List<PropertyKey> keysToAddOrUpdate, List<HelixProperty> objects, Map<String, T> cache) {
+    boolean ok = true;
+    logger.info(
+        String.format("AddOrUpdate %s objects: %s", keysToAddOrUpdate.size(), keysToAddOrUpdate));
+    boolean[] addOrUpdateResults = _viewClusterDataAccessor.setChildren(keysToAddOrUpdate, objects);
+    for (int i = 0; i < addOrUpdateResults.length; i++) {
+      if (!addOrUpdateResults[i]) {
+        // Don't add item to cache yet - will retry during next refresh
+        logger.warn(String.format("Failed to create or update live instance %s, will retry later",
+            keysToAddOrUpdate.get(i).getPath()));
+        ok = false;
+      } else {
+        // Successfully updated ViewClusterZK, proceed to update cache
+        @SuppressWarnings("unchecked")
+        T property = (T) objects.get(i);
+        cache.put(getBaseObjectNameFromPropertyKey(keysToAddOrUpdate.get(i)), property);
+      }
+    }
+    return ok;
+  }
+
+  /**
+   * Delete properties in ZK specified by a list of property keys. Update the given cache
+   * for the objects that got successfully deleted in ZK
+   * @param keysToDelete
+   * @param cache
+   * @param <T> HelixProperty
+   * @return true if all objects got successfully deleted else false
+   */
+  private <T extends HelixProperty> boolean deleteProperties(List<PropertyKey> keysToDelete,
+      Map<String, T> cache) {
+    boolean ok = true;
+    logger.info(String.format("Deleting %s objects: %s", keysToDelete.size(), keysToDelete));
+    for (PropertyKey key : keysToDelete) {
+      if (!_viewClusterDataAccessor.removeProperty(key)) {
+        // Don't remove item from cache yet - will retry during next refresh
+        ok = false;
+        logger.warn(String.format("Failed to create or update live instance %s, will retry later",
+            key.getPath()));
+      } else {
+        // Successfully updated ViewClusterZK, proceed to update cache
+        cache.remove(getBaseObjectNameFromPropertyKey(key));
+      }
+    }
+    return ok;
+  }
+
+  /**
+   * Parse property key and get the id of the ZNode that property key represents
+   * @param key
+   * @return
+   */
+  private static String getBaseObjectNameFromPropertyKey(PropertyKey key) {
+    String[] params = key.getParams();
+    return params[params.length - 1];
+  }
+
+  private void logRefreshResult(PropertyType type, boolean ok) {
+    if (!ok) {
+      logger.warn(String
+          .format("Failed to refresh all %s for view cluster %s, will retry",
+              type.name(), _viewClusterName));
+    } else {
+      logger.info(String.format("Successfully refreshed all %s for view cluster %s",
+          type.name(), _viewClusterName));
+    }
+  }
+}

--- a/helix-view-aggregator/src/main/java/org/apache/helix/view/common/ClusterViewEvent.java
+++ b/helix-view-aggregator/src/main/java/org/apache/helix/view/common/ClusterViewEvent.java
@@ -1,0 +1,56 @@
+package org.apache.helix.view.common;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class ClusterViewEvent {
+  public enum Type {
+    LiveInstanceChange,
+    ExternalViewChange,
+    InstanceConfigChange,
+    ConfigChange,
+    PeriodicViewRefresh
+  }
+
+  private String _clusterName;
+  private Type _eventType;
+  private long _eventProcessBackoffMs;
+
+  public ClusterViewEvent(String clusterName, Type eventType) {
+    _clusterName = clusterName;
+    _eventType = eventType;
+    _eventProcessBackoffMs = 0;
+  }
+
+  public String getClusterName() {
+    return _clusterName;
+  }
+
+  public Type getEventType() {
+    return _eventType;
+  }
+
+  public void setEventProcessBackoff(long backoffMs) {
+    _eventProcessBackoffMs = backoffMs;
+  }
+
+  public long getEventProcessBackoff() {
+    return _eventProcessBackoffMs;
+  }
+}

--- a/helix-view-aggregator/src/main/java/org/apache/helix/view/dataprovider/SourceClusterDataProvider.java
+++ b/helix-view-aggregator/src/main/java/org/apache/helix/view/dataprovider/SourceClusterDataProvider.java
@@ -1,0 +1,217 @@
+package org.apache.helix.view.dataprovider;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+import org.I0Itec.zkclient.exception.ZkInterruptedException;
+import org.apache.helix.HelixConstants;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.PropertyType;
+import org.apache.helix.api.config.ViewClusterSourceConfig;
+import org.apache.helix.api.listeners.ExternalViewChangeListener;
+import org.apache.helix.api.listeners.InstanceConfigChangeListener;
+import org.apache.helix.api.listeners.LiveInstanceChangeListener;
+import org.apache.helix.api.listeners.PreFetch;
+import org.apache.helix.common.DedupEventProcessor;
+import org.apache.helix.common.caches.BasicClusterDataCache;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.view.common.ClusterViewEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * SourceClusterDataProvider listens to changes in 1 source cluster, notifies cluster data cache,
+ * generates event for event processor and provide methods to read data cache
+ */
+public class SourceClusterDataProvider extends BasicClusterDataCache
+    implements InstanceConfigChangeListener, LiveInstanceChangeListener,
+    ExternalViewChangeListener {
+  private static final Logger LOG = LoggerFactory.getLogger(SourceClusterDataProvider.class);
+
+  private final HelixManager _helixManager;
+  private final DedupEventProcessor<ClusterViewEvent.Type, ClusterViewEvent> _eventProcessor;
+
+  protected ViewClusterSourceConfig _sourceClusterConfig;
+  private HelixDataAccessor _dataAccessor;
+  private PropertyKey.Builder _propertyKeyBuilder;
+
+  public SourceClusterDataProvider(ViewClusterSourceConfig config,
+      DedupEventProcessor<ClusterViewEvent.Type, ClusterViewEvent> eventProcessor) {
+    super(config.getName());
+    _eventProcessor = eventProcessor;
+    _sourceClusterConfig = config;
+    _helixManager = HelixManagerFactory.getZKHelixManager(config.getName(),
+        generateHelixManagerInstanceName(config.getName()),
+        InstanceType.SPECTATOR, config.getZkAddress());
+  }
+
+  public String getName() {
+    return _helixManager.getInstanceName();
+  }
+
+  /**
+   * Set up ClusterDataProvider. After setting up, the class should start listening
+   * on change events and perform corresponding reactions
+   * @throws Exception
+   */
+  public void setup() throws Exception {
+    if (_helixManager != null && _helixManager.isConnected()) {
+      LOG.info(String.format("Data provider %s is already setup", _helixManager.getInstanceName()));
+      return;
+    }
+    try {
+      _helixManager.connect();
+      for (PropertyType property : _sourceClusterConfig.getProperties()) {
+        HelixConstants.ChangeType changeType;
+        switch (property) {
+        case INSTANCES:
+          _helixManager.addInstanceConfigChangeListener(this);
+          changeType = HelixConstants.ChangeType.INSTANCE_CONFIG;
+          break;
+        case LIVEINSTANCES:
+          _helixManager.addLiveInstanceChangeListener(this);
+          changeType = HelixConstants.ChangeType.LIVE_INSTANCE;
+          break;
+        case EXTERNALVIEW:
+          _helixManager.addExternalViewChangeListener(this);
+          changeType = HelixConstants.ChangeType.EXTERNAL_VIEW;
+          break;
+        default:
+          LOG.warn(String
+              .format("Unsupported property type: %s. Skip adding listener", property.name()));
+          continue;
+        }
+        notifyDataChange(changeType);
+      }
+      _dataAccessor = _helixManager.getHelixDataAccessor();
+      _propertyKeyBuilder = _dataAccessor.keyBuilder();
+      LOG.info(String.format("Data provider %s (%s) started. Source cluster detail: %s",
+          _helixManager.getInstanceName(), hashCode(),
+              _sourceClusterConfig.toString()));
+    } catch(Exception e) {
+      shutdown();
+      throw e;
+    }
+  }
+
+  public void shutdown() {
+    // Clear cache to make sure memory is released
+    for (HelixConstants.ChangeType changeType : HelixConstants.ChangeType.values()) {
+      clearCache(changeType);
+    }
+    if (_helixManager != null && _helixManager.isConnected()) {
+      try {
+        _helixManager.disconnect();
+        LOG.info(
+            String.format("Data provider %s (%s) shutdown cleanly.", _helixManager.getInstanceName(), hashCode()));
+      } catch (ZkInterruptedException e) {
+        // OK
+      }
+    }
+  }
+
+  public void refreshCache() {
+    refresh(_dataAccessor);
+  }
+
+  /**
+   * Get current instance config names. ListName is a more reliable way to find
+   * current instance config names. This is needed for ViewClusterRefresher when
+   * it is generating diffs to push to ViewCluster
+   * @return
+   */
+  public List<String> getInstanceConfigNames() {
+    return _dataAccessor.getChildNames(_propertyKeyBuilder.instanceConfigs());
+  }
+
+  /**
+   * Get current live instance names.
+   * @return
+   */
+  public List<String> getLiveInstanceNames() {
+    return _dataAccessor.getChildNames(_propertyKeyBuilder.liveInstances());
+  }
+
+  /**
+   * Get external view names
+   * @return
+   */
+  public List<String> getExternalViewNames() {
+    return _dataAccessor.getChildNames(_propertyKeyBuilder.externalViews());
+  }
+
+  public List<PropertyType> getPropertiesToAggregate() {
+    return _sourceClusterConfig.getProperties();
+  }
+
+  @Override
+  @PreFetch(enabled = false)
+  public void onInstanceConfigChange(List<InstanceConfig> instanceConfigs,
+      NotificationContext context) {
+    queueEvent(context, ClusterViewEvent.Type.InstanceConfigChange,
+        HelixConstants.ChangeType.INSTANCE_CONFIG);
+  }
+
+  @Override
+  @PreFetch(enabled = false)
+  public void onLiveInstanceChange(List<LiveInstance> liveInstances,
+      NotificationContext changeContext) {
+    queueEvent(changeContext, ClusterViewEvent.Type.LiveInstanceChange,
+        HelixConstants.ChangeType.LIVE_INSTANCE);
+  }
+
+  @Override
+  @PreFetch(enabled = false)
+  public void onExternalViewChange(List<ExternalView> externalViewList,
+      NotificationContext changeContext) {
+    queueEvent(changeContext, ClusterViewEvent.Type.ExternalViewChange,
+        HelixConstants.ChangeType.EXTERNAL_VIEW);
+  }
+
+  private void queueEvent(NotificationContext context, ClusterViewEvent.Type changeType,
+      HelixConstants.ChangeType cacheChangeType)
+      throws IllegalStateException {
+    // TODO: in case of FINALIZE, if we are not shutdown, re-connect helix manager and report error
+    if (context != null && context.getType() != NotificationContext.Type.FINALIZE) {
+      notifyDataChange(cacheChangeType);
+      _eventProcessor.queueEvent(changeType, new ClusterViewEvent(_clusterName, changeType));
+    } else {
+      LOG.info("Skip queuing event from source cluster {}. ChangeType: {}, ContextType: {}",
+          _clusterName, cacheChangeType.name(),
+          context == null ? "NoContext" : context.getType().name());
+    }
+  }
+
+  private static String generateHelixManagerInstanceName(String clusterName) {
+    return String.format("SourceClusterSpectatorHelixManager-%s", clusterName);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s::%s", getClass().getSimpleName(), hashCode());
+  }
+}

--- a/helix-view-aggregator/src/main/java/org/apache/helix/view/monitoring/ViewAggregatorMonitor.java
+++ b/helix-view-aggregator/src/main/java/org/apache/helix/view/monitoring/ViewAggregatorMonitor.java
@@ -1,0 +1,89 @@
+package org.apache.helix.view.monitoring;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.management.JMException;
+import org.apache.helix.monitoring.mbeans.MBeanRegistrar;
+import org.apache.helix.monitoring.mbeans.MonitorDomainNames;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
+
+public class ViewAggregatorMonitor extends DynamicMBeanProvider {
+  /* package */ static final String MBEAN_DOMAIN = MonitorDomainNames.ClusterStatus.name();
+  /* package */ static final String MONITOR_KEY = "ViewClusterName";
+  private static final String MBEAN_DESCRIPTION = "Monitor helix view aggregator activity";
+  private final String _clusterName;
+  private final String _sensorName;
+
+  // Counters
+  private final SimpleDynamicMetric<Long> _refreshViewFailureCounter;
+  private final SimpleDynamicMetric<Long> _sourceReadFailureCounter;
+  private final SimpleDynamicMetric<Long> _processViewConfigFailureCounter;
+  private final SimpleDynamicMetric<Long> _processedSourceClusterEventCounter;
+
+  // Gauges
+  private final HistogramDynamicMetric _viewRefreshLatencyGauge;
+
+  public ViewAggregatorMonitor(String clusterName) {
+    _clusterName = clusterName;
+    _sensorName = String.format("%s.%s.%s", MBEAN_DOMAIN, MONITOR_KEY, clusterName);
+
+    // Initialize metrics
+    _refreshViewFailureCounter =
+        new SimpleDynamicMetric<>("ViewClusterRefreshFailureCounter", 0L);
+    _sourceReadFailureCounter =
+        new SimpleDynamicMetric<>("SourceClusterRefreshFailureCounter", 0L);
+    _processedSourceClusterEventCounter =
+        new SimpleDynamicMetric<>("ProcessedSourceClusterEventCounter", 0L);
+    _processViewConfigFailureCounter =
+        new SimpleDynamicMetric<>("ProcessViewConfigFailureCounter", 0L);
+    _viewRefreshLatencyGauge = new HistogramDynamicMetric("ViewClusterRefreshDurationGauge",
+        new Histogram(
+            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+  }
+
+  public void recordViewRefreshFailure() {
+    _refreshViewFailureCounter.updateValue(_refreshViewFailureCounter.getValue() + 1);
+  }
+
+  public void recordViewConfigProcessFailure() {
+    _processViewConfigFailureCounter.updateValue(_processViewConfigFailureCounter.getValue() + 1);
+  }
+
+  public void recordReadSourceFailure() {
+    _sourceReadFailureCounter.updateValue(_sourceReadFailureCounter.getValue() + 1);
+  }
+
+  public void recordProcessedSourceEvent() {
+    _processedSourceClusterEventCounter
+        .updateValue(_processedSourceClusterEventCounter.getValue() + 1);
+  }
+
+  public void recordRefreshViewLatency(long latency) {
+    _viewRefreshLatencyGauge.updateValue(latency);
+  }
+
+  @Override
+  public String getSensorName() {
+    return _sensorName;
+  }
+
+  @Override
+  public DynamicMBeanProvider register() throws JMException {
+    List<DynamicMetric<?, ?>> attributeList = new ArrayList<>();
+    attributeList.add(_sourceReadFailureCounter);
+    attributeList.add(_refreshViewFailureCounter);
+    attributeList.add(_processViewConfigFailureCounter);
+    attributeList.add(_processedSourceClusterEventCounter);
+    attributeList.add(_viewRefreshLatencyGauge);
+
+    doRegister(attributeList, MBEAN_DESCRIPTION, MBeanRegistrar
+        .buildObjectName(MBEAN_DOMAIN, MONITOR_KEY, _clusterName));
+    return this;
+  }
+}

--- a/helix-view-aggregator/src/main/java/org/apache/helix/view/statemodel/DistViewAggregatorStateModel.java
+++ b/helix-view-aggregator/src/main/java/org/apache/helix/view/statemodel/DistViewAggregatorStateModel.java
@@ -1,0 +1,105 @@
+package org.apache.helix.view.statemodel;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.NotificationContext;
+import org.apache.helix.model.Message;
+import org.apache.helix.participant.AbstractHelixLeaderStandbyStateModel;
+import org.apache.helix.participant.statemachine.StateModelInfo;
+import org.apache.helix.view.aggregator.HelixViewAggregator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@StateModelInfo(initialState = "OFFLINE", states = {
+    "LEADER", "STANDBY"
+})
+public class DistViewAggregatorStateModel extends AbstractHelixLeaderStandbyStateModel {
+  private final static Logger logger = LoggerFactory.getLogger(DistViewAggregatorStateModel.class);
+  private final static Object stateTransitionLock = new Object();
+  private static HelixViewAggregator _aggregator;
+
+  public DistViewAggregatorStateModel(String zkAddr) {
+    super(zkAddr);
+  }
+
+  @Override
+  public void onBecomeStandbyFromOffline(Message message, NotificationContext context) {
+    logStateTransition("OFFLINE", "STANDBY", message.getPartitionName(), message.getTgtName());
+  }
+
+  @Override
+  public void onBecomeLeaderFromStandby(Message message, NotificationContext context)
+      throws Exception {
+    String viewClusterName = message.getPartitionName();
+
+    synchronized (stateTransitionLock) {
+      if (_aggregator != null) {
+        logger.warn("Aggregator already exists for view cluster {}: {}: cleaning it up.",
+            viewClusterName, _aggregator.getAggregatorInstanceName());
+        reset();
+      }
+      logger.info("Creating new HelixViewAggregator for view cluster {}", viewClusterName);
+      try {
+        _aggregator = new HelixViewAggregator(viewClusterName, _zkAddr);
+        _aggregator.start();
+      } catch (Exception e) {
+        logger.error("Aggregator failed to become leader from stand by for view cluster {}",
+            viewClusterName, e);
+        reset();
+        throw e;
+      }
+      logStateTransition("STANDBY", "LEADER", message.getPartitionName(), message.getTgtName());
+    }
+
+  }
+
+  @Override
+  public void onBecomeStandbyFromLeader(Message message, NotificationContext context) {
+    reset();
+    logStateTransition("LEADER", "STANDBY", message.getPartitionName(), message.getTgtName());
+  }
+
+  @Override
+  public void onBecomeOfflineFromStandby(Message message, NotificationContext context) {
+    logStateTransition("OFFLINE", "DROPPED", message.getPartitionName(), message.getTgtName());
+  }
+
+  @Override
+  public void onBecomeDroppedFromOffline(Message message, NotificationContext context) {
+    logStateTransition("OFFLINE", "DROPPED", message.getPartitionName(), message.getTgtName());
+  }
+
+
+  @Override
+  public void reset() {
+    synchronized (stateTransitionLock) {
+      if (_aggregator != null) {
+        logger.error("Resetting view aggregator {}", _aggregator.getAggregatorInstanceName());
+        _aggregator.shutdown();
+        _aggregator = null;
+      }
+    }
+  }
+
+  @Override
+  public String getStateModeInstanceDescription(String partitionName, String instanceName) {
+    return String.format("View Aggregator (%s) for view cluster %s", instanceName, partitionName);
+  }
+}

--- a/helix-view-aggregator/src/main/java/org/apache/helix/view/statemodel/DistViewAggregatorStateModelFactory.java
+++ b/helix-view-aggregator/src/main/java/org/apache/helix/view/statemodel/DistViewAggregatorStateModelFactory.java
@@ -1,0 +1,36 @@
+package org.apache.helix.view.statemodel;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.participant.statemachine.StateModelFactory;
+
+public class DistViewAggregatorStateModelFactory extends
+    StateModelFactory<DistViewAggregatorStateModel> {
+  private final String _zkAddr;
+
+  public DistViewAggregatorStateModelFactory(String zkAddr) {
+    _zkAddr = zkAddr;
+  }
+
+  @Override
+  public DistViewAggregatorStateModel createNewStateModel(String resourceName, String partitionKey) {
+    return new DistViewAggregatorStateModel(_zkAddr);
+  }
+}

--- a/helix-view-aggregator/src/test/conf/testng.xml
+++ b/helix-view-aggregator/src/test/conf/testng.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Suite" parallel="false">
+  <test name="Test" preserve-order="true">
+    <packages>
+      <package name="org.apache.helix.view.*"/>
+    </packages>
+  </test>
+</suite>

--- a/helix-view-aggregator/src/test/java/org/apache/helix/view/aggregator/TestViewClusterRefresher.java
+++ b/helix-view-aggregator/src/test/java/org/apache/helix/view/aggregator/TestViewClusterRefresher.java
@@ -1,0 +1,338 @@
+package org.apache.helix.view.aggregator;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.HelixConstants;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixProperty;
+import org.apache.helix.MockAccessor;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.PropertyType;
+import org.apache.helix.api.config.ViewClusterSourceConfig;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.view.dataprovider.SourceClusterDataProvider;
+import org.apache.helix.view.mock.MockSourceClusterDataProvider;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestViewClusterRefresher {
+  private static final String viewClusterName = "viewCluster";
+  private static final int numSourceCluster = 3;
+  private static final int numInstancePerSourceCluster = 2;
+  private static final int numExternalViewPerSourceCluster = 3;
+  private static final int numPartition = 3;
+  private static final List<PropertyType> defaultProperties =
+      Arrays.asList(PropertyType.LIVEINSTANCES, PropertyType.INSTANCES, PropertyType.EXTERNALVIEW);
+
+  private class CounterBasedMockAccessor extends MockAccessor {
+    private int _setCount;
+    private int _removeCount;
+
+    public CounterBasedMockAccessor(String clusterName) {
+      super(clusterName);
+      resetCounters();
+    }
+
+    public void resetCounters() {
+      _setCount = 0;
+      _removeCount = 0;
+    }
+
+    @Override
+    public boolean setProperty(PropertyKey key, HelixProperty value) {
+      _setCount += 1;
+      return super.setProperty(key, value);
+    }
+
+    @Override
+    public boolean removeProperty(PropertyKey key) {
+      _removeCount += 1;
+      return super.removeProperty(key);
+    }
+
+    public int getSetCount() {
+      return _setCount;
+    }
+
+    public int getRemoveCount() {
+      return _removeCount;
+    }
+  }
+
+  @Test
+  public void testRefreshWithNoChange() {
+    CounterBasedMockAccessor viewClusterDataAccessor =
+        new CounterBasedMockAccessor(viewClusterName);
+    Map<String, SourceClusterDataProvider> dataProviderMap = new HashMap<>();
+    createMockDataProviders(dataProviderMap);
+
+    ViewClusterRefresher refresher =
+        new ViewClusterRefresher(viewClusterName, viewClusterDataAccessor);
+    refresher.updateProviderView(new HashSet<>(dataProviderMap.values()));
+
+    // Refresh an empty view cluster
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.LIVEINSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.INSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.EXTERNALVIEW));
+    viewClusterDataAccessor.resetCounters();
+
+    // Refresh again without change
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.LIVEINSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.INSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.EXTERNALVIEW));
+    Assert.assertEquals(viewClusterDataAccessor.getSetCount(), 0);
+  }
+
+  @Test
+  public void testRefreshWithInstanceChange() {
+    CounterBasedMockAccessor viewClusterDataAccessor =
+        new CounterBasedMockAccessor(viewClusterName);
+    Map<String, SourceClusterDataProvider> dataProviderMap = new HashMap<>();
+    createMockDataProviders(dataProviderMap);
+
+    ViewClusterRefresher refresher =
+        new ViewClusterRefresher(viewClusterName, viewClusterDataAccessor);
+    refresher.updateProviderView(new HashSet<>(dataProviderMap.values()));
+    MockSourceClusterDataProvider sampleProvider =
+        (MockSourceClusterDataProvider) dataProviderMap.get("cluster0");
+
+    // Refresh an empty view cluster
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.LIVEINSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.INSTANCES));
+    // multiply by 2 for both instance config and live instances
+    Assert.assertEquals(viewClusterDataAccessor.getSetCount(),
+        numSourceCluster * numInstancePerSourceCluster * 2);
+    verifyInstances(viewClusterDataAccessor, dataProviderMap);
+
+    // Source cluster has instances deleted
+    viewClusterDataAccessor.resetCounters();
+    sampleProvider.clearCache(HelixConstants.ChangeType.LIVE_INSTANCE);
+    sampleProvider.clearCache(HelixConstants.ChangeType.INSTANCE_CONFIG);
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.LIVEINSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.INSTANCES));
+    Assert.assertEquals(viewClusterDataAccessor.getRemoveCount(), numInstancePerSourceCluster * 2);
+
+    verifyInstances(viewClusterDataAccessor, dataProviderMap);
+
+    // Source cluster has live instances added
+    viewClusterDataAccessor.resetCounters();
+    List<LiveInstance> liveInstances =
+        new ArrayList<>(sampleProvider.getLiveInstances().values());
+    liveInstances.add(new LiveInstance("newLiveInstance"));
+    sampleProvider.setLiveInstances(liveInstances);
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.LIVEINSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.INSTANCES));
+    Assert.assertEquals(viewClusterDataAccessor.getSetCount(), 1);
+
+    verifyInstances(viewClusterDataAccessor, dataProviderMap);
+  }
+
+  @Test
+  public void testRefreshWithExternalViewChange() {
+    CounterBasedMockAccessor accessor =
+        new CounterBasedMockAccessor(viewClusterName);
+    Map<String, SourceClusterDataProvider> dataProviderMap = new HashMap<>();
+    createMockDataProviders(dataProviderMap);
+
+    ViewClusterRefresher refresher =
+        new ViewClusterRefresher(viewClusterName, accessor);
+    refresher.updateProviderView(new HashSet<>(dataProviderMap.values()));
+    MockSourceClusterDataProvider sampleProvider =
+        (MockSourceClusterDataProvider) dataProviderMap.get("cluster0");
+
+    // Refresh an empty view cluster
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.EXTERNALVIEW));
+    // We only have 2 resource names so should be setting 2 evs
+    Assert.assertEquals(accessor.getSetCount(), numExternalViewPerSourceCluster);
+    Assert.assertEquals(accessor.getRemoveCount(), 0);
+    // Partition count should be maintained
+    // Since we are creating 1 replica per source cluster so replica should be aggregated.
+    verifyExternalView(accessor, numExternalViewPerSourceCluster, numPartition, numSourceCluster);
+
+    // One cluster deletes all its EVs, number of partition should reflect in changes
+    accessor.resetCounters();
+    sampleProvider.clearCache(HelixConstants.ChangeType.EXTERNAL_VIEW);
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.EXTERNALVIEW));
+    Assert.assertEquals(accessor.getSetCount(), numExternalViewPerSourceCluster);
+    Assert.assertEquals(accessor.getRemoveCount(), 0);
+    verifyExternalView(accessor, numExternalViewPerSourceCluster, numPartition,
+        numSourceCluster - 1);
+
+    // All EVs are deleted, and all EVs should be removed from view cluster
+    for (SourceClusterDataProvider provider : dataProviderMap.values()) {
+      provider.clearCache(HelixConstants.ChangeType.EXTERNAL_VIEW);
+    }
+    accessor.resetCounters();
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.EXTERNALVIEW));
+    Assert.assertEquals(accessor.getSetCount(), 0);
+    Assert.assertEquals(accessor.getRemoveCount(), numExternalViewPerSourceCluster);
+    verifyExternalView(accessor, 0, 0, 0);
+  }
+
+  @Test
+  public void testRefreshWithProviderChange() {
+    CounterBasedMockAccessor viewClusterDataAccessor =
+        new CounterBasedMockAccessor(viewClusterName);
+    Map<String, SourceClusterDataProvider> dataProviderMap = new HashMap<>();
+    createMockDataProviders(dataProviderMap);
+
+    ViewClusterRefresher refresher =
+        new ViewClusterRefresher(viewClusterName, viewClusterDataAccessor);
+    refresher.updateProviderView(new HashSet<>(dataProviderMap.values()));
+    MockSourceClusterDataProvider sampleProvider =
+        (MockSourceClusterDataProvider) dataProviderMap.get("cluster0");
+
+    // Refresh an empty view cluster
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.LIVEINSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.INSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.EXTERNALVIEW));
+    verifyInstances(viewClusterDataAccessor, dataProviderMap);
+    verifyExternalView(viewClusterDataAccessor, numExternalViewPerSourceCluster, numPartition,
+        numSourceCluster);
+    viewClusterDataAccessor.resetCounters();
+
+    // remove InstanceConfig and ExternalView requirement from sample provider
+    sampleProvider.getConfig()
+        .setProperties(Collections.singletonList(PropertyType.LIVEINSTANCES));
+
+    // Refresh again
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.LIVEINSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.INSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.EXTERNALVIEW));
+
+    // Removing external view from config of 1 cluster will not result in removing any external view
+    // but to update external views
+    Assert.assertEquals(viewClusterDataAccessor.getSetCount(), numExternalViewPerSourceCluster);
+    Assert.assertEquals(viewClusterDataAccessor.getRemoveCount(), numInstancePerSourceCluster);
+    verifyExternalView(viewClusterDataAccessor, numExternalViewPerSourceCluster, numPartition,
+        numSourceCluster - 1);
+    verifyInstances(viewClusterDataAccessor, dataProviderMap);
+
+    // Remove external view from all source clusters, will resulting in removing all external views
+    viewClusterDataAccessor.resetCounters();
+    for (SourceClusterDataProvider provider : dataProviderMap.values()) {
+      MockSourceClusterDataProvider mockProvider = (MockSourceClusterDataProvider) provider;
+      if (mockProvider != sampleProvider) {
+        mockProvider.getConfig().setProperties(Arrays
+            .asList(PropertyType.LIVEINSTANCES, PropertyType.INSTANCES));
+      }
+    }
+
+    // Refresh again
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.LIVEINSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.INSTANCES));
+    Assert.assertTrue(refresher.refreshPropertiesInViewCluster(PropertyType.EXTERNALVIEW));
+
+    // No change in instances, but external views are all removed
+    Assert.assertEquals(viewClusterDataAccessor.getSetCount(), 0);
+    Assert.assertEquals(viewClusterDataAccessor.getRemoveCount(), numExternalViewPerSourceCluster);
+    verifyExternalView(viewClusterDataAccessor, 0, 0, 0);
+    verifyInstances(viewClusterDataAccessor, dataProviderMap);
+  }
+
+  private void verifyExternalView(HelixDataAccessor accessor, int expectedResourceCnt,
+      int expectedPartitionPerResource, int expectedReplicaPerPartition) {
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    Assert.assertEquals(accessor.getChildNames(keyBuilder.externalViews()).size(),
+        expectedResourceCnt);
+    for (String resourceName : accessor.getChildNames(keyBuilder.externalViews())) {
+      ExternalView ev = accessor.getProperty(keyBuilder.externalView(resourceName));
+
+      Assert.assertEquals(ev.getPartitionSet().size(), expectedPartitionPerResource);
+      for (String partitionName : ev.getPartitionSet()) {
+        Assert.assertEquals(ev.getStateMap(partitionName).size(), expectedReplicaPerPartition);
+      }
+    }
+  }
+
+  private void verifyInstances(HelixDataAccessor accessor,
+      Map<String, SourceClusterDataProvider> dataProviderMap) {
+    // Verify live instances - since we don't modify ZNode's internal content,
+    // we just verify names
+    Set<String> fetchedNames = new HashSet<>(accessor
+        .getChildNames(accessor.keyBuilder().liveInstances()));
+    Set<String> expectedNames = new HashSet<>();
+    for (SourceClusterDataProvider provider : dataProviderMap.values()) {
+      if (provider.getPropertiesToAggregate().contains(PropertyType.LIVEINSTANCES)) {
+        expectedNames.addAll(provider.getLiveInstanceNames());
+      }
+    }
+    Assert.assertEquals(fetchedNames, expectedNames);
+
+    // Verify instance configs - since we don't modify ZNode's internal content,
+    // we just verify names
+    fetchedNames = new HashSet<>(accessor
+        .getChildNames(accessor.keyBuilder().instanceConfigs()));
+    expectedNames = new HashSet<>();
+    for (SourceClusterDataProvider provider : dataProviderMap.values()) {
+      if (provider.getPropertiesToAggregate().contains(PropertyType.INSTANCES)) {
+        expectedNames.addAll(provider.getInstanceConfigNames());
+      }
+    }
+    Assert.assertEquals(fetchedNames, expectedNames);
+  }
+
+  private void createMockDataProviders(Map<String, SourceClusterDataProvider> dataProviderMap) {
+    for (int i = 0; i < numSourceCluster; i++) {
+      String sourceClusterName = "cluster" + i;
+      ViewClusterSourceConfig sourceConfig =
+          new ViewClusterSourceConfig(sourceClusterName, "", defaultProperties);
+      MockSourceClusterDataProvider provider =
+          new MockSourceClusterDataProvider(sourceConfig, null);
+      List<LiveInstance> liveInstanceList = new ArrayList<>();
+      List<InstanceConfig> instanceConfigList = new ArrayList<>();
+      List<ExternalView> externalViewList = new ArrayList<>();
+
+      // InstanceConfig and LiveInstance
+      for (int j = 0; j < numInstancePerSourceCluster; j++) {
+        String instanceName = String.format("%s-instance%s", sourceClusterName, j);
+        liveInstanceList.add(new LiveInstance(instanceName));
+        instanceConfigList.add(new InstanceConfig(instanceName));
+      }
+      provider.setLiveInstances(liveInstanceList);
+      provider.setInstanceConfigs(instanceConfigList);
+
+      // ExternalView
+      for (int j = 0; j < numExternalViewPerSourceCluster; j++) {
+        String resourceName = String.format("Resource%s", j);
+        ExternalView ev = new ExternalView(resourceName);
+        for (int k = 0; k < numPartition; k++) {
+          String partitionName = String.format("Partition%s", k);
+          Map<String, String> stateMap = new HashMap<>();
+          stateMap.put(String.format("%s-instance", sourceClusterName), "MASTER");
+          ev.setStateMap(partitionName, stateMap);
+        }
+        externalViewList.add(ev);
+      }
+      provider.setExternalViews(externalViewList);
+      dataProviderMap.put(sourceClusterName, provider);
+    }
+  }
+}

--- a/helix-view-aggregator/src/test/java/org/apache/helix/view/dataprovider/DataProviderTestUtil.java
+++ b/helix-view-aggregator/src/test/java/org/apache/helix/view/dataprovider/DataProviderTestUtil.java
@@ -1,0 +1,48 @@
+package org.apache.helix.view.dataprovider;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.helix.PropertyType;
+import org.apache.helix.api.config.ViewClusterSourceConfig;
+import org.apache.helix.model.ClusterConfig;
+
+public class DataProviderTestUtil {
+  private static final int viewClusterRefreshPeriod = 10;
+  private static final String testZkAddr = "localhost:1010";
+  private static final List<PropertyType> testProperties =
+      Arrays.asList(PropertyType.LIVEINSTANCES, PropertyType.EXTERNALVIEW, PropertyType.INSTANCES);
+
+  public static ClusterConfig createDefaultViewClusterConfig(String viewClusterName,
+      int numSourceCluster) {
+    ClusterConfig config = new ClusterConfig(viewClusterName);
+    config.setViewCluster();
+    config.setViewClusterRefreshPeriod(viewClusterRefreshPeriod);
+    List<ViewClusterSourceConfig> sourceConfigs = new ArrayList<>();
+    for (int i = 0; i < numSourceCluster; i++) {
+      String sourceClusterName = "cluster" + i;
+      sourceConfigs.add(new ViewClusterSourceConfig(sourceClusterName, testZkAddr, testProperties));
+    }
+    config.setViewClusterSourceConfigs(sourceConfigs);
+    return config;
+  }
+}

--- a/helix-view-aggregator/src/test/java/org/apache/helix/view/dataprovider/TestSourceClusterConfigChangeAction.java
+++ b/helix-view-aggregator/src/test/java/org/apache/helix/view/dataprovider/TestSourceClusterConfigChangeAction.java
@@ -1,0 +1,133 @@
+package org.apache.helix.view.dataprovider;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.helix.PropertyType;
+import org.apache.helix.api.config.ViewClusterSourceConfig;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.view.aggregator.SourceClusterConfigChangeAction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestSourceClusterConfigChangeAction {
+  private static final String viewClusterName = "testSourceClusterConfigChangeAction-viewCluster";
+  private static final String testZkAddr = "localhost:5050";
+
+  @Test
+  public void testActionComputationOnStartup() {
+    ClusterConfig config = DataProviderTestUtil.createDefaultViewClusterConfig(viewClusterName, 2);
+    SourceClusterConfigChangeAction action = new SourceClusterConfigChangeAction(null, config);
+    action.computeAction();
+    Assert.assertEquals(action.getConfigsToAdd().size(),
+        config.getViewClusterSourceConfigs().size());
+    Assert.assertEquals(action.getConfigsToDelete().size(), 0);
+    Assert.assertTrue(action.shouldResetTimer());
+    Assert.assertEquals(action.getCurrentRefreshPeriodMs(),
+        config.getViewClusterRefershPeriod() * 1000);
+    Assert.assertTrue(compareSourceClusterConfigs(action.getConfigsToAdd(),
+        config.getViewClusterSourceConfigs()));
+  }
+
+  @Test
+  public void testActionComputationOnConfigModified() {
+    ClusterConfig config = DataProviderTestUtil.createDefaultViewClusterConfig(viewClusterName, 2);
+    ClusterConfig newConfig = new ClusterConfig(viewClusterName);
+    newConfig.setViewCluster();
+
+    List<PropertyType> newProperties =
+        Arrays.asList(new PropertyType[] { PropertyType.LIVEINSTANCES, PropertyType.EXTERNALVIEW });
+    List<ViewClusterSourceConfig> newSourceConfigs =
+        new ArrayList<>(config.getViewClusterSourceConfigs());
+    newConfig.setViewClusterRefreshPeriod(config.getViewClusterRefershPeriod());
+
+    // Remove one source cluster, and add another source cluster
+    ViewClusterSourceConfig removed = newSourceConfigs.get(0);
+    newSourceConfigs.remove(0);
+    newSourceConfigs.add(new ViewClusterSourceConfig("cluster3", testZkAddr, newProperties));
+    newConfig.setViewClusterSourceConfigs(newSourceConfigs);
+
+    SourceClusterConfigChangeAction action = new SourceClusterConfigChangeAction(config, newConfig);
+    action.computeAction();
+    Assert.assertEquals(action.getConfigsToDelete().size(), 1);
+    Assert.assertEquals(action.getConfigsToAdd().size(), 1);
+    Assert.assertEquals(action.getConfigsToDelete().get(0), removed);
+    Assert.assertEquals(action.getConfigsToAdd().get(0),
+        newConfig.getViewClusterSourceConfigs().get(1));
+
+    // modify one source cluster
+    newSourceConfigs = new ArrayList<>(config.getViewClusterSourceConfigs());
+    newSourceConfigs.get(0).setProperties(newProperties);
+    newConfig.setViewClusterSourceConfigs(newSourceConfigs);
+    action = new SourceClusterConfigChangeAction(config, newConfig);
+    action.computeAction();
+
+    Assert.assertEquals(action.getConfigsToDelete().size(), 1);
+    Assert.assertEquals(action.getConfigsToAdd().size(), 1);
+    Assert.assertEquals(action.getConfigsToDelete().get(0),
+        config.getViewClusterSourceConfigs().get(0));
+    Assert.assertEquals(action.getConfigsToAdd().get(0),
+        newConfig.getViewClusterSourceConfigs().get(0));
+  }
+
+  @Test
+  public void testActionComputationNoChange() {
+    ClusterConfig config = DataProviderTestUtil.createDefaultViewClusterConfig(viewClusterName, 2);
+    SourceClusterConfigChangeAction action = new SourceClusterConfigChangeAction(config, config);
+    Assert.assertEquals(action.getConfigsToAdd().size(), 0);
+    Assert.assertEquals(action.getConfigsToDelete().size(), 0);
+    Assert.assertFalse(action.shouldResetTimer());
+  }
+
+  @Test
+  public void testActionComputationInvalidInitialization() {
+    ClusterConfig config = DataProviderTestUtil.createDefaultViewClusterConfig(viewClusterName, 2);
+    ClusterConfig badConfig = new ClusterConfig(viewClusterName);
+    try {
+      SourceClusterConfigChangeAction action = new SourceClusterConfigChangeAction(config, null);
+      Assert.assertFalse(true, "New config should not be null");
+    } catch (IllegalArgumentException e) {
+      // OK
+    }
+
+    try {
+      SourceClusterConfigChangeAction action =
+          new SourceClusterConfigChangeAction(badConfig, config);
+      Assert.assertFalse(true, "Old config should be view cluster config");
+    } catch (IllegalArgumentException e) {
+      // OK
+    }
+
+    try {
+      SourceClusterConfigChangeAction action =
+          new SourceClusterConfigChangeAction(config, badConfig);
+      Assert.assertFalse(true, "New config should be view cluster config");
+    } catch (IllegalArgumentException e) {
+      // OK
+    }
+  }
+
+  private static boolean compareSourceClusterConfigs(List<ViewClusterSourceConfig> list1,
+      List<ViewClusterSourceConfig> list2) {
+    return list1.containsAll(list2) && list2.containsAll(list1);
+  }
+}

--- a/helix-view-aggregator/src/test/java/org/apache/helix/view/integration/TestHelixViewAggregator.java
+++ b/helix-view-aggregator/src/test/java/org/apache/helix/view/integration/TestHelixViewAggregator.java
@@ -1,0 +1,274 @@
+package org.apache.helix.view.integration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixException;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.PropertyType;
+import org.apache.helix.api.config.ViewClusterSourceConfig;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.Message;
+import org.apache.helix.participant.statemachine.StateModelParser;
+import org.apache.helix.view.mock.MockViewClusterSpectator;
+import org.apache.helix.view.statemodel.DistViewAggregatorStateModel;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestHelixViewAggregator extends ViewAggregatorIntegrationTestBase {
+  private static final int numSourceCluster = 3;
+  private static final String stateModel = "LeaderStandby";
+  private static final int numResourcePerSourceCluster = 3;
+  private static final int numResourcePartition = 3;
+  private static final int numReplicaPerResourcePartition = 2;
+  private static final String resourceNamePrefix = "testResource";
+  private static final String viewClusterName = "ViewCluster-TestHelixViewAggregator";
+  private static final StateModelParser stateModelParser = new StateModelParser();
+  private int _viewClusterRefreshPeriodSec = 5;
+  private ConfigAccessor _configAccessor;
+  private HelixAdmin _helixAdmin;
+  private MockViewClusterSpectator _monitor;
+  private Set<String> _allResources = new HashSet<>();
+  private DistViewAggregatorStateModel _viewAggregatorStateModel;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    // Set up source clusters
+    super.beforeClass();
+
+    // Setup tools
+    _configAccessor = new ConfigAccessor(_gZkClient);
+    _helixAdmin = new ZKHelixAdmin(_gZkClient);
+
+    // Set up view cluster
+    _gSetupTool.addCluster(viewClusterName, true);
+    ClusterConfig viewClusterConfig = new ClusterConfig(viewClusterName);
+    viewClusterConfig.setViewCluster();
+    viewClusterConfig.setViewClusterRefreshPeriod(_viewClusterRefreshPeriodSec);
+    List<ViewClusterSourceConfig> sourceConfigs = new ArrayList<>();
+    for (String sourceClusterName : _allSourceClusters) {
+      // We are going to aggregate all supported properties
+      sourceConfigs.add(new ViewClusterSourceConfig(sourceClusterName, ZK_ADDR,
+          ViewClusterSourceConfig.getValidPropertyTypes()));
+    }
+    viewClusterConfig.setViewClusterSourceConfigs(sourceConfigs);
+    _configAccessor.setClusterConfig(viewClusterName, viewClusterConfig);
+
+    // Set up view cluster monitor
+    _monitor = new MockViewClusterSpectator(viewClusterName, ZK_ADDR);
+
+    _viewAggregatorStateModel = new DistViewAggregatorStateModel(ZK_ADDR);
+    triggerViewAggregatorStateTransition("OFFLINE", "STANDBY");
+  }
+
+  private void triggerViewAggregatorStateTransition(String fromState, String toState)
+      throws Exception {
+    if (!_viewAggregatorStateModel.getCurrentState().equalsIgnoreCase(fromState)) {
+      throw new IllegalStateException(String
+          .format("From state (%s) != current state (%s).", fromState,
+              _viewAggregatorStateModel.getCurrentState()));
+    } else if (_viewAggregatorStateModel.getCurrentState().equalsIgnoreCase(toState)) {
+      return;
+    }
+    NotificationContext context = new NotificationContext(null);
+    Message msg = new Message(Message.MessageType.STATE_TRANSITION, "msgId");
+    msg.setPartitionName(viewClusterName);
+    msg.setFromState(fromState);
+    msg.setToState(toState);
+    Method method = stateModelParser.getMethodForTransition(_viewAggregatorStateModel.getClass(),
+        fromState, toState, new Class[] { Message.class, NotificationContext.class });
+    method.invoke(_viewAggregatorStateModel, msg, context);
+    _viewAggregatorStateModel.updateState(toState);
+  }
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    _monitor.shutdown();
+    super.afterClass();
+  }
+
+  @Test
+  public void testHelixViewAggregator() throws Exception {
+    // Clean up initial events
+    _monitor.reset();
+
+    // Start view aggregator
+    triggerViewAggregatorStateTransition("STANDBY", "LEADER");
+
+    // Wait for refresh and verify
+    Thread.sleep((_viewClusterRefreshPeriodSec + 2) * 1000);
+    verifyViewClusterEventChanges(false, true, true);
+    Set<String> allParticipantNames = new HashSet<>();
+    for (MockParticipantManager participant : _allParticipants) {
+      allParticipantNames.add(participant.getInstanceName());
+    }
+    Assert.assertEquals(
+        new HashSet<>(_monitor.getPropertyNamesFromViewCluster(PropertyType.LIVEINSTANCES)),
+        allParticipantNames);
+    Assert.assertEquals(
+        new HashSet<>(_monitor.getPropertyNamesFromViewCluster(PropertyType.INSTANCES)),
+        allParticipantNames);
+    _monitor.reset();
+
+    // Create resource and trigger rebalance
+    createResources();
+    rebalanceResources();
+
+    // Wait for refresh and verify
+    Thread.sleep((_viewClusterRefreshPeriodSec + 2) * 1000);
+    verifyViewClusterEventChanges(true, false, false);
+    Assert.assertEquals(
+        new HashSet<>(_monitor.getPropertyNamesFromViewCluster(PropertyType.EXTERNALVIEW)),
+        _allResources);
+    _monitor.reset();
+
+    // Remove 1 resource from a cluster, we should get corresponding changes in view cluster
+    List<String> resourceNameList = new ArrayList<>(_allResources);
+    _gSetupTool.dropResourceFromCluster(_allSourceClusters.get(0), resourceNameList.get(0));
+    rebalanceResources();
+
+    // Wait for refresh and verify
+    Thread.sleep((_viewClusterRefreshPeriodSec + 2) * 1000);
+    verifyViewClusterEventChanges(true, false, false);
+    Assert.assertEquals(
+        new HashSet<>(_monitor.getPropertyNamesFromViewCluster(PropertyType.EXTERNALVIEW)), _allResources);
+    _monitor.reset();
+
+    // Modify view cluster config
+    _viewClusterRefreshPeriodSec = 3;
+    List<PropertyType> newProperties =
+        new ArrayList<>(ViewClusterSourceConfig.getValidPropertyTypes());
+    newProperties.remove(PropertyType.LIVEINSTANCES);
+    resetViewClusterConfig(_viewClusterRefreshPeriodSec, newProperties);
+
+    // Wait for refresh and verify
+    Thread.sleep((_viewClusterRefreshPeriodSec + 2) * 1000);
+    verifyViewClusterEventChanges(false, false, true);
+    Assert.assertEquals(_monitor.getPropertyNamesFromViewCluster(PropertyType.LIVEINSTANCES).size(),
+        0);
+    _monitor.reset();
+
+    // Simulate view aggregator service crashed and got reset
+    triggerViewAggregatorStateTransition("LEADER", "STANDBY");
+    _viewAggregatorStateModel
+        .rollbackOnError(new Message(Message.MessageType.STATE_TRANSITION, "test"),
+            new NotificationContext(null), null);
+    _viewAggregatorStateModel.updateState("ERROR");
+    triggerViewAggregatorStateTransition("ERROR", "OFFLINE");
+
+    // Change happened during view aggregator down
+    newProperties = new ArrayList<>(ViewClusterSourceConfig.getValidPropertyTypes());
+    newProperties.remove(PropertyType.INSTANCES);
+    resetViewClusterConfig(_viewClusterRefreshPeriodSec, newProperties);
+    MockParticipantManager participant = _allParticipants.get(0);
+
+    participant.syncStop();
+    _helixAdmin.enableInstance(participant.getClusterName(), participant.getInstanceName(), false);
+    _gSetupTool.dropInstanceFromCluster(participant.getClusterName(), participant.getInstanceName());
+    rebalanceResources();
+    allParticipantNames.remove(participant.getInstanceName());
+
+    // Restart helix view aggregator
+    triggerViewAggregatorStateTransition("OFFLINE", "STANDBY");
+    triggerViewAggregatorStateTransition("STANDBY", "LEADER");
+
+    // Wait for refresh and verify
+    Thread.sleep((_viewClusterRefreshPeriodSec + 2) * 1000);
+    verifyViewClusterEventChanges(true, true, true);
+    Assert.assertEquals(
+        new HashSet<>(_monitor.getPropertyNamesFromViewCluster(PropertyType.EXTERNALVIEW)),
+        _allResources);
+    Assert.assertEquals(
+        new HashSet<>(_monitor.getPropertyNamesFromViewCluster(PropertyType.LIVEINSTANCES)),
+        allParticipantNames);
+    Assert.assertEquals(_monitor.getPropertyNamesFromViewCluster(PropertyType.INSTANCES).size(), 0);
+
+    // Stop view aggregator
+    triggerViewAggregatorStateTransition("LEADER", "STANDBY");
+  }
+
+  private void resetViewClusterConfig(int refreshPeriod, List<PropertyType> properties) {
+    List<ViewClusterSourceConfig> sourceConfigs = new ArrayList<>();
+    for (String sourceCluster : _allSourceClusters) {
+      sourceConfigs.add(new ViewClusterSourceConfig(sourceCluster, ZK_ADDR, properties));
+    }
+
+    ClusterConfig viewClusterConfig = _configAccessor.getClusterConfig(viewClusterName);
+    viewClusterConfig.setViewClusterRefreshPeriod(refreshPeriod);
+    viewClusterConfig.setViewClusterSourceConfigs(sourceConfigs);
+    _configAccessor.setClusterConfig(viewClusterName, viewClusterConfig);
+  }
+
+  private void verifyViewClusterEventChanges(boolean externalViewChange,
+      boolean instanceConfigChange, boolean liveInstancesChange) {
+    Assert.assertEquals(_monitor.getExternalViewChangeCount() > 0, externalViewChange);
+    Assert.assertEquals(_monitor.getInstanceConfigChangeCount() > 0, instanceConfigChange);
+    Assert.assertEquals(_monitor.getLiveInstanceChangeCount() > 0, liveInstancesChange);
+  }
+
+  /**
+   * Create same sets of resources for each cluster
+   */
+  private void createResources() {
+    System.out.println("Creating resources ...");
+    for (String sourceClusterName : _allSourceClusters) {
+      for (int i = 0; i < numResourcePerSourceCluster; i++) {
+        String resourceName = resourceNamePrefix + i;
+        _gSetupTool.addResourceToCluster(sourceClusterName, resourceName, numResourcePartition,
+            stateModel);
+        _allResources.add(resourceName);
+      }
+    }
+  }
+
+  /**
+   * Rebalance all resources on each cluster
+   */
+  private void rebalanceResources() {
+    System.out.println("Rebalancing resources ...");
+    for (String sourceClusterName : _allSourceClusters) {
+      for (String resourceName : _allResources) {
+        // We always rebalance all resources, even if it would be deleted during test
+        // We assume rebalance will be successful
+        try {
+          _gSetupTool
+              .rebalanceResource(sourceClusterName, resourceName, numReplicaPerResourcePartition);
+        } catch (HelixException e) {
+          // ok
+        }
+      }
+    }
+  }
+
+  @Override
+  protected int getNumSourceCluster() {
+    return numSourceCluster;
+  }
+}

--- a/helix-view-aggregator/src/test/java/org/apache/helix/view/integration/TestSourceClusterDataProvider.java
+++ b/helix-view-aggregator/src/test/java/org/apache/helix/view/integration/TestSourceClusterDataProvider.java
@@ -1,0 +1,141 @@
+package org.apache.helix.view.integration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import org.apache.helix.PropertyType;
+import org.apache.helix.api.config.ViewClusterSourceConfig;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.view.dataprovider.SourceClusterDataProvider;
+import org.apache.helix.view.mock.MockClusterEventProcessor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestSourceClusterDataProvider extends ViewAggregatorIntegrationTestBase {
+  private static final int numSourceCluster = 1;
+  private static final String stateModel = "MasterSlave";
+  private static final String testResource = "testResource";
+
+  @Test
+  public void testSourceClusterDataProviderWatchAndRefresh() throws Exception {
+    String clusterName = _allSourceClusters.get(0);
+    List<PropertyType> properties = Arrays
+        .asList(PropertyType.LIVEINSTANCES, PropertyType.EXTERNALVIEW, PropertyType.INSTANCES);
+
+    ViewClusterSourceConfig sourceClusterConfig =
+        new ViewClusterSourceConfig(clusterName, ZK_ADDR, properties);
+
+    MockClusterEventProcessor processor = new MockClusterEventProcessor(clusterName);
+    processor.start();
+
+    SourceClusterDataProvider dataProvider =
+        new SourceClusterDataProvider(sourceClusterConfig, processor);
+
+    // setup can be re-called
+    dataProvider.setup();
+    dataProvider.setup();
+
+    Assert.assertEquals(new HashSet<>(dataProvider.getPropertiesToAggregate()),
+        new HashSet<>(properties));
+
+    // When first connected, data provider will have some initial events
+    Assert.assertEquals(processor.getHandledExternalViewChangeCount(), 1);
+    Assert.assertEquals(processor.getHandledInstanceConfigChangeCount(), 1);
+    Assert.assertEquals(processor.getHandledLiveInstancesChangeCount(), 1);
+    processor.resetHandledEventCount();
+
+    // ListNames should work
+    Assert.assertEquals(dataProvider.getInstanceConfigNames().size(), numParticipant);
+    Assert.assertEquals(dataProvider.getLiveInstanceNames().size(), numParticipant);
+    Assert.assertEquals(dataProvider.getExternalViewNames().size(), 0);
+
+    processor.resetHandledEventCount();
+
+    // rebalance resource to check external view related events
+    _gSetupTool.addResourceToCluster(clusterName, testResource, numParticipant, stateModel);
+    _gSetupTool.rebalanceResource(clusterName, testResource, 3);
+    Thread.sleep(1000);
+    Assert.assertTrue(processor.getHandledExternalViewChangeCount() > 0);
+    Assert.assertEquals(dataProvider.getExternalViewNames().size(), 1);
+
+    // refresh data provider will have correct data loaded
+    dataProvider.refreshCache();
+    Assert.assertEquals(dataProvider.getLiveInstances().size(), numParticipant);
+    Assert.assertEquals(dataProvider.getInstanceConfigMap().size(), numParticipant);
+    Assert.assertEquals(dataProvider.getExternalViews().size(), 1);
+    processor.resetHandledEventCount();
+
+    // Add additional participant will have corresponding change
+    String testParticipantName = "testParticipant";
+    _gSetupTool.addInstanceToCluster(clusterName, testParticipantName);
+    MockParticipantManager participant =
+        new MockParticipantManager(ZK_ADDR, clusterName, testParticipantName);
+    participant.syncStart();
+
+    Thread.sleep(500);
+    Assert.assertEquals(processor.getHandledInstanceConfigChangeCount(), 1);
+    Assert.assertEquals(processor.getHandledLiveInstancesChangeCount(), 1);
+
+    // shutdown can be re-called
+    dataProvider.shutdown();
+    dataProvider.shutdown();
+
+    // Verify cache is cleaned up
+    Assert.assertEquals(dataProvider.getLiveInstances().size(), 0);
+    Assert.assertEquals(dataProvider.getInstanceConfigMap().size(), 0);
+    Assert.assertEquals(dataProvider.getExternalViews().size(), 0);
+  }
+
+  @Test
+  public void testSourceClusterDataProviderPropertyFilter() throws Exception {
+    String clusterName = _allSourceClusters.get(0);
+    List<PropertyType> properties = Arrays.asList(
+        new PropertyType[] { PropertyType.LIVEINSTANCES, PropertyType.EXTERNALVIEW });
+
+    ViewClusterSourceConfig sourceClusterConfig =
+        new ViewClusterSourceConfig(clusterName, ZK_ADDR, properties);
+
+    MockClusterEventProcessor processor = new MockClusterEventProcessor(clusterName);
+    processor.start();
+
+    SourceClusterDataProvider dataProvider =
+        new SourceClusterDataProvider(sourceClusterConfig, processor);
+    dataProvider.setup();
+
+    Assert.assertEquals(new HashSet<>(dataProvider.getPropertiesToAggregate()),
+        new HashSet<>(properties));
+
+    // When first connected, data provider will have some initial events, but InstanceConfig
+    // will be filtered out since its not in properties
+    Assert.assertEquals(processor.getHandledExternalViewChangeCount(), 1);
+    Assert.assertEquals(processor.getHandledInstanceConfigChangeCount(), 0);
+    Assert.assertEquals(processor.getHandledLiveInstancesChangeCount(), 1);
+
+    dataProvider.shutdown();
+  }
+
+  @Override
+  protected int getNumSourceCluster() {
+    return numSourceCluster;
+  }
+
+}

--- a/helix-view-aggregator/src/test/java/org/apache/helix/view/integration/ViewAggregatorIntegrationTestBase.java
+++ b/helix-view-aggregator/src/test/java/org/apache/helix/view/integration/ViewAggregatorIntegrationTestBase.java
@@ -1,0 +1,87 @@
+package org.apache.helix.view.integration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+public class ViewAggregatorIntegrationTestBase extends ZkTestBase {
+  protected static final int numSourceCluster = 2;
+  protected static final int numParticipant = 3;
+  protected static final String testSourceClusterNamePrefix = "testSourceCluster";
+  protected static final String testParticipantNamePrefix = "testParticipant";
+  protected static final String testControllerNamePrefix = "testController";
+
+  protected List<String> _allSourceClusters = new ArrayList<>();
+  protected List<MockParticipantManager> _allParticipants = new ArrayList<>();
+  protected List<ClusterControllerManager> _allControllers = new ArrayList<>();
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    for (int i = 0; i < getNumSourceCluster(); i++) {
+      // Setup cluster
+      String clusterName =
+          String.format("%s-%s-%s", testSourceClusterNamePrefix, this.hashCode(), i);
+      _gSetupTool.addCluster(clusterName, false);
+      // Setup participants
+      for (int j = 0; j < numParticipant; j++) {
+        String instanceName = String.format("%s-%s-%s", clusterName, testParticipantNamePrefix, j);
+        _gSetupTool.addInstanceToCluster(clusterName, instanceName);
+        MockParticipantManager participant =
+            new MockParticipantManager(ZK_ADDR, clusterName, instanceName);
+        participant.syncStart();
+        _allParticipants.add(participant);
+      }
+
+      // Setup controller
+      ClusterControllerManager controller = new ClusterControllerManager(ZK_ADDR, clusterName,
+          String.format("%s-%s", testControllerNamePrefix, clusterName));
+      controller.syncStart();
+      _allControllers.add(controller);
+      _allSourceClusters.add(clusterName);
+    }
+  }
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    // Stop all controllers
+    for (ClusterControllerManager controller : _allControllers) {
+      if (controller.isConnected()) {
+        controller.syncStop();
+      }
+    }
+
+    // Stop all participants
+    for (MockParticipantManager participant : _allParticipants) {
+      if (participant.isConnected()) {
+        participant.syncStop();
+      }
+    }
+  }
+
+  protected int getNumSourceCluster() {
+    return numSourceCluster;
+  }
+}

--- a/helix-view-aggregator/src/test/java/org/apache/helix/view/mock/MockClusterEventProcessor.java
+++ b/helix-view-aggregator/src/test/java/org/apache/helix/view/mock/MockClusterEventProcessor.java
@@ -1,0 +1,79 @@
+package org.apache.helix.view.mock;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.common.DedupEventProcessor;
+import org.apache.helix.view.common.ClusterViewEvent;
+
+public class MockClusterEventProcessor
+    extends DedupEventProcessor<ClusterViewEvent.Type, ClusterViewEvent> {
+  private int _handledClusterConfigChange;
+  private int _handledExternalViewChange;
+  private int _handledInstanceConfigChange;
+  private int _handledLiveInstancesChange;
+
+  public MockClusterEventProcessor(String clusterName) {
+    super(clusterName);
+    resetHandledEventCount();
+  }
+
+  public int getHandledClusterConfigChangeCount() {
+    return _handledClusterConfigChange;
+  }
+
+  public int getHandledExternalViewChangeCount() {
+    return _handledExternalViewChange;
+  }
+
+  public int getHandledInstanceConfigChangeCount() {
+    return _handledInstanceConfigChange;
+  }
+
+  public int getHandledLiveInstancesChangeCount() {
+    return _handledLiveInstancesChange;
+  }
+
+  public void resetHandledEventCount() {
+    _handledClusterConfigChange = 0;
+    _handledExternalViewChange = 0;
+    _handledInstanceConfigChange = 0;
+    _handledLiveInstancesChange = 0;
+  }
+
+  @Override
+  public void handleEvent(ClusterViewEvent event) {
+    switch (event.getEventType()) {
+    case ConfigChange:
+      _handledClusterConfigChange += 1;
+      break;
+    case LiveInstanceChange:
+      _handledLiveInstancesChange += 1;
+      break;
+    case InstanceConfigChange:
+      _handledInstanceConfigChange += 1;
+      break;
+    case ExternalViewChange:
+      _handledExternalViewChange += 1;
+      break;
+    default:
+      break;
+    }
+  }
+}

--- a/helix-view-aggregator/src/test/java/org/apache/helix/view/mock/MockSourceClusterDataProvider.java
+++ b/helix-view-aggregator/src/test/java/org/apache/helix/view/mock/MockSourceClusterDataProvider.java
@@ -1,0 +1,104 @@
+package org.apache.helix.view.mock;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.api.config.ViewClusterSourceConfig;
+import org.apache.helix.common.DedupEventProcessor;
+import org.apache.helix.common.caches.ExternalViewCache;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.view.common.ClusterViewEvent;
+import org.apache.helix.view.dataprovider.SourceClusterDataProvider;
+
+public class MockSourceClusterDataProvider extends SourceClusterDataProvider {
+
+  static class MockExternalViewCache extends ExternalViewCache {
+
+    public MockExternalViewCache(String clusterName) {
+      super(clusterName);
+    }
+
+    public void setExternalView(List<ExternalView> externalViews) {
+      Map<String, ExternalView> evMap = new HashMap<>();
+      for (ExternalView ev : externalViews) {
+        evMap.put(ev.getId(), ev);
+      }
+      // Set _externalViewMap instead of _externalViewCache as we serve ExternalViewCache
+      // APIs using data inside the map
+      _externalViewMap = evMap;
+    }
+  }
+
+  public MockSourceClusterDataProvider(ViewClusterSourceConfig config,
+      DedupEventProcessor<ClusterViewEvent.Type, ClusterViewEvent> processor) {
+    super(config, processor);
+    _externalViewCache = new MockExternalViewCache("Test");
+  }
+
+  @Override
+  public void setup() {}
+
+  @Override
+  public void refreshCache() {}
+
+  @Override
+  public List<String> getInstanceConfigNames() {
+    return new ArrayList<>(getInstanceConfigMap().keySet());
+  }
+
+  @Override
+  public List<String> getLiveInstanceNames() {
+    return new ArrayList<>(getLiveInstances().keySet());
+  }
+
+  @Override
+  public List<String> getExternalViewNames() {
+    return new ArrayList<>(getExternalViews().keySet());
+  }
+
+  public void setConfig(ViewClusterSourceConfig config) {
+    _sourceClusterConfig = config;
+  }
+
+  public ViewClusterSourceConfig getConfig() {
+    return _sourceClusterConfig;
+  }
+
+  public void setInstanceConfigs(List<InstanceConfig> instanceConfigList) {
+    for (InstanceConfig config : instanceConfigList) {
+      _instanceConfigMap.put(config.getInstanceName(), config);
+    }
+  }
+
+  public void setLiveInstances(List<LiveInstance> liveInstanceList) {
+    for (LiveInstance instance : liveInstanceList) {
+      _liveInstanceMap.put(instance.getInstanceName(), instance);
+    }
+  }
+
+  public void setExternalViews(List<ExternalView> externalViewList) {
+    ((MockExternalViewCache) _externalViewCache).setExternalView(externalViewList);
+  }
+}

--- a/helix-view-aggregator/src/test/java/org/apache/helix/view/mock/MockViewClusterSpectator.java
+++ b/helix-view-aggregator/src/test/java/org/apache/helix/view/mock/MockViewClusterSpectator.java
@@ -1,0 +1,123 @@
+package org.apache.helix.view.mock;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.PropertyType;
+import org.apache.helix.api.listeners.ExternalViewChangeListener;
+import org.apache.helix.api.listeners.InstanceConfigChangeListener;
+import org.apache.helix.api.listeners.LiveInstanceChangeListener;
+import org.apache.helix.api.listeners.PreFetch;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.view.common.ClusterViewEvent;
+
+/**
+ * MockViewClusterSpectator monitors change in view cluster. When event happens, it push event to
+ * MockClusterEventProcessor which records event change count in view cluster
+ */
+public class MockViewClusterSpectator implements ExternalViewChangeListener,
+    InstanceConfigChangeListener, LiveInstanceChangeListener{
+  private final HelixManager _manager;
+  private final MockClusterEventProcessor _eventProcessor;
+  private final String _viewClusterName;
+  private final HelixDataAccessor _dataAccessor;
+
+  public MockViewClusterSpectator(String viewClusterName, String zkAddr) throws Exception {
+    _viewClusterName = viewClusterName;
+    _eventProcessor = new MockClusterEventProcessor(viewClusterName);
+    _eventProcessor.start();
+    _manager = HelixManagerFactory
+        .getZKHelixManager(viewClusterName, "MockViewClusterSpectator-" + viewClusterName,
+            InstanceType.SPECTATOR, zkAddr);
+    _manager.connect();
+    _manager.addExternalViewChangeListener(this);
+    _manager.addLiveInstanceChangeListener(this);
+    _manager.addInstanceConfigChangeListener(this);
+    _dataAccessor = _manager.getHelixDataAccessor();
+  }
+
+  public void shutdown() throws Exception {
+    _eventProcessor.interrupt();
+    if (_manager != null && _manager.isConnected()) {
+      _manager.disconnect();
+    }
+  }
+
+  @Override
+  @PreFetch(enabled = false)
+  public void onExternalViewChange(List<ExternalView> externalViewList,
+      NotificationContext changeContext) {
+    _eventProcessor.queueEvent(ClusterViewEvent.Type.ExternalViewChange,
+        new ClusterViewEvent(_viewClusterName, ClusterViewEvent.Type.ExternalViewChange));
+  }
+
+  @Override
+  @PreFetch(enabled = false)
+  public void onInstanceConfigChange(List<InstanceConfig> instanceConfigs,
+      NotificationContext context) {
+    _eventProcessor.queueEvent(ClusterViewEvent.Type.InstanceConfigChange,
+        new ClusterViewEvent(_viewClusterName, ClusterViewEvent.Type.InstanceConfigChange));
+  }
+
+  @Override
+  @PreFetch(enabled = false)
+  public void onLiveInstanceChange(List<LiveInstance> liveInstances,
+      NotificationContext changeContext) {
+    _eventProcessor.queueEvent(ClusterViewEvent.Type.LiveInstanceChange,
+        new ClusterViewEvent(_viewClusterName, ClusterViewEvent.Type.LiveInstanceChange));
+  }
+
+  public int getLiveInstanceChangeCount() {
+    return _eventProcessor.getHandledLiveInstancesChangeCount();
+  }
+
+  public int getInstanceConfigChangeCount() {
+    return _eventProcessor.getHandledInstanceConfigChangeCount();
+  }
+
+  public int getExternalViewChangeCount() {
+    return _eventProcessor.getHandledExternalViewChangeCount();
+  }
+
+  public void reset() {
+    _eventProcessor.resetHandledEventCount();
+  }
+
+  public List<String> getPropertyNamesFromViewCluster(PropertyType propertyType) {
+    switch (propertyType) {
+    case INSTANCES:
+      return _dataAccessor.getChildNames(_dataAccessor.keyBuilder().instanceConfigs());
+    case LIVEINSTANCES:
+      return _dataAccessor.getChildNames(_dataAccessor.keyBuilder().liveInstances());
+    case EXTERNALVIEW:
+      return _dataAccessor.getChildNames(_dataAccessor.keyBuilder().externalViews());
+    default:
+      return null;
+    }
+  }
+
+}

--- a/helix-view-aggregator/src/test/java/org/apache/helix/view/monitoring/TestViewAggregatorMonitor.java
+++ b/helix-view-aggregator/src/test/java/org/apache/helix/view/monitoring/TestViewAggregatorMonitor.java
@@ -1,0 +1,92 @@
+package org.apache.helix.view.monitoring;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.lang.management.ManagementFactory;
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.apache.helix.monitoring.mbeans.MBeanRegistrar;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestViewAggregatorMonitor {
+  private static final MBeanServer _beanServer = ManagementFactory.getPlatformMBeanServer();
+
+  @Test
+  public void testViewAggregatorMonitorMBeanRegistration() throws Exception {
+    String cluster1 = "cluster1";
+    String cluster2 = "cluster2";
+    ObjectName name1 = generateObjectName(cluster1);
+    ObjectName name2 = generateObjectName(cluster2);
+
+    ViewAggregatorMonitor monitor1 = new ViewAggregatorMonitor(cluster1);
+    monitor1.register();
+
+    ViewAggregatorMonitor monitor2 = new ViewAggregatorMonitor(cluster2);
+    monitor2.register();
+
+    Assert.assertTrue(_beanServer.isRegistered(name1));
+    Assert.assertTrue(_beanServer.isRegistered(name2));
+
+    monitor1.unregister();
+    monitor2.unregister();
+
+    Assert.assertFalse(_beanServer.isRegistered(name1));
+    Assert.assertFalse(_beanServer.isRegistered(name2));
+  }
+
+  @Test
+  public void testViewAggregatorMonitorDataRecording() throws Exception {
+    String cluster = "testViewCluster";
+    ViewAggregatorMonitor monitor = new ViewAggregatorMonitor(cluster);
+    monitor.register();
+    ObjectName objectName = generateObjectName(cluster);
+
+    monitor.recordProcessedSourceEvent();
+    monitor.recordViewConfigProcessFailure();
+    monitor.recordViewRefreshFailure();
+    monitor.recordReadSourceFailure();
+    monitor.recordRefreshViewLatency(100);
+
+    Assert.assertEquals(
+        (long) _beanServer.getAttribute(objectName, "ViewClusterRefreshFailureCounter"), 1);
+    Assert.assertEquals(
+        (long) _beanServer.getAttribute(objectName, "SourceClusterRefreshFailureCounter"), 1);
+    Assert.assertEquals(
+        (long) _beanServer.getAttribute(objectName, "ProcessedSourceClusterEventCounter"), 1);
+    Assert.assertEquals(
+        (long) _beanServer.getAttribute(objectName, "ProcessViewConfigFailureCounter"), 1);
+    Assert.assertEquals(
+        (long) _beanServer.getAttribute(objectName, "ViewClusterRefreshDurationGauge.Max"), 100);
+    Assert
+        .assertEquals(_beanServer.getAttribute(objectName, "ViewClusterRefreshDurationGauge.Mean"),
+            100.0);
+    Assert.assertEquals(
+        _beanServer.getAttribute(objectName, "ViewClusterRefreshDurationGauge.StdDev"), 0.0);
+  }
+
+  private ObjectName generateObjectName(String viewClusterName) throws JMException {
+    return MBeanRegistrar
+        .buildObjectName(ViewAggregatorMonitor.MBEAN_DOMAIN, ViewAggregatorMonitor.MONITOR_KEY,
+            viewClusterName);
+  }
+
+}

--- a/helix-view-aggregator/src/test/resources/log4j.properties
+++ b/helix-view-aggregator/src/test/resources/log4j.properties
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Set root logger level to DEBUG and its only appender to R.
+log4j.rootLogger=ERROR, C
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.C=org.apache.log4j.ConsoleAppender
+log4j.appender.C.layout=org.apache.log4j.PatternLayout
+log4j.appender.C.layout.ConversionPattern=[%d] [%-5p] [%t] [%c:%L] - %m%n
+
+log4j.appender.R=org.apache.log4j.RollingFileAppender
+log4j.appender.R.layout=org.apache.log4j.PatternLayout
+log4j.appender.R.layout.ConversionPattern=[%d] [%-5p] [%t] [%c:%L] - %m%n
+log4j.appender.R.File=target/ClusterManagerLogs/log.txt
+
+log4j.appender.STATUSDUMP=org.apache.log4j.RollingFileAppender
+log4j.appender.STATUSDUMP.layout=org.apache.log4j.SimpleLayout
+log4j.appender.STATUSDUMP.File=target/ClusterManagerLogs/statusUpdates.log
+
+log4j.logger.org.I0Itec=ERROR
+log4j.logger.org.apache=ERROR
+log4j.logger.org.apache.helix.view=INFO
+log4j.logger.com.noelios=ERROR
+log4j.logger.org.restlet=ERROR
+
+log4j.logger.org.apache.helix.monitoring.ZKPathDataDumpTask=ERROR,STATUSDUMP

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,7 @@ under the License.
     <module>helix-admin-webapp</module>
     <module>helix-rest</module>
     <module>helix-agent</module>
+    <module>helix-view-aggregator</module>
     <!-- <module>helix-front</module> -->
     <module>recipes</module>
   </modules>


### PR DESCRIPTION
Based on #266 , design of helix view aggregator, here is the implementation. Helix view aggregator will be a different module under helix repo, and the impl will use components from helix-core.
Here is a debrief of this PR:

- View cluster related information will be added to `ClusterConfig`, and related java apis will be added to helix-core.
- `SourceClusterDataProvider` is a component that watches changes from source cluster, updates its cached data, and notify data change event via a given channel
- `ViewClusterRefresher` is a component that does the actual refresh operation of the view cluster. It computes diff between source clusters and view cluster, make changes to view cluster accordingly
- `SourceClusterConfigChangeAction` is a wrapper containing information about what to update for a source cluster. It takes in old and new `ClusterConfig` and compute actions to adopt view cluster to the changes
- `HelixViewAggregator` hooks up small components and contains the main reconciliation loop for refreshing view cluster
- Metrics recording mechanism is added
- starting helix view aggregator in a stand-alone mode and distributed mode (by adding state model into helix participant) is supported
- related unit tests and integration tests are added
