### PR TITLE
Fix null response for instance stoppable check when connection refused.

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/json/instance/StoppableCheck.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/json/instance/StoppableCheck.java
@@ -38,6 +38,10 @@ public class StoppableCheck {
     Category(String prefix) {
       this.prefix = prefix;
     }
+
+    public String getPrefix() {
+      return prefix;
+    }
   }
 
   @JsonProperty("stoppable")

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
@@ -45,7 +45,6 @@ import org.apache.helix.rest.common.HelixDataAccessorWrapper;
 import org.apache.helix.rest.server.json.instance.InstanceInfo;
 import org.apache.helix.rest.server.json.instance.StoppableCheck;
 import org.apache.helix.util.InstanceValidationUtil;
-import org.apache.http.conn.HttpHostConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -216,21 +215,17 @@ public class InstanceServiceImpl implements InstanceService {
   }
 
   private StoppableCheck performCustomInstanceCheck(String clusterId, String instanceName,
-      String baseUrl, Map<String, String> customPayLoads) throws IOException {
+      String baseUrl, Map<String, String> customPayLoads) {
     LOG.info("Perform instance level client side health checks for {}/{}", clusterId, instanceName);
     try {
       return new StoppableCheck(
           _customRestClient.getInstanceStoppableCheck(baseUrl, customPayLoads),
           StoppableCheck.Category.CUSTOM_INSTANCE_CHECK);
-    } catch (HttpHostConnectException ex) {
-      LOG.error("Custom client side instance level health check for {}/{} failed "
-          + "because of connection refused.", clusterId, instanceName, ex);
+    } catch (IOException ex) {
+      LOG.error("Custom client side instance level health check for {}/{} failed.", clusterId,
+          instanceName, ex);
       return new StoppableCheck(false, Arrays.asList(instanceName),
           StoppableCheck.Category.CUSTOM_INSTANCE_CHECK);
-    } catch (IOException e) {
-      LOG.error("Failed to perform custom client side instance level health checks for {}/{}",
-          clusterId, instanceName, e);
-      throw e;
     }
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
@@ -223,9 +223,8 @@ public class InstanceServiceImpl implements InstanceService {
           _customRestClient.getInstanceStoppableCheck(baseUrl, customPayLoads),
           StoppableCheck.Category.CUSTOM_INSTANCE_CHECK);
     } catch (HttpHostConnectException ex) {
-      String msg = "Custom client side instance level health check for {}/{} failed "
-          + "because of connection refused.";
-      LOG.error(msg, clusterId, instanceName, ex);
+      LOG.error("Custom client side instance level health check for {}/{} failed "
+          + "because of connection refused.", clusterId, instanceName, ex);
       return new StoppableCheck(false, Arrays.asList(instanceName),
           StoppableCheck.Category.CUSTOM_INSTANCE_CHECK);
     } catch (IOException e) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
@@ -21,6 +21,7 @@ package org.apache.helix.rest.server.service;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +45,7 @@ import org.apache.helix.rest.common.HelixDataAccessorWrapper;
 import org.apache.helix.rest.server.json.instance.InstanceInfo;
 import org.apache.helix.rest.server.json.instance.StoppableCheck;
 import org.apache.helix.util.InstanceValidationUtil;
