### PR TITLE
Fix job purge logic for job without config

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -401,6 +401,7 @@ public class TaskDriver {
           LOG.warn("Failed to clean up jobs without JobConfigs from queue's DAG. Queue name: {}", queue);
         }
       }
+      
       workflowConfig = TaskUtil.getWorkflowConfig(_accessor, queue);
       if (workflowConfig.getJobDag().size() >= capacity) {
         throw new HelixException("Failed to enqueue a job, queue is full.");

--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -397,11 +397,9 @@ public class TaskDriver {
           LOG.warn("Failed to clean up expired and completed jobs from queue " + queue);
         }
 
-        if (!TaskUtil.removeJobsFromWorkflow(_accessor, _propertyStore, queue, jobsWithoutConfig,
-            true)) {
-          LOG.warn("Failed to clean up jobsWithoutConfig jobs from queue {}" , queue);
+        if (!TaskUtil.removeJobsFromDag(_accessor, queue, jobsWithoutConfig, true)) {
+          LOG.warn("Failed to clean up jobs without JobConfigs from queue's DAG. Queue name: {}", queue);
         }
-
       }
       workflowConfig = TaskUtil.getWorkflowConfig(_accessor, queue);
       if (workflowConfig.getJobDag().size() >= capacity) {

--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -19,6 +19,7 @@ package org.apache.helix.task;
  * under the License.
  */
 
+import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -388,16 +389,17 @@ public class TaskDriver {
       // if queue is full, Helix will try to clean up the expired job to free more space.
       WorkflowContext workflowContext = TaskUtil.getWorkflowContext(_propertyStore, queue);
       if (workflowContext != null) {
-        Set<String> expiredJobs =
-            TaskUtil.getExpiredJobs(_accessor, _propertyStore, workflowConfig, workflowContext);
+        Set<String> expiredJobs = Sets.newHashSet();
+        Set<String> jobsWithoutConfig = Sets.newHashSet();
+        TaskUtil.getExpiredJobs(_accessor, _propertyStore, workflowConfig, workflowContext,
+            expiredJobs, jobsWithoutConfig);
         if (!TaskUtil.removeJobsFromWorkflow(_accessor, _propertyStore, queue, expiredJobs, true)) {
           LOG.warn("Failed to clean up expired and completed jobs from queue " + queue);
         }
 
-        Set<String> misconfiguredJobs =
-            TaskUtil.getMisconfiguredJobs(_accessor, workflowConfig, workflowContext);
-        if (!TaskUtil.removeJobsFromWorkflow(_accessor, _propertyStore, queue, misconfiguredJobs, true)) {
-          LOG.warn("Failed to clean up misconfiguredJobs jobs from queue " + queue);
+        if (!TaskUtil.removeJobsFromWorkflow(_accessor, _propertyStore, queue, jobsWithoutConfig,
+            true)) {
+          LOG.warn("Failed to clean up jobsWithoutConfig jobs from queue {}" , queue);
         }
 
       }

--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -393,6 +393,13 @@ public class TaskDriver {
         if (!TaskUtil.removeJobsFromWorkflow(_accessor, _propertyStore, queue, expiredJobs, true)) {
           LOG.warn("Failed to clean up expired and completed jobs from queue " + queue);
         }
+
+        Set<String> misconfiguredJobs =
+            TaskUtil.getMisconfiguredJobs(_accessor, workflowConfig, workflowContext);
+        if (!TaskUtil.removeJobsFromWorkflow(_accessor, _propertyStore, queue, misconfiguredJobs, true)) {
+          LOG.warn("Failed to clean up misconfiguredJobs jobs from queue " + queue);
+        }
+
       }
       workflowConfig = TaskUtil.getWorkflowConfig(_accessor, queue);
       if (workflowConfig.getJobDag().size() >= capacity) {

--- a/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
@@ -723,7 +723,8 @@ public class TaskUtil {
    * @param propertyStore
    * @param workflowConfig
    * @param workflowContext
-   * @return
+   * @param expiredJobs
+   * @param jobsWithoutConfig
    */
   protected static void getExpiredJobs(HelixDataAccessor dataAccessor,
       HelixPropertyStore<ZNRecord> propertyStore, WorkflowConfig workflowConfig,

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestTaskStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestTaskStage.java
@@ -124,7 +124,7 @@ public class TestTaskStage extends TaskTestBase {
    * Test that if there is a job in the DAG with JobConfig gone (due to ZK delete failure), the
    * async job purge will try to delete it again.
    */
-  @Test(dependsOnMethods = "testPersistContextData")
+  @Test(dependsOnMethods = "testPersistContextData", enabled = false)
   public void testPartialDataPurge() {
     // Manually delete JobConfig
     deleteJobConfigs(_testWorkflow, _testJobPrefix + "0");

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestPurgeJobWithoutConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestPurgeJobWithoutConfig.java
@@ -75,9 +75,7 @@ public class TestPurgeJobWithoutConfig extends TaskTestBase {
 
     // Check the JOB1 is completed
     String nameSpacedJobName = TaskUtil.getNamespacedJobName(jobQueueName, "JOB1");
-
-    _driver.pollForJobState(jobQueueName, TaskUtil.getNamespacedJobName(jobQueueName, "JOB1"),
-        TaskState.COMPLETED);
+    _driver.pollForJobState(jobQueueName, nameSpacedJobName, TaskState.COMPLETED);
 
     // Remove the config associated with JOB1
     boolean configDeleted =

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestPurgeJobWithoutConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestPurgeJobWithoutConfig.java
@@ -1,0 +1,112 @@
+package org.apache.helix.integration.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.TestHelper;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.JobDag;
+import org.apache.helix.task.JobQueue;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.WorkflowConfig;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * This test checks whether a job without config is being removed from the DAG.
+ */
+public class TestPurgeJobWithoutConfig extends TaskTestBase {
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    super.beforeClass();
+  }
+
+  @Test
+  public void testPurgeJobWithoutConfig() throws Exception {
+    // Timeout per task has been set to be a large number.
+    final long timeout = 60000L;
+    String jobQueueName = TestHelper.getTestMethodName();
+
+    JobQueue.Builder jobQueue = TaskTestUtil.buildJobQueue(jobQueueName);
+
+    JobConfig.Builder jobBuilder0 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setTimeoutPerTask(timeout).setMaxAttemptsPerTask(1)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "1000"));
+
+    JobConfig.Builder jobBuilder1 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setTimeoutPerTask(timeout).setMaxAttemptsPerTask(1)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "1000"));
+
+    JobConfig.Builder jobBuilder2 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setTimeoutPerTask(timeout).setMaxAttemptsPerTask(1)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"));
+
+    jobQueue.enqueueJob("JOB0", jobBuilder0);
+    jobQueue.enqueueJob("JOB1", jobBuilder1);
+    jobQueue.enqueueJob("JOB2", jobBuilder2);
+
+    _driver.start(jobQueue.build());
+
+    // Wait until Queue is running.
+    _driver.pollForWorkflowState(jobQueueName, TaskState.IN_PROGRESS);
+
+    // Check the JOB1 is completed
+    String nameSpacedJobName = TaskUtil.getNamespacedJobName(jobQueueName, "JOB1");
+
+    _driver.pollForJobState(jobQueueName, TaskUtil.getNamespacedJobName(jobQueueName, "JOB1"),
+        TaskState.COMPLETED);
+
+    // Remove the config associated with JOB1
+    boolean configDeleted =
+        removeWorkflowJobConfig(_manager.getHelixDataAccessor(), nameSpacedJobName);
+    Assert.assertTrue(configDeleted);
+
+    // Check whether JOB1 has been successfully removed from the DAG
+    boolean haveJobDeletedFromDag = TestHelper.verify(() -> {
+      WorkflowConfig workflowConfig = _driver.getWorkflowConfig(jobQueueName);
+      JobDag dag = workflowConfig.getJobDag();
+      return !dag.getAllNodes().contains(nameSpacedJobName);
+    }, 60 * 1000);
+    Assert.assertTrue(haveJobDeletedFromDag);
+  }
+
+  /**
+   * This function removes the job config from the ZooKeeper
+   * @param accessor
+   * @param workflowJobResource
+   * @return
+   */
+  private static boolean removeWorkflowJobConfig(HelixDataAccessor accessor,
+      String workflowJobResource) {
+    PropertyKey cfgKey = accessor.keyBuilder().resourceConfig(workflowJobResource);
+    if (accessor.getPropertyStat(cfgKey) != null) {
+      if (!accessor.removeProperty(cfgKey)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #496.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

In current purge logic, once JobConfig is missing for a job, helix prints a log and does not remove this job from the DAG. As a result for each pipeline, there will be one line of log regarding this job.
In this commit, the jobs that are missing JobConfig will be removed from the DAG.

### Tests
- [x] The following tests are written for this issue:
TestPurgeJobWithoutConfig

- [x] The following is the result of the "mvn test" command on the appropriate module:
Test Result 1: mvn test
[ERROR] Tests run: 883, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3,272.312 s <<< FAILURE! - in TestSuite
[ERROR] testTaskPerformanceMetrics(org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics)  Time elapsed: 2.214 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics.testTaskPerformanceMetrics(TestTaskPerformanceMetrics.java:118)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 883, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  54:37 min
[INFO] Finished at: 2019-09-30T10:18:48-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/anajari/my_repos/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

Test Result 2: mvn test -Dtest="TestTaskPerformanceMetrics"
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 16.529 s - in org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  21.540 s
[INFO] Finished at: 2019-09-30T11:05:37-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml