### PR TITLE
Fix CustomRebalancer's assignment computation

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
@@ -134,6 +134,8 @@ public class CustomRebalancer extends AbstractRebalancer<ResourceControllerDataP
           && !HelixDefinedState.ERROR.toString().equals(currentStateMap.get(instance));
       boolean enabled = !disabledInstancesForPartition.contains(instance) && isResourceEnabled;
 
+      // Note: if instance is not live, the mapping for that instance will not show up in
+      // BestPossibleMapping (and ExternalView)
       if (liveInstancesMap.containsKey(instance) && notInErrorState) {
         if (enabled) {
           instanceStateMap.put(instance, idealStateMap.get(instance));

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
@@ -130,14 +130,17 @@ public class CustomRebalancer extends AbstractRebalancer<ResourceControllerDataP
 
     Map<String, LiveInstance> liveInstancesMap = cache.getLiveInstances();
     for (String instance : idealStateMap.keySet()) {
-      boolean notInErrorState =
-          currentStateMap == null || currentStateMap.get(instance) == null
-              || !currentStateMap.get(instance).equals(HelixDefinedState.ERROR.toString());
-
+      boolean notInErrorState = currentStateMap != null
+          && !HelixDefinedState.ERROR.toString().equals(currentStateMap.get(instance));
       boolean enabled = !disabledInstancesForPartition.contains(instance) && isResourceEnabled;
 
-      if (liveInstancesMap.containsKey(instance) && notInErrorState && enabled) {
-        instanceStateMap.put(instance, idealStateMap.get(instance));
+      if (liveInstancesMap.containsKey(instance) && notInErrorState) {
+        if (enabled) {
+          instanceStateMap.put(instance, idealStateMap.get(instance));
+        } else {
+          // if disabled, put it in initial state
+          instanceStateMap.put(instance, stateModelDef.getInitialState());
+        }
       }
     }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestCustomRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestCustomRebalancer.java
@@ -38,6 +38,15 @@ import static org.mockito.Mockito.*;
 
 public class TestCustomRebalancer {
 
+  /**
+   * This test was written because there is an edge case where an instance becomes disabled while a
+   * partition is bootstrapping by way of pending
+   * messages.
+   * The newly bootstrapped partitions never get further state transitions because the instance
+   * won't ever get added to instanceStateMap (this issue has been fixed). In other words, if there
+   * are mapping changes while a partition is bootstrapping, the final state should go into the best
+   * possible mapping for clusters to converge correctly.
+   */
   @Test
   public void testDisabledBootstrappingPartitions() {
     String resourceName = "Test";

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestCustomRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestCustomRebalancer.java
@@ -1,0 +1,72 @@
+package org.apache.helix.integration.rebalancer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.rebalancer.CustomRebalancer;
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.OnlineOfflineSMD;
+import org.apache.helix.model.Partition;
+import org.apache.helix.model.Resource;
+import org.apache.helix.model.ResourceAssignment;
+import org.apache.helix.model.StateModelDefinition;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+public class TestCustomRebalancer {
+
+  @Test
+  public void testDisabledBootstrappingPartitions() {
+    String resourceName = "Test";
+    String partitionName = "Test0";
+    String instanceName = "localhost";
+    String stateModelName = "OnlineOffline";
+    StateModelDefinition stateModelDef = new OnlineOfflineSMD();
+
+    IdealState idealState = new IdealState(resourceName);
+    idealState.setStateModelDefRef(stateModelName);
+    idealState.setPartitionState(partitionName, instanceName, "ONLINE");
+
+    Resource resource = new Resource(resourceName);
+    resource.addPartition(partitionName);
+
+    CustomRebalancer customRebalancer = new CustomRebalancer();
+    ResourceControllerDataProvider cache = mock(ResourceControllerDataProvider.class);
+    when(cache.getStateModelDef(stateModelName)).thenReturn(stateModelDef);
+    when(cache.getDisabledInstancesForPartition(resource.getResourceName(), partitionName))
+        .thenReturn(ImmutableSet.of(instanceName));
+    when(cache.getLiveInstances())
+        .thenReturn(ImmutableMap.of(instanceName, new LiveInstance(instanceName)));
+
+    CurrentStateOutput currOutput = new CurrentStateOutput();
+    ResourceAssignment resourceAssignment =
+        customRebalancer.computeBestPossiblePartitionState(cache, idealState, resource, currOutput);
+
+    Assert.assertEquals(
+        resourceAssignment.getReplicaMap(new Partition(partitionName)).get(instanceName),
+        stateModelDef.getInitialState());
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #467 and #377 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

It was observed that sometimes CustomRebalancer would leave out an instance entirely if an instance is disabled or the partition on the instance was still bootstrapping (current state is null). This would cause a cluster not to converge. 

This diff fixes this by 1) still including an assignment from IdealState even though the current state is null (maybe due to a pending state transition) 2) putting disabled partitions in InitialState.

### Tests

- [x] The following tests are written for this issue:

**TestCustomRebalancer**

This problem was originally reported by Apache Pinot. **Ran the following test repeatedly several hundred times for 10+ hours without failure**.

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 16.313 sec - in **org.apache.pinot.controller.helix.ControllerInstanceToggleTest**
testInstanceToggle(org.apache.pinot.controller.helix.ControllerInstanceToggleTest)  Time elapsed: 7.004 sec
08:44:21.209 zk.zookeeper.ZkClient: (Thread 22) - zookeeper state changed (Disconnected)
08:44:21.209 zk.zookeeper.ZkClient: (Thread 22) - zookeeper state changed (Disconnected)
08:44:21.209 zk.zookeeper.ZkClient: (Thread 22) - zookeeper state changed (Disconnected)

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

[INFO]
[INFO] --- jacoco-maven-plugin:0.7.7.201606060606:report-aggregate (report) @ pinot-controller ---
[INFO] Loading execution data file /home/hulee/mp/incubator-pinot/pinot-controller/target/jacoco.exec
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  28.132 s
[INFO] Finished at: 2019-09-12T08:44:24-07:00
[INFO] ------------------------------------------------------------------------

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] testTagSetIncorrect(org.apache.helix.integration.TestAlertingRebalancerFailure)  Time elapsed: 180.085 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.integration.TestAlertingRebalancerFailure.checkResourceBestPossibleCalFailureState(TestAlertingRebalancerFailure.java:310)
	at org.apache.helix.integration.TestAlertingRebalancerFailure.testTagSetIncorrect(TestAlertingRebalancerFailure.java:174)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 854, Failures: 1, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  56:35 min
[INFO] Finished at: 2019-09-15T19:45:48-07:00
[INFO] ------------------------------------------------------------------------


[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.234 s - in org.apache.helix.integration.TestAlertingRebalancerFailure
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  9.046 s
[INFO] Finished at: 2019-09-15T23:08:35-07:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml