### PR TITLE
Make CustomRebalancer re-compute upon CurrentState and Message change

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateCache.java
@@ -78,20 +78,12 @@ public class CurrentStateCache extends AbstractDataCache<CurrentState> {
       String[] params = key.getParams();
       if (currentState != null && params.length >= 4) {
         String instanceName = params[1];
-        String sessionId = params[2];
-        String stateName = params[3];
         Map<String, Map<String, CurrentState>> instanceCurStateMap =
             allCurStateMap.get(instanceName);
         if (instanceCurStateMap == null) {
           instanceCurStateMap = Maps.newHashMap();
           allCurStateMap.put(instanceName, instanceCurStateMap);
         }
-        Map<String, CurrentState> sessionCurStateMap = instanceCurStateMap.get(sessionId);
-        if (sessionCurStateMap == null) {
-          sessionCurStateMap = Maps.newHashMap();
-          instanceCurStateMap.put(sessionId, sessionCurStateMap);
-        }
-        sessionCurStateMap.put(stateName, currentState);
       }
     }
 
@@ -108,7 +100,7 @@ public class CurrentStateCache extends AbstractDataCache<CurrentState> {
       LogUtil.logDebug(LOG, genEventInfo(),
           String.format("Current State refreshed : %s", _currentStateMap.toString()));
     }
-    return true;
+    return getExistsChange();
   }
 
   // reload current states that has been changed from zk to local cache.

--- a/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateCache.java
@@ -78,12 +78,20 @@ public class CurrentStateCache extends AbstractDataCache<CurrentState> {
       String[] params = key.getParams();
       if (currentState != null && params.length >= 4) {
         String instanceName = params[1];
+        String sessionId = params[2];
+        String stateName = params[3];
         Map<String, Map<String, CurrentState>> instanceCurStateMap =
             allCurStateMap.get(instanceName);
         if (instanceCurStateMap == null) {
           instanceCurStateMap = Maps.newHashMap();
           allCurStateMap.put(instanceName, instanceCurStateMap);
         }
+        Map<String, CurrentState> sessionCurStateMap = instanceCurStateMap.get(sessionId);
+        if (sessionCurStateMap == null) {
+          sessionCurStateMap = Maps.newHashMap();
+          instanceCurStateMap.put(sessionId, sessionCurStateMap);
+        }
+        sessionCurStateMap.put(stateName, currentState);
       }
     }
 

