### PR TITLE
Log the enqueue time of clusterEvent, used to measure the blocking qu…

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -920,6 +920,7 @@ public class GenericHelixController implements IdealStateChangeListener,
     enqueueEvent(_eventQueue, event);
     enqueueEvent(_taskEventQueue,
         event.clone(String.format("%s_%s", uid, Pipeline.Type.TASK.name())));
+    logger.info(String.format("Enqueue cluster event: %s, type: %s", event.getEventId(), event.getEventType()));
   }
 
   private void enqueueEvent(ClusterEventBlockingQueue queue, ClusterEvent event) {


### PR DESCRIPTION
When investigating the prod issue, I found now it lacks logs of when a ClusterEvent gets pushed into the queue. I've added the simple log here so that we would be able to measure the blocking queue processing speed for an event.