### PR TITLE
Revert "Reenable helix-front module for official release."

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@ under the License.
     <module>helix-admin-webapp</module>
     <module>helix-rest</module>
     <module>helix-agent</module>
-    <module>helix-front</module>
+    <!--<module>helix-front</module>-->
     <module>recipes</module>
   </modules>
 


### PR DESCRIPTION
This reverts commit 3c3db0bf797cbc1e0c1aec59395c8632ed6455db.