### PR TITLE
Improve equals() on config objects

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -442,10 +442,12 @@ public class ClusterConfig extends HelixProperty {
   public boolean equals(Object obj) {
     if (obj instanceof ClusterConfig) {
       ClusterConfig that = (ClusterConfig) obj;
-
       if (this.getId().equals(that.getId())) {
-        return true;
+        if (that.getRecord() != null) {
+          return that.getRecord().equals(this.getRecord());
+        }
       }
+      return false;
     }
     return false;
   }

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -509,10 +509,12 @@ public class InstanceConfig extends HelixProperty {
   public boolean equals(Object obj) {
     if (obj instanceof InstanceConfig) {
       InstanceConfig that = (InstanceConfig) obj;
-
       if (this.getId().equals(that.getId())) {
-        return true;
+        if (that.getRecord() != null) {
+          return that.getRecord().equals(this.getRecord());
+        }
       }
+      return false;
     }
     return false;
   }

--- a/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
@@ -333,11 +333,7 @@ public class ResourceConfig extends HelixProperty {
   public List<String> getPreferenceList(String partitionName) {
     List<String> instanceStateList = _record.getListField(partitionName);
 
-    if (instanceStateList != null) {
-      return instanceStateList;
-    }
-
-    return null;
+    return instanceStateList;
   }
 
   /**
@@ -437,10 +433,12 @@ public class ResourceConfig extends HelixProperty {
   public boolean equals(Object obj) {
     if (obj instanceof ResourceConfig) {
       ResourceConfig that = (ResourceConfig) obj;
-
       if (this.getId().equals(that.getId())) {
-        return true;
+        if (that.getRecord() != null) {
+          return that.getRecord().equals(this.getRecord());
+        }
       }
+      return false;
     }
     return false;
   }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes $407


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:


ClusterConfig, InstanceConfig, ResourceConfig's equals() methods were only comparing the IDs, which is not desirable because it is possible to have two instances of each with the same IDs but different contents/fields. This diff improves the equals() methods for these configs so that the actual contents are compared as well.

Changelist:
1. Change equals() on the said config classes so that the actual content is compared

### Tests

- [ ] The following tests are written for this issue:

Simple equals() method. No tests needed.

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml


