### PR TITLE
#493 Set jersey servlet application name with namespace name.

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
@@ -143,6 +143,7 @@ public class HelixRestServer {
   private ResourceConfig getResourceConfig(HelixRestNamespace namespace, ServletType type) {
     ResourceConfig cfg = new ResourceConfig();
     cfg.packages(type.getServletPackageArray());
+    cfg.setApplicationName(namespace.getName());
 
     // Enable the default statistical monitoring MBean for Jersey server
     cfg.property(ServerProperties.MONITORING_STATISTICS_MBEANS_ENABLED, true);


### PR DESCRIPTION
### Issues

- [x]  My PR addresses the following Helix issues and references them in the PR title:
Set jersey servlet application name with namespace name #493

### Description
Currently the servlet application name is random like "App_32de3a", which can not help us identify namespaced servlet. So if we can set the servlet app name with its namespace name, it would really help, especially when setting mbean monitor.

- [x]  Here are some details about my PR, including screenshots of any UI changes:
(Write a concise description including what, why, how)
Set jersey servlet application name with namespace name

After change:
![image](https://user-images.githubusercontent.com/5187721/65811231-18c72c80-e16a-11e9-891b-d8e85fea2c6d.png)


### Tests

- []  The following tests are written for this issue:
(List the names of added unit/integration tests)
testMBeanApplicationName

- [x]  The following is the result of the "mvn test" command on the appropriate module:
(Copy & paste the result of "mvn test")
Test in helix-rest module.

[INFO] Tests run: 85, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.876 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 85, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  28.863 s
[INFO] Finished at: 2019-09-30T10:17:05-07:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x]  My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "How to write a good git commit message":
Subject is separated from body by a blank line
Subject is limited to 50 characters (not including Jira issue reference)
Subject does not end with a period
Subject uses the imperative mood ("add", not "adding")
Body wraps at 72 characters
Body explains "what" and "why", not "how"
Documentation

  In case of new functionality, my PR adds documentation in the following wiki page:
(Link the GitHub wiki you added)

### Code Quality

- [x]  My diff has been formatted using helix-style.xml