### PR TITLE
Skip resources with state model def ref as Task during top state handoff

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
@@ -42,6 +42,7 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
   private static final long DEFAULT_HANDOFF_USER_LATENCY = 0L;
   private static Logger LOG = LoggerFactory.getLogger(TopStateHandoffReportStage.class);
   public static final long TIMESTAMP_NOT_RECORDED = -1L;
+  private static final String TASK_STATE_MODEL_NAME = "Task";
 
   @Override
   public void process(ClusterEvent event) throws Exception {
@@ -88,7 +89,8 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
 
     for (Resource resource : resourceMap.values()) {
       StateModelDefinition stateModelDef = cache.getStateModelDef(resource.getStateModelDefRef());
-      if (stateModelDef == null) {
+      if (stateModelDef == null || resource.getStateModelDefRef()
+          .equalsIgnoreCase(TASK_STATE_MODEL_NAME)) {
         // Resource does not have valid state model, just skip processing
         continue;
       }


### PR DESCRIPTION
We should not report top state handoff for resources with state model def ref as "Task" as this is meaningless and creates too many mbeans in task-intense environments.