--- a/helix-core/src/main/java/org/apache/helix/common/caches/InstanceMessagesCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/InstanceMessagesCache.java
@@ -96,8 +96,11 @@ public class InstanceMessagesCache {
     long purgeSum = 0;
     for (String instanceName : liveInstanceMap.keySet()) {
       // get the cache
-      Map<String, Message> cachedMap =
-          _messageCache.computeIfAbsent(instanceName, k -> Maps.newHashMap());
+      Map<String, Message> cachedMap = _messageCache.get(instanceName);
+      if (cachedMap == null) {
+        cachedMap = Maps.newHashMap();
+        _messageCache.put(instanceName, cachedMap);
+      }
       msgMap.put(instanceName, cachedMap);
 
       // get the current names

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -331,8 +331,22 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     updateOfflineInstanceHistory(accessor);
 
     // Refresh derived data
-    _instanceMessagesCache.refresh(accessor, _liveInstanceCache.getPropertyMap());
-    _currentStateCache.refresh(accessor, _liveInstanceCache.getPropertyMap());
+    if (_instanceMessagesCache.refresh(accessor, _liveInstanceCache.getPropertyMap())) {
+      LogUtil.logInfo(logger, getClusterEventId(), String.format(
+          "Reloaded messages for cluster %s, %s pipeline.", _clusterName, getPipelineName()));
+      refreshedTypes.add(HelixConstants.ChangeType.MESSAGE);
+    } else {
+      LogUtil.logInfo(logger, getClusterEventId(), String.format(
+          "No message change for %s cluster, %s pipeline", _clusterName, getPipelineName()));
+    }
+    if (_currentStateCache.refresh(accessor, _liveInstanceCache.getPropertyMap())) {
+      LogUtil.logInfo(logger, getClusterEventId(), String.format(
+          "Reloaded CurrentStates for cluster %s, %s pipeline.", _clusterName, getPipelineName()));
+      refreshedTypes.add(HelixConstants.ChangeType.CURRENT_STATE);
+    } else {
+      LogUtil.logInfo(logger, getClusterEventId(), String.format(
+          "No CurrentState change for %s cluster, %s pipeline", _clusterName, getPipelineName()));
+    }
 
     // current state must be refreshed before refreshing relay messages
     // because we need to use current state to validate all relay messages.

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -118,7 +118,9 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
     if (propertyRefreshed.contains(HelixConstants.ChangeType.IDEAL_STATE)
         || propertyRefreshed.contains(HelixConstants.ChangeType.LIVE_INSTANCE)
         || propertyRefreshed.contains(HelixConstants.ChangeType.INSTANCE_CONFIG)
-        || propertyRefreshed.contains(HelixConstants.ChangeType.RESOURCE_CONFIG)) {
+        || propertyRefreshed.contains(HelixConstants.ChangeType.RESOURCE_CONFIG)
+        || propertyRefreshed.contains(HelixConstants.ChangeType.CURRENT_STATE)
+        || propertyRefreshed.contains(HelixConstants.ChangeType.MESSAGE)) {
       clearCachedResourceAssignments();
     }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
@@ -56,15 +56,18 @@ public class CustomRebalancer extends AbstractRebalancer<ResourceControllerDataP
   public ResourceAssignment computeBestPossiblePartitionState(ResourceControllerDataProvider cache,
       IdealState idealState, Resource resource, CurrentStateOutput currentStateOutput) {
     // Looking for cached BestPossible mapping for this resource, if it is already there, do not recompute it again.
-    // The cached mapping will be cleared in ResourceControllerDataProvider if there is anything changed in cluster state that can
+    // The cached mapping will be cleared in ResourceControllerDataProvider if there is anything
+    // changed in cluster state that can
     // cause the potential changes in BestPossible state.
     ResourceAssignment partitionMapping =
         cache.getCachedResourceAssignment(resource.getResourceName());
     if (partitionMapping != null) {
+      LOG.info("Reuse cached BestPossibleMapping for {}. Skipping BestPossible computation...",
+          resource.getResourceName());
       return partitionMapping;
     }
 
-    LOG.info("Computing BestPossibleMapping for " + resource.getResourceName());
+    LOG.info("Computing BestPossibleMapping for {}...", resource.getResourceName());
 
     String stateModelDefName = idealState.getStateModelDefRef();
     StateModelDefinition stateModelDef = cache.getStateModelDef(stateModelDefName);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #467 and #377 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Previously, CustomRebalancer would cache the result of the previous best possible mapping and use it and skip the whole calculation step. For the users of CustomRebalancer, this was causing the cluster to not converge intermittently. This is because the rebalancer should recompute the best possible mapping upon cluster change, but it was not doing so for changes like CurrentState and Message changes.
Changelist:
1. Enhance logging in CustomRebalancer
2. Create a boolean result for CurrentState refresh and message refresh so that the controller could record the changeType
3. Clear cached resource assignments upon refresh so that appropriate messages would be generated to make the cluster converge

### Tests

- [x] The following tests are written for this issue:

This problem was originally reported by Apache Pinot. **Ran the following test repeatedly several hundred times for 10+ hours without failure**.

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 16.313 sec - in **org.apache.pinot.controller.helix.ControllerInstanceToggleTest**
testInstanceToggle(org.apache.pinot.controller.helix.ControllerInstanceToggleTest)  Time elapsed: 7.004 sec
08:44:21.209 zk.zookeeper.ZkClient: (Thread 22) - zookeeper state changed (Disconnected)
08:44:21.209 zk.zookeeper.ZkClient: (Thread 22) - zookeeper state changed (Disconnected)
08:44:21.209 zk.zookeeper.ZkClient: (Thread 22) - zookeeper state changed (Disconnected)

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

[INFO]
[INFO] --- jacoco-maven-plugin:0.7.7.201606060606:report-aggregate (report) @ pinot-controller ---
[INFO] Loading execution data file /home/hulee/mp/incubator-pinot/pinot-controller/target/jacoco.exec
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  28.132 s
[INFO] Finished at: 2019-09-12T08:44:24-07:00
[INFO] ------------------------------------------------------------------------

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO] 
[INFO] Tests run: 854, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  54:12 min
[INFO] Finished at: 2019-09-12T11:25:21-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml

