### PR TITLE
Fix TestWagedRebalancer and add constructor in AssignmentMetadataStore

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
@@ -21,6 +21,8 @@ package org.apache.helix.controller.rebalancer.waged;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import org.I0Itec.zkclient.serialize.ZkSerializer;
 import org.apache.helix.BucketDataAccessor;
 import org.apache.helix.HelixException;
@@ -30,9 +32,6 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordJacksonSerializer;
 import org.apache.helix.manager.zk.ZkBucketDataAccessor;
 import org.apache.helix.model.ResourceAssignment;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A placeholder before we have the real assignment metadata store.
@@ -51,12 +50,15 @@ public class AssignmentMetadataStore {
   private Map<String, ResourceAssignment> _globalBaseline;
   private Map<String, ResourceAssignment> _bestPossibleAssignment;
 
+  AssignmentMetadataStore(BucketDataAccessor bucketDataAccessor, String clusterName) {
+    _dataAccessor = bucketDataAccessor;
+    _baselinePath = String.format(BASELINE_TEMPLATE, clusterName, ASSIGNMENT_METADATA_KEY);
+    _bestPossiblePath = String.format(BEST_POSSIBLE_TEMPLATE, clusterName, ASSIGNMENT_METADATA_KEY);
+  }
+
   AssignmentMetadataStore(HelixManager helixManager) {
-    _dataAccessor = new ZkBucketDataAccessor(helixManager.getMetadataStoreConnectionString());
-    _baselinePath =
-        String.format(BASELINE_TEMPLATE, helixManager.getClusterName(), ASSIGNMENT_METADATA_KEY);
-    _bestPossiblePath = String.format(BEST_POSSIBLE_TEMPLATE, helixManager.getClusterName(),
-        ASSIGNMENT_METADATA_KEY);
+    this(new ZkBucketDataAccessor(helixManager.getMetadataStoreConnectionString()),
+        helixManager.getClusterName());
   }
 
   public Map<String, ResourceAssignment> getBaseline() {

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/MockAssignmentMetadataStore.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/MockAssignmentMetadataStore.java
@@ -19,11 +19,10 @@ package org.apache.helix.controller.rebalancer.waged;
  * under the License.
  */
 
-import org.apache.helix.HelixManager;
-import org.apache.helix.model.ResourceAssignment;
-
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.helix.BucketDataAccessor;
+import org.apache.helix.model.ResourceAssignment;
 
 /**
  * A mock up metadata store for unit test.
@@ -33,9 +32,8 @@ public class MockAssignmentMetadataStore extends AssignmentMetadataStore {
   private Map<String, ResourceAssignment> _persistGlobalBaseline = new HashMap<>();
   private Map<String, ResourceAssignment> _persistBestPossibleAssignment = new HashMap<>();
 
-  public MockAssignmentMetadataStore() {
-    // In-memory mock component, so pass null for HelixManager since it's not needed
-    super(null);
+  MockAssignmentMetadataStore(BucketDataAccessor bucketDataAccessor, String clusterName) {
+    super(bucketDataAccessor, clusterName);
   }
 
   public Map<String, ResourceAssignment> getBaseline() {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #459 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fix TestWagedRebalancer and add constructor in AssignmentMetadataStore

TestWagedRebalancer was failing because it was not using a proper HelixManager to instantiate a mock version of AssignmentMetadataStore. This diff refactors the constructors in AssignmentMetadataStore and fixes the failing test.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Running org.apache.helix.controller.rebalancer.waged.TestWagedRebalancer
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.661 s - in org.apache.helix.controller.rebalancer.waged.TestWagedRebalancer
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.991 s
[INFO] Finished at: 2019-09-10T09:47:28-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml

