### PR TITLE
Add integration test for workflow ForceDelete

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -645,10 +645,10 @@ public class TaskDriver {
    * @param forceDelete, CAUTION: if set true, workflow and all of its jobs' related zk nodes will
    *          be clean up immediately from zookeeper, no matter whether there are jobs
    *          are running or not.
-   *
    *          Enabling this option can cause a ZooKeeper delete failure as Helix might
-   *          inadvertently try to write the deleted ZNodes back to ZooKeeper. Do not
-   *          use unless the cluster is in a paused state or inactive (no controller).
+   *          inadvertently try to write the deleted ZNodes back to ZooKeeper. Also this option
+   *          might corrupt Task Framework cache. At any rate, it shouldn't be used while the
+   *          controller is running or the cluster is active.
    */
   public void delete(String workflow, boolean forceDelete) {
     WorkflowContext wCtx = TaskUtil.getWorkflowContext(_propertyStore, workflow);

--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -645,6 +645,10 @@ public class TaskDriver {
    * @param forceDelete, CAUTION: if set true, workflow and all of its jobs' related zk nodes will
    *          be clean up immediately from zookeeper, no matter whether there are jobs
    *          are running or not.
+   *
+   *          Enabling this option can cause a ZooKeeper delete failure as Helix might
+   *          inadvertently try to write the deleted ZNodes back to ZooKeeper. Do not
+   *          use unless the cluster is in a paused state or inactive (no controller).
    */
   public void delete(String workflow, boolean forceDelete) {
     WorkflowContext wCtx = TaskUtil.getWorkflowContext(_propertyStore, workflow);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestForceDeleteWorkflow.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestForceDeleteWorkflow.java
@@ -46,7 +46,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/*
+/**
 This test checks the functionality of the ForceDelete in various conditions.
  */
 public class TestForceDeleteWorkflow extends TaskTestBase {
@@ -55,7 +55,7 @@ public class TestForceDeleteWorkflow extends TaskTestBase {
   private static final String SHORT_EXECUTION_TIME = "1000";
   private static final String MEDIUM_EXECUTION_TIME = "10000";
   private static final String LONG_EXECUTION_TIME = "100000";
-  // Long delay to simulate the tasks that do not stop.
+  // Long delay to simulate the tasks that are stuck in Task.cancel().
   private static final String STOP_DELAY = "1000000";
   private HelixAdmin _admin;
   protected HelixManager _manager;

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestForceDeleteWorkflow.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestForceDeleteWorkflow.java
@@ -19,41 +19,162 @@ package org.apache.helix.integration.task;
  * under the License.
  */
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import org.apache.helix.AccessOption;
+import java.util.Map;
 import org.apache.helix.HelixAdmin;
-import org.apache.helix.HelixManager;
-import org.apache.helix.TestHelper;
-import org.apache.helix.task.JobConfig;
-import org.apache.helix.task.TaskConfig;
-import org.apache.helix.task.TaskConstants;
-import org.apache.helix.task.TaskState;
 import org.apache.helix.task.TaskUtil;
+import org.apache.helix.HelixException;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
 import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
 import org.apache.helix.task.WorkflowContext;
+import org.apache.helix.tools.ClusterSetup;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /*
-This test checks the functionality of the forcedelete in various conditions.
+This test checks the functionality of the ForceDelete in various conditions.
  */
+public class TestForceDeleteWorkflow extends ZkTestBase {
+  protected int _numNodes = 5;
+  protected int _startPort = 12918;
+  protected int _numPartitions = 20;
+  protected int _numReplicas = 3;
+  protected int _numDbs = 1;
 
-public class TestForceDeleteWorkflow extends TaskTestBase {
-  private HelixAdmin admin;
-  // Delay considered for force deletion and delay considered for disableling the  cluster.
-  private static final int DELETE_DELAY = 2000;
-  private long Disable_Delay = 1000L;
+  protected ClusterControllerManager _controller;
+  protected HelixManager _manager;
+  protected TaskDriver _driver;
+
+  protected List<String> _testDbs = new ArrayList<>();
+
+  protected final String MASTER_SLAVE_STATE_MODEL = "MasterSlave";
+  protected final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + getShortClassName();
+  protected MockParticipantManager[] _participants;
+
+  protected ZkHelixClusterVerifier _clusterVerifier;
+  private HelixAdmin _admin;
 
   @BeforeClass
   public void beforeClass() throws Exception {
     super.beforeClass();
-    admin = _gSetupTool.getClusterManagementTool();
-    createManagers();
+    _participants = new MockParticipantManager[_numNodes];
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
 
+    setupParticipants(_gSetupTool);
+    setupDBs();
+
+    for (int i = 0; i < _numNodes; i++) {
+      startParticipant(ZK_ADDR, i);
+    }
+
+    _manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "Admin",
+        InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+
+    _clusterVerifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    _admin = _gSetupTool.getClusterManagementTool();
+  }
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    if (_controller != null && _controller.isConnected()) {
+      _controller.syncStop();
+    }
+    if (_manager != null && _manager.isConnected()) {
+      _manager.disconnect();
+    }
+    for (int i = 0; i < _numNodes; i++) {
+      stopParticipant(i);
+    }
+    deleteCluster(CLUSTER_NAME);
+  }
+
+  protected void setupDBs() {
+    setupDBs(_gSetupTool);
+  }
+
+  protected void setupDBs(ClusterSetup clusterSetup) {
+    // Set up target db
+    boolean partitionVary = true;
+    if (_numDbs > 1) {
+      for (int i = 0; i < _numDbs; i++) {
+        int varyNum = partitionVary ? 10 * i : 0;
+        String db = WorkflowGenerator.DEFAULT_TGT_DB + i;
+        clusterSetup.addResourceToCluster(CLUSTER_NAME, db, _numPartitions + varyNum,
+            MASTER_SLAVE_STATE_MODEL, IdealState.RebalanceMode.FULL_AUTO.toString());
+        clusterSetup.rebalanceStorageCluster(CLUSTER_NAME, db, _numReplicas);
+        _testDbs.add(db);
+      }
+    } else {
+      clusterSetup.addResourceToCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB,
+          _numPartitions, MASTER_SLAVE_STATE_MODEL, IdealState.RebalanceMode.FULL_AUTO.name());
+      clusterSetup.rebalanceStorageCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB,
+          _numReplicas);
+    }
+  }
+
+  protected void setupParticipants(ClusterSetup setupTool) {
+    _participants = new MockParticipantManager[_numNodes];
+    for (int i = 0; i < _numNodes; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+      setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+  }
+
+  protected void startParticipant(String zkAddr, int i) {
+    Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
+    taskFactoryReg.put(DelayedStopTask.TASK_COMMAND, DelayedStopTask::new);
+    String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+    _participants[i] = new MockParticipantManager(zkAddr, CLUSTER_NAME, instanceName);
+
+    // Register a Task state model factory.
+    StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+    stateMachine.registerStateModelFactory("Task",
+        new TaskStateModelFactory(_participants[i], taskFactoryReg));
+    _participants[i].syncStart();
+  }
+
+  protected void stopParticipant(int i) {
+    if (_participants.length <= i) {
+      throw new HelixException(
+          String.format("Can't stop participant %s, only %s participants" + "were set up.", i,
+              _participants.length));
+    }
+    if (_participants[i] != null && _participants[i].isConnected()) {
+      _participants[i].syncStop();
+    }
   }
 
   @Test
@@ -61,32 +182,7 @@ public class TestForceDeleteWorkflow extends TaskTestBase {
     // Create a simple workflow and wait for its completion. Then delete the IdealState,
     // WorkflowContext and WorkflowConfig.
     String workflowName = TestHelper.getTestMethodName();
-    Workflow.Builder builder = new Workflow.Builder(workflowName);
-
-    //Workflow Schematic:
-    //               JOB0
-    //                /\
-    //               /  \
-    //             JOB1 JOB2
-
-    JobConfig.Builder jobBuilder0 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
-        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
-        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "1000"));
-
-    JobConfig.Builder jobBuilder1 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
-        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
-        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "1000"));
-
-    JobConfig.Builder jobBuilder2 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
-        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
-        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "1000"));
-
-    builder.addParentChildDependency("JOB0", "JOB1");
-    builder.addParentChildDependency("JOB0", "JOB2");
-    builder.addJob("JOB0", jobBuilder0);
-    builder.addJob("JOB1", jobBuilder1);
-    builder.addJob("JOB2", jobBuilder2);
-
+    Workflow.Builder builder = createCustomWorkflow(workflowName, "1000", "0");
     _driver.start(builder.build());
 
     // Wait until workflow is created and completed.
@@ -100,57 +196,35 @@ public class TestForceDeleteWorkflow extends TaskTestBase {
     // workflow
     Assert.assertNotNull(_driver.getWorkflowConfig(workflowName));
     Assert.assertNotNull(_driver.getWorkflowContext(workflowName));
-    Assert.assertNotNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+    Assert.assertNotNull(_admin.getResourceIdealState(CLUSTER_NAME, workflowName));
 
-    // Disable the cluster before Force Delete
-    admin.enableCluster(CLUSTER_NAME, false);
-    Thread.sleep(Disable_Delay);
+    // Stop the Controller
+    _controller.syncStop();
 
     _driver.delete(workflowName, true);
-    Thread.sleep(DELETE_DELAY);
-
-    // Enable the cluster before Force Delete
-    admin.enableCluster(CLUSTER_NAME, true);
 
     // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed deleted for this
-    // workflow
-    Assert.assertNull(_driver.getWorkflowConfig(workflowName));
-    Assert.assertNull(_driver.getWorkflowContext(workflowName));
-    Assert.assertNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+    // workflow.
+    boolean isWorkflowDeleted = TestHelper.verify(() -> {
+      WorkflowConfig wfcfg = _driver.getWorkflowConfig(workflowName);
+      WorkflowContext wfctx = _driver.getWorkflowContext(workflowName);
+      IdealState is = _admin.getResourceIdealState(CLUSTER_NAME, workflowName);
+      return (wfcfg == null && wfctx == null && is == null);
+    }, 60 * 1000);
+    Assert.assertTrue(isWorkflowDeleted);
+
+    // Start the Controller
+    String controllerName = CONTROLLER_PREFIX + "_1";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
   }
 
-  @Test
+  @Test(dependsOnMethods = "testDeleteCompletedWorkflowForcefully")
   public void testDeleteRunningWorkflowForcefully() throws Exception {
     // Create a simple workflow and wait until it reaches the Running state. Then delete the
-    // IdealState,
-    // WorkflowContext and WorkflowConfig.
+    // IdealState, WorkflowContext and WorkflowConfig.
     String workflowName = TestHelper.getTestMethodName();
-    Workflow.Builder builder = new Workflow.Builder(workflowName);
-
-    //Workflow Schematic:
-    //               JOB0
-    //                /\
-    //               /  \
-    //             JOB1 JOB2
-
-    JobConfig.Builder jobBuilder0 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
-        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
-        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "100000"));
-
-    JobConfig.Builder jobBuilder1 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
-        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
-        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "100000"));
-
-    JobConfig.Builder jobBuilder2 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
-        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
-        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "100000"));
-
-    builder.addParentChildDependency("JOB0", "JOB1");
-    builder.addParentChildDependency("JOB0", "JOB2");
-    builder.addJob("JOB0", jobBuilder0);
-    builder.addJob("JOB1", jobBuilder1);
-    builder.addJob("JOB2", jobBuilder2);
-
+    Workflow.Builder builder = createCustomWorkflow(workflowName, "100000", "0");
     _driver.start(builder.build());
 
     // Wait until workflow is created and goes to running stage.
