### PR TITLE
Make State Transition Throttling respect MIN_ACTIVE_REPLICA

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -733,7 +733,12 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
       preferenceList = Collections.emptyList();
     }
 
-    int replica = idealState.getReplicaCount(preferenceList.size());
+    // If there is a minimum active replica number specified in IS, we should respect it.
+    // TODO: We should implement the per replica level throttling with generated message
+    // Issue: https://github.com/apache/helix/issues/343
+    int replica = idealState.getMinActiveReplicas() == -1
+        ? idealState.getReplicaCount(preferenceList.size())
+        : idealState.getMinActiveReplicas();
     Set<String> activeList = new HashSet<>(preferenceList);
     activeList.retainAll(cache.getEnabledLiveInstances());
 

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/BaseStageTest.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/BaseStageTest.java
@@ -55,6 +55,7 @@ import org.testng.annotations.BeforeMethod;
 public class BaseStageTest {
   public final static String HOSTNAME_PREFIX = "localhost_";
   public final static String SESSION_PREFIX = "session_";
+  private final static int MIN_ACTIVE_REPLICA_NOT_SET = -1;
 
   protected String _clusterName;
   protected HelixManager manager;
@@ -142,19 +143,19 @@ public class BaseStageTest {
   protected List<IdealState> setupIdealState(int nodes, String[] resources, int partitions,
       int replicas, RebalanceMode rebalanceMode) {
     return setupIdealState(nodes, resources, partitions, replicas, rebalanceMode,
-        BuiltInStateModelDefinitions.MasterSlave.name(), null, null, -1);
+        BuiltInStateModelDefinitions.MasterSlave.name(), null, null, MIN_ACTIVE_REPLICA_NOT_SET);
   }
 
   protected List<IdealState> setupIdealState(int nodes, String[] resources, int partitions,
       int replicas, RebalanceMode rebalanceMode, String stateModelName) {
     return setupIdealState(nodes, resources, partitions, replicas, rebalanceMode, stateModelName,
-        null, null, -1);
+        null, null, MIN_ACTIVE_REPLICA_NOT_SET);
   }
 
   protected List<IdealState> setupIdealState(int nodes, String[] resources, int partitions,
       int replicas, RebalanceMode rebalanceMode, String stateModelName, String rebalanceClassName) {
     return setupIdealState(nodes, resources, partitions, replicas, rebalanceMode, stateModelName,
-        rebalanceClassName, null, -1);
+        rebalanceClassName, null, MIN_ACTIVE_REPLICA_NOT_SET);
   }
 
   protected List<String> setupLiveInstances(int numLiveInstances) {

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/BaseStageTest.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/BaseStageTest.java
@@ -104,7 +104,7 @@ public class BaseStageTest {
 
   protected List<IdealState> setupIdealState(int nodes, String[] resources, int partitions,
       int replicas, RebalanceMode rebalanceMode, String stateModelName, String rebalanceClassName,
-      String rebalanceStrategyName) {
+      String rebalanceStrategyName, int minActiveReplica) {
     List<IdealState> idealStates = new ArrayList<IdealState>();
     for (String resourceName : resources) {
       ZNRecord record = new ZNRecord(resourceName);
@@ -128,6 +128,10 @@ public class BaseStageTest {
       idealStates.add(idealState);
       idealState.setReplicas(String.valueOf(replicas));
 
+      if (minActiveReplica > 0) {
+        idealState.setMinActiveReplicas(minActiveReplica);
+      }
+
       Builder keyBuilder = accessor.keyBuilder();
 
       accessor.setProperty(keyBuilder.idealStates(resourceName), idealState);
@@ -138,19 +142,19 @@ public class BaseStageTest {
   protected List<IdealState> setupIdealState(int nodes, String[] resources, int partitions,
       int replicas, RebalanceMode rebalanceMode) {
     return setupIdealState(nodes, resources, partitions, replicas, rebalanceMode,
-        BuiltInStateModelDefinitions.MasterSlave.name(), null, null);
+        BuiltInStateModelDefinitions.MasterSlave.name(), null, null, -1);
   }
 
   protected List<IdealState> setupIdealState(int nodes, String[] resources, int partitions,
       int replicas, RebalanceMode rebalanceMode, String stateModelName) {
-    return setupIdealState(nodes, resources, partitions, replicas, rebalanceMode,
-        stateModelName, null, null);
+    return setupIdealState(nodes, resources, partitions, replicas, rebalanceMode, stateModelName,
+        null, null, -1);
   }
 
   protected List<IdealState> setupIdealState(int nodes, String[] resources, int partitions,
       int replicas, RebalanceMode rebalanceMode, String stateModelName, String rebalanceClassName) {
-    return setupIdealState(nodes, resources, partitions, replicas, rebalanceMode,
-      stateModelName, rebalanceClassName, null);
+    return setupIdealState(nodes, resources, partitions, replicas, rebalanceMode, stateModelName,
+        rebalanceClassName, null, -1);
   }
 
   protected List<String> setupLiveInstances(int numLiveInstances) {

--- a/helix-core/src/test/resources/TestRecoveryLoadBalance.MasterSlave.json
+++ b/helix-core/src/test/resources/TestRecoveryLoadBalance.MasterSlave.json
@@ -253,5 +253,115 @@
         }
       }
     }
+  },
+  {
+    "statemodel": "MasterSlave",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 0,
+    "loadBalanceThrottle": "0",
+    "minActiveReplica": "2",
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "OFFLINE",
+          "localhost_3": "OFFLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE",
+          "localhost_3": "DROPPED"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "OFFLINE",
+          "localhost_3": "OFFLINE"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "SLAVE",
+          "localhost_1": "SLAVE",
+          "localhost_2": "OFFLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        }
+      }
+    }
+  },
+  {
+    "statemodel": "MasterSlave",
+    "errorOrRecoveryPartitionThresholdForLoadBalance": 0,
+    "loadBalanceThrottle": "2",
+    "minActiveReplica": "2",
+    "inputs": {
+      "resource_0_0": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE",
+          "localhost_3": "OFFLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "OFFLINE",
+          "localhost_3": "DROPPED"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "OFFLINE",
+          "localhost_3": "DROPPED"
+        }
+      },
+      "resource_0_1": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "OFFLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE"
+        }
+      },
+      "resource_0_2": {
+        "currentStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "OFFLINE",
+          "localhost_3": "OFFLINE"
+        },
+        "bestPossibleStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "SLAVE",
+          "localhost_3": "SLAVE"
+        },
+        "expectedStates": {
+          "localhost_0": "MASTER",
+          "localhost_1": "SLAVE",
+          "localhost_2": "OFFLINE",
+          "localhost_3": "OFFLINE"
+        }
+      }
+    }
   }
 ]


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #343 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

There are two phases for improving Helix state transition throttling:
1. Respect MIN_ACTIVE_REPLICA
2. Throttle per replica state transitions.

This commit contains the logic of respecting MIN_ACTIVE_REPLICA in IntermediateCalStage and state transition throttling.

### Tests

- [ ] The following tests are written for this issue:

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures: 
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[ERROR]   TestGetLastScheduledTaskExecInfo.testGetLastScheduledTaskExecInfo:73 expected:<COMPLETED> but was:<RUNNING>
[INFO] 
[ERROR] Tests run: 853, Failures: 2, Errors: 0, Skipped: 0

[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 25.967 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml

