### PR TITLE
HELIX: Fix null tgtSessionId message bug

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -267,6 +267,15 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
       for (String state : statesPriorityList) {
         if (messageMap.containsKey(state)) {
           for (Message message : messageMap.get(state)) {
+            // This is for a bug where a message's target session id is null
+            if (!message.isValid()) {
+              LogUtil.logError(logger, _eventId, String.format(
+                  "An invalid message was generated! Discarding this message. sessionIdMap: %s, CurrentStateMap: %s, InstanceStateMap: %s, AllInstances: %s, LiveInstances: %s, Message: %s",
+                  sessionIdMap, currentStateOutput.getCurrentStateMap(resourceName, partition),
+                  instanceStateMap, cache.getAllInstances(), cache.getLiveInstances().keySet(),
+                  message));
+              continue; // Do not add this message
+            }
             output.addMessage(resourceName, partition, message);
           }
         }

--- a/helix-core/src/main/java/org/apache/helix/model/Message.java
+++ b/helix-core/src/main/java/org/apache/helix/model/Message.java
@@ -905,16 +905,15 @@ public class Message extends HelixProperty {
     // TODO: refactor message to state transition message and task-message and
     // implement this function separately
 
-    if (getMsgType().equals(MessageType.STATE_TRANSITION.name())) {
-      boolean isNotValid =
-          isNullOrEmpty(getTgtName()) || isNullOrEmpty(getPartitionName())
-              || isNullOrEmpty(getResourceName()) || isNullOrEmpty(getStateModelDef())
-              || isNullOrEmpty(getToState()) || isNullOrEmpty(getStateModelFactoryName())
-              || isNullOrEmpty(getFromState());
+    if (getMsgType().equals(MessageType.STATE_TRANSITION.name())
+        || getMsgType().equals(MessageType.STATE_TRANSITION_CANCELLATION.name())) {
+      boolean isNotValid = isNullOrEmpty(getTgtName()) || isNullOrEmpty(getPartitionName())
+          || isNullOrEmpty(getResourceName()) || isNullOrEmpty(getStateModelDef())
+          || isNullOrEmpty(getToState()) || isNullOrEmpty(getFromState())
+          || isNullOrEmpty(getTgtSessionId());
 
       return !isNotValid;
     }
-
     return true;
   }
 }


### PR DESCRIPTION
It has been reported that the Controller sometimes sends a message with a null tgtSessionId, which was causing an NPE on the Participant.
Changelist:
    1. Controller side fix
    2. Participant side fix with a try-catch
    3. Modify isValid for messages