### PR TITLE
Integrate statistical measurement in the final OptimalAssignment output

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -74,7 +74,7 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
       if (optimalAssignment.hasAnyFailure()) {
         String errorMessage = String.format(
             "Unable to find any available candidate node for partition %s; Fail reasons: %s",
-            replica.getPartitionName(), optimalAssignment.getFailures());
+            replica.getPartitionName(), optimalAssignment.getErrorMessage());
         throw new HelixRebalanceException(errorMessage,
             HelixRebalanceException.Type.FAILED_TO_CALCULATE);
       }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
@@ -222,6 +222,12 @@ public class AssignableNode implements Comparable<AssignableNode> {
     return _currentCapacityMap;
   }
 
+
+  //TODO: will implement by merging other changes
+  public Map<String, Integer> getCapacityUsage() {
+    return Collections.emptyMap();
+  }
+
   /**
    * Return the most concerning capacity utilization number for evenly partition assignment.
    * The method dynamically returns the highest utilization number among all the capacity

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/OptimalAssignment.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/OptimalAssignment.java
@@ -19,14 +19,20 @@ package org.apache.helix.controller.rebalancer.waged.model;
  * under the License.
  */
 
+import static com.google.common.math.DoubleMath.mean;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.helix.HelixException;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.ResourceAssignment;
+
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
 
 /**
  * The data model represents the optimal assignment of N replicas assigned to M instances;
@@ -40,8 +46,8 @@ public class OptimalAssignment {
       new HashMap<>();
 
   /**
-   * Update the OptimalAssignment instance with the existing assignment recorded in the input cluster model.
-   *
+   * Update the OptimalAssignment instance with the existing assignment recorded in the input
+   * cluster model.
    * @param clusterModel
    */
   public void updateAssignments(ClusterModel clusterModel) {
@@ -51,21 +57,79 @@ public class OptimalAssignment {
   }
 
   /**
+   * The coefficient of variation (CV) is a statistical measure of the dispersion of data points in
+   * a data series around the mean.
+   * The coefficient of variation represents the ratio of the standard deviation to the mean, and it
+   * is a useful statistic for comparing the degree of variation from one data series to another,
+   * even if the means are drastically different from one another.
+   * It's used as a tool to evaluate the "evenness" of an partitions to instances assignment
+   * @return a multi-dimension CV keyed by capacity key
+   */
+  public Map<String, Double> getCoefficientOfVariationAsEvenness() {
+    List<AssignableNode> instances = new ArrayList<>(_optimalAssignment.keySet());
+    Map<String, List<Integer>> usages = new HashMap<>();
+    for (AssignableNode instance : instances) {
+      Map<String, Integer> capacityUsage = instance.getCapacityUsage();
+      for (String key : capacityUsage.keySet()) {
+        usages.computeIfAbsent(key, k -> new ArrayList<>()).add(capacityUsage.get(key));
+      }
+    }
+
+    return usages.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> getCoefficientOfVariation(e.getValue())));
+  }
+
+  /**
+   * Compare this round of calculated assignment compared to the last assignment and get the
+   * partition movements count
+   * @param baseAssignment The base assignment (could be best possible/baseline assignment)
+   * @return a simple cumulative count of total movements where differences of movements in terms of
+   *         location, size, etc is ignored
+   */
+  public int getTotalPartitionMovements(Map<String, ResourceAssignment> baseAssignment) {
+    Map<String, ResourceAssignment> optimalAssignment = getOptimalResourceAssignment();
+    int movements = 0;
+    for (String resource : optimalAssignment.keySet()) {
+      final ResourceAssignment resourceAssignment = optimalAssignment.get(resource);
+      if (!baseAssignment.containsKey(resource)) {
+        // It means the resource is a newly added resource
+        movements += resourceAssignment.getMappedPartitions().stream()
+            .map(resourceAssignment::getReplicaMap).map(Map::size).count();
+      } else {
+        ResourceAssignment lastResourceAssignment = baseAssignment.get(resource);
+        for (Partition partition : resourceAssignment.getMappedPartitions()) {
+          Map<String, String> thisInstanceToStates =
+              new HashMap<>(resourceAssignment.getReplicaMap(partition));
+          Map<String, String> lastInstanceToStates =
+              new HashMap<>(lastResourceAssignment.getReplicaMap(partition));
+          MapDifference<String, String> diff =
+              Maps.difference(thisInstanceToStates, lastInstanceToStates);
+          // common keys(instances) but have different values (states)
+          movements += diff.entriesDiffering().size();
+          // Moved to different instances
+          movements += diff.entriesOnlyOnLeft().size();
+        }
+      }
+    }
+    return movements;
+  }
+
+  /**
    * @return The optimal assignment in the form of a <Resource Name, ResourceAssignment> map.
    */
   public Map<String, ResourceAssignment> getOptimalResourceAssignment() {
     if (hasAnyFailure()) {
       throw new HelixException(
           "Cannot get the optimal resource assignment since a calculation failure is recorded. "
-              + getFailures());
+              + getErrorMessage());
     }
     Map<String, ResourceAssignment> assignmentMap = new HashMap<>();
     for (AssignableNode node : _optimalAssignment.keySet()) {
       for (AssignableReplica replica : _optimalAssignment.get(node)) {
         String resourceName = replica.getResourceName();
         Partition partition = new Partition(replica.getPartitionName());
-        ResourceAssignment resourceAssignment = assignmentMap
-            .computeIfAbsent(resourceName, key -> new ResourceAssignment(resourceName));
+        ResourceAssignment resourceAssignment = assignmentMap.computeIfAbsent(resourceName,
+            key -> new ResourceAssignment(resourceName));
         Map<String, String> partitionStateMap = resourceAssignment.getReplicaMap(partition);
         if (partitionStateMap.isEmpty()) {
           // ResourceAssignment returns immutable empty map while no such assignment recorded yet.
@@ -88,8 +152,29 @@ public class OptimalAssignment {
     return !_failedAssignments.isEmpty();
   }
 
-  public String getFailures() {
-    // TODO: format the error string
-    return _failedAssignments.toString();
+  public String getErrorMessage() {
+    StringBuilder errorMessageBuilder = new StringBuilder();
+    for (AssignableReplica replica : _failedAssignments.keySet()) {
+      String partitionName = replica.toString();
+      errorMessageBuilder.append(partitionName).append("\n");
+      Map<AssignableNode, List<String>> failedAssignments = _failedAssignments.get(replica);
+      failedAssignments.entrySet().forEach(entry ->
+        errorMessageBuilder.append("\t")
+                .append(entry.getKey().getInstanceName())
+                .append(":")
+                .append(String.join(",", entry.getValue().stream().sorted().collect(Collectors.toList())))
+                .append("\n"));
+    }
+    return errorMessageBuilder.toString();
+  }
+
+  private static double getCoefficientOfVariation(List<Integer> nums) {
+    int sum = 0;
+    double mean = mean(nums);
+    for (int num : nums) {
+      sum += Math.pow((num - mean), 2);
+    }
+    double std = Math.sqrt(sum / (nums.size() - 1));
+    return std / mean;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestOptimalAssignment.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestOptimalAssignment.java
@@ -54,6 +54,8 @@ public class TestOptimalAssignment extends ClusterModelTestHelper {
     model.assign(_resourceNames.get(0), _partitionNames.get(0), "MASTER", _testInstanceId);
     assignment.updateAssignments(model);
     optimalAssignmentMap = assignment.getOptimalResourceAssignment();
+    Assert.assertEquals(assignment.getTotalPartitionMovements(Collections.emptyMap()), 2);
+    Assert.assertEquals(assignment.getTotalPartitionMovements(optimalAssignmentMap), 0);
     Assert.assertEquals(optimalAssignmentMap.get(_resourceNames.get(0)).getMappedPartitions(),
         Arrays
             .asList(new Partition(_partitionNames.get(0)), new Partition(_partitionNames.get(1))));


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

(#480)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
Added CV and movements measurement tools for the statistical understanding of the final optimal assignment 

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml