### PR TITLE
Add soft constraint: ResourcetopStateAntiAffinityConstraint

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ResourceTopStateAntiAffinityConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ResourceTopStateAntiAffinityConstraint.java
@@ -25,7 +25,8 @@ import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
 
 /**
  * Evaluate the proposed assignment according to the top state replication count on the instacne.
- * The more total top state partitions assigned to the instance, the lower the score, vice versa.
+ * The higher number the number of top state partitions assigned to the instance, the lower the
+ * score, vice versa.
  */
 public class ResourceTopStateAntiAffinityConstraint extends SoftConstraint {
   @Override

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ResourceTopStateAntiAffinityConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ResourceTopStateAntiAffinityConstraint.java
@@ -1,0 +1,45 @@
+package org.apache.helix.controller.rebalancer.waged.constraints;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
+import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
+import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
+
+/**
+ * Evaluate the proposed assignment according to the top state replication count on the instacne.
+ * The more total top state partitions assigned to the instance, the lower the score, vice versa.
+ */
+public class ResourceTopStateAntiAffinityConstraint extends SoftConstraint {
+  @Override
+  protected float getAssignmentScore(AssignableNode node, AssignableReplica replica,
+      ClusterContext clusterContext) {
+    if (!replica.isReplicaTopState()) {
+      return (getMaxScore() + getMinScore()) / 2;
+    }
+
+    int curTopPartitionCountForResource = node.getAssignedTopStatePartitionsCount();
+    int doubleMaxTopStateCount = 2 * clusterContext.getEstimatedMaxTopStateCount();
+
+    return Math.max(
+        ((float) doubleMaxTopStateCount - curTopPartitionCountForResource) / doubleMaxTopStateCount,
+        0);
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ResourceTopStateAntiAffinityConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ResourceTopStateAntiAffinityConstraint.java
@@ -24,7 +24,7 @@ import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
 
 /**
- * Evaluate the proposed assignment according to the top state replication count on the instacne.
+ * Evaluate the proposed assignment according to the top state replication count on the instance.
  * The higher number the number of top state partitions assigned to the instance, the lower the
  * score, vice versa.
  */

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
@@ -187,10 +187,10 @@ public class AssignableNode implements Comparable<AssignableNode> {
   /**
    * @return The total count of assigned top state partitions.
    */
-  public long getAssignedTopStatePartitionsCount() {
-    return _currentAssignedReplicaMap.values().stream()
+  public int getAssignedTopStatePartitionsCount() {
+    return (int) _currentAssignedReplicaMap.values().stream()
         .flatMap(replicaMap -> replicaMap.values().stream())
-        .filter(replica -> replica.isReplicaTopState()).count();
+        .filter(AssignableReplica::isReplicaTopState).count();
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestResourceTopStateAntiAffinityConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestResourceTopStateAntiAffinityConstraint.java
@@ -1,0 +1,65 @@
+package org.apache.helix.controller.rebalancer.waged.constraints;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
+import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
+import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestResourceTopStateAntiAffinityConstraint {
+  private final AssignableReplica _testReplica = Mockito.mock(AssignableReplica.class);
+  private final AssignableNode _testNode = Mockito.mock(AssignableNode.class);
+  private final ClusterContext _clusterContext = Mockito.mock(ClusterContext.class);
+
+  private final SoftConstraint _constraint = new ResourceTopStateAntiAffinityConstraint();
+
+  @Test
+  public void testGetAssignmentScoreWhenReplicaNotTopState() {
+    when(_testReplica.isReplicaTopState()).thenReturn(false);
+    float score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertEquals(score, (_constraint.getMaxScore() + _constraint.getMinScore()) / 2);
+    verifyZeroInteractions(_testNode);
+    verifyZeroInteractions(_clusterContext);
+  }
+
+  @Test
+  public void testGetAssignmentScoreWhenReplicaIsTopStateHeavyLoad() {
+    when(_testReplica.isReplicaTopState()).thenReturn(true);
+    when(_testNode.getAssignedTopStatePartitionsCount()).thenReturn(20);
+    when(_clusterContext.getEstimatedMaxTopStateCount()).thenReturn(20);
+    float score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertEquals(score, 0.5f);
+  }
+
+  @Test
+  public void testGetAssignmentScoreWhenReplicaIsTopStateLightLoad() {
+    when(_testReplica.isReplicaTopState()).thenReturn(true);
+    when(_testNode.getAssignedTopStatePartitionsCount()).thenReturn(0);
+    when(_clusterContext.getEstimatedMaxTopStateCount()).thenReturn(20);
+    float score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertEquals(score, 1f);
+  }
+}


### PR DESCRIPTION

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#421 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

The more total top state partitions assigned to the instance, the lower the score, vice versa.


### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)
Unit test

- [x] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml