### PR TITLE
#328 Exclude ANY_INSTANCE for customized sibling checks

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ExternalView.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ExternalView.java
@@ -40,7 +40,8 @@ public class ExternalView extends HelixProperty {
     RESOURCE_GROUP_NAME,
     GROUP_ROUTING_ENABLED,
     MIN_ACTIVE_REPLICAS,
-    STATE_MODEL_DEF_REF
+    STATE_MODEL_DEF_REF,
+    REPLICAS
   }
 
   /**
@@ -148,6 +149,14 @@ public class ExternalView extends HelixProperty {
    */
   public String getStateModelDefRef() {
     return _record.getSimpleField(ExternalViewProperty.STATE_MODEL_DEF_REF.toString());
+  }
+
+  /**
+   * Get the number of replicas for each partition of this resource
+   * @return number of replicas (as a string)
+   */
+  public String getReplicas() {
+    return _record.getSimpleField(ExternalViewProperty.REPLICAS.name());
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
@@ -35,6 +35,7 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.task.TaskConstants;
 import org.slf4j.Logger;
@@ -210,6 +211,13 @@ public class InstanceValidationUtil {
     List<String> unhealthyPartitions = new ArrayList<>();
 
     for (ExternalView externalView : externalViews) {
+      // Skip ANY_LIVEINSTANCES resources check, since ANY_LIVEINSTANCES resources have single partition
+      // with 1 replica. There is no need to check sibiling replicas.
+      if (ResourceConfig.ResourceConfigConstants.ANY_LIVEINSTANCE.name()
+          .equals(externalView.getReplicas())) {
+        continue;
+      }
+
       StateModelDefinition stateModelDefinition = dataAccessor
           .getProperty(dataAccessor.keyBuilder().stateModelDef(externalView.getStateModelDefRef()));
       for (String partition : externalView.getPartitionSet()) {


### PR DESCRIPTION
Current Helix HealthCheck API checks the ANY_INSTANCE resources, which is not necessary. Since ANY_INSTANCE resources only have single partition with 1 replica, there is no need to check sibling health status.

This commit fixes issue #328

TEST RESULT:
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestWorkflowTermination.testWorkflowSucceed:89->verifyWorkflowCleanup:256 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 834, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 59:42 min
[INFO] Finished at: 2019-07-09T17:51:09-07:00
[INFO] Final Memory: 30M/981M
[INFO] ------------------------------------------------------------------------

[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.637 s - in org.apache.helix.integration.task.TestWorkflowTermination
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 44.461 s
[INFO] Finished at: 2019-07-09T17:53:16-07:00
[INFO] Final Memory: 30M/988M
[INFO] ------------------------------------------------------------------------

