### PR TITLE
TASK: Fix forceDelete for jobs in JobQueue

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestDeleteJobFromJobQueue.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestDeleteJobFromJobQueue.java
@@ -59,6 +59,7 @@ public class TestDeleteJobFromJobQueue extends TaskTestBase {
 
     try {
       _driver.deleteJob(jobQueueName, "job2");
+      Assert.fail("Regular, non-force deleteJob should fail since the workflow is in progress!");
     } catch (IllegalStateException e) {
       // Expect IllegalStateException because job2 is still in progress
     }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestDeleteJobFromJobQueue.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestDeleteJobFromJobQueue.java
@@ -1,0 +1,75 @@
+package org.apache.helix.integration.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.helix.TestHelper;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.JobQueue;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskUtil;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestDeleteJobFromJobQueue extends TaskTestBase {
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _numPartitions = 1;
+    super.beforeClass();
+  }
+
+  @Test
+  public void testForceDeleteJobFromJobQueue() throws InterruptedException {
+    String jobQueueName = TestHelper.getTestMethodName();
+
+    // Create two jobs: job1 will complete fast, and job2 will be stuck in progress. The idea is to
+    // force-delete a stuck job (job2).
+    JobConfig.Builder jobBuilder = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(jobQueueName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10"));
+    JobConfig.Builder jobBuilder2 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(jobQueueName)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "100000")).setTimeout(100000);
+
+    JobQueue.Builder jobQueue = TaskTestUtil.buildJobQueue(jobQueueName);
+    jobQueue.enqueueJob("job1", jobBuilder);
+    jobQueue.enqueueJob("job2", jobBuilder2);
+    _driver.start(jobQueue.build());
+    _driver.pollForJobState(jobQueueName, TaskUtil.getNamespacedJobName(jobQueueName, "job2"),
+        TaskState.IN_PROGRESS);
+
+    try {
+      _driver.deleteJob(jobQueueName, "job2");
+    } catch (IllegalStateException e) {
+      // Expect IllegalStateException because job2 is still in progress
+    }
+
+    // The following force delete for the job should go through without getting an exception
+    _driver.deleteJob(jobQueueName, "job2", true);
+
+    // Check that the job has been force-deleted (fully gone from ZK)
+    Assert.assertNull(_driver.getJobConfig(TaskUtil.getNamespacedJobName(jobQueueName, "job2")));
+    Assert.assertNull(_driver.getJobContext(TaskUtil.getNamespacedJobName(jobQueueName, "job2")));
+    Assert.assertNull(_manager.getClusterManagmentTool().getResourceIdealState(CLUSTER_NAME,
+        TaskUtil.getNamespacedJobName(jobQueueName, "job2")));
+  }
+}

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/JobAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/JobAccessor.java
@@ -133,7 +133,7 @@ public class JobAccessor extends AbstractHelixResource {
   public Response deleteJob(@PathParam("clusterId") String clusterId,
       @PathParam("workflowName") String workflowName, @PathParam("jobName") String jobName,
       @QueryParam("force") @DefaultValue("false") String forceDelete) {
-    boolean force = Boolean.valueOf(forceDelete);
+    boolean force = Boolean.parseBoolean(forceDelete);
     TaskDriver driver = getTaskDriver(clusterId);
 
     try {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #445 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We observed that the force delete functionality doesn't really work when the job is running, saying that the job is currently running. Force delete should go through regardless of the current job status.
Changelist:
1. Change the semantics in deleteJobFromQueue
2. Add an integration test: TestDeleteJobFromJobQueue

### Tests

- [x] The following tests are written for this issue:

TestDeleteJobFromJobQueue

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Tests run: 850, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3,198.931 s <<< FAILURE! - in TestSuite
[ERROR] testNoDoubleAssign(org.apache.helix.integration.task.TestNoDoubleAssign)  Time elapsed: 14.736 s  <<< FAILURE!
java.lang.AssertionError: expected:<false> but was:<true>
	at org.apache.helix.integration.task.TestNoDoubleAssign.testNoDoubleAssign(TestNoDoubleAssign.java:119)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestNoDoubleAssign.testNoDoubleAssign:119 expected:<false> but was:<true>
[INFO] 
[ERROR] Tests run: 850, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  53:23 min
[INFO] Finished at: 2019-09-03T19:29:08-07:00
[INFO] ------------------------------------------------------------------------

$ mvn test -Dtest=TestNoDoubleAssign

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 24.569 s - in org.apache.helix.integration.task.TestNoDoubleAssign
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml

