### PR TITLE
Read Failure while reading non-existent znode.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/CrushRebalanceStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/CrushRebalanceStrategy.java
@@ -89,7 +89,16 @@ public class CrushRebalanceStrategy implements RebalanceStrategy<ResourceControl
       long data = partitionName.hashCode();
 
       // apply the placement rules
-      List<Node> selected = select(topNode, data, _replicas, eventId);
+      List<Node> selected;
+      try {
+        selected = select(topNode, data, _replicas, eventId);
+      } catch (IllegalStateException e) {
+        String errorMessage = String
+            .format("Could not select enough number of nodes. %s partition %s, required %d",
+                _resourceName, partitionName, _replicas);
+        LogUtil.logError(Log, eventId, errorMessage);
+        throw new HelixException(errorMessage, e);
+      }
 
       if (selected.size() < _replicas) {
         LogUtil.logError(Log, eventId, String

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/CRUSHPlacementAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/CRUSHPlacementAlgorithm.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.helix.HelixException;
 import org.apache.helix.controller.rebalancer.topology.Node;
 import org.apache.helix.util.JenkinsHash;
 import org.slf4j.Logger;
@@ -305,7 +306,7 @@ public class CRUSHPlacementAlgorithm {
         }
       }
       if (selected == null) {
-        throw new IllegalStateException();
+        throw new HelixException("Selected node is null");
       }
       return selected;
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/CRUSHPlacementAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/CRUSHPlacementAlgorithm.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.helix.HelixException;
 import org.apache.helix.controller.rebalancer.topology.Node;
 import org.apache.helix.util.JenkinsHash;
 import org.slf4j.Logger;
@@ -306,7 +305,7 @@ public class CRUSHPlacementAlgorithm {
         }
       }
       if (selected == null) {
-        throw new HelixException("Selected node is null");
+        throw new IllegalStateException();
       }
       return selected;
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -241,15 +241,14 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
       try {
         HelixManager manager = event.getAttribute(AttributeName.helixmanager.name());
         rebalancer.init(manager);
-        idealState =
-            rebalancer.computeNewIdealState(resourceName, idealState, currentStateOutput, cache);
+        idealState = rebalancer.computeNewIdealState(resourceName, idealState, currentStateOutput, cache);
 
         output.setPreferenceLists(resourceName, idealState.getPreferenceLists());
 
         // Use the internal MappingCalculator interface to compute the final assignment
         // The next release will support rebalancers that compute the mapping from start to finish
-        partitionStateAssignment = mappingCalculator
-            .computeBestPossiblePartitionState(cache, idealState, resource, currentStateOutput);
+        partitionStateAssignment =
+            mappingCalculator.computeBestPossiblePartitionState(cache, idealState, resource, currentStateOutput);
         for (Partition partition : resource.getPartitions()) {
           Map<String, String> newStateMap = partitionStateAssignment.getReplicaMap(partition);
           output.setState(resourceName, partition, newStateMap);
@@ -257,9 +256,13 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
 
         // Check if calculation is done successfully
         return checkBestPossibleStateCalculation(idealState);
+      } catch (HelixException e){
+        //No eligible instance is found.
+        LogUtil
+            .logError(logger, _eventId, "PartitionStateAssignment is null. Skipping.");
       } catch (Exception e) {
         LogUtil
-            .logError(logger, _eventId, "Error computing assignment for resource " + resourceName + ". Skipping.");
+            .logError(logger, _eventId, "Error computing assignment for resource " + resourceName + ". Skipping.", e);
         // TODO : remove this part after debugging NPE
         StringBuilder sb = new StringBuilder();
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -257,9 +257,9 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
         // Check if calculation is done successfully
         return checkBestPossibleStateCalculation(idealState);
       } catch (HelixException e){
-        //No eligible instance is found.
+        // No eligible instance is found.
         LogUtil
-            .logError(logger, _eventId, "PartitionStateAssignment is null. Skipping.");
+            .logError(logger, _eventId, e.getMessage());
       } catch (Exception e) {
         LogUtil
             .logError(logger, _eventId, "Error computing assignment for resource " + resourceName + ". Skipping.", e);

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -263,19 +263,6 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
       } catch (Exception e) {
         LogUtil
             .logError(logger, _eventId, "Error computing assignment for resource " + resourceName + ". Skipping.", e);
-        // TODO : remove this part after debugging NPE
-        StringBuilder sb = new StringBuilder();
-
-        sb.append(String
-            .format("HelixManager is null : %s\n", event.getAttribute("helixmanager") == null));
-        sb.append(String.format("Rebalancer is null : %s\n", rebalancer == null));
-        sb.append(String.format("Calculated idealState is null : %s\n", idealState == null));
-        sb.append(String.format("MappingCaculator is null : %s\n", mappingCalculator == null));
-        sb.append(
-            String.format("PartitionAssignment is null : %s\n", partitionStateAssignment == null));
-        sb.append(String.format("Output is null : %s\n", output == null));
-
-        LogUtil.logError(logger, _eventId, sb.toString());
       }
     }
     // Exception or rebalancer is not found

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -259,7 +259,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
         return checkBestPossibleStateCalculation(idealState);
       } catch (Exception e) {
         LogUtil
-            .logError(logger, _eventId, "Error computing assignment for resource " + resourceName + ". Skipping.", e);
+            .logError(logger, _eventId, "Error computing assignment for resource " + resourceName + ". Skipping.");
         // TODO : remove this part after debugging NPE
         StringBuilder sb = new StringBuilder();
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
@@ -721,6 +721,9 @@ public class ZkClient implements Watcher {
       });
       record(path, null, startT, ZkClientMonitor.AccessType.READ);
       return children;