@@ -164,55 +238,37 @@ public class TestForceDeleteWorkflow extends TaskTestBase {
     // workflow
     Assert.assertNotNull(_driver.getWorkflowConfig(workflowName));
     Assert.assertNotNull(_driver.getWorkflowContext(workflowName));
-    Assert.assertNotNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+    Assert.assertNotNull(_admin.getResourceIdealState(CLUSTER_NAME, workflowName));
 
-    // Disable the cluster before Force Delete
-    admin.enableCluster(CLUSTER_NAME, false);
-    Thread.sleep(Disable_Delay);
+    // Stop the Controller
+    _controller.syncStop();
 
     _driver.delete(workflowName, true);
-    Thread.sleep(DELETE_DELAY);
-
-    // Enable the cluster before Force Delete
-    admin.enableCluster(CLUSTER_NAME, true);
 
     // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed deleted for this
     // workflow
-    Assert.assertNull(_driver.getWorkflowConfig(workflowName));
-    Assert.assertNull(_driver.getWorkflowContext(workflowName));
-    Assert.assertNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+    boolean isWorkflowDeleted = TestHelper.verify(() -> {
+      WorkflowConfig wfcfg = _driver.getWorkflowConfig(workflowName);
+      WorkflowContext wfctx = _driver.getWorkflowContext(workflowName);
+      IdealState is = _admin.getResourceIdealState(CLUSTER_NAME, workflowName);
+      return (wfcfg == null && wfctx == null && is == null);
+    }, 60 * 1000);
+    Assert.assertTrue(isWorkflowDeleted);
+
+    // Start the Controller
+    String controllerName = CONTROLLER_PREFIX + "_2";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
   }
 
-  @Test
+  @Test(dependsOnMethods = "testDeleteRunningWorkflowForcefully")
   public void testDeleteStoppedWorkflowForcefully() throws Exception {
+    // Create a simple workflow. Stop the workflow and wait for completion. Delete the workflow forcefully afterwards
     String workflowName = TestHelper.getTestMethodName();
-    Workflow.Builder builder = new Workflow.Builder(workflowName);
-
-    //Workflow Schematic:
-    //               JOB0
-    //                /\
-    //               /  \
-    //             JOB1 JOB2
-
-    JobConfig.Builder jobBuilder0 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
-        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
-        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
-
-    JobConfig.Builder jobBuilder1 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
-        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
-        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
-
-    JobConfig.Builder jobBuilder2 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
-        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
-        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
-
-    builder.addParentChildDependency("JOB0", "JOB1");
-    builder.addParentChildDependency("JOB0", "JOB2");
-    builder.addJob("JOB0", jobBuilder0);
-    builder.addJob("JOB1", jobBuilder1);
-    builder.addJob("JOB2", jobBuilder2);
-
+    Workflow.Builder builder = createCustomWorkflow(workflowName, "10000", "0");
     _driver.start(builder.build());
+
     // Wait until workflow is created.
     boolean isWorkflowCreated = TestHelper.verify(() -> {
       WorkflowContext wCtx1 = _driver.getWorkflowContext(workflowName);
@@ -229,33 +285,92 @@ public class TestForceDeleteWorkflow extends TaskTestBase {
     Assert.assertTrue(isWorkflowStopped);
 
     // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed created for this
-    // workflow
+    // workflow.
     Assert.assertNotNull(_driver.getWorkflowConfig(workflowName));
     Assert.assertNotNull(_driver.getWorkflowContext(workflowName));
-    Assert.assertNotNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+    Assert.assertNotNull(_admin.getResourceIdealState(CLUSTER_NAME, workflowName));
 
-    // Disable the cluster before Force Delete
-    admin.enableCluster(CLUSTER_NAME, false);
-    Thread.sleep(Disable_Delay);
+    // Stop the Controller
+    _controller.syncStop();
 
     _driver.delete(workflowName, true);
-    Thread.sleep(DELETE_DELAY);
-
-    // Enable the cluster before Force Delete
-    admin.enableCluster(CLUSTER_NAME, true);
 
     // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed deleted for this
-    // workflow
-    Assert.assertNull(_driver.getWorkflowConfig(workflowName));
-    Assert.assertNull(_driver.getWorkflowContext(workflowName));
-    Assert.assertNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+    // workflow.
+    boolean isWorkflowDeleted = TestHelper.verify(() -> {
+      WorkflowConfig wfcfg = _driver.getWorkflowConfig(workflowName);
+      WorkflowContext wfctx = _driver.getWorkflowContext(workflowName);
+      IdealState is = _admin.getResourceIdealState(CLUSTER_NAME, workflowName);
+      return (wfcfg == null && wfctx == null && is == null);
+    }, 60 * 1000);
+    Assert.assertTrue(isWorkflowDeleted);
+
+    // Start the Controller
+    String controllerName = CONTROLLER_PREFIX + "_3";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
   }
 
-  @Test
-  public void testDeleteNotStartedWorkflowForcefully() throws Exception {
+  @Test(dependsOnMethods = "testDeleteStoppedWorkflowForcefully")
+  public void testDeleteStoppingStuckWorkflowForcefully() throws Exception {
     String workflowName = TestHelper.getTestMethodName();
-    Workflow.Builder builder = new Workflow.Builder(workflowName);
+    Workflow.Builder builder = createCustomWorkflow(workflowName, "10000", "1000000");
+    _driver.start(builder.build());
 
+    // Wait until workflow is created.
+    boolean isWorkflowCreated = TestHelper.verify(() -> {
+      WorkflowContext wCtx1 = _driver.getWorkflowContext(workflowName);
+      return (wCtx1 != null);
+    }, 60 * 1000);
+    Assert.assertTrue(isWorkflowCreated);
+
+    _driver.stop(workflowName);
+    // Wait until workflow is stopped.
+
+    boolean isWorkflowStopped = TestHelper.verify(() -> {
+      WorkflowContext wCtx1 = _driver.getWorkflowContext(workflowName);
+      return ((wCtx1.getWorkflowState() == TaskState.STOPPED
+          || wCtx1.getWorkflowState() == TaskState.STOPPING));
+    }, 60 * 1000);
+    Assert.assertTrue(isWorkflowStopped);
+
+    boolean isJobStopped = TestHelper.verify(() -> {
+      WorkflowContext wCtx1 = _driver.getWorkflowContext(workflowName);
+      return wCtx1.getJobState(TaskUtil.getNamespacedJobName(workflowName + "_JOB0"))==TaskState.STOPPED;
+    }, 60 * 1000);
+    Assert.assertFalse(isJobStopped);
+
+    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed created for this
+    // workflow.
+    Assert.assertNotNull(_driver.getWorkflowConfig(workflowName));
+    Assert.assertNotNull(_driver.getWorkflowContext(workflowName));
+    Assert.assertNotNull(_admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+
+    // Stop the Controller.
+    _controller.syncStop();
+
+    _driver.delete(workflowName, true);
+
+    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed deleted for this
+    // workflow.
+    boolean isWorkflowDeleted = TestHelper.verify(() -> {
+      WorkflowConfig wfcfg = _driver.getWorkflowConfig(workflowName);
+      WorkflowContext wfctx = _driver.getWorkflowContext(workflowName);
+      IdealState is = _admin.getResourceIdealState(CLUSTER_NAME, workflowName);
+      return (wfcfg == null && wfctx == null && is == null);
+    }, 60 * 1000);
+    Assert.assertTrue(isWorkflowDeleted);
+
+    // Start the Controller.
+    String controllerName = CONTROLLER_PREFIX + "_2";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+  }
+
+  private Workflow.Builder createCustomWorkflow(String workflowName, String executionTime,
+      String stopDelay) {
+    Workflow.Builder builder = new Workflow.Builder(workflowName);
     //Workflow Schematic:
     //               JOB0
     //                /\
@@ -264,74 +379,55 @@ public class TestForceDeleteWorkflow extends TaskTestBase {
 
     JobConfig.Builder jobBuilder0 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
         .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
-        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
+        .setJobCommandConfigMap(ImmutableMap.of(DelayedStopTask.JOB_DELAY, executionTime))
+        .setJobCommandConfigMap(ImmutableMap.of(DelayedStopTask.JOB_DELAY_CANCEL, stopDelay));
 
     JobConfig.Builder jobBuilder1 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
         .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
-        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
+        .setJobCommandConfigMap(ImmutableMap.of(DelayedStopTask.JOB_DELAY, executionTime))
+        .setJobCommandConfigMap(ImmutableMap.of(DelayedStopTask.JOB_DELAY_CANCEL, stopDelay));
 
     JobConfig.Builder jobBuilder2 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
         .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
-        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, executionTime))
+        .setJobCommandConfigMap(ImmutableMap.of(DelayedStopTask.JOB_DELAY_CANCEL, stopDelay));
 
-    // Execution delay if set to be large number in order to have enough time to change the status
-    // of the workflow to not started.
     builder.addParentChildDependency("JOB0", "JOB1");
     builder.addParentChildDependency("JOB0", "JOB2");
-    builder.addJob("JOB0", jobBuilder0.setExecutionDelay(10000000000L));
+
+    builder.addJob("JOB0", jobBuilder0);
     builder.addJob("JOB1", jobBuilder1);
     builder.addJob("JOB2", jobBuilder2);
 
-    _driver.start(builder.build());
-    // Wait until workflow is created.
-    boolean isWorkflowCreated = TestHelper.verify(() -> {
-      WorkflowContext wCtx1 = _driver.getWorkflowContext(workflowName);
-      return (wCtx1 != null);
-    }, 60 * 1000);
-    Assert.assertTrue(isWorkflowCreated);
-
-    // Change the workflow state to Not-Started and set its start time of the workflow.
-    long startTime = System.currentTimeMillis() + 100000000L;
-    WorkflowContext workflowContext = TaskTestUtil.buildWorkflowContext(workflowName,
-        TaskState.NOT_STARTED, startTime, TaskState.NOT_STARTED);
-    setWorkflowContext(_manager, workflowName, workflowContext);
-
-    // Wait until workflow is stopped.
-    boolean isWorkflowInNotStartedState = TestHelper.verify(() -> {
-      WorkflowContext wCtx1 = _driver.getWorkflowContext(workflowName);
-      return (wCtx1.getWorkflowState() == TaskState.NOT_STARTED);
-    }, 60 * 1000);
-    Assert.assertTrue(isWorkflowInNotStartedState);
-
-    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed created for this
-    // workflow
-    Assert.assertNotNull(_driver.getWorkflowConfig(workflowName));
-    Assert.assertNotNull(_driver.getWorkflowContext(workflowName));
-    Assert.assertNotNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
-
-    // Disable the cluster before Force Delete
-    admin.enableCluster(CLUSTER_NAME, false);
-    Thread.sleep(Disable_Delay);
-
-    _driver.delete(workflowName, true);
-    Thread.sleep(DELETE_DELAY);
-
-    // Enable the cluster before Force Delete
-    admin.enableCluster(CLUSTER_NAME, true);
-
-    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed deleted for this
-    // workflow
-    Assert.assertNull(_driver.getWorkflowConfig(workflowName));
-    Assert.assertNull(_driver.getWorkflowContext(workflowName));
-    Assert.assertNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
-
+    return builder;
   }
 
-  private void setWorkflowContext(HelixManager manager, String workflow,
-      WorkflowContext workflowContext) {
-    String CONTEXT_NODE = "Context";
-    manager.getHelixPropertyStore().set(
-        Joiner.on("/").join(TaskConstants.REBALANCER_CONTEXT_ROOT, workflow, CONTEXT_NODE),
-        workflowContext.getRecord(), AccessOption.PERSISTENT);
+  /**
+   * A mock task that extents MockTask class and delays cancellation of the tasks.
+   */
+  private class DelayedStopTask extends MockTask {
+    public static final String JOB_DELAY_CANCEL = "Delay";
+    private long _delayCancel;
+
+    DelayedStopTask(TaskCallbackContext context) {
+      super(context);
+      Map<String, String> cfg = context.getJobConfig().getJobCommandConfigMap();
+      if (cfg == null) {
+        cfg = new HashMap<>();
+      }
+      _delayCancel =
+          cfg.containsKey(JOB_DELAY_CANCEL) ? Long.parseLong(cfg.get(JOB_DELAY_CANCEL)) : 0L;
+    }
+
+    @Override
+    public void cancel() {
+      try {
+        Thread.sleep(_delayCancel);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+      super.cancel();
+    }
   }
+
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestForceDeleteWorkflow.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestForceDeleteWorkflow.java
@@ -47,7 +47,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
-This test checks the functionality of the ForceDelete in various conditions.
+ * This test checks the functionality of the ForceDelete in various conditions.
  */
 public class TestForceDeleteWorkflow extends TaskTestBase {
   private static final long LONG_TIMEOUT = 200000L;
@@ -62,6 +62,10 @@ public class TestForceDeleteWorkflow extends TaskTestBase {
   protected TaskDriver _driver;
 
   // These AtomicIntegers are used to check tasks are stuck in Task.cancel().
+  // CANCEL shows that the task cancellation process has been started. (Incremented at the beginning
+  // of Task.cancel())
+  // STOP shows that the task cancellation process has been finished. (Incremented at the end of
+  // Task.cancel())
   private static final AtomicInteger CANCEL_COUNT = new AtomicInteger(0);
   private static final AtomicInteger STOP_COUNT = new AtomicInteger(0);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestForceDeleteWorkflow.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestForceDeleteWorkflow.java
@@ -1,0 +1,337 @@
+package org.apache.helix.integration.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.helix.AccessOption;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
+import org.apache.helix.TestHelper;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskConstants;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowContext;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/*
+This test checks the functionality of the forcedelete in various conditions.
+ */
+
+public class TestForceDeleteWorkflow extends TaskTestBase {
+  private HelixAdmin admin;
+  // Delay considered for force deletion and delay considered for disableling the  cluster.
+  private static final int DELETE_DELAY = 2000;
+  private long Disable_Delay = 1000L;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    super.beforeClass();
+    admin = _gSetupTool.getClusterManagementTool();
+    createManagers();
+
+  }
+
+  @Test
+  public void testDeleteCompletedWorkflowForcefully() throws Exception {
+    // Create a simple workflow and wait for its completion. Then delete the IdealState,
+    // WorkflowContext and WorkflowConfig.
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder builder = new Workflow.Builder(workflowName);
+
+    //Workflow Schematic:
+    //               JOB0
+    //                /\
+    //               /  \
+    //             JOB1 JOB2
+
+    JobConfig.Builder jobBuilder0 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "1000"));
+
+    JobConfig.Builder jobBuilder1 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "1000"));
+
+    JobConfig.Builder jobBuilder2 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "1000"));
+
+    builder.addParentChildDependency("JOB0", "JOB1");
+    builder.addParentChildDependency("JOB0", "JOB2");
+    builder.addJob("JOB0", jobBuilder0);
+    builder.addJob("JOB1", jobBuilder1);
+    builder.addJob("JOB2", jobBuilder2);
+
+    _driver.start(builder.build());
+
+    // Wait until workflow is created and completed.
+    boolean isWorkflowCompleted = TestHelper.verify(() -> {
+      WorkflowContext wCtx1 = _driver.getWorkflowContext(workflowName);
+      return (wCtx1 != null && wCtx1.getWorkflowState() == TaskState.COMPLETED);
+    }, 60 * 1000);
+    Assert.assertTrue(isWorkflowCompleted);
+
+    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed created for this
+    // workflow
+    Assert.assertNotNull(_driver.getWorkflowConfig(workflowName));
+    Assert.assertNotNull(_driver.getWorkflowContext(workflowName));
+    Assert.assertNotNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+
+    // Disable the cluster before Force Delete
+    admin.enableCluster(CLUSTER_NAME, false);
+    Thread.sleep(Disable_Delay);
+
+    _driver.delete(workflowName, true);
+    Thread.sleep(DELETE_DELAY);
+
+    // Enable the cluster before Force Delete
+    admin.enableCluster(CLUSTER_NAME, true);
+
+    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed deleted for this
+    // workflow
+    Assert.assertNull(_driver.getWorkflowConfig(workflowName));
+    Assert.assertNull(_driver.getWorkflowContext(workflowName));
+    Assert.assertNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+  }
+
+  @Test
+  public void testDeleteRunningWorkflowForcefully() throws Exception {
+    // Create a simple workflow and wait until it reaches the Running state. Then delete the
+    // IdealState,
+    // WorkflowContext and WorkflowConfig.
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder builder = new Workflow.Builder(workflowName);
+
+    //Workflow Schematic:
+    //               JOB0
+    //                /\
+    //               /  \
+    //             JOB1 JOB2
+
+    JobConfig.Builder jobBuilder0 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "100000"));
+
+    JobConfig.Builder jobBuilder1 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "100000"));
+
+    JobConfig.Builder jobBuilder2 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "100000"));
+
+    builder.addParentChildDependency("JOB0", "JOB1");
+    builder.addParentChildDependency("JOB0", "JOB2");
+    builder.addJob("JOB0", jobBuilder0);
+    builder.addJob("JOB1", jobBuilder1);
+    builder.addJob("JOB2", jobBuilder2);
+
+    _driver.start(builder.build());
+
+    // Wait until workflow is created and goes to running stage.
+    boolean isWorkflowRunning = TestHelper.verify(() -> {
+      WorkflowContext wCtx1 = _driver.getWorkflowContext(workflowName);
+      return (wCtx1 != null && wCtx1.getWorkflowState() == TaskState.IN_PROGRESS);
+    }, 60 * 1000);
+    Assert.assertTrue(isWorkflowRunning);
+
+    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed created for this
+    // workflow
+    Assert.assertNotNull(_driver.getWorkflowConfig(workflowName));
+    Assert.assertNotNull(_driver.getWorkflowContext(workflowName));
+    Assert.assertNotNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+
+    // Disable the cluster before Force Delete
+    admin.enableCluster(CLUSTER_NAME, false);
+    Thread.sleep(Disable_Delay);
+
+    _driver.delete(workflowName, true);
+    Thread.sleep(DELETE_DELAY);
+
+    // Enable the cluster before Force Delete
+    admin.enableCluster(CLUSTER_NAME, true);
+
+    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed deleted for this
+    // workflow
+    Assert.assertNull(_driver.getWorkflowConfig(workflowName));
+    Assert.assertNull(_driver.getWorkflowContext(workflowName));
+    Assert.assertNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+  }
+
+  @Test
+  public void testDeleteStoppedWorkflowForcefully() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder builder = new Workflow.Builder(workflowName);
+
+    //Workflow Schematic:
+    //               JOB0
+    //                /\
+    //               /  \
+    //             JOB1 JOB2
+
+    JobConfig.Builder jobBuilder0 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
+
+    JobConfig.Builder jobBuilder1 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
+
+    JobConfig.Builder jobBuilder2 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
+
+    builder.addParentChildDependency("JOB0", "JOB1");
+    builder.addParentChildDependency("JOB0", "JOB2");
+    builder.addJob("JOB0", jobBuilder0);
+    builder.addJob("JOB1", jobBuilder1);
+    builder.addJob("JOB2", jobBuilder2);
+
+    _driver.start(builder.build());
+    // Wait until workflow is created.
+    boolean isWorkflowCreated = TestHelper.verify(() -> {
+      WorkflowContext wCtx1 = _driver.getWorkflowContext(workflowName);
+      return (wCtx1 != null);
+    }, 60 * 1000);
+    Assert.assertTrue(isWorkflowCreated);
+
+    _driver.stop(workflowName);
+    // Wait until workflow is stopped.
+    boolean isWorkflowStopped = TestHelper.verify(() -> {
+      WorkflowContext wCtx1 = _driver.getWorkflowContext(workflowName);
+      return (wCtx1.getWorkflowState() == TaskState.STOPPED);
+    }, 60 * 1000);
+    Assert.assertTrue(isWorkflowStopped);
+
+    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed created for this
+    // workflow
+    Assert.assertNotNull(_driver.getWorkflowConfig(workflowName));
+    Assert.assertNotNull(_driver.getWorkflowContext(workflowName));
+    Assert.assertNotNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+
+    // Disable the cluster before Force Delete
+    admin.enableCluster(CLUSTER_NAME, false);
+    Thread.sleep(Disable_Delay);
+
+    _driver.delete(workflowName, true);
+    Thread.sleep(DELETE_DELAY);
+
+    // Enable the cluster before Force Delete
+    admin.enableCluster(CLUSTER_NAME, true);
+
+    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed deleted for this
+    // workflow
+    Assert.assertNull(_driver.getWorkflowConfig(workflowName));
+    Assert.assertNull(_driver.getWorkflowContext(workflowName));
+    Assert.assertNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+  }
+
+  @Test
+  public void testDeleteNotStartedWorkflowForcefully() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder builder = new Workflow.Builder(workflowName);
+
+    //Workflow Schematic:
+    //               JOB0
+    //                /\
+    //               /  \
+    //             JOB1 JOB2
+
+    JobConfig.Builder jobBuilder0 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
+
+    JobConfig.Builder jobBuilder1 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
+
+    JobConfig.Builder jobBuilder2 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
+
+    // Execution delay if set to be large number in order to have enough time to change the status
+    // of the workflow to not started.
+    builder.addParentChildDependency("JOB0", "JOB1");
+    builder.addParentChildDependency("JOB0", "JOB2");
+    builder.addJob("JOB0", jobBuilder0.setExecutionDelay(10000000000L));
+    builder.addJob("JOB1", jobBuilder1);
+    builder.addJob("JOB2", jobBuilder2);
+
+    _driver.start(builder.build());
+    // Wait until workflow is created.
+    boolean isWorkflowCreated = TestHelper.verify(() -> {
+      WorkflowContext wCtx1 = _driver.getWorkflowContext(workflowName);
+      return (wCtx1 != null);
+    }, 60 * 1000);
+    Assert.assertTrue(isWorkflowCreated);
+
+    // Change the workflow state to Not-Started and set its start time of the workflow.
+    long startTime = System.currentTimeMillis() + 100000000L;
+    WorkflowContext workflowContext = TaskTestUtil.buildWorkflowContext(workflowName,
+        TaskState.NOT_STARTED, startTime, TaskState.NOT_STARTED);
+    setWorkflowContext(_manager, workflowName, workflowContext);
+
+    // Wait until workflow is stopped.
+    boolean isWorkflowInNotStartedState = TestHelper.verify(() -> {
+      WorkflowContext wCtx1 = _driver.getWorkflowContext(workflowName);
+      return (wCtx1.getWorkflowState() == TaskState.NOT_STARTED);
+    }, 60 * 1000);
+    Assert.assertTrue(isWorkflowInNotStartedState);
+
+    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed created for this
+    // workflow
+    Assert.assertNotNull(_driver.getWorkflowConfig(workflowName));
+    Assert.assertNotNull(_driver.getWorkflowContext(workflowName));
+    Assert.assertNotNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+
+    // Disable the cluster before Force Delete
+    admin.enableCluster(CLUSTER_NAME, false);
+    Thread.sleep(Disable_Delay);
+
+    _driver.delete(workflowName, true);
+    Thread.sleep(DELETE_DELAY);
+
+    // Enable the cluster before Force Delete
+    admin.enableCluster(CLUSTER_NAME, true);
+
+    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed deleted for this
+    // workflow
+    Assert.assertNull(_driver.getWorkflowConfig(workflowName));
+    Assert.assertNull(_driver.getWorkflowContext(workflowName));
+    Assert.assertNull(admin.getResourceIdealState(CLUSTER_NAME, workflowName));
+
+  }
+
+  private void setWorkflowContext(HelixManager manager, String workflow,
+      WorkflowContext workflowContext) {
+    String CONTEXT_NODE = "Context";
+    manager.getHelixPropertyStore().set(
+        Joiner.on("/").join(TaskConstants.REBALANCER_CONTEXT_ROOT, workflow, CONTEXT_NODE),
+        workflowContext.getRecord(), AccessOption.PERSISTENT);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestForceDeleteWorkflow.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestForceDeleteWorkflow.java
@@ -61,7 +61,7 @@ public class TestForceDeleteWorkflow extends TaskTestBase {
   protected HelixManager _manager;
   protected TaskDriver _driver;
 
-  // These AtomicIntegers are used to check tasks are stuck in Task.cancel().
+  // These AtomicIntegers are used to verify that the tasks are indeed stuck in Task.cancel().
   // CANCEL shows that the task cancellation process has been started. (Incremented at the beginning
   // of Task.cancel())
   // STOP shows that the task cancellation process has been finished. (Incremented at the end of


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Issue #385 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This commit adds integration tests for ForceDelete.
Add comment to ForceDelete that discourages users from using ForceDelete.
Several workflow states have been considered and checked for ForceDelete.


### Tests

- [x] The following tests are written for this issue:
TestForceDeleteWorkflow

- [x] The following is the result of the "mvn test" command on the appropriate module:

Test Result 1: mvn test
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 846, Failures: 1, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  53:55 min
[INFO] Finished at: 2019-08-21T11:49:57-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/anajari/my_repos/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles


Test Result 2: mvn test -Dtest="TestAlertingRebalancerFailure"
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.242 s - in org.apache.helix.integration.TestAlertingRebalancerFailure
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  9.150 s
[INFO] Finished at: 2019-08-21T12:19:34-07:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml


