### PR TITLE
Fix RoutingTableProvider statePropagationLatency metric reporting bug

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateCache.java
@@ -135,13 +135,14 @@ public class CurrentStateCache extends AbstractDataCache<CurrentState> {
     Set<PropertyKey> cachedKeys = new HashSet<>(_currentStateCache.keySet());
     cachedKeys.retainAll(currentStateKeys);
 
+    Set<PropertyKey> reloadedKeys = new HashSet<>();
     Map<PropertyKey, CurrentState> newStateCache = Collections.unmodifiableMap(
-        refreshProperties(accessor, new ArrayList<>(reloadKeys), new ArrayList<>(cachedKeys),
-            _currentStateCache));
+        refreshProperties(accessor, reloadKeys, new ArrayList<>(cachedKeys),
+            _currentStateCache, reloadedKeys));
 
     // if the cache was not initialized, the previous state should not be included in the snapshot
     if (_initialized) {
-      _snapshot = new CurrentStateSnapshot(newStateCache, _currentStateCache, reloadKeys);
+      _snapshot = new CurrentStateSnapshot(newStateCache, _currentStateCache, reloadedKeys);
     } else {
       _snapshot = new CurrentStateSnapshot(newStateCache);
       _initialized = true;

--- a/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateSnapshot.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateSnapshot.java
@@ -8,8 +8,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class CurrentStateSnapshot extends AbstractDataSnapshot<CurrentState> {
+  private static final Logger LOG = LoggerFactory.getLogger(CurrentStateSnapshot.class.getName());
+
   private Set<PropertyKey> _updatedStateKeys = null;
   private Map<PropertyKey, CurrentState> _prevStateMap = null;
 
@@ -32,6 +37,7 @@ public class CurrentStateSnapshot extends AbstractDataSnapshot<CurrentState> {
     if (_updatedStateKeys != null && _prevStateMap != null) {
       // Note if the prev state map is empty, this is the first time refresh.
       // So the update is not considered as "recent" change.
+      int driftCnt = 0; // clock drift count for comparing timestamp
       for (PropertyKey propertyKey : _updatedStateKeys) {
         CurrentState prevState = _prevStateMap.get(propertyKey);
         CurrentState curState = _properties.get(propertyKey);
@@ -39,11 +45,25 @@ public class CurrentStateSnapshot extends AbstractDataSnapshot<CurrentState> {
         Map<String, Long> partitionUpdateEndTimes = null;
         for (String partition : curState.getPartitionStateMap().keySet()) {
           long newEndTime = curState.getEndTime(partition);
-          if (prevState == null || prevState.getEndTime(partition) < newEndTime) {
+          // if prevState is null, and newEndTime is -1, we should not record -1 in endTimeMap; otherwise,
+          // statePropagation latency calculation in RoutingTableProvider would spit out extremely large metrics.
+          if ((prevState == null || prevState.getEndTime(partition) < newEndTime) && newEndTime != -1) {
             if (partitionUpdateEndTimes == null) {
               partitionUpdateEndTimes = new HashMap<>();
             }
             partitionUpdateEndTimes.put(partition, newEndTime);
+          } else if (prevState != null && prevState.getEndTime(partition) > newEndTime) {
+            // This can happen due to clock drift.
+            // updatedStateKeys is the path to resource in an instance config.
+            // Thus, the space of inner loop is Sigma{replica(i) * partition(i)}; i over all resources in the cluster
+            // This space can be large. In order not to print too many lines, we print first warning for the first case.
+            // If clock drift turns out to be common, we can consider print out more logs, or expose an metric.
+            if (driftCnt < 1) {
+              LOG.warn(
+                  "clock drift. partition:" + partition + " curState:" + curState.getState(partition) + " prevState: "
+                      + prevState.getState(partition));
+            }
+            driftCnt++;
           }
         }
 

--- a/helix-core/src/main/java/org/apache/helix/common/caches/ExternalViewCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/ExternalViewCache.java
@@ -95,8 +95,8 @@ public class ExternalViewCache extends AbstractDataCache<ExternalView> {
     reloadKeys.removeAll(cachedKeys);
 
     Map<PropertyKey, ExternalView> updatedMap =
-        refreshProperties(accessor, new LinkedList<>(reloadKeys), new ArrayList<>(cachedKeys),
-            cachedExternalViewMap);
+        refreshProperties(accessor, reloadKeys, new ArrayList<>(cachedKeys),
+            cachedExternalViewMap, new HashSet<>());
     Map<String, ExternalView> newExternalViewMap = Maps.newHashMap();
     for (ExternalView externalView : updatedMap.values()) {
       newExternalViewMap.put(externalView.getResourceName(), externalView);

--- a/helix-core/src/main/java/org/apache/helix/common/caches/IdealStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/IdealStateCache.java
@@ -85,8 +85,8 @@ public class IdealStateCache extends AbstractDataCache<IdealState> {
     reloadKeys.removeAll(cachedKeys);
 
     Map<PropertyKey, IdealState> updatedMap =
-        refreshProperties(accessor, new LinkedList<>(reloadKeys), new ArrayList<>(cachedKeys),
-            cachedIdealStateMap);
+        refreshProperties(accessor, reloadKeys, new ArrayList<>(cachedKeys),
+            cachedIdealStateMap, new HashSet<>());
     Map<String, IdealState> newIdealStateMap = Maps.newHashMap();
     for (IdealState idealState : updatedMap.values()) {
       newIdealStateMap.put(idealState.getResourceName(), idealState);

--- a/helix-core/src/main/java/org/apache/helix/common/caches/PropertyCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/PropertyCache.java
@@ -22,6 +22,7 @@ package org.apache.helix.common.caches;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -172,8 +173,8 @@ public class PropertyCache<T extends HelixProperty> extends AbstractDataCache<T>
   private void doRefreshWithSelectiveUpdate(final HelixDataAccessor accessor) {
     SelectivePropertyRefreshInputs<T> input =
         genSelectiveUpdateInput(accessor, _objCache, _keyFuncs);
-    Map<PropertyKey, T> updatedData = refreshProperties(accessor, input.getReloadKeys(),
-        input.getCachedKeys(), input.getCachedPropertyMap());
+    Map<PropertyKey, T> updatedData = refreshProperties(accessor, new HashSet<>(input.getReloadKeys()),
+        input.getCachedKeys(), input.getCachedPropertyMap(), new HashSet<>());
     _objCache = propertyKeyMapToStringMap(updatedData, _keyFuncs);
 
     // need to separate keys so we can potentially update cache map asynchronously while

--- a/helix-core/src/test/java/org/apache/helix/common/caches/TestCurrentStateSnapshot.java
+++ b/helix-core/src/test/java/org/apache/helix/common/caches/TestCurrentStateSnapshot.java
@@ -1,0 +1,112 @@
+package org.apache.helix.common.caches;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.MockAccessor;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.LiveInstance;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link CurrentStateSnapshot}
+ */
+public class TestCurrentStateSnapshot {
+
+  // This test makes sure that currentStateEndTimes calculation would record correct partition replica.
+  // Specifically, if a replicate has not endTime field set, we should not put an entry into currentStateEndTime
+  // calculation. Otherwise, we see huge statePropagation latency of 1.4Tms.
+  @Test(description = "test getNewCurrentStateEndTimes")
+  public void testGetNewCurrentStateEndTimes() {
+    String instance1 = "instance1";
+    String session1 = "session1";
+    String resource1 = "resource1";
+
+    String partition1 = "partition1";
+    String partition2 = "partition2";
+
+    PropertyKey key = new PropertyKey.Builder("cluster").currentState(instance1, session1, resource1);
+
+    CurrentState nxtState = new CurrentState(resource1);
+    // partition 1, expect to record in endTimesMap
+    nxtState.setState(partition1, "SLAVE");
+    nxtState.setEndTime(partition1, 200);
+    // partition 2, expect to not record in endTimeMap. This is fixing current 1.4T observed timestamp issue
+    nxtState.setState(partition2, "MASTER");
+
+    Map<PropertyKey, CurrentState> currentStateMap = new HashMap<>();
+    Map<PropertyKey, CurrentState> nextStateMap = new HashMap<>();
+    nextStateMap.put(key, nxtState);
+
+    Set<PropertyKey> updateKeys = new HashSet<>();
+    updateKeys.add(key);
+
+    CurrentStateSnapshot snapshot = new CurrentStateSnapshot(nextStateMap, currentStateMap, updateKeys);
+
+    Map<PropertyKey, Map<String, Long>> endTimesMap = snapshot.getNewCurrentStateEndTimes();
+
+    Assert.assertEquals(endTimesMap.size(), 1);
+    Assert.assertTrue(endTimesMap.get(key).get(partition1) == 200);
+  }
+
+  // This test makes sure that all the changed current State is reflected in newCurrentStateEndTimes calculation.
+  // Previously, we have bugs that all newly created current state would be reflected in newCurrentStateEndTimes
+  // calculation.
+  @Test(description = "testRefreshCurrentStateCache")
+  public void testRefreshCurrentStateCache() {
+    String instanceName = "instance1";
+    long instanceSession = 12345;
+    String resourceName = "resource";
+    String partitionName = "resource_partition1";
+
+    MockAccessor accessor = new MockAccessor();
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+
+    // construct liveInstance
+    ZNRecord record = new ZNRecord(instanceName);
+    record.setEphemeralOwner(instanceSession);
+    LiveInstance instance = new LiveInstance(record);
+
+    boolean retVal = accessor.setProperty(keyBuilder.liveInstance(instanceName), instance);
+    Assert.assertTrue(retVal);
+
+    // construct currentstate
+    CurrentState originState = new CurrentState(resourceName);
+    originState.setEndTime(partitionName, 100);
+
+    CurrentState currentState = new CurrentState(resourceName);
+    currentState.setEndTime(partitionName, 300);
+    retVal = accessor.setProperty(keyBuilder.currentState(instanceName, instance.getEphemeralOwner(), resourceName),
+        originState);
+    Assert.assertTrue(retVal);
+
+    CurrentStateCache cache = new CurrentStateCache("cluster");
+
+    Map<String, LiveInstance> liveInstanceMap = new HashMap<>();
+    liveInstanceMap.put(instanceName, instance);
+
+    retVal = cache.refresh(accessor, liveInstanceMap);
+    Assert.assertTrue(retVal);
+
+    retVal = accessor.setProperty(keyBuilder.currentState(instanceName, instance.getEphemeralOwner(), resourceName),
+        currentState);
+    Assert.assertTrue(retVal);
+
+    retVal = cache.refresh(accessor, liveInstanceMap);
+    Assert.assertTrue(retVal);
+
+    CurrentStateSnapshot snapshot = cache.getSnapshot();
+
+    Map<PropertyKey, Map<String, Long>> endTimesMap = snapshot.getNewCurrentStateEndTimes();
+
+    Assert.assertEquals(endTimesMap.size(), 1);
+    // note, without this fix, the endTimesMap would be size zero.
+    Assert.assertTrue(endTimesMap.get(keyBuilder.currentState(instanceName, instance.getEphemeralOwner(), resourceName))
+        .get(partitionName) == 300);
+  }
+}


### PR DESCRIPTION
**Issue**:
#364 
CurrentStateCache updating snapshot would miss all the existing partitions that having state change.

RoutingTableProvider callback on the main event thread. Time is not accounted in log.

**Description**:
fix the bug by updating the snapshot with the correct reloadkeys.

enhanced log to accout for user callback code separately.

**Tests**:
cd helix-core; mvn test
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[INFO] 
[ERROR] Tests run: 837, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  59:26 min
[INFO] Finished at: 2019-07-28T16:40:47-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/ksun/helix_kaisun2000/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
mvn test -Dtest=TestJobQueueCleanUp
The test will pass