### PR TITLE
Read ClusterConfig from ZK selectively

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -220,6 +220,17 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     _instanceMessagesCache = new InstanceMessagesCache(_clusterName);
   }
 
+  private void refreshClusterConfig(final HelixDataAccessor accessor,
+      Set<HelixConstants.ChangeType> refreshedType) {
+    if (_propertyDataChangedMap.get(HelixConstants.ChangeType.CLUSTER_CONFIG).getAndSet(false)) {
+      _clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+      refreshedType.add(HelixConstants.ChangeType.CLUSTER_CONFIG);
+    } else {
+      LogUtil.logInfo(logger, getClusterEventId(), String.format(
+          "No ClusterConfig change for cluster %s, pipeline %s", _clusterName, getPipelineName()));
+    }
+  }
+
   private void refreshIdealState(final HelixDataAccessor accessor,
       Set<HelixConstants.ChangeType> refreshedType) {
     if (_propertyDataChangedMap.get(HelixConstants.ChangeType.IDEAL_STATE).getAndSet(false)) {
@@ -307,7 +318,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     Set<HelixConstants.ChangeType> refreshedTypes = new HashSet<>();
 
     // Refresh raw data
-    _clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+    refreshClusterConfig(accessor, refreshedTypes);
     refreshIdealState(accessor, refreshedTypes);
     refreshLiveInstances(accessor, refreshedTypes);
     refreshInstanceConfigs(accessor, refreshedTypes);

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestControllerDataProviderSelectiveUpdate.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestControllerDataProviderSelectiveUpdate.java
@@ -59,8 +59,7 @@ public class TestControllerDataProviderSelectiveUpdate extends ZkStandAloneCMTes
     Assert.assertEquals(accessor.getReadCount(PropertyType.EXTERNALVIEW), 0);
     Assert.assertEquals(accessor.getReadCount(PropertyType.LIVEINSTANCES), 0);
     Assert.assertEquals(accessor.getReadCount(PropertyType.CURRENTSTATES), 0);
-    // cluster config always get reloaded
-    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), 1);
+    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), 0);
 
     accessor.clearReadCounters();
     // refresh again should read nothing as ideal state is same
@@ -70,7 +69,7 @@ public class TestControllerDataProviderSelectiveUpdate extends ZkStandAloneCMTes
     Assert.assertEquals(accessor.getReadCount(PropertyType.EXTERNALVIEW), 0);
     Assert.assertEquals(accessor.getReadCount(PropertyType.LIVEINSTANCES), 0);
     Assert.assertEquals(accessor.getReadCount(PropertyType.CURRENTSTATES), 0);
-    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), 1);
+    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), 0);
 
     accessor.clearReadCounters();
     cache.notifyDataChange(HelixConstants.ChangeType.LIVE_INSTANCE);
@@ -79,7 +78,7 @@ public class TestControllerDataProviderSelectiveUpdate extends ZkStandAloneCMTes
     Assert.assertEquals(accessor.getReadCount(PropertyType.EXTERNALVIEW), 0);
     Assert.assertEquals(accessor.getReadCount(PropertyType.LIVEINSTANCES), 0);
     Assert.assertEquals(accessor.getReadCount(PropertyType.CURRENTSTATES), 0);
-    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), 1);
+    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), 0);
   }
 
   @Test(dependsOnMethods = {"testUpdateOnNotification"})
@@ -105,7 +104,7 @@ public class TestControllerDataProviderSelectiveUpdate extends ZkStandAloneCMTes
     Assert.assertEquals(accessor.getReadCount(PropertyType.EXTERNALVIEW), 0);
     Assert.assertEquals(accessor.getReadCount(PropertyType.LIVEINSTANCES), 0);
     Assert.assertEquals(accessor.getReadCount(PropertyType.CURRENTSTATES), 0);
-    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), 1);
+    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), 0);
 
     // add a new resource
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, "TestDB_1", _PARTITIONS, STATE_MODEL);
@@ -148,7 +147,7 @@ public class TestControllerDataProviderSelectiveUpdate extends ZkStandAloneCMTes
 
     cache.notifyDataChange(HelixConstants.ChangeType.RESOURCE_CONFIG);
     cache.refresh(accessor);
-    // 1 Cluster Config change + 2 Resource Config Changes
-    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), 3);
+    // 2 Resource Config Changes
+    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), 2);
   }
 }


### PR DESCRIPTION
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Previously, ClusterConfig would be read from ZK every pipeline run. This PR makes it a selective read and also add to the set of all changed types so that cluster change detector could more easily tell whether ClusterConfig changed without having to store two copies of ClusterConfig objects.

### Tests

The logic for selective update has already been tested in existing tests.

mvn test:
`[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[ERROR]   TestControllerDataProviderSelectiveUpdate.testUpdateOnNotification:63 expected:<1> but was:<0>
[ERROR]   TestStopWorkflow.testStopTask » ThreadTimeout Method org.testng.internal.TestN...
[INFO] 
[ERROR] Tests run: 837, Failures: 3, Errors: 0, Skipped: 2
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  58:34 min
[INFO] Finished at: 2019-08-06T13:53:07-07:00
[INFO] ------------------------------------------------------------------------
`
TestAlertingRebalancerFailure, TestControllerDataProviderSelectiveUpdate, and TestStopWorkflow all passed.

**TestControllerDataProviderSelectiveUpdate** was modified to adjust for the changes around ClusterConfig.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml

