### PR TITLE
Fixing IllegalStateException for CRUSH based rebalance strategy algorithm.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -259,7 +259,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
         return checkBestPossibleStateCalculation(idealState);
       } catch (Exception e) {
         LogUtil
-            .logError(logger, _eventId, "Error computing assignment for resource " + resourceName + ". Skipping.", e);
+            .logError(logger, _eventId, "Error computing assignment for resource " + resourceName + ". Skipping.");
         // TODO : remove this part after debugging NPE
         StringBuilder sb = new StringBuilder();
 


### PR DESCRIPTION
In CRUSH based rebalance strategy, when there is no eligible instance for the controller to use, it shows an exception which is not desirable. This commit fixes the error log and just shows an error message instead of showing an exception.

This commit fixes issue #322 

TEST RESULT: 
[INFO] Tests run: 834, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,099.331 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 834, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  51:43 min
[INFO] Finished at: 2019-07-15T18:22:50-07:00
[INFO] ------------------------------------------------------------------------
