### PR TITLE
HELIX-816 use System.currentTimeMillis()

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/AsyncCallback.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/AsyncCallback.java
@@ -108,7 +108,7 @@ public abstract class AsyncCallback {
   final synchronized void startTimer() {
     if (_timer == null && _timeout > 0) {
       if (_startTimeStamp == 0) {
-        _startTimeStamp = new Date().getTime();
+        _startTimeStamp = System.currentTimeMillis();
       }
       _timer = new Timer(true);
       _timer.schedule(new TimeoutTask(this), _timeout);

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -337,7 +337,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
 
       _statusUpdateUtil.logInfo(message, HelixStateTransitionHandler.class,
           "Message handling task begin execute", manager);
-      message.setExecuteStartTimeStamp(new Date().getTime());
+      message.setExecuteStartTimeStamp(System.currentTimeMillis());
 
       try {
         preHandleMessage();


### PR DESCRIPTION
new Date() is just a thin wrapper around System.currentTimeMillis(). Using System.currentTimeMillis() can help speed up the system