### PR TITLE
Daemonize SubscribeChangeEventProcessor thread in CallbackProcessor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -135,6 +135,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
           }
         };
 
+    SubscribeChangeEventProcessor.setDaemon(true);
     SubscribeChangeEventProcessor.start();
   }
 


### PR DESCRIPTION
`CallbackProcessor.SubscribeChangeEventProcessor` is a `DedupEventProcessor extends Thread`. It is started in a static initializer in `CallbackProcessor` and never shut down.

This causes process JVM shutdown to never finish as this thread is hanging.

There is no obvious place to shut down the `SubscribeChangeEventProcessor` thread. I propose fixing this by making it a daemon thread. This causes the thread to be abandoned at shutdown. But this might have some unwanted side effects?