+    } catch (ZkNoNodeException e){
+      record(path, null, startT, ZkClientMonitor.AccessType.READ);
+      throw e;
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.READ);
       throw e;
@@ -760,6 +763,9 @@ public class ZkClient implements Watcher {
       });
       record(path, null, startT, ZkClientMonitor.AccessType.READ);
       return exists;
+    } catch (ZkNoNodeException e){
+      record(path, null, startT, ZkClientMonitor.AccessType.READ);
+      throw e;
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.READ);
       throw e;
@@ -778,10 +784,12 @@ public class ZkClient implements Watcher {
   private Stat getStat(final String path, final boolean watch) {
     long startT = System.currentTimeMillis();
     try {
-      Stat stat = retryUntilConnected(
-          () -> ((ZkConnection) getConnection()).getZookeeper().exists(path, watch));
+      Stat stat = retryUntilConnected(() -> ((ZkConnection) getConnection()).getZookeeper().exists(path, watch));
       record(path, null, startT, ZkClientMonitor.AccessType.READ);
       return stat;
+    } catch (ZkNoNodeException e){
+      record(path, null, startT, ZkClientMonitor.AccessType.READ);
+      throw e;
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.READ);
       throw e;
@@ -1293,6 +1301,9 @@ public class ZkClient implements Watcher {
       });
       record(path, data, startT, ZkClientMonitor.AccessType.READ);
       return (T) deserialize(data, path);
+    } catch (ZkNoNodeException e){
+      record(path, data, startT, ZkClientMonitor.AccessType.READ);
+      throw e;
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.READ);
       throw e;

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestConstraintRebalanceStrategy.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestConstraintRebalanceStrategy.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import org.apache.helix.HelixException;
 import org.apache.helix.api.rebalancer.constraint.AbstractRebalanceHardConstraint;
 import org.apache.helix.api.rebalancer.constraint.AbstractRebalanceSoftConstraint;
 import org.apache.helix.api.rebalancer.constraint.dataprovider.CapacityProvider;
@@ -271,7 +272,7 @@ public class TestConstraintRebalanceStrategy {
           Collections.<AbstractRebalanceHardConstraint>singletonList(capacityConstraint),
           Collections.EMPTY_LIST);
       Assert.fail("Assignment should fail because of insufficient capacity.");
-    } catch (IllegalStateException e) {
+    } catch (HelixException e) {
       // expected
     }
   }
@@ -300,7 +301,7 @@ public class TestConstraintRebalanceStrategy {
     try {
       calculateAssignment(constraints, Collections.EMPTY_LIST);
       Assert.fail("Assignment should fail because of the conflicting capacity constraint.");
-    } catch (IllegalStateException e) {
+    } catch (HelixException e) {
       // expected
     }
   }


### PR DESCRIPTION
In this commit, when we encounter NoNodeException while reading data from a znode that does not exist, we catch NoNodeException and do not increase readfailurecounter. Instead, the related information regarding the current read will be recorded.

This commit fixes issue #345 
Test Results:
[INFO] Tests run: 834, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,221.117 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 834, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  53:45 min
[INFO] Finished at: 2019-07-19T14:27:10-07:00
[INFO] ------------------------------------------------------------------------


