### PR TITLE
Make the reservoir used in ZkClientPathMonitor metric configurable.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/SystemPropertyKeys.java
+++ b/helix-core/src/main/java/org/apache/helix/SystemPropertyKeys.java
@@ -35,4 +35,7 @@ public class SystemPropertyKeys {
 
   // Controller
   public static final String CONTROLLER_MESSAGE_PURGE_DELAY = "helix.controller.stages.MessageGenerationPhase.messagePurgeDelay";
+
+  // MBean monitor for helix.
+  public static final String HELIX_MONITOR_TIME_WINDOW_LENGTH_MS = "helix.monitor.slidingTimeWindow.ms";
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterEventMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterEventMonitor.java
@@ -26,7 +26,6 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
-import org.apache.helix.util.HelixUtil;
 
 import javax.management.JMException;
 import java.util.ArrayList;

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterEventMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterEventMonitor.java
@@ -58,9 +58,7 @@ public class ClusterEventMonitor extends DynamicMBeanProvider {
     _clusterStatusMonitor = clusterStatusMonitor;
 
     _duration = new HistogramDynamicMetric("DurationGauge", new Histogram(
-        new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _count = new SimpleDynamicMetric("EventCounter", 0l);
     _maxDuration = new SimpleDynamicMetric("MaxSingleDurationGauge", 0l);
     _totalDuration = new SimpleDynamicMetric("TotalDurationCounter", 0l);

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterEventMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterEventMonitor.java
@@ -26,6 +26,7 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
+import org.apache.helix.util.HelixUtil;
 
 import javax.management.JMException;
 import java.util.ArrayList;
@@ -57,7 +58,9 @@ public class ClusterEventMonitor extends DynamicMBeanProvider {
     _clusterStatusMonitor = clusterStatusMonitor;
 
     _duration = new HistogramDynamicMetric("DurationGauge", new Histogram(
-        new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+        new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
     _count = new SimpleDynamicMetric("EventCounter", 0l);
     _maxDuration = new SimpleDynamicMetric("MaxSingleDurationGauge", 0l);
     _totalDuration = new SimpleDynamicMetric("TotalDurationCounter", 0l);

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/HelixCallbackMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/HelixCallbackMonitor.java
@@ -65,9 +65,7 @@ public class HelixCallbackMonitor extends DynamicMBeanProvider {
             changeType.name());
 
     _latencyGauge = new HistogramDynamicMetric("LatencyGauge", new Histogram(
-        new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _totalLatencyCounter = new SimpleDynamicMetric("LatencyCounter", 0l);
     _unbatchedCounter = new SimpleDynamicMetric("UnbatchedCounter", 0l);
     _counter = new SimpleDynamicMetric("Counter", 0l);

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/HelixCallbackMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/HelixCallbackMonitor.java
@@ -27,7 +27,6 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
-import org.apache.helix.util.HelixUtil;
 
 import javax.management.JMException;
 import java.util.ArrayList;

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/HelixCallbackMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/HelixCallbackMonitor.java
@@ -27,6 +27,7 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
+import org.apache.helix.util.HelixUtil;
 
 import javax.management.JMException;
 import java.util.ArrayList;
@@ -64,7 +65,9 @@ public class HelixCallbackMonitor extends DynamicMBeanProvider {
             changeType.name());
 
     _latencyGauge = new HistogramDynamicMetric("LatencyGauge", new Histogram(
-        new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+        new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
     _totalLatencyCounter = new SimpleDynamicMetric("LatencyCounter", 0l);
     _unbatchedCounter = new SimpleDynamicMetric("UnbatchedCounter", 0l);
     _counter = new SimpleDynamicMetric("Counter", 0l);

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/JobMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/JobMonitor.java
@@ -31,7 +31,6 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
 import org.apache.helix.task.TaskState;
-import org.apache.helix.util.HelixUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/JobMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/JobMonitor.java
@@ -31,6 +31,7 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
 import org.apache.helix.task.TaskState;
+import org.apache.helix.util.HelixUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,16 +86,21 @@ public class JobMonitor extends DynamicMBeanProvider {
 
     // Instantiate histogram dynamic metrics
     _jobLatencyGauge = new HistogramDynamicMetric("JobLatencyGauge", new Histogram(
-        new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
-    _submissionToProcessDelayGauge =
-        new HistogramDynamicMetric("SubmissionToProcessDelayGauge", new Histogram(
-            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
-    _submissionToScheduleDelayGauge =
-        new HistogramDynamicMetric("SubmissionToScheduleDelayGauge", new Histogram(
-            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
-    _controllerInducedDelayGauge =
-        new HistogramDynamicMetric("ControllerInducedDelayGauge", new Histogram(
-            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+        new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
+    _submissionToProcessDelayGauge = new HistogramDynamicMetric("SubmissionToProcessDelayGauge",
+        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
+    _submissionToScheduleDelayGauge = new HistogramDynamicMetric("SubmissionToScheduleDelayGauge",
+        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
+    _controllerInducedDelayGauge = new HistogramDynamicMetric("ControllerInducedDelayGauge",
+        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/JobMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/JobMonitor.java
@@ -86,21 +86,16 @@ public class JobMonitor extends DynamicMBeanProvider {
 
     // Instantiate histogram dynamic metrics
     _jobLatencyGauge = new HistogramDynamicMetric("JobLatencyGauge", new Histogram(
-        new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _submissionToProcessDelayGauge = new HistogramDynamicMetric("SubmissionToProcessDelayGauge",
-        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new Histogram(
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _submissionToScheduleDelayGauge = new HistogramDynamicMetric("SubmissionToScheduleDelayGauge",
-        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new Histogram(
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _controllerInducedDelayGauge = new HistogramDynamicMetric("ControllerInducedDelayGauge",
-        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new Histogram(
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/MessageLatencyMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/MessageLatencyMonitor.java
@@ -27,6 +27,7 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
+import org.apache.helix.util.HelixUtil;
 
 import javax.management.JMException;
 import java.util.ArrayList;
@@ -49,7 +50,9 @@ public class MessageLatencyMonitor extends DynamicMBeanProvider {
         "MessageLatency");
 
     _messageLatencyGauge = new HistogramDynamicMetric("MessagelatencyGauge", new Histogram(
-        new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+        new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
     _totalMessageLatency = new SimpleDynamicMetric("TotalMessageLatency", 0l);
     _totalMessageCount = new SimpleDynamicMetric("TotalMessageCount", 0l);
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/MessageLatencyMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/MessageLatencyMonitor.java
@@ -27,7 +27,6 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
-import org.apache.helix.util.HelixUtil;
 
 import javax.management.JMException;
 import java.util.ArrayList;

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/MessageLatencyMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/MessageLatencyMonitor.java
@@ -50,9 +50,7 @@ public class MessageLatencyMonitor extends DynamicMBeanProvider {
         "MessageLatency");
 
     _messageLatencyGauge = new HistogramDynamicMetric("MessagelatencyGauge", new Histogram(
-        new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _totalMessageLatency = new SimpleDynamicMetric("TotalMessageLatency", 0l);
     _totalMessageCount = new SimpleDynamicMetric("TotalMessageCount", 0l);
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -38,6 +38,7 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
+import org.apache.helix.util.HelixUtil;
 
 public class ResourceMonitor extends DynamicMBeanProvider {
 
@@ -140,14 +141,20 @@ public class ResourceMonitor extends DynamicMBeanProvider {
 
     _partitionTopStateHandoffDurationGauge =
         new HistogramDynamicMetric("PartitionTopStateHandoffDurationGauge", new Histogram(
-            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+            new SlidingTimeWindowArrayReservoir(HelixUtil
+                .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY,
+                    DEFAULT_RESET_INTERVAL_MS), TimeUnit.MILLISECONDS)));
 
     _partitionTopStateHandoffHelixLatencyGauge =
         new HistogramDynamicMetric("PartitionTopStateHandoffHelixLatencyGauge", new Histogram(
-            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+            new SlidingTimeWindowArrayReservoir(HelixUtil
+                .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY,
+                    DEFAULT_RESET_INTERVAL_MS), TimeUnit.MILLISECONDS)));
     _partitionTopStateNonGracefulHandoffDurationGauge =
         new HistogramDynamicMetric("PartitionTopStateNonGracefulHandoffGauge", new Histogram(
-            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+            new SlidingTimeWindowArrayReservoir(HelixUtil
+                .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY,
+                    DEFAULT_RESET_INTERVAL_MS), TimeUnit.MILLISECONDS)));
 
     _totalMessageReceived = new SimpleDynamicMetric("TotalMessageReceived", 0L);
     _maxSinglePartitionTopStateHandoffDuration =

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -38,7 +38,6 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
-import org.apache.helix.util.HelixUtil;
 
 public class ResourceMonitor extends DynamicMBeanProvider {
 
@@ -141,20 +140,14 @@ public class ResourceMonitor extends DynamicMBeanProvider {
 
     _partitionTopStateHandoffDurationGauge =
         new HistogramDynamicMetric("PartitionTopStateHandoffDurationGauge", new Histogram(
-            new SlidingTimeWindowArrayReservoir(HelixUtil
-                .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY,
-                    DEFAULT_RESET_INTERVAL_MS), TimeUnit.MILLISECONDS)));
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
 
     _partitionTopStateHandoffHelixLatencyGauge =
         new HistogramDynamicMetric("PartitionTopStateHandoffHelixLatencyGauge", new Histogram(
-            new SlidingTimeWindowArrayReservoir(HelixUtil
-                .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY,
-                    DEFAULT_RESET_INTERVAL_MS), TimeUnit.MILLISECONDS)));
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _partitionTopStateNonGracefulHandoffDurationGauge =
         new HistogramDynamicMetric("PartitionTopStateNonGracefulHandoffGauge", new Histogram(
-            new SlidingTimeWindowArrayReservoir(HelixUtil
-                .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY,
-                    DEFAULT_RESET_INTERVAL_MS), TimeUnit.MILLISECONDS)));
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
 
     _totalMessageReceived = new SimpleDynamicMetric("TotalMessageReceived", 0L);
     _maxSinglePartitionTopStateHandoffDuration =

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/RoutingTableProviderMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/RoutingTableProviderMonitor.java
@@ -26,7 +26,6 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
-import org.apache.helix.util.HelixUtil;
 
 import javax.management.JMException;
 import javax.management.MalformedObjectNameException;

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/RoutingTableProviderMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/RoutingTableProviderMonitor.java
@@ -26,6 +26,7 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
+import org.apache.helix.util.HelixUtil;
 
 import javax.management.JMException;
 import javax.management.MalformedObjectNameException;
@@ -60,13 +61,17 @@ public class RoutingTableProviderMonitor extends DynamicMBeanProvider {
             _propertyType.name());
 
     _dataRefreshLatencyGauge = new HistogramDynamicMetric("DataRefreshLatencyGauge", new Histogram(
-        new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+        new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
     _callbackCounter = new SimpleDynamicMetric("CallbackCounter", 0l);
     _eventQueueSizeGauge = new SimpleDynamicMetric("EventQueueSizeGauge", 0l);
     _dataRefreshCounter = new SimpleDynamicMetric("DataRefreshCounter", 0l);
     if (propertyType.equals(PropertyType.CURRENTSTATES)) {
-      _statePropLatencyGauge = new HistogramDynamicMetric("StatePropagationLatencyGauge", new Histogram(
-          new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+      _statePropLatencyGauge = new HistogramDynamicMetric("StatePropagationLatencyGauge",
+          new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
+              .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY,
+                  DEFAULT_RESET_INTERVAL_MS), TimeUnit.MILLISECONDS)));
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/RoutingTableProviderMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/RoutingTableProviderMonitor.java
@@ -61,17 +61,14 @@ public class RoutingTableProviderMonitor extends DynamicMBeanProvider {
             _propertyType.name());
 
     _dataRefreshLatencyGauge = new HistogramDynamicMetric("DataRefreshLatencyGauge", new Histogram(
-        new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _callbackCounter = new SimpleDynamicMetric("CallbackCounter", 0l);
     _eventQueueSizeGauge = new SimpleDynamicMetric("EventQueueSizeGauge", 0l);
     _dataRefreshCounter = new SimpleDynamicMetric("DataRefreshCounter", 0l);
     if (propertyType.equals(PropertyType.CURRENTSTATES)) {
       _statePropLatencyGauge = new HistogramDynamicMetric("StatePropagationLatencyGauge",
-          new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
-              .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY,
-                  DEFAULT_RESET_INTERVAL_MS), TimeUnit.MILLISECONDS)));
+          new Histogram(
+              new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/StateTransitionStatMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/StateTransitionStatMonitor.java
@@ -27,14 +27,12 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.management.JMException;
 import javax.management.ObjectName;
-import org.apache.helix.monitoring.StatCollector;
 import org.apache.helix.monitoring.StateTransitionContext;
 import org.apache.helix.monitoring.StateTransitionDataPoint;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
-import org.apache.helix.util.HelixUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/StateTransitionStatMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/StateTransitionStatMonitor.java
@@ -34,6 +34,7 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
+import org.apache.helix.util.HelixUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,13 +65,17 @@ public class StateTransitionStatMonitor extends DynamicMBeanProvider {
     _totalSuccessTransitionCounter = new SimpleDynamicMetric<>("TotalSuccessTransitionCounter", 0L);
 
     _transitionLatencyGauge = new HistogramDynamicMetric("TransitionLatencyGauge", new Histogram(
-        new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+        new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
     _transitionExecutionLatencyGauge = new HistogramDynamicMetric("TransitionExecutionLatencyGauge",
-        new Histogram(
-            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
     _transitionMessageLatency = new HistogramDynamicMetric("TransitionMessageLatencyGauge",
-        new Histogram(
-            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/StateTransitionStatMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/StateTransitionStatMonitor.java
@@ -65,17 +65,13 @@ public class StateTransitionStatMonitor extends DynamicMBeanProvider {
     _totalSuccessTransitionCounter = new SimpleDynamicMetric<>("TotalSuccessTransitionCounter", 0L);
 
     _transitionLatencyGauge = new HistogramDynamicMetric("TransitionLatencyGauge", new Histogram(
-        new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _transitionExecutionLatencyGauge = new HistogramDynamicMetric("TransitionExecutionLatencyGauge",
-        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new Histogram(
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _transitionMessageLatency = new HistogramDynamicMetric("TransitionMessageLatencyGauge",
-        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new Histogram(
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientPathMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientPathMonitor.java
@@ -129,27 +129,21 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
     _readCounter = new SimpleDynamicMetric(PredefinedMetricDomains.ReadCounter.name(), 0l);
 
     _readLatencyGauge = new HistogramDynamicMetric(PredefinedMetricDomains.ReadLatencyGauge.name(),
-        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new Histogram(
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _writeLatencyGauge =
         new HistogramDynamicMetric(PredefinedMetricDomains.WriteLatencyGauge.name(), new Histogram(
-            new SlidingTimeWindowArrayReservoir(HelixUtil
-                .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY,
-                    DEFAULT_RESET_INTERVAL_MS), TimeUnit.MILLISECONDS)));
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _readBytesGauge = new HistogramDynamicMetric(PredefinedMetricDomains.ReadBytesGauge.name(),
-        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new Histogram(
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _writeBytesGauge = new HistogramDynamicMetric(PredefinedMetricDomains.WriteBytesGauge.name(),
-        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
-            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
-            TimeUnit.MILLISECONDS)));
+        new Histogram(
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _dataPropagationLatencyGauge =
         new HistogramDynamicMetric(PredefinedMetricDomains.DataPropagationLatencyGuage.name(),
-            new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
-                .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY,
-                    DEFAULT_RESET_INTERVAL_MS), TimeUnit.MILLISECONDS)));
+            new Histogram(new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(),
+                TimeUnit.MILLISECONDS)));
   }
 
   public ZkClientPathMonitor register() throws JMException {

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientPathMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientPathMonitor.java
@@ -31,7 +31,6 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
-import org.apache.helix.util.HelixUtil;
 
 public class ZkClientPathMonitor extends DynamicMBeanProvider {
   public static final String MONITOR_PATH = "PATH";

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientPathMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientPathMonitor.java
@@ -31,6 +31,7 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
+import org.apache.helix.util.HelixUtil;
 
 public class ZkClientPathMonitor extends DynamicMBeanProvider {
   public static final String MONITOR_PATH = "PATH";
@@ -128,21 +129,27 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
     _readCounter = new SimpleDynamicMetric(PredefinedMetricDomains.ReadCounter.name(), 0l);
 
     _readLatencyGauge = new HistogramDynamicMetric(PredefinedMetricDomains.ReadLatencyGauge.name(),
-        new Histogram(
-            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
     _writeLatencyGauge =
         new HistogramDynamicMetric(PredefinedMetricDomains.WriteLatencyGauge.name(), new Histogram(
-            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+            new SlidingTimeWindowArrayReservoir(HelixUtil
+                .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY,
+                    DEFAULT_RESET_INTERVAL_MS), TimeUnit.MILLISECONDS)));
     _readBytesGauge = new HistogramDynamicMetric(PredefinedMetricDomains.ReadBytesGauge.name(),
-        new Histogram(
-            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
     _writeBytesGauge = new HistogramDynamicMetric(PredefinedMetricDomains.WriteBytesGauge.name(),
-        new Histogram(
-            new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS, TimeUnit.MILLISECONDS)));
+        new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
+            .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS),
+            TimeUnit.MILLISECONDS)));
     _dataPropagationLatencyGauge =
         new HistogramDynamicMetric(PredefinedMetricDomains.DataPropagationLatencyGuage.name(),
-            new Histogram(new SlidingTimeWindowArrayReservoir(DEFAULT_RESET_INTERVAL_MS,
-                TimeUnit.MILLISECONDS)));
+            new Histogram(new SlidingTimeWindowArrayReservoir(HelixUtil
+                .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY,
+                    DEFAULT_RESET_INTERVAL_MS), TimeUnit.MILLISECONDS)));
   }
 
   public ZkClientPathMonitor register() throws JMException {

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
@@ -40,6 +40,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.monitoring.SensorNameProvider;
 import org.apache.helix.monitoring.mbeans.MBeanRegistrar;
 import org.apache.helix.util.HelixUtil;
@@ -231,7 +232,7 @@ public abstract class DynamicMBeanProvider implements DynamicMBean, SensorNamePr
    * in the system env variables. If not found, use default value.
    */
   protected Long getResetIntervalInMs() {
-    return HelixUtil
-        .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS);
+    return HelixUtil.getSystemPropertyAsLong(SystemPropertyKeys.HELIX_MONITOR_TIME_WINDOW_LENGTH_MS,
+        DEFAULT_RESET_INTERVAL_MS);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
@@ -230,7 +230,7 @@ public abstract class DynamicMBeanProvider implements DynamicMBean, SensorNamePr
    * Return the interval length for the underlying reservoir used by the MBean metric configured
    * in the system env variables. If not found, use default value.
    */
-  protected Long getResetIntervalInMs() {
+  public Long getResetIntervalInMs() {
     return HelixUtil
         .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS);
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
@@ -230,7 +230,7 @@ public abstract class DynamicMBeanProvider implements DynamicMBean, SensorNamePr
    * Return the interval length for the underlying reservoir used by the MBean metric configured
    * in the system env variables. If not found, use default value.
    */
-  public Long getResetIntervalInMs() {
+  protected Long getResetIntervalInMs() {
     return HelixUtil
         .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS);
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
 public abstract class DynamicMBeanProvider implements DynamicMBean, SensorNameProvider {
   protected final Logger _logger = LoggerFactory.getLogger(getClass());
   protected static final long DEFAULT_RESET_INTERVAL_MS = 60 * 60 * 1000; // Reset time every hour
+  protected static final String RESET_INTERVAL_SYSTEM_PROPERTY_KEY = "reservoir.length.ms";
   private static String SENSOR_NAME_TAG = "SensorName";
   private static String DEFAULT_DESCRIPTION =
       "Information on the management interface of the MBean";

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
@@ -53,7 +53,6 @@ import org.slf4j.LoggerFactory;
 public abstract class DynamicMBeanProvider implements DynamicMBean, SensorNameProvider {
   protected final Logger _logger = LoggerFactory.getLogger(getClass());
   protected static final long DEFAULT_RESET_INTERVAL_MS = 60 * 60 * 1000; // Reset time every hour
-  protected static final String RESET_INTERVAL_SYSTEM_PROPERTY_KEY = "reservoir.length.ms";
   private static String SENSOR_NAME_TAG = "SensorName";
   private static String DEFAULT_DESCRIPTION =
       "Information on the management interface of the MBean";

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
@@ -42,6 +42,7 @@ import java.util.Map;
 
 import org.apache.helix.monitoring.SensorNameProvider;
 import org.apache.helix.monitoring.mbeans.MBeanRegistrar;
+import org.apache.helix.util.HelixUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -223,5 +224,14 @@ public abstract class DynamicMBeanProvider implements DynamicMBean, SensorNamePr
    */
   protected void incrementSimpleDynamicMetric(SimpleDynamicMetric<Long> metric, long value) {
     metric.updateValue(metric.getValue() + value);
+  }
+
+  /**
+   * Return the interval length for the underlying reservoir used by the MBean metric configured
+   * in the system env variables. If not found, use default value.
+   */
+  protected Long getResetIntervalInMs() {
+    return HelixUtil
+        .getSystemPropertyAsLong(RESET_INTERVAL_SYSTEM_PROPERTY_KEY, DEFAULT_RESET_INTERVAL_MS);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
@@ -154,7 +154,7 @@ public class TestZkClientMonitor {
 
   @Test
   public void testCustomizedResetInterval() throws JMException, InterruptedException {
-    // Use a customized reservoir length of 1 ms.
+    // Use a customized reservoir sliding length of 1 ms.
     System.setProperty("reservoir.length.ms", "1");
     final String TEST_TAG = "test_tag_3";
     final String TEST_KEY = "test_key_3";

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
@@ -156,9 +156,9 @@ public class TestZkClientMonitor {
   public void testCustomizedResetInterval() throws JMException, InterruptedException {
     // Use a customized reservoir sliding length of 1 ms.
     System.setProperty("reservoir.length.ms", "1");
-    final String TEST_TAG = "test_tag_3";
-    final String TEST_KEY = "test_key_3";
-    final String TEST_INSTANCE = "test_instance_3";
+    final String TEST_TAG = "test_tag_x";
+    final String TEST_KEY = "test_key_x";
+    final String TEST_INSTANCE = "test_instance_x";
 
     ZkClientMonitor monitor = new ZkClientMonitor(TEST_TAG, TEST_KEY, TEST_INSTANCE, false, null);
     monitor.register();

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
@@ -155,7 +155,7 @@ public class TestZkClientMonitor {
   @Test
   public void testCustomizedResetInterval() throws JMException, InterruptedException {
     // Use a customized reservoir sliding length of 1 ms.
-    System.setProperty("reservoir.length.ms", "1");
+    System.setProperty("helix.monitor.slidingTimeWindow.ms", "1");
     final String TEST_TAG = "test_tag_x";
     final String TEST_KEY = "test_key_x";
     final String TEST_INSTANCE = "test_instance_x";

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
@@ -151,4 +151,13 @@ public class TestZkClientMonitor {
         .assertEquals((long) _beanServer.getAttribute(idealStateName, "DataPropagationLatencyGuage.Max"),
             0);
   }
+
+  @Test
+  public void testCustomizedResetInverval() {
+    // Use a customized reservoir length of 1 mins.
+    System.setProperty("reservoir.length.ms", "60000");
+    ZkClientMonitor monitor =
+        new ZkClientMonitor("TEST_TAG", "TEST_KEY", "TEST_INSTANCE", false, null);
+    Assert.assertEquals(monitor.getResetIntervalInMs().longValue(), 60000L);
+  }
 }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
@@ -153,7 +153,7 @@ public class TestZkClientMonitor {
   }
 
   @Test
-  public void testCustomizedResetInverval() {
+  public void testCustomizedResetInterval() {
     // Use a customized reservoir length of 1 mins.
     System.setProperty("reservoir.length.ms", "60000");
     ZkClientMonitor monitor =


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR title:

(#382 )

### Description

- [x] Currently it is hardcoded as a SlidingTimeWindowArrayReservoir which uses a default interval of 1hr. While the reservoir choice is fine (but still should be configurable for upgrade), the window length of 1 hour occupies too much heap space for a busy Prod Helix client. More importantly, one really does not need 1 hour window to compute a histogram stats. Typically **1 min** is used. E.g., Our heapdump here in Uber shows as much as 4G or even higher of heap could be used for these metrics (initiated through ZkHelixPropertyStore). This creates too much memory and GC pressure. As in the manual for the SlidingTimeWindowArrayReservoir, a 1 minute window could used as much as 9M of memory already. So we believe a much lower interval length should be passed in. Even better, the reservoir should be made configurable.

### Tests

- [x] The following tests are written for this issue:

TestZkClientMonitor.testCustomizedResetInterval

- [x] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml