### PR TITLE
Add import order for java and javax.

### DIFF
--- a/helix-style-intellij.xml
+++ b/helix-style-intellij.xml
@@ -29,6 +29,10 @@
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
+      <package name="java" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="javax" withSubpackages="true" static="false" />
+      <emptyLine />
       <package name="" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="" withSubpackages="true" static="true" />

--- a/helix-style-intellij.xml
+++ b/helix-style-intellij.xml
@@ -30,7 +30,6 @@
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
       <package name="java" withSubpackages="true" static="false" />
-      <emptyLine />
       <package name="javax" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="" withSubpackages="true" static="false" />


### PR DESCRIPTION
### Issues

- [x]  My PR addresses the following Helix issues and references them in the PR title:
#499 Add import order for java and javax.

### Description

- [x]  Here are some details about my PR, including screenshots of any UI changes:
(Write a concise description including what, why, how)
Set import order for java and javax in helix code style xml.
Order will be java, javax.

### Tests

- [x]  The following tests are written for this issue:
(List the names of added unit/integration tests)

- [x]  The following is the result of the "mvn test" command on the appropriate module:
(Copy & paste the result of "mvn test")


### Commits

- [x]  My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "How to write a good git commit message":
Subject is separated from body by a blank line
Subject is limited to 50 characters (not including Jira issue reference)
Subject does not end with a period
Subject uses the imperative mood ("add", not "adding")
Body wraps at 72 characters
Body explains "what" and "why", not "how"
Documentation

  In case of new functionality, my PR adds documentation in the following wiki page:
(Link the GitHub wiki you added)

### Code Quality

- [x]  My diff has been formatted using helix-style.xml