### PR TITLE
 Fix ZNode does not exist in HealthCheck

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/json/cluster/PartitionHealth.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/json/cluster/PartitionHealth.java
@@ -20,6 +20,7 @@ package org.apache.helix.rest.server.json.cluster;
  */
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,10 @@ public class PartitionHealth {
       String partitionName) {
     _instanceToPartitionsMap
         .computeIfAbsent(instanceName, partitions -> new ArrayList<>()).add(partitionName);
+  }
+
+  public void addInstanceThatNeedDirectCall(String instanceName) {
+    _instanceToPartitionsMap.put(instanceName, Collections.EMPTY_LIST);
   }
 
   public void addSinglePartitionHealthForInstance(String instanceName, String partitionName,


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR title:
A smart quick fix, no need to create an issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
If the ZNode of PartitionHealth does not exist, REST will return failed checks due to NPE. The fix will be adding the instance to be refreshed entirely. Then REST can check based on API refreshed result.

### Tests

- [ ] The following tests are written for this issue:

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 82, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.657 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 82, Failures: 0, Errors: 0, Skipped: 0

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

### Code Quality

- [x] My diff has been formatted using helix-style.xml

