### PR TITLE
[WIP] Add getWorkflows(long timeout) to TaskDriver.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -82,6 +82,8 @@ public class TaskDriver {
   /** Default time out for monitoring workflow or job state */
   private final static int DEFAULT_TIMEOUT = 5 * 60 * 1000; /* 5 mins */
 
+  private static final int POOL_SHUTDOWN_TIMEOUT = 10;
+
   /** Default pool size for the executor service. */
   private static final int DEFAULT_POOL_SIZE = 5;
 
@@ -190,11 +192,11 @@ public class TaskDriver {
     pool.shutdown();
     try {
       // Wait a while for existing tasks to terminate
-      if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
+      if (!pool.awaitTermination(POOL_SHUTDOWN_TIMEOUT, TimeUnit.SECONDS)) {
         // Cancel currently executing tasks
         pool.shutdownNow();
         // Wait a while for tasks to respond to being cancelled
-        if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
+        if (!pool.awaitTermination(POOL_SHUTDOWN_TIMEOUT, TimeUnit.SECONDS)) {
           LOG.error("Pool did not terminate.");
         }
       }

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowConfig.java
@@ -322,6 +322,22 @@ public class WorkflowConfig extends ResourceConfig {
     return Builder.fromMap(configs).setWorkflowId(property.getId()).build();
   }
 
+  /**
+   * Build a WorkflowConfig from a HelixProperty.
+   *
+   * @param property a HelixProperty
+   * @return a WorkflowConfig if the property is a valid WorkflowConfig.
+   *         Otherwise return null
+   */
+  public static WorkflowConfig parseWorkflowConfig(HelixProperty property)
+      throws IllegalArgumentException {
+    Map<String, String> configs = property.getRecord().getSimpleFields();
+    if (!configs.containsKey(WorkflowConfigProperty.Dag.name())) {
+      return null;
+    }
+    return Builder.fromMap(configs).setWorkflowId(property.getId()).build();
+  }
+
   public static class Builder {
     private String _workflowId = null;
     private JobDag _taskDag = DEFAULT_JOB_DAG;

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowConfig.java
@@ -322,21 +322,6 @@ public class WorkflowConfig extends ResourceConfig {
     return Builder.fromMap(configs).setWorkflowId(property.getId()).build();
   }
 
-  /**
-   * Build a WorkflowConfig from a HelixProperty.
-   *
-   * @param property a HelixProperty
-   * @return a WorkflowConfig if the property is a valid WorkflowConfig.
-   *         Otherwise return null
-   */
-  public static WorkflowConfig parseWorkflowConfig(HelixProperty property)
-      throws IllegalArgumentException {
-    Map<String, String> configs = property.getRecord().getSimpleFields();
-    if (!configs.containsKey(WorkflowConfigProperty.Dag.name())) {
-      return null;
-    }
-    return Builder.fromMap(configs).setWorkflowId(property.getId()).build();
-  }
 
   public static class Builder {
     private String _workflowId = null;

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestGetWorkflowsTimeout.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestGetWorkflowsTimeout.java
@@ -48,6 +48,8 @@ public class TestGetWorkflowsTimeout extends TaskTestBase {
       _driver.pollForWorkflowState(workflow.getName(), TaskState.COMPLETED);
     }
 
+    _driver.startPool();
+
     // Disconnect ZkManager to make getWorkflows timeout.
     _manager.disconnect();
 
@@ -56,5 +58,7 @@ public class TestGetWorkflowsTimeout extends TaskTestBase {
     } catch (Exception e) {
       // Exepected timeout.
     }
+
+    _driver.shutdownPool();
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestGetWorkflowsTimeout.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestGetWorkflowsTimeout.java
@@ -31,12 +31,13 @@ import org.apache.helix.task.Workflow;
 import org.apache.helix.task.WorkflowConfig;
 import org.apache.helix.task.WorkflowContext;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class TestGetWorkflowsTimeout extends TaskTestBase {
-  @Test
-  public void testGetWorkflowsTimeout() throws Exception {
-    List<Workflow> workflowList = new ArrayList<>();
+  @BeforeClass
+  private void buildWorkflows() throws Exception {
+    List<Workflow> workflowList = new ArrayList<Workflow>();
     for (int i = 0; i < 2; i++) {
       Workflow workflow = WorkflowGenerator
           .generateDefaultRepeatedJobWorkflowBuilder(TestHelper.getTestMethodName() + i).build();
@@ -47,7 +48,10 @@ public class TestGetWorkflowsTimeout extends TaskTestBase {
     for (Workflow workflow : workflowList) {
       _driver.pollForWorkflowState(workflow.getName(), TaskState.COMPLETED);
     }
+  }
 
+  @Test
+  public void testGetWorkflowsTimeout() throws Exception {
     _driver.startPool();
 
     // Disconnect ZkManager to make getWorkflows timeout.

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestGetWorkflowsTimeout.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestGetWorkflowsTimeout.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.helix.integration.task;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.helix.TestHelper;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.JobContext;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.task.WorkflowContext;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestGetWorkflowsTimeout extends TaskTestBase {
+  @Test
+  public void testGetWorkflowsTimeout() throws Exception {
+    List<Workflow> workflowList = new ArrayList<>();
+    for (int i = 0; i < 2; i++) {
+      Workflow workflow = WorkflowGenerator
+          .generateDefaultRepeatedJobWorkflowBuilder(TestHelper.getTestMethodName() + i).build();
+      _driver.start(workflow);
+      workflowList.add(workflow);
+    }
+
+    for (Workflow workflow : workflowList) {
+      _driver.pollForWorkflowState(workflow.getName(), TaskState.COMPLETED);
+    }
+
+    // Disconnect ZkManager to make getWorkflows timeout.
+    _manager.disconnect();
+
+    try {
+      Map<String, WorkflowConfig> workflowConfigMap = _driver.getWorkflows(5_000L);
+    } catch (Exception e) {
+      // Exepected timeout.
+    }
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestRetrieveWorkflows.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestRetrieveWorkflows.java
@@ -79,7 +79,12 @@ public class TestRetrieveWorkflows extends TaskTestBase {
       _driver.pollForWorkflowState(workflow.getName(), TaskState.COMPLETED);
     }
 
+    _driver.startPool();
+
     Map<String, WorkflowConfig> workflowConfigMap = _driver.getWorkflows(0L);
+
+    _driver.shutdownPool();
+
     Assert.assertEquals(workflowConfigMap.size(), workflowList.size());
 
     for (Map.Entry<String, WorkflowConfig> workflow : workflowConfigMap.entrySet()) {

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestRetrieveWorkflows.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestRetrieveWorkflows.java
@@ -22,6 +22,7 @@ package org.apache.helix.integration.task;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.helix.TestHelper;
 import org.apache.helix.task.JobConfig;
 import org.apache.helix.task.JobContext;
@@ -47,6 +48,38 @@ public class TestRetrieveWorkflows extends TaskTestBase {
     }
 
     Map<String, WorkflowConfig> workflowConfigMap = _driver.getWorkflows();
+    Assert.assertEquals(workflowConfigMap.size(), workflowList.size());
+
+    for (Map.Entry<String, WorkflowConfig> workflow : workflowConfigMap.entrySet()) {
+      WorkflowConfig workflowConfig = workflow.getValue();
+      WorkflowContext workflowContext = _driver.getWorkflowContext(workflow.getKey());
+      Assert.assertNotNull(workflowContext);
+
+      for (String job : workflowConfig.getJobDag().getAllNodes()) {
+        JobConfig jobConfig = _driver.getJobConfig(job);
+        JobContext jobContext = _driver.getJobContext(job);
+
+        Assert.assertNotNull(jobConfig);
+        Assert.assertNotNull(jobContext);
+      }
+    }
+  }
+
+  @Test
+  public void testGetWorkflowsTimeoutDisabled() throws Exception {
+    List<Workflow> workflowList = new ArrayList<>();
+    for (int i = 0; i < 2; i++) {
+      Workflow workflow = WorkflowGenerator
+          .generateDefaultRepeatedJobWorkflowBuilder(TestHelper.getTestMethodName() + i).build();
+      _driver.start(workflow);
+      workflowList.add(workflow);
+    }
+
+    for (Workflow workflow : workflowList) {
+      _driver.pollForWorkflowState(workflow.getName(), TaskState.COMPLETED);
+    }
+
+    Map<String, WorkflowConfig> workflowConfigMap = _driver.getWorkflows(0L);
     Assert.assertEquals(workflowConfigMap.size(), workflowList.size());
 
     for (Map.Entry<String, WorkflowConfig> workflow : workflowConfigMap.entrySet()) {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issue #326:
Sometimes zookeeper hangs in the getWorkflows() call.

### Description
We could provide an API with a timeout to handle this at the application level:
getWorkflows(long timeoutMillis)

- [x] Here are some details about my PR, including screenshots of any UI changes:

Use ExcecutorService and Future to implement the timeout function.
Call future.get(long timeout, TimeUnit timeUnit) to wait for result.
This commit resolves #326:
1. Add a static API parseWorkflowConfig to class WorkflowConfig.
The API can parse HelixProperty.
2. Add an API getWorkflows(long timeout) to TaskDriver.

### Tests

- [x] The following tests are written for this issue:
TestGetWorkflowsTimeout.testGetWorkflowsTimeout()

TestRetrieveWorkflows.testGetWorkflowsTimeoutDisabled()

- [x] The following is the result of the "mvn test" command on the appropriate module:
START testGetWorkflowsTimeoutDisabled at Fri Jul 26 01:25:14 PDT 2019
===============================================
Default Suite
Total tests run: 1, Failures: 0, Skips: 0
===============================================

START testGetWorkflowsTimeout at Fri Jul 26 01:36:18 PDT 2019

Default Suite
Total tests run: 1, Failures: 0, Skips: 0


### Code Quality

- [x] My diff has been formatted using helix-style.xml