### PR TITLE
Change the rebalancer assignment record to be ResourceAssignment

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/RebalanceAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/RebalanceAlgorithm.java
@@ -22,6 +22,7 @@ package org.apache.helix.controller.rebalancer.waged;
 import org.apache.helix.controller.rebalancer.waged.constraints.HardConstraint;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.model.ResourceAssignment;
 
 import java.util.Map;
 
@@ -40,6 +41,6 @@ public interface RebalanceAlgorithm {
    *                       If the map is null, no failure will be returned.
    * @return A map <ResourceName, FailureReason> of the rebalanced resource assignments that are saved in the IdeaStates.
    */
-  Map<String, IdealState> rebalance(ClusterModel clusterModel,
+  Map<String, ResourceAssignment> rebalance(ClusterModel clusterModel,
       Map<String, Map<HardConstraint.FailureReason, Integer>> failureReasons);
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintsRebalanceAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintsRebalanceAlgorithm.java
@@ -22,6 +22,7 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
 import org.apache.helix.controller.rebalancer.waged.RebalanceAlgorithm;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.model.ResourceAssignment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +43,7 @@ public class ConstraintsRebalanceAlgorithm implements RebalanceAlgorithm {
   }
 
   @Override
-  public Map<String, IdealState> rebalance(ClusterModel clusterModel,
+  public Map<String, ResourceAssignment> rebalance(ClusterModel clusterModel,
       Map<String, Map<HardConstraint.FailureReason, Integer>> failureReasons) {
     return new HashMap<>();
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModel.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModel.java
@@ -21,6 +21,7 @@ package org.apache.helix.controller.rebalancer.waged.model;
 
 import org.apache.helix.HelixException;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.model.ResourceAssignment;
 
 import java.util.Collections;
 import java.util.Map;
@@ -40,10 +41,10 @@ public class ClusterModel {
   private final Map<String, AssignableNode> _assignableNodeMap;
 
   // Records about the previous assignment
-  // <ResourceName, IdealState contains the baseline assignment>
-  private final Map<String, IdealState> _baselineAssignment;
-  // <ResourceName, IdealState contains the best possible assignment>
-  private final Map<String, IdealState> _bestPossibleAssignment;
+  // <ResourceName, ResourceAssignment contains the baseline assignment>
+  private final Map<String, ResourceAssignment> _baselineAssignment;
+  // <ResourceName, ResourceAssignment contains the best possible assignment>
+  private final Map<String, ResourceAssignment> _bestPossibleAssignment;
 
   /**
    * @param clusterContext         The initialized cluster context.
@@ -54,8 +55,8 @@ public class ClusterModel {
    * @param bestPossibleAssignment The current best possible assignment.
    */
   ClusterModel(ClusterContext clusterContext, Set<AssignableReplica> assignableReplicas,
-      Set<AssignableNode> assignableNodes, Map<String, IdealState> baselineAssignment,
-      Map<String, IdealState> bestPossibleAssignment) {
+      Set<AssignableNode> assignableNodes, Map<String, ResourceAssignment> baselineAssignment,
+      Map<String, ResourceAssignment> bestPossibleAssignment) {
     _clusterContext = clusterContext;
 
     // Save all the to be assigned replication
@@ -87,11 +88,11 @@ public class ClusterModel {
     return _assignableReplicaMap;
   }
 
-  public Map<String, IdealState> getBaseline() {
+  public Map<String, ResourceAssignment> getBaseline() {
     return _baselineAssignment;
   }
 
-  public Map<String, IdealState> getBestPossibleAssignment() {
+  public Map<String, ResourceAssignment> getBestPossibleAssignment() {
     return _bestPossibleAssignment;
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR title:

This change is related to #392 
After the change, we will be able to refine the provider's PR.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Change the rebalancer assignment record to be ResourceAssignment instead of IdealState.
ResourceAssignment fit the usage better. And there will be no unnecessary information to be recorded or read during the rebalance calculation.

### Tests

- [x] The following tests are written for this issue:

No new test is required. The modified part has been covered by the WAGED rebalancer unit tests.

- [x] The following is the result of the "mvn test" command on the appropriate module:

The feature has not been merged to master yet. Run unit tests only.
All passed.
TestAssignableNode
TestAssignableReplica
TestClusterContext
TestClusterModel

Default Suite
Total tests run: 9, Failures: 0, Skips: 0


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

https://github.com/apache/helix/wiki/Weight-aware-Globally-Evenly-distributed-Rebalancer

### Code Quality

- [x] My diff has been formatted using helix-style.xml

