### PR TITLE
Convert all the internal assignment state objects to be ResourceAssignment

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
@@ -19,7 +19,7 @@ package org.apache.helix.controller.rebalancer.waged;
  * under the License.
  */
 
-import org.apache.helix.model.IdealState;
+import org.apache.helix.model.ResourceAssignment;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,23 +28,23 @@ import java.util.Map;
  * A placeholder before we have the real assignment metadata store.
  */
 public class AssignmentMetadataStore {
-  private Map<String, IdealState> _persistGlobalBaseline = new HashMap<>();
-  private Map<String, IdealState> _persistBestPossibleAssignment = new HashMap<>();
+  private Map<String, ResourceAssignment> _persistGlobalBaseline = new HashMap<>();
+  private Map<String, ResourceAssignment> _persistBestPossibleAssignment = new HashMap<>();
 
-  public Map<String, IdealState> getBaseline() {
+  public Map<String, ResourceAssignment> getBaseline() {
     return _persistGlobalBaseline;
   }
 
-  public void persistBaseline(Map<String, IdealState> globalBaseline) {
+  public void persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
     // TODO clean up invalid items
     _persistGlobalBaseline = globalBaseline;
   }
 
-  public Map<String, IdealState> getBestPossibleAssignment() {
+  public Map<String, ResourceAssignment> getBestPossibleAssignment() {
     return _persistBestPossibleAssignment;
   }
 
-  public void persistBestPossibleAssignment(Map<String, IdealState> bestPossibleAssignment) {
+  public void persistBestPossibleAssignment(Map<String, ResourceAssignment> bestPossibleAssignment) {
     // TODO clean up invalid items
     _persistBestPossibleAssignment.putAll(bestPossibleAssignment);
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ClusterDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ClusterDataProvider.java
@@ -21,7 +21,7 @@ package org.apache.helix.controller.rebalancer.waged;
 
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
-import org.apache.helix.model.IdealState;
+import org.apache.helix.model.ResourceAssignment;
 
 import java.util.Map;
 import java.util.Set;
@@ -46,7 +46,8 @@ public class ClusterDataProvider {
    */
   protected static ClusterModel generateClusterModel(ResourceControllerDataProvider dataProvider,
       Set<String> activeInstances, Map<ClusterDataDetector.ChangeType, Set<String>> clusterChanges,
-      Map<String, IdealState> baselineAssignment, Map<String, IdealState> bestPossibleAssignment) {
+      Map<String, ResourceAssignment> baselineAssignment,
+      Map<String, ResourceAssignment> bestPossibleAssignment) {
     // TODO finish the implementation.
     return null;
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/RebalanceAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/RebalanceAlgorithm.java
@@ -21,7 +21,6 @@ package org.apache.helix.controller.rebalancer.waged;
 
 import org.apache.helix.controller.rebalancer.waged.constraints.HardConstraint;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
-import org.apache.helix.model.IdealState;
 import org.apache.helix.model.ResourceAssignment;
 
 import java.util.Map;
@@ -39,7 +38,7 @@ public interface RebalanceAlgorithm {
    * @param clusterModel
    * @param failureReasons Return the failures <ResourceName, <FailureReason, Count>> that happen during the rebalance calculation.
    *                       If the map is null, no failure will be returned.
-   * @return A map <ResourceName, FailureReason> of the rebalanced resource assignments that are saved in the IdeaStates.
+   * @return A map of <ResourceName, ResourceAssignment>.
    */
   Map<String, ResourceAssignment> rebalance(ClusterModel clusterModel,
       Map<String, Map<HardConstraint.FailureReason, Integer>> failureReasons);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintsRebalanceAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintsRebalanceAlgorithm.java
@@ -21,7 +21,6 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
 
 import org.apache.helix.controller.rebalancer.waged.RebalanceAlgorithm;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
-import org.apache.helix.model.IdealState;
 import org.apache.helix.model.ResourceAssignment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR title:

#392 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This is the 2nd part of updating that contains the AssignmentMetadataStore interfaces update.
Also, include several leftover changes that were not included in the previous PR unintentionally.

### Tests

- [x] The following tests are written for this issue:

TestAssignableNode
TestAssignableReplica
TestClusterContext
TestClusterModel

- [x] The following is the result of the "mvn test" command on the appropriate module:

NA

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

NA

### Code Quality

- [x] My diff has been formatted using helix-style.xml