### PR TITLE
Read Failure while reading non-existent znode.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
@@ -721,6 +721,9 @@ public class ZkClient implements Watcher {
       });
       record(path, null, startT, ZkClientMonitor.AccessType.READ);
       return children;
+    } catch (ZkNoNodeException e) {
+      record(path, null, startT, ZkClientMonitor.AccessType.READ);
+      throw e;
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.READ);
       throw e;
@@ -760,6 +763,9 @@ public class ZkClient implements Watcher {
       });
       record(path, null, startT, ZkClientMonitor.AccessType.READ);
       return exists;
+    } catch (ZkNoNodeException e) {
+      record(path, null, startT, ZkClientMonitor.AccessType.READ);
+      throw e;
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.READ);
       throw e;
@@ -782,6 +788,9 @@ public class ZkClient implements Watcher {
           () -> ((ZkConnection) getConnection()).getZookeeper().exists(path, watch));
       record(path, null, startT, ZkClientMonitor.AccessType.READ);
       return stat;
+    } catch (ZkNoNodeException e) {
+      record(path, null, startT, ZkClientMonitor.AccessType.READ);
+      throw e;
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.READ);
       throw e;
@@ -1293,6 +1302,9 @@ public class ZkClient implements Watcher {
       });
       record(path, data, startT, ZkClientMonitor.AccessType.READ);
       return (T) deserialize(data, path);
+    } catch (ZkNoNodeException e) {
+      record(path, data, startT, ZkClientMonitor.AccessType.READ);
+      throw e;
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.READ);
       throw e;


### PR DESCRIPTION
**Issues**
In case of encountering NoNodeException while reading data from a znode that does not exist, readfailurecounter will be incremented which shouldn't happen. 
(#345)  

**Description**
NoNodeException will be caught and readfailurecounter won't increase. Instead, the related information (read Counter, read Latency, etc.) is recorded.

**Tests**
Test Result 1: (mvn test)
[ERROR] Failures: 
[ERROR]   TestStopWorkflow.testStopTaskForQuota » ThreadTimeout Method org.testng.intern...
[INFO] 
[ERROR] Tests run: 835, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Helix 0.9.1-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  0.517 s]
[INFO] Apache Helix :: Core ............................... FAILURE [58:36 min]
[INFO] Apache Helix :: Admin Webapp ....................... SKIPPED
[INFO] Apache Helix :: Restful Interface .................. SKIPPED
[INFO] Apache Helix :: HelixAgent ......................... SKIPPED
[INFO] Apache Helix :: Recipes ............................ SKIPPED
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SKIPPED
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SKIPPED
[INFO] Apache Helix :: Recipes :: distributed lock manager  SKIPPED
[INFO] Apache Helix :: Recipes :: distributed task execution SKIPPED
[INFO] Apache Helix :: Recipes :: service discovery ....... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  58:37 min
[INFO] Finished at: 2019-07-22T20:30:10-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/anajari/my_repos/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :helix-core

Test Result 2: (mvn test -Dtest="TestStopWorkflow")
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.585 s - in org.apache.helix.integration.task.TestStopWorkflow
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  28.123 s
[INFO] Finished at: 2019-07-22T22:42:05-07:00
[INFO] ------------------------------------------------------------------------

**Commits**
ZKClient.java has been changed for read accesses.