### PR TITLE
Remove TODO NPE log for computeResourceBestPossibleState

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -250,6 +250,13 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
         // The next release will support rebalancers that compute the mapping from start to finish
         partitionStateAssignment = mappingCalculator
             .computeBestPossiblePartitionState(cache, idealState, resource, currentStateOutput);
+
+        if (partitionStateAssignment == null) {
+          LogUtil.logWarn(logger, _eventId,
+              "PartitionStateAssignment is null, resource: " + resourceName);
+          return false;
+        }
+
         for (Partition partition : resource.getPartitions()) {
           Map<String, String> newStateMap = partitionStateAssignment.getReplicaMap(partition);
           output.setState(resourceName, partition, newStateMap);
@@ -263,19 +270,6 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
       } catch (Exception e) {
         LogUtil.logError(logger, _eventId,
             "Error computing assignment for resource " + resourceName + ". Skipping.");
-        // TODO : remove this part after debugging NPE
-        StringBuilder sb = new StringBuilder();
-
-        sb.append(String
-            .format("HelixManager is null : %s\n", event.getAttribute("helixmanager") == null));
-        sb.append(String.format("Rebalancer is null : %s\n", rebalancer == null));
-        sb.append(String.format("Calculated idealState is null : %s\n", idealState == null));
-        sb.append(String.format("MappingCaculator is null : %s\n", mappingCalculator == null));
-        sb.append(
-            String.format("PartitionAssignment is null : %s\n", partitionStateAssignment == null));
-        sb.append(String.format("Output is null : %s\n", output == null));
-
-        LogUtil.logError(logger, _eventId, sb.toString());
       }
     }
     // Exception or rebalancer is not found


### PR DESCRIPTION
**Issues**
The logs related to NPE in computeResourceBestPossibleState is not needed anymore and can be removed.
(#351)

**Description**
Since this NPE condition has been thoroughly checked, these logs can be removed.

**Tests**
Since this PR just removes the logs, tests are not necessary. However, the mvn test results are included here:
Test Result 1: (mvn test)
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestStopWorkflow.testStopTask » ThreadTimeout Method org.testng.internal.TestN...
[ERROR]   TestClusterVerifier.testResourceSubset:183 » ThreadTimeout Method org.testng.i...
[INFO] 
[ERROR] Tests run: 835, Failures: 2, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:02 h
[INFO] Finished at: 2019-07-23T16:21:05-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/anajari/my_repos/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

Test Result 2: (mvn test -Dtest="TestStopWorkflow,TestClusterVerifier")
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 59.003 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:03 min
[INFO] Finished at: 2019-07-23T16:32:01-07:00
[INFO] ------------------------------------------------------------------------


**Commits**
In this commit, the TODO part of BestPossibleStateCalcStage.java has been removed.