### PR TITLE
Add soft constraint: ResourcePartitionAntiAffinityConstraint

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ResourcePartitionAntiAffinityConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ResourcePartitionAntiAffinityConstraint.java
@@ -1,0 +1,44 @@
+package org.apache.helix.controller.rebalancer.waged.constraints;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
+import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
+import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
+
+/**
+ * Evaluate the proposed assignment according to the other partitions assignment within the scope of
+ * the same resource.
+ * If the resource of the partition overall has a light load on the instance, the score is higher compared to
+ * case when the resource is heavily loaded on the instance
+ */
+public class ResourcePartitionAntiAffinityConstraint extends SoftConstraint {
+
+  @Override
+  protected float getAssignmentScore(AssignableNode node, AssignableReplica replica,
+      ClusterContext clusterContext) {
+    String resource = replica.getResourceName();
+    int curPartitionCountForResource = node.getAssignedPartitionsByResource(resource).size();
+    int doubleMaxPartitionCountForResource =
+        2 * clusterContext.getEstimatedMaxPartitionByResource(resource);
+    return Math.max(((float) doubleMaxPartitionCountForResource - curPartitionCountForResource)
+        / doubleMaxPartitionCountForResource, 0);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestResourcePartitionAntiAffinityConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestResourcePartitionAntiAffinityConstraint.java
@@ -21,6 +21,8 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
 
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+
 import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
@@ -29,8 +31,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
-
-import java.util.Collections;
 
 public class TestResourcePartitionAntiAffinityConstraint {
   private static final String TEST_PARTITION = "TestPartition";
@@ -48,7 +48,9 @@ public class TestResourcePartitionAntiAffinityConstraint {
     when(_clusterContext.getEstimatedMaxPartitionByResource(TEST_RESOURCE)).thenReturn(10);
 
     float score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    float normalizedScore = _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
     Assert.assertEquals(score, 0.85f);
+    Assert.assertEquals(normalizedScore, 0.85f);
   }
 
   @Test
@@ -58,6 +60,8 @@ public class TestResourcePartitionAntiAffinityConstraint {
     when(_clusterContext.getEstimatedMaxPartitionByResource(TEST_RESOURCE)).thenReturn(10);
 
     float score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    float normalizedScore = _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
     Assert.assertEquals(score, 1f);
+    Assert.assertEquals(normalizedScore, 1f);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestResourcePartitionAntiAffinityConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestResourcePartitionAntiAffinityConstraint.java
@@ -1,0 +1,63 @@
+package org.apache.helix.controller.rebalancer.waged.constraints;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.mockito.Mockito.when;
+
+import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
+import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
+import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collections;
+
+public class TestResourcePartitionAntiAffinityConstraint {
+  private static final String TEST_PARTITION = "TestPartition";
+  private static final String TEST_RESOURCE = "TestResource";
+  private final AssignableReplica _testReplica = Mockito.mock(AssignableReplica.class);
+  private final AssignableNode _testNode = Mockito.mock(AssignableNode.class);
+  private final ClusterContext _clusterContext = Mockito.mock(ClusterContext.class);
+  private final SoftConstraint _constraint = new ResourcePartitionAntiAffinityConstraint();
+
+  @Test
+  public void testGetAssignmentScore() {
+    when(_testReplica.getResourceName()).thenReturn(TEST_RESOURCE);
+    when(_testNode.getAssignedPartitionsByResource(TEST_RESOURCE)).thenReturn(
+        ImmutableSet.of(TEST_PARTITION + "1", TEST_PARTITION + "2", TEST_PARTITION + "3"));
+    when(_clusterContext.getEstimatedMaxPartitionByResource(TEST_RESOURCE)).thenReturn(10);
+
+    float score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertEquals(score, 0.85f);
+  }
+
+  @Test
+  public void testGetAssignmentScoreMaxScore() {
+    when(_testReplica.getResourceName()).thenReturn(TEST_RESOURCE);
+    when(_testNode.getAssignedPartitionsByResource(TEST_RESOURCE)).thenReturn(Collections.emptySet());
+    when(_clusterContext.getEstimatedMaxPartitionByResource(TEST_RESOURCE)).thenReturn(10);
+
+    float score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertEquals(score, 1f);
+  }
+}


### PR DESCRIPTION

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

(#421)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

If the resource of the partition overall has a light load on the instance, the score is higher compared to
case when the resource is heavily loaded on the instance

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)
Unit test

- [x] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml