### PR TITLE
Remove DEFAULT_VIEW_CLUSTER_REFRESH_PERIOD from ClusterConfig #358

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -91,7 +91,6 @@ public class ClusterConfig extends HelixProperty {
   // is not set and will be given a default value of 1
   private final static int DEFAULT_ERROR_OR_RECOVERY_PARTITION_THRESHOLD_FOR_LOAD_BALANCE = -1;
   private static final String IDEAL_STATE_RULE_PREFIX = "IdealStateRule!";
-  private final static int DEFAULT_VIEW_CLUSTER_REFRESH_PERIOD = 30;
 
   public final static String TASK_QUOTA_RATIO_NOT_SET = "-1";
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR title:

#358 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

DEFAULT_VIEW_CLUSTER_REFRESH_PERIOD is a constant field for View Aggregator. Since this component was removed from the master branch, this constant field should be removed as well.

### Tests

No tests were written/run because this is just removal of an unused constant.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml