### PR TITLE
Fix the scenario where the context is not updated properly after tasks being stopped

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskStopQueue.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskStopQueue.java
@@ -1,0 +1,113 @@
+package org.apache.helix.integration.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.helix.AccessOption;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.ZkTestHelper;
+import org.apache.helix.manager.zk.ZkClient;
+import org.apache.helix.task.JobQueue;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskState;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * This test makes sure the workflow can be stopped if previousAssignment and currentState are
+ * deleted.
+ */
+public class TestTaskStopQueue extends TaskTestBase {
+  private static final long TIMEOUT = 200000L;
+  private static final String EXECUTION_TIME = "100000";
+  private HelixAdmin _admin;
+  protected HelixManager _manager;
+  protected TaskDriver _driver;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    super.beforeClass();
+    _manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "Admin",
+        InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+    _admin = _gSetupTool.getClusterManagementTool();
+  }
+
+  @Test
+  public void testStopRunningQueue() throws InterruptedException {
+    String jobQueueName = TestHelper.getTestMethodName();
+
+    JobConfig.Builder jobBuilder0 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setTimeoutPerTask(TIMEOUT).setMaxAttemptsPerTask(10).setWorkflow(jobQueueName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, EXECUTION_TIME));
+
+    JobQueue.Builder jobQueue = TaskTestUtil.buildJobQueue(jobQueueName);
+    jobQueue.enqueueJob("JOB0", jobBuilder0);
+
+    _driver.start(jobQueue.build());
+
+    _driver.pollForWorkflowState(jobQueueName, TaskState.IN_PROGRESS);
+    _driver.pollForJobState(jobQueueName, TaskUtil.getNamespacedJobName(jobQueueName, "JOB0"),
+        TaskState.IN_PROGRESS);
+
+    _controller.syncStop();
+
+    _driver.stop(jobQueueName);
+
+    String namespacedJobName = TaskUtil.getNamespacedJobName(jobQueueName, "JOB0");
+
+    for (int i = 0; i < _numNodes; i++) {
+      String instance = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+      ZkClient client = (ZkClient) _participants[i].getZkClient();
+      String sessionId = ZkTestHelper.getSessionId(client);
+      String currentStatePath = "/" + CLUSTER_NAME + "/INSTANCES/" + instance + "/CURRENTSTATES/"
+          + sessionId + "/" + namespacedJobName;
+      _manager.getHelixDataAccessor().getBaseDataAccessor().remove(currentStatePath,
+          AccessOption.PERSISTENT);
+      Assert.assertFalse(_manager.getHelixDataAccessor().getBaseDataAccessor()
+          .exists(currentStatePath, AccessOption.PERSISTENT));
+    }
+
+    String previousAssignment = "/" + CLUSTER_NAME + "/PROPERTYSTORE/TaskRebalancer/"
+        + namespacedJobName + "/PreviousResourceAssignment";
+    _manager.getHelixDataAccessor().getBaseDataAccessor().remove(previousAssignment,
+        AccessOption.PERSISTENT);
+    Assert.assertFalse(_manager.getHelixDataAccessor().getBaseDataAccessor()
+        .exists(previousAssignment, AccessOption.PERSISTENT));
+
+    // Start the Controller
+    String controllerName = CONTROLLER_PREFIX + "_1";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    _driver.pollForWorkflowState(jobQueueName, TaskState.STOPPED);
+    _driver.pollForJobState(jobQueueName, TaskUtil.getNamespacedJobName(jobQueueName, "JOB0"),
+        TaskState.STOPPED);
+  }
+}


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Issues #434 and #384.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Scenario: User stops a queue that is in running state. After this request, participants will drop the the tasks and as a result currenstates becomes null. At the same time, for some reason Previous Assignment has been deleted.
Outcome: The context is not updated accordingly.

In this commit,
1- A method has been added which extracts the "prevInstanceToTaskAssignments" information from the context (it is needed because previous assignment has been deleted.)
2- Once it is checked and confirmed that the currentstate is null, an "if statement" has been added which sets the context using the target state information.
3- An integration test is added that checks the correctness of this PR.


### Tests

- [x] The following tests are written for this issue:
TestTaskStopQueue

- [x] The following is the result of the "mvn test" command on the appropriate module:

Test Result 1: mvn test
[ERROR] Tests run: 850, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 3,585.439 s <<< FAILURE! - in TestSuite
[ERROR] testTaskPerformanceMetrics(org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics)  Time elapsed: 2.204 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics.testTaskPerformanceMetrics(TestTaskPerformanceMetrics.java:118)

[ERROR] testBounceDisableAndDrop(org.apache.helix.integration.TestBucketizedResource)  Time elapsed: 300.009 s  <<< FAILURE!
org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testBounceDisableAndDrop() didn't finish within the time-out 300000
	at org.apache.helix.integration.TestBucketizedResource.testBounceDisableAndDrop(TestBucketizedResource.java:151)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestBucketizedResource.testBounceDisableAndDrop:151 » ThreadTimeout Method org...
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 850, Failures: 2, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  59:50 min
[INFO] Finished at: 2019-09-06T15:45:43-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/anajari/my_repos/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException



Test Result 2: mvn test -Dtest="TestBucketizedResource,TestTaskPerformanceMetrics"
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 28.463 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  32.730 s
[INFO] Finished at: 2019-09-06T15:47:23-07:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml