### PR TITLE
Fix the CallbackHandler registration logic in DistributedLeaderElection

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/healthcheck/ParticipantHealthReportTask.java
+++ b/helix-core/src/main/java/org/apache/helix/healthcheck/ParticipantHealthReportTask.java
@@ -54,7 +54,7 @@ public class ParticipantHealthReportTask extends HelixTimerTask {
   }
 
   @Override
-  public void start() {
+  public synchronized void start() {
     if (_timer == null) {
       LOG.info("Start HealthCheckInfoReportingTask");
       _timer = new Timer("ParticipantHealthReportTimerTask", true);
@@ -66,7 +66,7 @@ public class ParticipantHealthReportTask extends HelixTimerTask {
   }
 
   @Override
-  public void stop() {
+  public synchronized void stop() {
     if (_timer != null) {
       LOG.info("Stop ParticipantHealthReportTimerTask");
       _timer.cancel();

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/DistributedLeaderElection.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/DistributedLeaderElection.java
@@ -112,7 +112,6 @@ public class DistributedLeaderElection implements ControllerChangeListener {
       if (tryCreateController(manager)) {
         LOG.info("{} with session {} acquired leadership for cluster: {}",
             manager.getInstanceName(), manager.getSessionId(), manager.getClusterName());
-        updateHistory(manager);
         manager.getHelixDataAccessor().getBaseDataAccessor().reset();
         controllerHelper.addListenersToController(_controller);
         controllerHelper.startControllerTimerTasks();
@@ -132,8 +131,8 @@ public class DistributedLeaderElection implements ControllerChangeListener {
     newLeader.setSessionId(manager.getSessionId());
     newLeader.setHelixVersion(manager.getVersion());
     try {
-      boolean success = accessor.createControllerLeader(newLeader);
-      if (success) {
+      if (accessor.createControllerLeader(newLeader)) {
+        updateHistory(manager);
         return true;
       } else {
         LOG.info(

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -167,7 +167,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     }
 
     @Override
-    public void start() {
+    public synchronized void start() {
       long initialDelay = 0;
       long period = 15 * 60 * 1000;
       long timeThresholdNoChangeForStatusUpdates = 15 * 60 * 1000; // 15 minutes
@@ -185,7 +185,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     }
 
     @Override
-    public void stop() {
+    public synchronized void stop() {
       if (_timer != null) {
         LOG.info("Stop StatusDumpTask");
         _timer.cancel();

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestHandleNewSession.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestHandleNewSession.java
@@ -33,7 +33,6 @@ import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.controller.GenericHelixController;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.manager.zk.zookeeper.ZkClient;
-import org.apache.helix.messaging.DefaultMessagingService;
 import org.apache.helix.model.LiveInstance;
 import org.testng.Assert;
 import org.testng.annotations.Test;


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR title:

#394

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fix the CallbackHandler registration logic in DistributedLeaderElection that may cause a leader node has no callback registered.

### Tests

- [x] The following tests are written for this issue:

Add additional verification logic in the TestHandleNewSession which is testing the same scenario.

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[INFO] 
[ERROR] Tests run: 837, Failures: 1, Errors: 0, Skipped: 0

Rerun the failed test

[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

NA

### Code Quality

- [x] My diff has been formatted using helix-style.xml