### PR TITLE
Implementation of stateModelDef modification in REST 2.0

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestNamespacedAPIAccess.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestNamespacedAPIAccess.java
@@ -58,7 +58,7 @@ public class TestNamespacedAPIAccess extends AbstractTestClass {
   }
 
 
-  @Test
+  @Test(dependsOnMethods = "testDefaultNamespaceCompatibility")
   public void testNamespacedCRUD() throws IOException {
     String testClusterName = "testClusterForNamespacedCRUD";
 
@@ -91,7 +91,7 @@ public class TestNamespacedAPIAccess extends AbstractTestClass {
     get(String.format("/clusters/%s", testClusterName), null, Response.Status.OK.getStatusCode(), false);
   }
 
-  @Test
+  @Test(dependsOnMethods = "testNamespacedCRUD")
   public void testNamespaceServer() throws IOException {
     // Default endpoints should not have any namespace information returned
     get("/", null, Response.Status.NOT_FOUND.getStatusCode(), false);

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -161,7 +161,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
         _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME));
   }
 
-  @Test(dependsOnMethods = "updateInstance")
+  @Test(dependsOnMethods = "testGetInstanceById")
   public void testAddInstance() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     InstanceConfig instanceConfig = new InstanceConfig(INSTANCE_NAME + "TEST");
@@ -183,7 +183,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME + "TEST");
   }
 
-  @Test(dependsOnMethods = "testGetInstanceById")
+  @Test(dependsOnMethods = "testDeleteInstance")
   public void updateInstance() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     // Disable instance

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
@@ -133,7 +133,7 @@ public class TestResourceAccessor extends AbstractTestClass {
         _configAccessor.getResourceConfig(CLUSTER_NAME, RESOURCE_NAME));
   }
 
-  @Test(dependsOnMethods = "testAddResources")
+  @Test(dependsOnMethods = "testResourceConfig")
   public void testIdealState() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
 
@@ -144,7 +144,7 @@ public class TestResourceAccessor extends AbstractTestClass {
         _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, RESOURCE_NAME));
   }
 
-  @Test(dependsOnMethods = "testAddResources")
+  @Test(dependsOnMethods = "testIdealState")
   public void testExternalView() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
 
@@ -155,7 +155,7 @@ public class TestResourceAccessor extends AbstractTestClass {
         .getResourceExternalView(CLUSTER_NAME, RESOURCE_NAME));
   }
 
-  @Test
+  @Test(dependsOnMethods = "testExternalView")
   public void testPartitionHealth() throws Exception {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
 
@@ -380,7 +380,7 @@ public class TestResourceAccessor extends AbstractTestClass {
    * Test "update" command of updateResourceIdealState.
    * @throws Exception
    */
-  @Test(dependsOnMethods = "testResourceHealth")
+  @Test(dependsOnMethods = "deleteFromResourceConfig")
   public void updateResourceIdealState() throws Exception {
     // Get IdealState ZNode
     String zkPath = PropertyPathBuilder.idealState(CLUSTER_NAME, RESOURCE_NAME);

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestTaskAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestTaskAccessor.java
@@ -58,7 +58,7 @@ public class TestTaskAccessor extends AbstractTestClass {
     Assert.assertEquals(contentStore, map1);
   }
 
-  @Test
+  @Test(dependsOnMethods = "testGetAddTaskUserContent")
   public void testInvalidGetAddTaskUserContent() {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String validURI = "clusters/" + CLUSTER_NAME + "/workflows/Workflow_0/jobs/Job_0/tasks/0/userContent";


### PR DESCRIPTION
**Issues**
 My PR addresses the following Helix issues and references them in the PR title:
#338 

**Description**
Current implementation of Rest 2.0 does not support stateModelDef modification. Here, we will implement

delete -- remove the stateModelDef with the input id.

put -- create new statemodeldef if no existing one with same input id

set -- replace the content of node with input id

We also add the following test cases:

Test delete model one; expect success
Test delete model one again; expect success
Create the deleted model one; expect success
Create the deleted model one again; expect failure as the same model id exists
Set the model one with modified content; expect success
Read the model one; expect the content would be same as modified content
Set the model one to original content restore original state; expect success



**Tests**
mvn test in rest directory
[INFO] Tests run: 84, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.998 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 84, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  29.664 s
[INFO] Finished at: 2019-07-16T18:28:22-07:00
[INFO] ------------------------------------------------------------------------