+import org.apache.http.conn.HttpHostConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -219,6 +221,12 @@ public class InstanceServiceImpl implements InstanceService {
     try {
       return new StoppableCheck(
           _customRestClient.getInstanceStoppableCheck(baseUrl, customPayLoads),
+          StoppableCheck.Category.CUSTOM_INSTANCE_CHECK);
+    } catch (HttpHostConnectException ex) {
+      String msg = "Custom client side instance level health check for {}/{} failed "
+          + "because of connection refused.";
+      LOG.error(msg, clusterId, instanceName, ex);
+      return new StoppableCheck(false, Arrays.asList(instanceName),
           StoppableCheck.Category.CUSTOM_INSTANCE_CHECK);
     } catch (IOException e) {
       LOG.error("Failed to perform custom client side instance level health checks for {}/{}",

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
@@ -37,7 +37,6 @@ import org.apache.helix.model.RESTConfig;
 import org.apache.helix.rest.client.CustomRestClient;
 import org.apache.helix.rest.common.HelixDataAccessorWrapper;
 import org.apache.helix.rest.server.json.instance.StoppableCheck;
-import org.apache.http.conn.HttpHostConnectException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -124,7 +123,7 @@ public class TestInstanceService {
         };
 
     when(_customRestClient.getInstanceStoppableCheck(anyString(), anyMap()))
-        .thenThrow(HttpHostConnectException.class);
+        .thenThrow(IOException.class);
 
     Map<String, String> dataMap =
         ImmutableMap.of("instance", TEST_INSTANCE, "selection_base", "zone_based");

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
@@ -37,6 +37,8 @@ import org.apache.helix.model.RESTConfig;
 import org.apache.helix.rest.client.CustomRestClient;
 import org.apache.helix.rest.common.HelixDataAccessorWrapper;
 import org.apache.helix.rest.server.json.instance.StoppableCheck;
+import org.apache.http.conn.HttpHostConnectException;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
@@ -108,6 +110,36 @@ public class TestInstanceService {
     Assert.assertEquals(actual.getFailedChecks().size(), failedCheck.size());
     verify(_customRestClient, times(1)).getInstanceStoppableCheck(any(), any());
     verify(_customRestClient, times(0)).getPartitionStoppableCheck(any(), any(), any());
+  }
+
+  @Test
+  public void testGetInstanceStoppableCheckConnectionRefused() throws IOException {
+    InstanceService service =
+        new InstanceServiceImpl(_dataAccessor, _configAccessor, _customRestClient) {
+          @Override
+          protected Map<String, Boolean> getInstanceHealthStatus(String clusterId,
+              String instanceName, List<HealthCheck> healthChecks) {
+            return Collections.emptyMap();
+          }
+        };
+
+    when(_customRestClient.getInstanceStoppableCheck(anyString(), anyMap()))
+        .thenThrow(HttpHostConnectException.class);
+
+    Map<String, String> dataMap =
+        ImmutableMap.of("instance", TEST_INSTANCE, "selection_base", "zone_based");
+    String jsonContent = new ObjectMapper().writeValueAsString(dataMap);
+    StoppableCheck actual =
+        service.getInstanceStoppableCheck(TEST_CLUSTER, TEST_INSTANCE, jsonContent);
+
+    int expectedFailedChecksSize = 1;
+    String expectedFailedCheck =
+        StoppableCheck.Category.CUSTOM_INSTANCE_CHECK.getPrefix() + TEST_INSTANCE;
+
+    Assert.assertNotNull(actual);
+    Assert.assertFalse(actual.isStoppable());
+    Assert.assertEquals(actual.getFailedChecks().size(), expectedFailedChecksSize);
+    Assert.assertEquals(actual.getFailedChecks().get(0), expectedFailedCheck);
   }
 
   // TODO re-enable the test when partition health checks get decoupled


### PR DESCRIPTION
### Issues

- [x]  My PR addresses the following Helix issues and references them in the PR title:
#503 Null returned for instance stoppable check when connection refused

### Description

- [x]  Here are some details about my PR, including screenshots of any UI changes:
(Write a concise description including what, why, how)
instance stoppable check endpoint `/clusters/<cluster>/instances/<instanceId>/stoppable` return null when connection between helix rest server and storage node.
We return a `StoppableCheck` object when connection refused.

### Tests

- [x]  The following tests are written for this issue:
(List the names of added unit/integration tests)
`testGetInstanceStoppableCheckConnectionRefused`

- [x]  The following is the result of the "mvn test" command on the appropriate module:
(Copy & paste the result of "mvn test")

[INFO] Tests run: 86, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.438 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 86, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  30.896 s
[INFO] Finished at: 2019-10-03T19:13:15-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x]  My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "How to write a good git commit message":
Subject is separated from body by a blank line
Subject is limited to 50 characters (not including Jira issue reference)
Subject does not end with a period
Subject uses the imperative mood ("add", not "adding")
Body wraps at 72 characters
Body explains "what" and "why", not "how"
Documentation

  In case of new functionality, my PR adds documentation in the following wiki page:
(Link the GitHub wiki you added)

### Code Quality

- [x]  My diff has been formatted using helix-style-intellij.xml