### PR TITLE
Make the Java Doc for API more clear

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -143,8 +143,8 @@ public final class HelixUtil {
   /**
    * This method provides the ideal state mapping with corresponding rebalance strategy
    * @param clusterConfig         The cluster config
-   * @param instanceConfigs       List of instance configs
-   * @param liveInstances         List of live instance names
+   * @param instanceConfigs       List of all existing instance configs including disabled/down instances
+   * @param liveInstances         List of live and enabled instance names
    * @param idealState            The ideal state of current resource. If input is null, will be
    *                              treated as newly created resource.
    * @param partitions            The list of partition names


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Some users got confused with inputs based on the Java doc. Make it more clear for user usage.
### Tests

- [x] The following tests are written for this issue:

- [x] The following is the result of the "mvn test" command on the appropriate module:

Since this is Java Doc change, no need for test running.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml
