### PR TITLE
Fix RoutingDataCache always requiring full refresh for current state.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/common/caches/BasicClusterDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/BasicClusterDataCache.java
@@ -113,6 +113,7 @@ public class BasicClusterDataCache implements ControlContextProvider {
     if (_propertyDataChangedMap.get(HelixConstants.ChangeType.LIVE_INSTANCE)) {
       long start = System.currentTimeMillis();
       _propertyDataChangedMap.put(HelixConstants.ChangeType.LIVE_INSTANCE, Boolean.valueOf(false));
+      _propertyDataChangedMap.put(HelixConstants.ChangeType.CURRENT_STATE, true);
       _liveInstancePropertyCache.refresh(accessor);
       LOG.info("Reload LiveInstances: " + _liveInstancePropertyCache.getPropertyMap().keySet()
           + ". Takes " + (System.currentTimeMillis() - start) + " ms");

--- a/helix-core/src/main/java/org/apache/helix/common/caches/BasicClusterDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/BasicClusterDataCache.java
@@ -112,6 +112,7 @@ public class BasicClusterDataCache implements ControlContextProvider {
 
     if (_propertyDataChangedMap.get(HelixConstants.ChangeType.LIVE_INSTANCE)) {
       long start = System.currentTimeMillis();
+      System.out.println("reloading live instances");
       _propertyDataChangedMap.put(HelixConstants.ChangeType.LIVE_INSTANCE, false);
       _propertyDataChangedMap.put(HelixConstants.ChangeType.CURRENT_STATE, true);
       _liveInstancePropertyCache.refresh(accessor);

--- a/helix-core/src/main/java/org/apache/helix/common/caches/BasicClusterDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/BasicClusterDataCache.java
@@ -112,7 +112,6 @@ public class BasicClusterDataCache implements ControlContextProvider {
 
     if (_propertyDataChangedMap.get(HelixConstants.ChangeType.LIVE_INSTANCE)) {
       long start = System.currentTimeMillis();
-      System.out.println("reloading live instances");
       _propertyDataChangedMap.put(HelixConstants.ChangeType.LIVE_INSTANCE, false);
       _propertyDataChangedMap.put(HelixConstants.ChangeType.CURRENT_STATE, true);
       _liveInstancePropertyCache.refresh(accessor);

--- a/helix-core/src/main/java/org/apache/helix/common/caches/BasicClusterDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/BasicClusterDataCache.java
@@ -106,13 +106,13 @@ public class BasicClusterDataCache implements ControlContextProvider {
     long startTime = System.currentTimeMillis();
 
     if (_propertyDataChangedMap.get(HelixConstants.ChangeType.EXTERNAL_VIEW)) {
-      _propertyDataChangedMap.put(HelixConstants.ChangeType.EXTERNAL_VIEW, Boolean.valueOf(false));
+      _propertyDataChangedMap.put(HelixConstants.ChangeType.EXTERNAL_VIEW, false);
       _externalViewCache.refresh(accessor);
     }
 
     if (_propertyDataChangedMap.get(HelixConstants.ChangeType.LIVE_INSTANCE)) {
       long start = System.currentTimeMillis();
-      _propertyDataChangedMap.put(HelixConstants.ChangeType.LIVE_INSTANCE, Boolean.valueOf(false));
+      _propertyDataChangedMap.put(HelixConstants.ChangeType.LIVE_INSTANCE, false);
       _propertyDataChangedMap.put(HelixConstants.ChangeType.CURRENT_STATE, true);
       _liveInstancePropertyCache.refresh(accessor);
       LOG.info("Reload LiveInstances: " + _liveInstancePropertyCache.getPropertyMap().keySet()
@@ -121,8 +121,7 @@ public class BasicClusterDataCache implements ControlContextProvider {
 
     if (_propertyDataChangedMap.get(HelixConstants.ChangeType.INSTANCE_CONFIG)) {
       long start = System.currentTimeMillis();
-      _propertyDataChangedMap.put(HelixConstants.ChangeType.INSTANCE_CONFIG,
-          Boolean.valueOf(false));
+      _propertyDataChangedMap.put(HelixConstants.ChangeType.INSTANCE_CONFIG, false);
       _instanceConfigPropertyCache.refresh(accessor);
       LOG.info("Reload InstanceConfig: " + _instanceConfigPropertyCache.getPropertyMap().keySet()
           + ". Takes " + (System.currentTimeMillis() - start) + " ms");
@@ -183,7 +182,7 @@ public class BasicClusterDataCache implements ControlContextProvider {
    * @param changeType
    */
   public void notifyDataChange(HelixConstants.ChangeType changeType) {
-    _propertyDataChangedMap.put(changeType, Boolean.valueOf(true));
+    _propertyDataChangedMap.put(changeType, true);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -79,6 +79,7 @@ class RoutingDataCache extends BasicClusterDataCache {
     if (_sourceDataType.equals(PropertyType.CURRENTSTATES) && _propertyDataChangedMap
         .get(HelixConstants.ChangeType.CURRENT_STATE)) {
       long start = System.currentTimeMillis();
+      _propertyDataChangedMap.put(HelixConstants.ChangeType.CURRENT_STATE, false);
       Map<String, LiveInstance> liveInstanceMap = getLiveInstances();
       _currentStateCache.refresh(accessor, liveInstanceMap);
       LOG.info("Reload CurrentStates. Takes " + (System.currentTimeMillis() - start) + " ms");

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -69,8 +69,7 @@ class RoutingDataCache extends BasicClusterDataCache {
     if (_sourceDataType.equals(PropertyType.TARGETEXTERNALVIEW) && _propertyDataChangedMap
         .get(HelixConstants.ChangeType.TARGET_EXTERNAL_VIEW)) {
       long start = System.currentTimeMillis();
-      _propertyDataChangedMap
-          .put(HelixConstants.ChangeType.TARGET_EXTERNAL_VIEW, Boolean.valueOf(false));
+      _propertyDataChangedMap.put(HelixConstants.ChangeType.TARGET_EXTERNAL_VIEW, false);
       _targetExternalViewCache.refresh(accessor);
       LOG.info("Reload " + _targetExternalViewCache.getExternalViewMap().keySet().size()
           + " TargetExternalViews. Takes " + (System.currentTimeMillis() - start) + " ms");

--- a/helix-core/src/test/java/org/apache/helix/spectator/TestRoutingDataCache.java
+++ b/helix-core/src/test/java/org/apache/helix/spectator/TestRoutingDataCache.java
@@ -138,7 +138,8 @@ public class TestRoutingDataCache extends ZkStandAloneCMTestBase {
 
     // 1. Initial cache refresh.
     cache.refresh(accessor);
-    Map<String, Map<String, Map<String, CurrentState>>> currentStatesV1 = cache.getCurrentStatesMap();
+    Map<String, Map<String, Map<String, CurrentState>>> currentStatesV1 =
+        cache.getCurrentStatesMap();
 
     // Current states map is not empty and size equals to number of live instances.
     Assert.assertFalse(currentStatesV1.isEmpty());
@@ -153,7 +154,8 @@ public class TestRoutingDataCache extends ZkStandAloneCMTestBase {
     _participants[0].syncStop();
     cache.notifyDataChange(HelixConstants.ChangeType.LIVE_INSTANCE);
     cache.refresh(accessor);
-    Map<String, Map<String, Map<String, CurrentState>>> currentStatesV2 = cache.getCurrentStatesMap();
+    Map<String, Map<String, Map<String, CurrentState>>> currentStatesV2 =
+        cache.getCurrentStatesMap();
 
     // Current states cache should refresh and change.
     Assert.assertFalse(currentStatesV2.isEmpty());


### PR DESCRIPTION
### Issues

- [x]  My PR addresses the following Helix issues and references them in the PR title:
#483 Fix RoutingDataCache always does full refresh for current state.

### Description

- [x]  Here are some details about my PR, including screenshots of any UI changes:
(Write a concise description including what, why, how)

#483 Fix RoutingDataCache always does full refresh for current state.
If a current state changes, propertyDataMap doesn't mark current state type not to do full refresh next time. This causes current state refresh to always do full refresh. And this increases snapshot read latency. So we need to mark propertyDataMap's current state type to false, NOT requiring full refresh next time.

And for live instance changes, we need to mark propertyDataMap's current state to true, requiring current state full refresh next time.

### Tests

- [x]  The following tests are written for this issue:
TestRoutingDataCache.testCurrentStatesSelectiveUpdate

- [x]  The following is the result of the "mvn test" command on the appropriate module:
(Copy & paste the result of "mvn test")

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[ERROR]   TestPartitionLevelTransitionConstraint.test:173 expected:<true> but was:<false>
[ERROR]   TestZkConnectionLost.testLostZkConnection:140 » Helix Workflow "testLostZkConn...
[ERROR]   TestDeleteJobFromJobQueue.testForceDeleteJobFromJobQueue:75 » Helix Failed to ...
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 882, Failures: 5, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  57:51 min
[INFO] Finished at: 2019-09-18T17:51:09-07:00




[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.925 s - in org.apache.helix.integration.task.TestDeleteJobFromJobQueue
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.178 s
[INFO] Finished at: 2019-09-19T09:27:36-07:00


[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.92 s - in org.apache.helix.integration.TestAlertingRebalancerFailure
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.357 s
[INFO] Finished at: 2019-09-19T09:26:43-07:00


[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 16.092 s - in org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  20.176 s
[INFO] Finished at: 2019-09-19T09:28:14-07:00

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.066 s - in org.apache.helix.integration.TestPartitionLevelTransitionConstraint
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.440 s
[INFO] Finished at: 2019-09-19T09:29:22-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x]  My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "How to write a good git commit message":
Subject is separated from body by a blank line
Subject is limited to 50 characters (not including Jira issue reference)
Subject does not end with a period
Subject uses the imperative mood ("add", not "adding")
Body wraps at 72 characters
Body explains "what" and "why", not "how"
Documentation

  In case of new functionality, my PR adds documentation in the following wiki page:
(Link the GitHub wiki you added)

### Code Quality

- [x]  My diff has been formatted using helix-style.xml