### PR TITLE
Add special treatment for ClusterConfig

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeDetector.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeDetector.java
@@ -111,11 +111,14 @@ public class ResourceChangeDetector implements ChangeDetector {
       return snapshot.getResourceConfigMap();
     case LIVE_INSTANCE:
       return snapshot.getLiveInstances();
-    case CONFIG:
+    case CLUSTER_CONFIG:
+      // In the case of ClusterConfig, we return an empty map
+      // This is to allow the caller to iterate on the change types without throwing an exception or
+      // leaving a warn log for ClusterConfig changes
       return Collections.emptyMap();
     default:
       LOG.warn(
-          "ResourceChangeDetector cannot compute the names of changes for the given ChangeType: {}",
+          "ResourceChangeDetector cannot determine propertyMap for the given ChangeType: {}. Returning an empty map.",
           changeType);
       return Collections.emptyMap();
     }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#411 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This diff allows callers of getChangeType to iterate over the result of getChangeType() by changing determinePropertyMapByType so that it just returns an empty map for ClusterConfig.

### Tests

- [x] The following tests are written for this issue:

**TestResourceChangeDetector**

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml


