### PR TITLE
Improve ZK read with batch call for Helix REST

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
@@ -135,12 +135,11 @@ public class TestInstanceService {
     when(_dataAccessor.keyBuilder()).thenReturn(new PropertyKey.Builder(TEST_CLUSTER));
     when(_dataAccessor.getChildNames(new PropertyKey.Builder(TEST_CLUSTER).liveInstances()))
         .thenReturn(Arrays.asList("host0", "host1"));
-    when(_dataAccessor.getProperty(
-        new PropertyKey.Builder(TEST_CLUSTER).healthReport("host0", "PARTITION_HEALTH")))
-        .thenReturn(new HealthStat(healthData.get(0)));
-    when(_dataAccessor.getProperty(
-        new PropertyKey.Builder(TEST_CLUSTER).healthReport("host1", "PARTITION_HEALTH")))
-        .thenReturn(new HealthStat(healthData.get(1)));
+    when(_dataAccessor.getProperty(Arrays
+        .asList(new PropertyKey.Builder(TEST_CLUSTER).healthReport("host0", "PARTITION_HEALTH"),
+            new PropertyKey.Builder(TEST_CLUSTER).healthReport("host1", "PARTITION_HEALTH"))))
+        .thenReturn(
+            Arrays.asList(new HealthStat(healthData.get(0)), new HealthStat(healthData.get(1))));
     PartitionHealth computeResult = service.generatePartitionHealthMapFromZK();
     PartitionHealth expectedResult = generateExpectedResult();
     Assert.assertEquals(computeResult, expectedResult);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR title:

#390 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Current HealthReport read is single call for each participant. Improve it will batch call to ZK to reduce the number of calls.

### Tests

- [ ] The following tests are written for this issue:


- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 83, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.948 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 83, Failures: 0, Errors: 0, Skipped: 0

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

### Code Quality

- [x] My diff has been formatted using helix-style.xml

