### PR TITLE
Remove unused _forceRebalanceTimer from GenericHelixController

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -129,11 +129,6 @@ public class GenericHelixController implements IdealStateChangeListener,
    */
   Timer _periodicalRebalanceTimer = null;
 
-  /**
-   * The timer to schedule ad hoc forced rebalance or retry rebalance event.
-   */
-  Timer _forceRebalanceTimer = null;
-
   long _timerPeriod = Long.MAX_VALUE;
 
   /**
@@ -383,7 +378,6 @@ public class GenericHelixController implements IdealStateChangeListener,
     _taskEventThread =
         new ClusterEventProcessor(_taskCache, _taskEventQueue, "task-" + clusterName);
 
-    _forceRebalanceTimer = new Timer();
     _lastPipelineEndTimestamp = TopStateHandoffReportStage.TIMESTAMP_NOT_RECORDED;
 
     initializeAsyncFIFOWorkers();


### PR DESCRIPTION
`GenericHelixController. _forceRebalanceTimer` is a non-daemon `Timer` thread. It is started in the initializer of `GenericHelixController` and never shut down.

This causes process JVM shutdown to never finish as this thread is hanging.

However, ` _forceRebalanceTimer` is never actually used for anything. I propose fixing the issue by removing the timer thread entirely.