### PR TITLE
Change IllegalStateException to Helix Exception for CRUSH based rebalance strategy algorithm.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/CrushRebalanceStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/CrushRebalanceStrategy.java
@@ -89,7 +89,15 @@ public class CrushRebalanceStrategy implements RebalanceStrategy<ResourceControl
       long data = partitionName.hashCode();
 
       // apply the placement rules
-      List<Node> selected = select(topNode, data, _replicas, eventId);
+      List<Node> selected;
+      try {
+        selected = select(topNode, data, _replicas, eventId);
+      } catch (IllegalStateException e) {
+        String errorMessage = String
+            .format("Could not select enough number of nodes. %s partition %s, required %d",
+                _resourceName, partitionName, _replicas);
+        throw new HelixException(errorMessage, e);
+      }
 
       if (selected.size() < _replicas) {
         LogUtil.logError(Log, eventId, String

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -257,9 +257,12 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
 
         // Check if calculation is done successfully
         return checkBestPossibleStateCalculation(idealState);
+      } catch (HelixException e) {
+        // No eligible instance is found.
+        LogUtil.logError(logger, _eventId, e.getMessage());
       } catch (Exception e) {
-        LogUtil
-            .logError(logger, _eventId, "Error computing assignment for resource " + resourceName + ". Skipping.");
+        LogUtil.logError(logger, _eventId,
+            "Error computing assignment for resource " + resourceName + ". Skipping.");
         // TODO : remove this part after debugging NPE
         StringBuilder sb = new StringBuilder();
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestConstraintRebalanceStrategy.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestConstraintRebalanceStrategy.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import org.apache.helix.HelixException;
 import org.apache.helix.api.rebalancer.constraint.AbstractRebalanceHardConstraint;
 import org.apache.helix.api.rebalancer.constraint.AbstractRebalanceSoftConstraint;
 import org.apache.helix.api.rebalancer.constraint.dataprovider.CapacityProvider;
@@ -271,7 +272,7 @@ public class TestConstraintRebalanceStrategy {
           Collections.<AbstractRebalanceHardConstraint>singletonList(capacityConstraint),
           Collections.EMPTY_LIST);
       Assert.fail("Assignment should fail because of insufficient capacity.");
-    } catch (IllegalStateException e) {
+    } catch (HelixException e) {
       // expected
     }
   }
@@ -300,7 +301,7 @@ public class TestConstraintRebalanceStrategy {
     try {
       calculateAssignment(constraints, Collections.EMPTY_LIST);
       Assert.fail("Assignment should fail because of the conflicting capacity constraint.");
-    } catch (IllegalStateException e) {
+    } catch (HelixException e) {
       // expected
     }
   }


### PR DESCRIPTION
**Issues**
This PR addresses the following Helix issue:
While using CRUSH based rebalance strategy algorithm, if the related resource isn't enabled yet, Helix throws IllegalStateException which is not desirable.
(#322)

**Description** 
In this commit, IllegalStateException has been caught and HelixException has been thrown for the upper layer (BestPossibleStateCalcStage) instead. The error log shows more meaningful exception.
A test has been changed accordingly.

**Tests**
Test Result 1: (mvn test)
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestParticipantManager.testSessionExpiryInTransition:311 » ThreadTimeout Metho...
[ERROR]   TestClusterVerifier.testResourceSubset:183 » ThreadTimeout Method org.testng.i...
[INFO] 
[ERROR] Tests run: 835, Failures: 2, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:01 h
[INFO] Finished at: 2019-07-22T16:32:57-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/anajari/my_repos/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

Test Result 2: (mvn test -Dtest="TestParticipantManager,TestClusterVerifier")
[INFO] Results:
[INFO] 
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  51.157 s
[INFO] Finished at: 2019-07-22T16:44:45-07:00
[INFO] ------------------------------------------------------------------------

**Commits**
The type of exception has been thrown when not enough eligible instance is found in CRUSH algorithm has been changed. Also such exception (Helix exception) is handled on the BestPossibleStateCalcStage. A test has been adjusted to reflect this change.