### PR TITLE
Rest - Clean up /namespaces/default/* when default helix name space is set

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/common/ServletType.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/common/ServletType.java
@@ -26,17 +26,17 @@ public enum ServletType {
   /**
    * Servlet serving default API endpoints (/admin/v2/clusters/...)
    */
-  DEFAULT_SERVLET(HelixRestNamespace.DEFAULT_NAMESPACE_PATH_SPEC,
-      new String[] { AbstractHelixResource.class.getPackage().getName(),
-          NamespacesAccessor.class.getPackage().getName()
-      }),
+  DEFAULT_SERVLET(HelixRestNamespace.DEFAULT_NAMESPACE_PATH_SPEC, new String[] {
+      AbstractHelixResource.class.getPackage().getName(),
+      NamespacesAccessor.class.getPackage().getName()
+  }),
 
   /**
    * Servlet serving namespaced API endpoints (/admin/v2/namespaces/{namespaceName})
    */
-  COMMON_SERVLET("/namespaces/%s/*",
-      new String[] { AbstractHelixResource.class.getPackage().getName(),
-      });
+  COMMON_SERVLET("/namespaces/%s/*", new String[] {
+      AbstractHelixResource.class.getPackage().getName(),
+  });
 
   private final String _servletPathSpecTemplate;
   private final String[] _servletPackageArray;
@@ -48,6 +48,10 @@ public enum ServletType {
 
   public String getServletPathSpecTemplate() {
     return _servletPathSpecTemplate;
+  }
+
+  public String getServletPath(HelixRestNamespace namespace) {
+    return String.format(_servletPathSpecTemplate, namespace.getName());
   }
 
   public String[] getServletPackageArray() {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
@@ -128,7 +128,6 @@ public class HelixRestServer {
     // register servlet listener on path, e.g, http://localhost:8080/admin/v2/namespaces/default/*
     String path = servletType.getServletPath(namespace);
     LOG.info("Initializing Servlet on path: " + path);
-    System.out.println("Initializing Servlet on path: " + path);
     _servletContextHandler.addServlet(new ServletHolder(new ServletContainer(config)), path);
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR title:

It's just some simple refactoring works that make the HelixRestServer look cleaner.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
Added one feature - now the servlets have application names which make JMX debugging easier. 

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml