### PR TITLE
Separate AssignableNode properties by Immutable and Mutable

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/NodeCapacityConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/NodeCapacityConstraint.java
@@ -30,7 +30,7 @@ class NodeCapacityConstraint extends HardConstraint {
   @Override
   boolean isAssignmentValid(AssignableNode node, AssignableReplica replica,
       ClusterContext clusterContext) {
-    Map<String, Integer> nodeCapacity = node.getCurrentCapacity();
+    Map<String, Integer> nodeCapacity = node.getRemainingCapacity();
     Map<String, Integer> replicaCapacity = replica.getCapacity();
 
     for (String key : replicaCapacity.keySet()) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
@@ -29,11 +29,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.helix.HelixException;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.InstanceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
  * This class represents a possible allocation of the replication.
@@ -42,37 +45,23 @@ import org.slf4j.LoggerFactory;
 public class AssignableNode implements Comparable<AssignableNode> {
   private static final Logger LOG = LoggerFactory.getLogger(AssignableNode.class.getName());
 
-  // basic node information
+  // Immutable Instance Properties
   private final String _instanceName;
-  private Set<String> _instanceTags;
-  private String _faultZone;
-  private Map<String, List<String>> _disabledPartitionsMap;
-  private Map<String, Integer> _maxCapacity;
-  private int _maxPartition; // maximum number of the partitions that can be assigned to the node.
+  private final String _faultZone;
+  // maximum number of the partitions that can be assigned to the instance.
+  private final int _maxPartition;
+  private final ImmutableSet<String> _instanceTags;
+  private final ImmutableMap<String, List<String>> _disabledPartitionsMap;
+  private final ImmutableMap<String, Integer> _maxAllowedCapacity;
 
+  // Mutable (Dynamic) Instance Properties
   // A map of <resource name, <partition name, replica>> that tracks the replicas assigned to the
   // node.
-  private Map<String, Map<String, AssignableReplica>> _currentAssignedReplicaMap;
+  private Map<String, Map<String, AssignableReplica>> _currentAssignedReplicaMap = new HashMap<>();
   // A map of <capacity key, capacity value> that tracks the current available node capacity
-  private Map<String, Integer> _currentCapacityMap;
+  private Map<String, Integer> _remainingCapacity;
   // The maximum capacity utilization (0.0 - 1.0) across all the capacity categories.
-  private float _highestCapacityUtilization;
-
-  /**
-   * @param clusterConfig
-   * @param instanceConfig
-   * @param instanceName
-   */
-  AssignableNode(ClusterConfig clusterConfig, InstanceConfig instanceConfig, String instanceName) {
-    _instanceName = instanceName;
-    refresh(clusterConfig, instanceConfig);
-  }
-
-  private void reset() {
-    _currentAssignedReplicaMap = new HashMap<>();
-    _currentCapacityMap = new HashMap<>();
-    _highestCapacityUtilization = 0;
-  }
+  private float _highestCapacityUtilization = 0;
 
   /**
    * Update the node with a ClusterDataCache. This resets the current assignment and recalculates
@@ -82,18 +71,16 @@ public class AssignableNode implements Comparable<AssignableNode> {
    * refreshed. This is under the assumption that the capacity mappings of InstanceConfig and
    * ResourceConfig could
    * subject to change. If the assumption is no longer true, this function should become private.
-   * @param clusterConfig - the Cluster Config of the cluster where the node is located
-   * @param instanceConfig - the Instance Config of the node
    */
-  private void refresh(ClusterConfig clusterConfig, InstanceConfig instanceConfig) {
-    reset();
-
+  AssignableNode(ClusterConfig clusterConfig, InstanceConfig instanceConfig, String instanceName) {
+    _instanceName = instanceName;
     Map<String, Integer> instanceCapacity = fetchInstanceCapacity(clusterConfig, instanceConfig);
-    _currentCapacityMap.putAll(instanceCapacity);
     _faultZone = computeFaultZone(clusterConfig, instanceConfig);
-    _instanceTags = new HashSet<>(instanceConfig.getTags());
-    _disabledPartitionsMap = instanceConfig.getDisabledPartitionsMap();
-    _maxCapacity = instanceCapacity;
+    _instanceTags = ImmutableSet.copyOf(instanceConfig.getTags());
+    _disabledPartitionsMap = ImmutableMap.copyOf(instanceConfig.getDisabledPartitionsMap());
+    _maxAllowedCapacity = ImmutableMap.copyOf(instanceCapacity);
+    // make a copy of max capacity
+    _remainingCapacity = new HashMap<>(_maxAllowedCapacity);
     _maxPartition = clusterConfig.getMaxPartitionsPerInstance();
   }
 
@@ -219,7 +206,24 @@ public class AssignableNode implements Comparable<AssignableNode> {
    * @return The current available capacity.
    */
   public Map<String, Integer> getCurrentCapacity() {
-    return _currentCapacityMap;
+    return _remainingCapacity;
+  }
+
+  /**
+   * @return A map of <capacity category, capacity number> that describes the max capacity of the
+   *         node.
+   */
+  public Map<String, Integer> getMaxCapacity() {
+    return _maxAllowedCapacity;
+  }
+
+  public Map<String, Integer> getCapacityUsage() {
+    Map<String, Integer> result = new HashMap<>();
+    for (String key : _maxAllowedCapacity.keySet()) {
+      result.put(key, _maxAllowedCapacity.get(key) - _remainingCapacity.get(key));
+    }
+
+    return result;
   }
 
   /**
@@ -228,7 +232,6 @@ public class AssignableNode implements Comparable<AssignableNode> {
    * categories.
    * For example, if the current node usage is {CPU: 0.9, MEM: 0.4, DISK: 0.6}. Then this call shall
    * return 0.9.
-   *
    * @return The highest utilization number of the node among all the capacity category.
    */
   public float getHighestCapacityUtilization() {
@@ -260,14 +263,6 @@ public class AssignableNode implements Comparable<AssignableNode> {
   }
 
   /**
-   * @return A map of <capacity category, capacity number> that describes the max capacity of the
-   *         node.
-   */
-  public Map<String, Integer> getMaxCapacity() {
-    return _maxCapacity;
-  }
-
-  /**
    * @return The max partition count that are allowed to be allocated on the node.
    */
   public int getMaxPartition() {
@@ -294,14 +289,15 @@ public class AssignableNode implements Comparable<AssignableNode> {
     if (topologyStr == null || faultZoneType == null) {
       LOG.debug("Topology configuration is not complete. Topology define: {}, Fault Zone Type: {}",
           topologyStr, faultZoneType);
-      // Use the instance name, or the deprecated ZoneId field (if exists) as the default fault zone.
+      // Use the instance name, or the deprecated ZoneId field (if exists) as the default fault
+      // zone.
       String zoneId = instanceConfig.getZoneId();
       return zoneId == null ? instanceConfig.getInstanceName() : zoneId;
     } else {
       // Get the fault zone information from the complete topology definition.
       String[] topologyDef = topologyStr.trim().split("/");
-      if (topologyDef.length == 0 ||
-          Arrays.stream(topologyDef).noneMatch(type -> type.equals(faultZoneType))) {
+      if (topologyDef.length == 0
+          || Arrays.stream(topologyDef).noneMatch(type -> type.equals(faultZoneType))) {
         throw new HelixException(
             "The configured topology definition is empty or does not contain the fault zone type.");
       }
@@ -351,21 +347,16 @@ public class AssignableNode implements Comparable<AssignableNode> {
   }
 
   private void updateCapacityAndUtilization(String capacityKey, int valueToSubtract) {
-    if (_currentCapacityMap.containsKey(capacityKey)) {
-      int newCapacity = _currentCapacityMap.get(capacityKey) - valueToSubtract;
-      _currentCapacityMap.put(capacityKey, newCapacity);
-      // For the purpose of constraint calculation, the max utilization cannot be larger than 100%.
-      float utilization = Math.min(
-          (float) (_maxCapacity.get(capacityKey) - newCapacity) / _maxCapacity.get(capacityKey), 1);
-      _highestCapacityUtilization = Math.max(_highestCapacityUtilization, utilization);
-    }
-    // else if the capacityKey does not exist in the capacity map, this method essentially becomes
-    // a NOP; in other words, this node will be treated as if it has unlimited capacity.
+    int newCapacity = _remainingCapacity.get(capacityKey) - valueToSubtract;
+    _remainingCapacity.put(capacityKey, newCapacity);
+    // For the purpose of constraint calculation, the max utilization cannot be larger than 100%.
+    float utilization = Math.min((float) (_maxAllowedCapacity.get(capacityKey) - newCapacity)
+        / _maxAllowedCapacity.get(capacityKey), 1);
+    _highestCapacityUtilization = Math.max(_highestCapacityUtilization, utilization);
   }
 
   /**
    * Get and validate the instance capacity from instance config.
-   *
    * @throws HelixException if any required capacity key is not configured in the instance config.
    */
   private Map<String, Integer> fetchInstanceCapacity(ClusterConfig clusterConfig,

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -80,7 +80,7 @@ public class ClusterModelProvider {
             bestPossibleAssignment, allocatedReplicas);
 
     // Update the allocated replicas to the assignable nodes.
-    assignableNodes.stream().forEach(node -> node.assignNewBatch(
+    assignableNodes.stream().forEach(node -> node.assign(
         allocatedReplicas.getOrDefault(node.getInstanceName(), Collections.emptySet())));
 
     // Construct and initialize cluster context.

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -80,7 +80,7 @@ public class ClusterModelProvider {
             bestPossibleAssignment, allocatedReplicas);
 
     // Update the allocated replicas to the assignable nodes.
-    assignableNodes.stream().forEach(node -> node.assign(
+    assignableNodes.stream().forEach(node -> node.assignInitBatch(
         allocatedReplicas.getOrDefault(node.getInstanceName(), Collections.emptySet())));
 
     // Construct and initialize cluster context.

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestNodeCapacityConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestNodeCapacityConstraint.java
@@ -39,7 +39,7 @@ public class TestNodeCapacityConstraint {
   @Test
   public void testConstraintValidWhenNodeHasEnoughSpace() {
     String key = "testKey";
-    when(_testNode.getCurrentCapacity()).thenReturn(ImmutableMap.of(key,  10));
+    when(_testNode.getRemainingCapacity()).thenReturn(ImmutableMap.of(key,  10));
     when(_testReplica.getCapacity()).thenReturn(ImmutableMap.of(key, 5));
     Assert.assertTrue(_constraint.isAssignmentValid(_testNode, _testReplica, _clusterContext));
   }
@@ -47,7 +47,7 @@ public class TestNodeCapacityConstraint {
   @Test
   public void testConstraintInValidWhenNodeHasInsufficientSpace() {
     String key = "testKey";
-    when(_testNode.getCurrentCapacity()).thenReturn(ImmutableMap.of(key,  1));
+    when(_testNode.getRemainingCapacity()).thenReturn(ImmutableMap.of(key,  1));
     when(_testReplica.getCapacity()).thenReturn(ImmutableMap.of(key, 5));
     Assert.assertFalse(_constraint.isAssignmentValid(_testNode, _testReplica, _clusterContext));
   }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
@@ -64,7 +64,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
 
     AssignableNode assignableNode = new AssignableNode(testCache.getClusterConfig(),
         testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
-    assignableNode.assignNewBatch(assignmentSet);
+    assignableNode.assign(assignmentSet);
     Assert.assertEquals(assignableNode.getAssignedPartitionsMap(), expectedAssignment);
     Assert.assertEquals(assignableNode.getAssignedReplicaCount(), 4);
     Assert.assertEquals(assignableNode.getHighestCapacityUtilization(), 16.0 / 20.0, 0.005);
@@ -183,7 +183,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
 
     AssignableNode assignableNode = new AssignableNode(testCache.getClusterConfig(),
         testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
-    assignableNode.assignNewBatch(assignmentSet);
+    assignableNode.assign(assignmentSet);
     AssignableReplica duplicateReplica = new AssignableReplica(testCache.getClusterConfig(),
         testCache.getResourceConfig(_resourceNames.get(0)), _partitionNames.get(0), "SLAVE", 2);
     assignableNode.assign(duplicateReplica);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
@@ -19,6 +19,8 @@ package org.apache.helix.controller.rebalancer.waged.model;
  * under the License.
  */
 
+import static org.mockito.Mockito.when;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,8 +37,6 @@ import org.apache.helix.model.InstanceConfig;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import static org.mockito.Mockito.when;
 
 public class TestAssignableNode extends AbstractTestClusterModel {
   @BeforeClass
@@ -64,7 +64,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
 
     AssignableNode assignableNode = new AssignableNode(testCache.getClusterConfig(),
         testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
-    assignableNode.assign(assignmentSet);
+    assignableNode.assignInitBatch(assignmentSet);
     Assert.assertEquals(assignableNode.getAssignedPartitionsMap(), expectedAssignment);
     Assert.assertEquals(assignableNode.getAssignedReplicaCount(), 4);
     Assert.assertEquals(assignableNode.getHighestCapacityUtilization(), 16.0 / 20.0, 0.005);
@@ -183,7 +183,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
 
     AssignableNode assignableNode = new AssignableNode(testCache.getClusterConfig(),
         testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
-    assignableNode.assign(assignmentSet);
+    assignableNode.assignInitBatch(assignmentSet);
     AssignableReplica duplicateReplica = new AssignableReplica(testCache.getClusterConfig(),
         testCache.getResourceConfig(_resourceNames.get(0)), _partitionNames.get(0), "SLAVE", 2);
     assignableNode.assign(duplicateReplica);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
@@ -21,7 +21,6 @@ package org.apache.helix.controller.rebalancer.waged.model;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -74,7 +73,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     Assert.assertEquals(assignableNode.getInstanceTags(), _testInstanceTags);
     Assert.assertEquals(assignableNode.getFaultZone(), _testFaultZoneId);
     Assert.assertEquals(assignableNode.getDisabledPartitionsMap(), _disabledPartitionsMap);
-    Assert.assertEquals(assignableNode.getCurrentCapacity(), expectedCapacityMap);
+    Assert.assertEquals(assignableNode.getRemainingCapacity(), expectedCapacityMap);
     Assert.assertEquals(assignableNode.getAssignedReplicas(), assignmentSet);
     Assert.assertEquals(assignableNode.getAssignedPartitionsByResource(_resourceNames.get(0)),
         expectedAssignmentSet1);
@@ -114,7 +113,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     Assert.assertEquals(assignableNode.getInstanceTags(), _testInstanceTags);
     Assert.assertEquals(assignableNode.getFaultZone(), _testFaultZoneId);
     Assert.assertEquals(assignableNode.getDisabledPartitionsMap(), _disabledPartitionsMap);
-    Assert.assertEquals(assignableNode.getCurrentCapacity(), expectedCapacityMap);
+    Assert.assertEquals(assignableNode.getRemainingCapacity(), expectedCapacityMap);
     Assert.assertEquals(assignableNode.getAssignedReplicas(), assignmentSet);
     Assert.assertEquals(assignableNode.getAssignedPartitionsByResource(_resourceNames.get(0)),
         expectedAssignmentSet1);
@@ -147,7 +146,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     Assert.assertEquals(assignableNode.getInstanceTags(), _testInstanceTags);
     Assert.assertEquals(assignableNode.getFaultZone(), _testFaultZoneId);
     Assert.assertEquals(assignableNode.getDisabledPartitionsMap(), _disabledPartitionsMap);
-    Assert.assertEquals(assignableNode.getCurrentCapacity(), expectedCapacityMap);
+    Assert.assertEquals(assignableNode.getRemainingCapacity(), expectedCapacityMap);
     Assert.assertEquals(assignableNode.getAssignedReplicas(), assignmentSet);
     Assert.assertEquals(assignableNode.getAssignedPartitionsByResource(_resourceNames.get(0)),
         expectedAssignmentSet1);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

(#482)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

Separate AssignableNode properties  by Immutable and Mutable
It makes any misuses be detected earlier

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

        at java.lang.Thread.run(Thread.java:745)
Shut down zookeeper at port 2187 in thread main
[ERROR] Tests run: 20, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 37.871 s <<< FAILURE! - in TestSuite
[ERROR] test(org.apache.helix.webapp.resources.TestJobQueuesResource)  Time elapsed: 1.491 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.webapp.resources.TestJobQueuesResource.test(TestJobQueuesResource.java:192)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestJobQueuesResource.test:192 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 20, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Helix 0.9.2-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  0.496 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [  01:02 h]
[INFO] Apache Helix :: Admin Webapp ....................... FAILURE [ 39.496 s]
[INFO] Apache Helix :: Restful Interface .................. SKIPPED
[INFO] Apache Helix :: HelixAgent ......................... SKIPPED
[INFO] Apache Helix :: Recipes ............................ SKIPPED
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SKIPPED

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml