### PR TITLE
TASK: Drop all tasks whose requested states are DROPPED

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/task/TestDropTerminalTasksUponReset.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestDropTerminalTasksUponReset.java
@@ -1,0 +1,98 @@
+package org.apache.helix.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.Partition;
+import org.apache.helix.model.ResourceAssignment;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+public class TestDropTerminalTasksUponReset {
+
+  /**
+   * This is a unit test that tests that all task partitions with requested state = DROPPED will be
+   * added to tasksToDrop.
+   */
+  @Test
+  public void testDropAllTerminalTasksUponReset() {
+    Random random = new Random();
+    String jobName = "job";
+    String nodeName = "localhost";
+    int numTasks = 10;
+
+    // Create an Iterable of LiveInstances
+    Collection<String> liveInstances = new HashSet<>();
+    liveInstances.add("localhost");
+
+    // Create a dummy ResourceAssignment
+    ResourceAssignment prevAssignment = new ResourceAssignment(jobName);
+
+    // Create allTaskPartitions
+    Set<Integer> allTaskPartitions = new HashSet<>();
+
+    // Create a mock CurrentStateOutput
+    CurrentStateOutput currentStateOutput = mock(CurrentStateOutput.class);
+
+    // Generate a CurrentStateMap
+    Map<Partition, Map<String, String>> currentStateMap = new HashMap<>();
+    when(currentStateOutput.getCurrentStateMap(jobName)).thenReturn(currentStateMap);
+
+    for (int i = 0; i < numTasks; i++) {
+      allTaskPartitions.add(i);
+      Partition task = new Partition(jobName + "_" + i);
+      currentStateMap.put(task, new HashMap<>());
+
+      // Pick some random currentState between COMPLETED and TASK_ERROR
+      String currentState = (random.nextBoolean()) ? TaskPartitionState.COMPLETED.name()
+          : TaskPartitionState.TASK_ERROR.name();
+
+      // First half of the tasks to be dropped on each instance
+      if (i < numTasks / 2) {
+        // requested state is DROPPED
+        currentStateMap.get(task).put("localhost", currentState);
+        when(currentStateOutput.getRequestedState(jobName, task, nodeName))
+            .thenReturn(TaskPartitionState.DROPPED.name());
+      } else {
+        // requested state is nothing
+        when(currentStateOutput.getRequestedState(jobName, task, nodeName)).thenReturn(null);
+      }
+    }
+
+    // Create an empty tasksToDrop
+    Map<String, Set<Integer>> tasksToDrop = new HashMap<>();
+
+    // Call the static method we are testing
+    JobDispatcher.getPrevInstanceToTaskAssignments(liveInstances, prevAssignment, allTaskPartitions,
+        currentStateOutput, jobName, tasksToDrop);
+
+    // Check that tasksToDrop has (numTasks / 2) partitions as we intended regardless of what the
+    // current states of the tasks were
+    Assert.assertEquals(numTasks / 2, tasksToDrop.get(nodeName).size());
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR title:

Fixes #375 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Upon a Participant disconnect, the Participant would carry over from the last session. This would copy all previous task states to the current session and set their requested states as DROPPED (for INIT and RUNNING states).

It came to our attention that sometimes these Participants experience connection issues and the tasks happen to be in TASK_ERROR or COMPLETED states. These tasks would get stuck on the Participant and never be dropped. This issue proposes to add the logic that would get all tasks whose requested states are DROPPED to be dropped immediately.
Changelist:
1. Make sure all tasks whose requested state is DROPPED get added to tasksToDrop

### Tests

- [x] The following tests are written for this issue:

Added a unit test: **TestDropTerminalTasksUponReset**

Manually tested by modifying currentState to the following with the right timing parameters (for task duration). Integration tests that depend on timing are not desirable, so manual testing was done and checked that all CurrentStates that look like the following do **not** show up:

  "mapFields" : {
    "testDropCompletedTasksOnReset_JOB_7_2" : {
      "CURRENT_STATE" : "COMPLETED",
      "REQUESTED_STATE" : "DROPPED"
    },
    "testDropCompletedTasksOnReset_JOB_7_5" : {
      "CURRENT_STATE" : "COMPLETED",
      "REQUESTED_STATE" : "DROPPED"
    },
    "testDropCompletedTasksOnReset_JOB_7_6" : {
      "CURRENT_STATE" : "COMPLETED",
      "REQUESTED_STATE" : "DROPPED"
    }

- [x] The following is the result of the "mvn test" command on the appropriate module:


[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[ERROR]   TestIndependentTaskRebalancer.testDelayedRetry:276 expected:<2> but was:<3>
[INFO] 
[ERROR] Tests run: 837, Failures: 2, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  53:40 min
[INFO] Finished at: 2019-08-09T18:39:54-07:00

TestAlertingRebalancerFailure:
Pass when run independently

TestIndependentTaskRebalancer
Pass when run independently

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml

