### PR TITLE
Remove unnecessary touch logic issues that forces triggering Helix pipelines

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -215,8 +215,6 @@ public class TaskDriver {
     if (!TaskUtil.setWorkflowConfig(_accessor, workflow, newWorkflowConfig)) {
       LOG.error("Failed to update workflow configuration for workflow " + workflow);
     }
-
-    RebalanceScheduler.invokeRebalance(_accessor, workflow);
   }
 
   /**
@@ -496,8 +494,6 @@ public class TaskDriver {
     // This is to make it back-compatible with old Helix task driver.
     addWorkflowResourceIfNecessary(queue);
 
-    // Schedule the job
-    RebalanceScheduler.invokeRebalance(_accessor, queue);
   }
 
   /**
@@ -794,7 +790,6 @@ public class TaskDriver {
     PropertyKey workflowConfigKey = TaskUtil.getWorkflowConfigKey(_accessor, workflow);
     _accessor.getBaseDataAccessor().update(workflowConfigKey.getPath(), updater,
         AccessOption.PERSISTENT);
-    RebalanceScheduler.invokeRebalance(_accessor, workflow);
   }
 
   public WorkflowConfig getWorkflowConfig(String workflow) {


### PR DESCRIPTION
**Issues**
In the places that ZooKeeper Resourceconfig is updated, it is not necessary to do touch logic anymore to run the pipeline again. 
(#370)

**Description**
An update in Resourcesconfig in the ZooKeeper automatically triggers pipeline (since Helix controller gets notified). Hence, after updating Resourceconfig, there is no need do touch logic anymore.

**Tests**
Test result 1: mvn test
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 835, Failures: 1, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  55:06 min
[INFO] Finished at: 2019-08-01T11:54:04-07:00
[INFO] ------------------------------------------------------------------------

Test result 2: mvn test -Dtest="TestAlertingRebalancerFailure"
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.522 s
[INFO] Finished at: 2019-08-01T12:06:38-07:00
[INFO] ------------------------------------------------------------------------

**Commits**
In this commit, unnecessary touch logics have been identified and removed.
Subject is separated from body by a blank line
Subject is limited to 50 characters (not including Jira issue reference)
Subject does not end with a period
Subject uses the imperative mood ("add", not "adding")
Body wraps at 72 characters
Body explains "what" and "why", not "how"

**Code Quality**
My diff has been formatted using helix-style.xml