### PR TITLE
[helix-rest] Delete unused default namespace (api "/namespaces/default")

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/common/ServletType.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/common/ServletType.java
@@ -26,17 +26,17 @@ public enum ServletType {
   /**
    * Servlet serving default API endpoints (/admin/v2/clusters/...)
    */
-  DEFAULT_SERVLET(HelixRestNamespace.DEFAULT_NAMESPACE_PATH_SPEC, new String[] {
-      AbstractHelixResource.class.getPackage().getName(),
-      NamespacesAccessor.class.getPackage().getName()
-  }),
+  DEFAULT_SERVLET(HelixRestNamespace.DEFAULT_NAMESPACE_PATH_SPEC,
+      new String[] { AbstractHelixResource.class.getPackage().getName(),
+          NamespacesAccessor.class.getPackage().getName()
+      }),
 
   /**
    * Servlet serving namespaced API endpoints (/admin/v2/namespaces/{namespaceName})
    */
-  COMMON_SERVLET("/namespaces/%s/*", new String[] {
-      AbstractHelixResource.class.getPackage().getName(),
-  });
+  COMMON_SERVLET("/namespaces/%s/*",
+      new String[] { AbstractHelixResource.class.getPackage().getName(),
+      });
 
   private final String _servletPathSpecTemplate;
   private final String[] _servletPackageArray;

--- a/helix-rest/src/main/java/org/apache/helix/rest/common/ServletType.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/common/ServletType.java
@@ -26,17 +26,17 @@ public enum ServletType {
   /**
    * Servlet serving default API endpoints (/admin/v2/clusters/...)
    */
-  DEFAULT_SERVLET(HelixRestNamespace.DEFAULT_NAMESPACE_PATH_SPEC,
-      new String[] { AbstractHelixResource.class.getPackage().getName(),
-          NamespacesAccessor.class.getPackage().getName()
-      }),
+  DEFAULT_SERVLET(HelixRestNamespace.DEFAULT_NAMESPACE_PATH_SPEC, new String[] {
+      AbstractHelixResource.class.getPackage().getName(),
+      NamespacesAccessor.class.getPackage().getName()
+  }),
 
   /**
    * Servlet serving namespaced API endpoints (/admin/v2/namespaces/{namespaceName})
    */
-  COMMON_SERVLET("/namespaces/%s/*",
-      new String[] { AbstractHelixResource.class.getPackage().getName(),
-      });
+  COMMON_SERVLET("/namespaces/%s/*", new String[] {
+      AbstractHelixResource.class.getPackage().getName(),
+  });
 
   private final String _servletPathSpecTemplate;
   private final String[] _servletPackageArray;

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestHelixRestServer.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestHelixRestServer.java
@@ -59,7 +59,7 @@ public class TestHelixRestServer extends AbstractTestClass {
     try {
       List<HelixRestNamespace> invalidManifest3 = new ArrayList<>();
       invalidManifest3.add(
-          new HelixRestNamespace("DuplicatedName", HelixRestNamespace.HelixMetadataStoreType.ZOOKEEPER, ZK_ADDR, true));
+          new HelixRestNamespace("DuplicatedName", HelixRestNamespace.HelixMetadataStoreType.ZOOKEEPER, ZK_ADDR, false));
       invalidManifest3.add(
           new HelixRestNamespace("DuplicatedName", HelixRestNamespace.HelixMetadataStoreType.ZOOKEEPER, ZK_ADDR,
               false));

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestNamespacedAPIAccess.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestNamespacedAPIAccess.java
@@ -62,7 +62,7 @@ public class TestNamespacedAPIAccess extends AbstractTestClass {
   public void testNamespacedCRUD() throws IOException {
     String testClusterName = "testClusterForNamespacedCRUD";
 
-    // Create a cluster in test namespace and verify it only appears in test namespace
+    // Create cluster in test namespace and verify it's only appears in test namespace
     put(String.format("/namespaces/%s/clusters/%s", TEST_NAMESPACE, testClusterName), null,
         Entity.entity("", MediaType.APPLICATION_JSON_TYPE), Response.Status.CREATED.getStatusCode());
     get(String.format("/namespaces/%s/clusters/%s", TEST_NAMESPACE, testClusterName), null,

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestNamespacedAPIAccess.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestNamespacedAPIAccess.java
@@ -46,16 +46,13 @@ public class TestNamespacedAPIAccess extends AbstractTestClass {
     String testClusterName = "testDefaultNamespaceDisabled";
 
     // "/namespaces/default" is disabled.
-    get(String.format("/namespaces/%s", HelixRestNamespace.DEFAULT_NAMESPACE_NAME), null,
-        Response.Status.NOT_FOUND.getStatusCode(), false);
+    get(String.format("/namespaces/%s", HelixRestNamespace.DEFAULT_NAMESPACE_NAME), null, Response.Status.NOT_FOUND.getStatusCode(), false);
 
     // Create a cluster.
-    put(String.format("/clusters/%s", testClusterName), null,
-        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+    put(String.format("/clusters/%s", testClusterName), null, Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
         Response.Status.CREATED.getStatusCode());
 
-    get(String.format("/clusters/%s", testClusterName), null, Response.Status.OK.getStatusCode(),
-        false);
+    get(String.format("/clusters/%s", testClusterName), null, Response.Status.OK.getStatusCode(), false);
 
     // Remove empty test cluster. Otherwise, it could fail ClusterAccessor tests
     delete(String.format("/clusters/%s", testClusterName), Response.Status.OK.getStatusCode());
@@ -67,19 +64,15 @@ public class TestNamespacedAPIAccess extends AbstractTestClass {
 
     // Create a cluster in test namespace and verify it only appears in test namespace
     put(String.format("/namespaces/%s/clusters/%s", TEST_NAMESPACE, testClusterName), null,
-        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
-        Response.Status.CREATED.getStatusCode());
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE), Response.Status.CREATED.getStatusCode());
     get(String.format("/namespaces/%s/clusters/%s", TEST_NAMESPACE, testClusterName), null,
         Response.Status.OK.getStatusCode(), false);
-    get(String.format("/clusters/%s", testClusterName), null,
-        Response.Status.NOT_FOUND.getStatusCode(), false);
+    get(String.format("/clusters/%s", testClusterName), null, Response.Status.NOT_FOUND.getStatusCode(), false);
 
     // Create a cluster with same name in a different namespace
     put(String.format("/clusters/%s", testClusterName), null,
-        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
-        Response.Status.CREATED.getStatusCode());
-    get(String.format("/clusters/%s", testClusterName), null, Response.Status.OK.getStatusCode(),
-        false);
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE), Response.Status.CREATED.getStatusCode());
+    get(String.format("/clusters/%s", testClusterName), null, Response.Status.OK.getStatusCode(), false);
 
     // Modify cluster in default namespace
     post(String.format("/clusters/%s", testClusterName), ImmutableMap.of("command", "disable"),
@@ -95,8 +88,7 @@ public class TestNamespacedAPIAccess extends AbstractTestClass {
         Response.Status.OK.getStatusCode());
     get(String.format("/namespaces/%s/clusters/%s", TEST_NAMESPACE, testClusterName), null,
         Response.Status.NOT_FOUND.getStatusCode(), false);
-    get(String.format("/clusters/%s", testClusterName), null, Response.Status.OK.getStatusCode(),
-        false);
+    get(String.format("/clusters/%s", testClusterName), null, Response.Status.OK.getStatusCode(), false);
     // Remove empty test clusters. Otherwise, it could fail ClusterAccessor tests
     delete(String.format("/clusters/%s", testClusterName), Response.Status.OK.getStatusCode());
   }
@@ -107,14 +99,12 @@ public class TestNamespacedAPIAccess extends AbstractTestClass {
     get("/", null, Response.Status.NOT_FOUND.getStatusCode(), false);
 
     // Get invalid namespace should return not found
-    get("/namespaces/invalid-namespace", null,
-        Response.Status.NOT_FOUND.getStatusCode(), false);
+    get("/namespaces/invalid-namespace", null, Response.Status.NOT_FOUND.getStatusCode(), false);
 
     // list namespace should return a list of all namespaces
-    String body = get("/namespaces", null,
-        Response.Status.OK.getStatusCode(), true);
-    List<Map<String, String>> namespaceMaps = _mapper.readValue(body,
-        _mapper.getTypeFactory().constructCollectionType(List.class, Map.class));
+    String body = get("/namespaces", null, Response.Status.OK.getStatusCode(), true);
+    List<Map<String, String>> namespaceMaps = _mapper
+        .readValue(body, _mapper.getTypeFactory().constructCollectionType(List.class, Map.class));
     Assert.assertEquals(namespaceMaps.size(), 2);
 
     Set<String> expectedNamespaceNames = new HashSet<>();


### PR DESCRIPTION
### Issues

- [x]  My PR addresses the following Helix issues and references them in the PR title:
It's just some simple refactoring works that make the HelixRestServer look cleaner.

### Description

- [x]  Here are some details about my PR, including screenshots of any UI changes:
(Write a concise description including what, why, how)

What - https://github.com/apache/helix/issues/427  Delete unused default namespace. Api endpoint "/namespaces/default" will be disabled and deleted. 

Why - We have namespace api: /admin/v2/namespaces/{namespace}/.  However, the /namespaces/default path is not in use. We need to delete this.

How - On the code level, if there is not a default namespace, we won't create a DEFAULT_SERVLET. On the app/MP level, we can configure MP not to add name "default" namespace.

### Tests

- [x]  The following tests are written for this issue:
(List the names of added unit/integration tests)
testDefaultNamespaceDisabled

- [x]  The following is the result of the "mvn test" command on the appropriate module:
(Copy & paste the result of "mvn test")

mvn test in helix-rest.

[INFO] Tests run: 84, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.631 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 84, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  27.788 s
[INFO] Finished at: 2019-09-04T21:25:44-07:00
[INFO] ------------------------------------------------------------------------



### Commits

- [x]  My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "How to write a good git commit message":
Subject is separated from body by a blank line
Subject is limited to 50 characters (not including Jira issue reference)
Subject does not end with a period
Subject uses the imperative mood ("add", not "adding")
Body wraps at 72 characters
Body explains "what" and "why", not "how"
Documentation

  In case of new functionality, my PR adds documentation in the following wiki page:
(Link the GitHub wiki you added)

### Code Quality

- [x]  My diff has been formatted using helix-style.xml