### PR TITLE
Increase parallelism for ZkBucketDataAccessor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
@@ -50,6 +50,7 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
   private static final String LAST_SUCCESSFUL_WRITE_KEY = "LAST_SUCCESSFUL_WRITE";
   private static final String LAST_WRITE_KEY = "LAST_WRITE";
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  // Thread pool for deleting stale versions
   private static final ExecutorService GC_THREAD_POOL = Executors.newFixedThreadPool(1);
 
   // 100 KB for default bucket size
@@ -65,9 +66,6 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
    * @param bucketSize
    */
   public ZkBucketDataAccessor(String zkAddr, int bucketSize) {
-    // There are two HelixZkClients:
-    // 1. _zkBaseDataAccessor for writes of binary data
-    // 2. _znRecordBaseDataAccessor for writes of ZNRecord (metadata)
     _zkClient = DedicatedZkClientFactory.getInstance()
         .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddr));
     _zkClient.setZkSerializer(new ZkSerializer() {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
@@ -19,11 +19,16 @@ package org.apache.helix.manager.zk;
  * under the License.
  */
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Ints;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.I0Itec.zkclient.DataUpdater;
 import org.I0Itec.zkclient.exception.ZkMarshallingError;
 import org.I0Itec.zkclient.exception.ZkNoNodeException;
 import org.I0Itec.zkclient.serialize.ZkSerializer;
@@ -35,29 +40,27 @@ import org.apache.helix.HelixProperty;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.client.DedicatedZkClientFactory;
 import org.apache.helix.manager.zk.client.HelixZkClient;
-import org.apache.helix.manager.zk.client.SharedZkClientFactory;
 import org.apache.helix.util.GZipCompressionUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.codehaus.jackson.map.ObjectMapper;
 
 public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
-  private static Logger LOG = LoggerFactory.getLogger(ZkBucketDataAccessor.class);
-
-  private static final int DEFAULT_NUM_VERSIONS = 2;
+  private static final int DEFAULT_NUM_VERSIONS = 10;
   private static final String BUCKET_SIZE_KEY = "BUCKET_SIZE";
   private static final String DATA_SIZE_KEY = "DATA_SIZE";
   private static final String WRITE_LOCK_KEY = "WRITE_LOCK";
-  private static final String LAST_SUCCESS_KEY = "LAST_SUCCESS";
+
+  private static final String METADATA_KEY = "METADATA";
+  private static final String LAST_SUCCESSFUL_WRITE_KEY = "LAST_SUCCESSFUL_WRITE";
+  private static final String LAST_WRITE_KEY = "LAST_WRITE";
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   // 100 KB for default bucket size
   private static final int DEFAULT_BUCKET_SIZE = 50 * 1024;
   private final int _bucketSize;
-  private final int _numVersions;
   private ZkSerializer _zkSerializer;
   private HelixZkClient _zkClient;
-  private HelixZkClient _znRecordClient;
-  private BaseDataAccessor _zkBaseDataAccessor;
-  private BaseDataAccessor<ZNRecord> _znRecordBaseDataAccessor;
+  private BaseDataAccessor<byte[]> _zkBaseDataAccessor;
 
   /**
    * Constructor that allows a custom bucket size.
@@ -85,20 +88,9 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
         return data;
       }
     });
-    _zkBaseDataAccessor = new ZkBaseDataAccessor(_zkClient);
-
-    // TODO: Optimize serialization with Jackson
-    // TODO: Or use a better binary serialization protocol
-    // TODO: Consider making this also binary
-    // TODO: Consider an async write for the metadata as well
-    _znRecordClient = SharedZkClientFactory.getInstance()
-        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddr));
-    _znRecordBaseDataAccessor = new ZkBaseDataAccessor<>(_znRecordClient);
-    _znRecordClient.setZkSerializer(new ZNRecordSerializer());
-
+    _zkBaseDataAccessor = new ZkBaseDataAccessor<>(_zkClient);
     _zkSerializer = new ZNRecordJacksonSerializer();
     _bucketSize = bucketSize;
-    _numVersions = numVersions;
   }
 
   /**
@@ -112,6 +104,32 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
   @Override
   public <T extends HelixProperty> boolean compressedBucketWrite(String path, T value)
       throws IOException {
+    AtomicInteger versionRef = new AtomicInteger();
+    DataUpdater<byte[]> lastWriteVersionUpdater = dataInZk -> {
+      if (dataInZk == null || dataInZk.length == 0) {
+        // No last write version exists, so start with 0
+        return Ints.toByteArray(0);
+      }
+      // Last write exists, so increment and write it back
+      int lastWriteVersion = Ints.fromByteArray(dataInZk);
+      lastWriteVersion++;
+      // Set the AtomicReference
+      versionRef.set(lastWriteVersion);
+      return Ints.toByteArray(lastWriteVersion);
+    };
+
+    // 1. Increment lastWriteVersion using DataUpdater
+    if (!_zkBaseDataAccessor.update(path + "/" + LAST_WRITE_KEY, lastWriteVersionUpdater,
+        AccessOption.PERSISTENT)) {
+      throw new HelixException(
+          String.format("Failed to write the write version at path: %s!", path));
+    }
+    // Successfully reserved a version number
+    final int version = versionRef.get();
+
+    // 2. Write to the incremented last write version
+    String versionedDataPath = path + "/" + version;
+
     // Take the ZNrecord and serialize it (get byte[])
     byte[] serializedRecord = _zkSerializer.serialize(value.getRecord());
     // Compress the byte[]
@@ -119,69 +137,68 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
     // Compute N - number of buckets
     int numBuckets = (compressedRecord.length + _bucketSize - 1) / _bucketSize;
 
-    if (tryLock(path)) {
-      try {
-        // Read or initialize metadata and compute the last success version index
-        ZNRecord metadataRecord =
-            _znRecordBaseDataAccessor.get(path, null, AccessOption.PERSISTENT);
-        if (metadataRecord == null) {
-          metadataRecord = new ZNRecord(extractIdFromPath(path));
-        }
-        int lastSuccessIndex =
-            (metadataRecord.getIntField(LAST_SUCCESS_KEY, -1) + 1) % _numVersions;
-        String dataPath = path + "/" + lastSuccessIndex;
+    List<String> paths = new ArrayList<>();
+    List<byte[]> buckets = new ArrayList<>();
 
-        List<String> paths = new ArrayList<>();
-        List<Object> buckets = new ArrayList<>();
-
-        int ptr = 0;
-        int counter = 0;
-        while (counter < numBuckets) {
-          paths.add(dataPath + "/" + counter);
-          if (counter == numBuckets - 1) {
-            // Special treatment for the last bucket
-            buckets.add(Arrays.copyOfRange(compressedRecord, ptr,
-                ptr + compressedRecord.length % _bucketSize));
-          } else {
-            buckets.add(Arrays.copyOfRange(compressedRecord, ptr, ptr + _bucketSize));
-          }
-          ptr += _bucketSize;
-          counter++;
-        }
-
-        // Do a cleanup of previous data
-        if (!_zkBaseDataAccessor.remove(dataPath, AccessOption.PERSISTENT)) {
-          // Clean-up is not critical so upon failure, we log instead of throwing an exception
-          LOG.warn("Failed to clean up previous bucketed data in data path: {}", dataPath);
-        }
-
-        // Do an async set to ZK
-        boolean[] success =
-            _zkBaseDataAccessor.setChildren(paths, buckets, AccessOption.PERSISTENT);
-        // Exception and fail the write if any failed
-        for (boolean s : success) {
-          if (!s) {
-            throw new HelixException(
-                String.format("Failed to write the data buckets for path: %s", path));
-          }
-        }
-
-        // Data write completed, so update the metadata with last success index
-        // Note that the metadata ZNodes is written using sync write
-        metadataRecord.setIntField(BUCKET_SIZE_KEY, _bucketSize);
-        metadataRecord.setLongField(DATA_SIZE_KEY, compressedRecord.length);
-        metadataRecord.setIntField(LAST_SUCCESS_KEY, lastSuccessIndex);
-        if (!_znRecordBaseDataAccessor.set(path, metadataRecord, AccessOption.PERSISTENT)) {
-          throw new HelixException(
-              String.format("Failed to write the metadata at path: %s!", path));
-        }
-      } finally {
-        // Critical section for write ends here
-        unlock(path);
+    int ptr = 0;
+    int counter = 0;
+    while (counter < numBuckets) {
+      paths.add(versionedDataPath + "/" + counter);
+      if (counter == numBuckets - 1) {
+        // Special treatment for the last bucket
+        buckets.add(
+            Arrays.copyOfRange(compressedRecord, ptr, ptr + compressedRecord.length % _bucketSize));
+      } else {
+        buckets.add(Arrays.copyOfRange(compressedRecord, ptr, ptr + _bucketSize));
       }
-      return true;
+      ptr += _bucketSize;
+      counter++;
     }
-    throw new HelixException(String.format("Could not acquire lock for write. Path: %s", path));
+
+    // Do an async set to ZK
+    boolean[] success = _zkBaseDataAccessor.setChildren(paths, buckets, AccessOption.PERSISTENT);
+    // Exception and fail the write if any failed
+    for (boolean s : success) {
+      if (!s) {
+        throw new HelixException(
+            String.format("Failed to write the data buckets for path: %s", path));
+      }
+    }
+
+    // 3. Data write succeeded, so write the metadata by first serializing to byte array
+    Map<String, String> metadata = ImmutableMap.of(BUCKET_SIZE_KEY, Integer.toString(_bucketSize),
+        DATA_SIZE_KEY, Integer.toString(compressedRecord.length));
+    byte[] binaryMetadata = OBJECT_MAPPER.writeValueAsBytes(metadata);
+    if (!_zkBaseDataAccessor.set(path + "/" + version + "/" + METADATA_KEY, binaryMetadata,
+        AccessOption.PERSISTENT)) {
+      throw new HelixException(String.format("Failed to write the metadata at path: %s!", path));
+    }
+
+    // 4. Update lastSuccessfulWriteVersion using Updater
+    DataUpdater<byte[]> lastSuccessfulWriteVersionUpdater = dataInZk -> {
+      if (dataInZk == null || dataInZk.length == 0) {
+        // No last write version exists, so write version from this write
+        return Ints.toByteArray(version);
+      }
+      // Last successful write exists so check if it's smaller than my number
+      int lastWriteVersion = Ints.fromByteArray(dataInZk);
+      // TODO: Improve this with a high watermark (say, Integer.MAX_VALUE)
+      if (lastWriteVersion < version) {
+        // Smaller, so I can overwrite
+        return Ints.toByteArray(version);
+      } else {
+        // Greater, I have lagged behind. Return the existing data
+        return dataInZk;
+      }
+    };
+    if (!_zkBaseDataAccessor.update(path + "/" + LAST_SUCCESSFUL_WRITE_KEY,
+        lastSuccessfulWriteVersionUpdater, AccessOption.PERSISTENT)) {
+      throw new HelixException(
+          String.format("Failed to write the last successful write metadata at path: %s!", path));
+    }
+
+    // TODO: 5. Garbage collect
+    return true;
   }
 
   @Override
@@ -202,126 +219,87 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
     if (!_zkClient.isClosed()) {
       _zkClient.close();
     }
-    if (!_znRecordClient.isClosed()) {
-      _znRecordClient.close();
-    }
   }
 
   private HelixProperty compressedBucketRead(String path) {
-    // TODO: Incorporate parallelism into reads instead of locking the whole thing against other
-    // reads and writes
-    if (tryLock(path)) {
-      try {
-        // Retrieve the metadata
-        ZNRecord metadataRecord =
-            _znRecordBaseDataAccessor.get(path, null, AccessOption.PERSISTENT);
-        if (metadataRecord == null) {
-          throw new ZkNoNodeException(
-              String.format("Metadata ZNRecord does not exist for path: %s", path));
-        }
+    // 1. Get the version to read
+    byte[] binaryVersionToRead = _zkBaseDataAccessor.get(path + "/" + LAST_SUCCESSFUL_WRITE_KEY,
+        null, AccessOption.PERSISTENT);
+    if (binaryVersionToRead == null) {
+      throw new ZkNoNodeException(
+          String.format("Last successful write ZNode does not exist for path: %s", path));
+    }
+    int versionToRead = Ints.fromByteArray(binaryVersionToRead);
 
-        int bucketSize = metadataRecord.getIntField(BUCKET_SIZE_KEY, -1);
-        int dataSize = metadataRecord.getIntField(DATA_SIZE_KEY, -1);
-        int lastSuccessIndex = metadataRecord.getIntField(LAST_SUCCESS_KEY, -1);
-        if (lastSuccessIndex == -1) {
-          throw new HelixException(String.format("Metadata ZNRecord does not have %s! Path: %s",
-              LAST_SUCCESS_KEY, path));
-        }
-        if (bucketSize == -1) {
-          throw new HelixException(
-              String.format("Metadata ZNRecord does not have %s! Path: %s", BUCKET_SIZE_KEY, path));
-        }
-        if (dataSize == -1) {
-          throw new HelixException(
-              String.format("Metadata ZNRecord does not have %s! Path: %s", DATA_SIZE_KEY, path));
-        }
+    // 2. Get the metadata map
+    byte[] binaryMetadata = _zkBaseDataAccessor.get(path + "/" + versionToRead + "/" + METADATA_KEY,
+        null, AccessOption.PERSISTENT);
+    if (binaryMetadata == null) {
+      throw new ZkNoNodeException(
+          String.format("Metadata ZNode does not exist for path: %s", path));
+    }
+    Map metadata;
+    try {
+      metadata = OBJECT_MAPPER.readValue(binaryMetadata, Map.class);
+    } catch (IOException e) {
+      throw new HelixException(String.format("Failed to deserialize path metadata: %s!", path), e);
+    }
 
-        // Compute N - number of buckets
-        int numBuckets = (dataSize + _bucketSize - 1) / _bucketSize;
-        byte[] compressedRecord = new byte[dataSize];
-        String dataPath = path + "/" + lastSuccessIndex;
+    // 3. Read the data
+    Object bucketSizeObj = metadata.get(BUCKET_SIZE_KEY);
+    Object dataSizeObj = metadata.get(DATA_SIZE_KEY);
+    if (bucketSizeObj == null) {
+      throw new HelixException(
+          String.format("Metadata ZNRecord does not have %s! Path: %s", BUCKET_SIZE_KEY, path));
+    }
+    if (dataSizeObj == null) {
+      throw new HelixException(
+          String.format("Metadata ZNRecord does not have %s! Path: %s", DATA_SIZE_KEY, path));
+    }
+    int bucketSize = Integer.parseInt((String) bucketSizeObj);
+    int dataSize = Integer.parseInt((String) dataSizeObj);
 
-        List<String> paths = new ArrayList<>();
-        for (int i = 0; i < numBuckets; i++) {
-          paths.add(dataPath + "/" + i);
-        }
+    // Compute N - number of buckets
+    int numBuckets = (dataSize + _bucketSize - 1) / _bucketSize;
+    byte[] compressedRecord = new byte[dataSize];
+    String dataPath = path + "/" + versionToRead;
 
-        // Async get
-        List buckets = _zkBaseDataAccessor.get(paths, null, AccessOption.PERSISTENT, true);
+    List<String> paths = new ArrayList<>();
+    for (int i = 0; i < numBuckets; i++) {
+      paths.add(dataPath + "/" + i);
+    }
 
-        // Combine buckets into one byte array
-        int copyPtr = 0;
-        for (int i = 0; i < numBuckets; i++) {
-          if (i == numBuckets - 1) {
-            // Special treatment for the last bucket
-            System.arraycopy(buckets.get(i), 0, compressedRecord, copyPtr, dataSize % bucketSize);
-          } else {
-            System.arraycopy(buckets.get(i), 0, compressedRecord, copyPtr, bucketSize);
-            copyPtr += bucketSize;
-          }
-        }
+    // Async get
+    List<byte[]> buckets = _zkBaseDataAccessor.get(paths, null, AccessOption.PERSISTENT, true);
 
-        // Decompress the byte array
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(compressedRecord);
-        byte[] serializedRecord;
-        try {
-          serializedRecord = GZipCompressionUtil.uncompress(byteArrayInputStream);
-        } catch (IOException e) {
-          throw new HelixException(String.format("Failed to decompress path: %s!", path), e);
-        }
-
-        // Deserialize the record to retrieve the original
-        ZNRecord originalRecord = (ZNRecord) _zkSerializer.deserialize(serializedRecord);
-        return new HelixProperty(originalRecord);
-      } finally {
-        // Critical section for read ends here
-        unlock(path);
+    // Combine buckets into one byte array
+    int copyPtr = 0;
+    for (int i = 0; i < numBuckets; i++) {
+      if (i == numBuckets - 1) {
+        // Special treatment for the last bucket
+        System.arraycopy(buckets.get(i), 0, compressedRecord, copyPtr, dataSize % bucketSize);
+      } else {
+        System.arraycopy(buckets.get(i), 0, compressedRecord, copyPtr, bucketSize);
+        copyPtr += bucketSize;
       }
     }
-    throw new HelixException(String.format("Could not acquire lock for read. Path: %s", path));
-  }
 
-  /**
-   * Returns the last string element in a split String array by /.
-   * @param path
-   * @return
-   */
-  private String extractIdFromPath(String path) {
-    String[] splitPath = path.split("/");
-    return splitPath[splitPath.length - 1];
-  }
-
-  /**
-   * Acquires the lock (create an ephemeral node) only if it is free (no ephemeral node already
-   * exists) at the time of invocation.
-   * @param path
-   * @return
-   */
-  private boolean tryLock(String path) {
-    // Check if another write is taking place and if not, create an ephemeral node to simulate
-    // acquiring of a lock
-    return !_zkBaseDataAccessor.exists(path + "/" + WRITE_LOCK_KEY, AccessOption.EPHEMERAL)
-        && _zkBaseDataAccessor.set(path + "/" + WRITE_LOCK_KEY, new byte[0],
-            AccessOption.EPHEMERAL);
-  }
-
-  /**
-   * Releases the lock (removes the ephemeral node).
-   * @param path
-   */
-  private void unlock(String path) {
-    // Write succeeded, so release the lock
-    if (!_zkBaseDataAccessor.remove(path + "/" + WRITE_LOCK_KEY, AccessOption.EPHEMERAL)) {
-      throw new HelixException(String.format("Could not remove ephemeral node for path: %s", path));
+    // Decompress the byte array
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(compressedRecord);
+    byte[] serializedRecord;
+    try {
+      serializedRecord = GZipCompressionUtil.uncompress(byteArrayInputStream);
+    } catch (IOException e) {
+      throw new HelixException(String.format("Failed to decompress path: %s!", path), e);
     }
-    // TODO: In case of remove failure, we risk a lock never getting released.
-    // TODO: Consider two possible improvements
-    // TODO: 1. Use ephemeral owner id for the same connection to reclaim the lock
-    // TODO: 2. Use "lease" - lock with a timeout
+
+    // Deserialize the record to retrieve the original
+    ZNRecord originalRecord = (ZNRecord) _zkSerializer.deserialize(serializedRecord);
+    return new HelixProperty(originalRecord);
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     disconnect();
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -105,7 +105,7 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
   public void testMultipleWrites() throws Exception {
     int count = 50;
 
-    // Write 10 times
+    // Write "count" times
     for (int i = 0; i < count; i++) {
       _bucketDataAccessor.compressedBucketWrite(PATH, new HelixProperty(record));
     }
@@ -113,14 +113,13 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
     // Last known good version number should be "count"
     byte[] binarySuccessfulWriteVer = _zkBaseDataAccessor
         .get(PATH + "/" + LAST_SUCCESSFUL_WRITE_KEY, null, AccessOption.PERSISTENT);
-    long lastSuccessfulWriteVer =
-        Long.parseLong(new String(binarySuccessfulWriteVer).split("_")[0]);
+    long lastSuccessfulWriteVer = Long.parseLong(new String(binarySuccessfulWriteVer));
     Assert.assertEquals(lastSuccessfulWriteVer, count);
 
     // Last write version should be "count"
     byte[] binaryWriteVer =
         _zkBaseDataAccessor.get(PATH + "/" + LAST_WRITE_KEY, null, AccessOption.PERSISTENT);
-    long writeVer = Long.parseLong(new String(binaryWriteVer).split("_")[0]);
+    long writeVer = Long.parseLong(new String(binaryWriteVer));
     Assert.assertEquals(writeVer, count);
 
     // Test that all previous versions have been deleted

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -21,19 +21,25 @@ package org.apache.helix.manager.zk;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Longs;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import org.I0Itec.zkclient.exception.ZkMarshallingError;
+import org.I0Itec.zkclient.serialize.ZkSerializer;
 import org.apache.helix.AccessOption;
+import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.BucketDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.manager.zk.client.DedicatedZkClientFactory;
+import org.apache.helix.manager.zk.client.HelixZkClient;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -42,16 +48,44 @@ import org.testng.annotations.Test;
 public class TestZkBucketDataAccessor extends ZkTestBase {
   private static final String PATH = "/" + TestHelper.getTestClassName();
   private static final String NAME_KEY = TestHelper.getTestClassName();
+  private static final String LAST_SUCCESSFUL_WRITE_KEY = "LAST_SUCCESSFUL_WRITE";
+  private static final String LAST_WRITE_KEY = "LAST_WRITE";
 
   // Populate list and map fields for content comparison
   private static final List<String> LIST_FIELD = ImmutableList.of("1", "2");
   private static final Map<String, String> MAP_FIELD = ImmutableMap.of("1", "2");
 
   private BucketDataAccessor _bucketDataAccessor;
+  private BaseDataAccessor<byte[]> _zkBaseDataAccessor;
+
+  private ZNRecord record = new ZNRecord(NAME_KEY);
 
   @BeforeClass
   public void beforeClass() {
+    // Initialize ZK accessors for testing
     _bucketDataAccessor = new ZkBucketDataAccessor(ZK_ADDR);
+    HelixZkClient zkClient = DedicatedZkClientFactory.getInstance()
+        .buildZkClient(new HelixZkClient.ZkConnectionConfig(ZK_ADDR));
+    zkClient.setZkSerializer(new ZkSerializer() {
+      @Override
+      public byte[] serialize(Object data) throws ZkMarshallingError {
+        if (data instanceof byte[]) {
+          return (byte[]) data;
+        }
+        throw new HelixException("ZkBucketDataAccesor only supports a byte array as an argument!");
+      }
+
+      @Override
+      public Object deserialize(byte[] data) throws ZkMarshallingError {
+        return data;
+      }
+    });
+    _zkBaseDataAccessor = new ZkBaseDataAccessor<>(zkClient);
+
+    // Fill in some data for the record
+    record.setSimpleField(NAME_KEY, NAME_KEY);
+    record.setListField(NAME_KEY, LIST_FIELD);
+    record.setMapField(NAME_KEY, MAP_FIELD);
   }
 
   @AfterClass
@@ -65,21 +99,42 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
    */
   @Test
   public void testCompressedBucketWrite() throws IOException {
-    ZNRecord record = new ZNRecord(NAME_KEY);
-    record.setSimpleField(NAME_KEY, NAME_KEY);
-    record.setListField(NAME_KEY, LIST_FIELD);
-    record.setMapField(NAME_KEY, MAP_FIELD);
     Assert.assertTrue(_bucketDataAccessor.compressedBucketWrite(PATH, new HelixProperty(record)));
+  }
 
-    for (int i = 0; i < 10; i++) {
+  @Test(dependsOnMethods = "testCompressedBucketWrite")
+  public void testMultipleWrites() throws Exception {
+    int count = 50;
+
+    // Write 10 times
+    for (int i = 0; i < count; i++) {
       _bucketDataAccessor.compressedBucketWrite(PATH, new HelixProperty(record));
     }
+
+    // Last known good version number should be "count"
+    byte[] binarySuccessfulWriteVer = _zkBaseDataAccessor
+        .get(PATH + "/" + LAST_SUCCESSFUL_WRITE_KEY, null, AccessOption.PERSISTENT);
+    long lastSuccessfulWriteKey = Longs.fromByteArray(binarySuccessfulWriteVer);
+    Assert.assertEquals(lastSuccessfulWriteKey, count);
+
+    // Last write version should be "count"
+    byte[] binaryWriteVer =
+        _zkBaseDataAccessor.get(PATH + "/" + LAST_WRITE_KEY, null, AccessOption.PERSISTENT);
+    long writeVer = Longs.fromByteArray(binaryWriteVer);
+    Assert.assertEquals(writeVer, count);
+
+    // Test that all previous versions have been deleted
+    // Use Verifier because GC can take ZK delay
+    Assert.assertTrue(TestHelper.verify(() -> {
+      List<String> children = _zkBaseDataAccessor.getChildNames(PATH, AccessOption.PERSISTENT);
+      return children.size() == 3;
+    }, 60 * 1000L));
   }
 
   /**
    * The record written in {@link #testCompressedBucketWrite()} is the same record that was written.
    */
-  @Test(dependsOnMethods = "testCompressedBucketWrite")
+  @Test(dependsOnMethods = "testMultipleWrites")
   public void testCompressedBucketRead() {
     HelixProperty readRecord = _bucketDataAccessor.compressedBucketRead(PATH, HelixProperty.class);
     Assert.assertEquals(readRecord.getRecord().getSimpleField(NAME_KEY), NAME_KEY);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -21,7 +21,6 @@ package org.apache.helix.manager.zk;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.primitives.Longs;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -63,7 +62,7 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
   @BeforeClass
   public void beforeClass() {
     // Initialize ZK accessors for testing
-    _bucketDataAccessor = new ZkBucketDataAccessor(ZK_ADDR);
+    _bucketDataAccessor = new ZkBucketDataAccessor(ZK_ADDR, 50 * 1024, 0L);
     HelixZkClient zkClient = DedicatedZkClientFactory.getInstance()
         .buildZkClient(new HelixZkClient.ZkConnectionConfig(ZK_ADDR));
     zkClient.setZkSerializer(new ZkSerializer() {
@@ -114,13 +113,14 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
     // Last known good version number should be "count"
     byte[] binarySuccessfulWriteVer = _zkBaseDataAccessor
         .get(PATH + "/" + LAST_SUCCESSFUL_WRITE_KEY, null, AccessOption.PERSISTENT);
-    long lastSuccessfulWriteKey = Longs.fromByteArray(binarySuccessfulWriteVer);
-    Assert.assertEquals(lastSuccessfulWriteKey, count);
+    long lastSuccessfulWriteVer =
+        Long.parseLong(new String(binarySuccessfulWriteVer).split("_")[0]);
+    Assert.assertEquals(lastSuccessfulWriteVer, count);
 
     // Last write version should be "count"
     byte[] binaryWriteVer =
         _zkBaseDataAccessor.get(PATH + "/" + LAST_WRITE_KEY, null, AccessOption.PERSISTENT);
-    long writeVer = Longs.fromByteArray(binaryWriteVer);
+    long writeVer = Long.parseLong(new String(binaryWriteVer).split("_")[0]);
     Assert.assertEquals(writeVer, count);
 
     // Test that all previous versions have been deleted

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -40,12 +40,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class TestZkBucketDataAccessor extends ZkTestBase {
-
   private static final String PATH = "/" + TestHelper.getTestClassName();
   private static final String NAME_KEY = TestHelper.getTestClassName();
-  private static final String LAST_SUCCESS_KEY = "LAST_SUCCESS";
-  private static final String BUCKET_SIZE_KEY = "BUCKET_SIZE";
-  private static final String WRITE_LOCK_KEY = "WRITE_LOCK";
 
   // Populate list and map fields for content comparison
   private static final List<String> LIST_FIELD = ImmutableList.of("1", "2");
@@ -74,6 +70,10 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
     record.setListField(NAME_KEY, LIST_FIELD);
     record.setMapField(NAME_KEY, MAP_FIELD);
     Assert.assertTrue(_bucketDataAccessor.compressedBucketWrite(PATH, new HelixProperty(record)));
+
+    for (int i = 0; i < 10; i++) {
+      _bucketDataAccessor.compressedBucketWrite(PATH, new HelixProperty(record));
+    }
   }
 
   /**
@@ -89,42 +89,9 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
   }
 
   /**
-   * Do 10 writes and check that there are 5 versions of the data.
-   */
-  @Test(dependsOnMethods = "testCompressedBucketRead")
-  public void testManyWritesWithVersionCounts() throws IOException {
-    int bucketSize = 50 * 1024;
-    int numVersions = 5;
-    int expectedLastSuccessfulIndex = 4;
-    String path = PATH + "2";
-    ZNRecord record = new ZNRecord(NAME_KEY);
-    record.setSimpleField(NAME_KEY, NAME_KEY);
-    record.setListField(NAME_KEY, LIST_FIELD);
-    record.setMapField(NAME_KEY, MAP_FIELD);
-
-    BucketDataAccessor bucketDataAccessor =
-        new ZkBucketDataAccessor(ZK_ADDR, bucketSize, numVersions);
-    for (int i = 0; i < 10; i++) {
-      bucketDataAccessor.compressedBucketWrite(path, new HelixProperty(record));
-    }
-
-    // Check that there are numVersions number of children under path
-    List<String> children = _baseAccessor.getChildNames(path, AccessOption.PERSISTENT);
-    Assert.assertEquals(children.size(), numVersions);
-
-    // Check that last successful index is 4 (since we did 10 writes)
-    ZNRecord metadata = _baseAccessor.get(path, null, AccessOption.PERSISTENT);
-    Assert.assertEquals(metadata.getIntField(LAST_SUCCESS_KEY, -1), expectedLastSuccessfulIndex);
-
-    // Clean up
-    bucketDataAccessor.compressedBucketDelete(path);
-    bucketDataAccessor.disconnect();
-  }
-
-  /**
    * Write a HelixProperty with large number of entries using BucketDataAccessor and read it back.
    */
-  @Test(dependsOnMethods = "testManyWritesWithVersionCounts")
+  @Test(dependsOnMethods = "testCompressedBucketRead")
   public void testLargeWriteAndRead() throws IOException {
     String name = "largeResourceAssignment";
     HelixProperty property = createLargeHelixProperty(name, 100000);
@@ -144,71 +111,6 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
 
     // Check against the original HelixProperty
     Assert.assertEquals(readRecord, property);
-  }
-
-  /**
-   * Tests that each write cleans up previous bucketed data. This method writes some small amount of
-   * data and checks that the data buckets from the large write performed in the previous test
-   * method have been cleaned up.
-   * @throws IOException
-   */
-  @Test(dependsOnMethods = "testLargeWriteAndRead")
-  public void testCleanupBeforeWrite() throws IOException {
-    // Create a HelixProperty of a very small size with the same name as the large HelixProperty
-    // created from the previous method
-    String name = "largeResourceAssignment";
-    HelixProperty property = new HelixProperty(name);
-    property.getRecord().setIntField("Hi", 10);
-
-    // Get the bucket count from the write performed in the previous method
-    ZNRecord metadata = _baseAccessor.get("/" + name, null, AccessOption.PERSISTENT);
-    int origBucketSize = metadata.getIntField(BUCKET_SIZE_KEY, -1);
-
-    // Perform a write twice to overwrite both versions
-    _bucketDataAccessor.compressedBucketWrite("/" + name, property);
-    _bucketDataAccessor.compressedBucketWrite("/" + name, property);
-
-    // Check that the children count for version 0 (version for the large write) is 1
-    Assert.assertEquals(
-        _baseAccessor.getChildNames("/" + name + "/0", AccessOption.PERSISTENT).size(), 1);
-
-    // Clean up
-    _bucketDataAccessor.compressedBucketDelete("/" + name);
-  }
-
-  /**
-   * Test that no concurrent reads and writes are allowed by triggering multiple operations after
-   * creating an artificial lock.
-   * @throws IOException
-   */
-  @Test(dependsOnMethods = "testCleanupBeforeWrite")
-  public void testFailureToAcquireLock() throws Exception {
-    String name = "acquireLock";
-    // Use a large HelixProperty to simulate a write that keeps the lock for some time
-    HelixProperty property = createLargeHelixProperty(name, 100);
-
-    // Artificially create the ephemeral ZNode
-    _baseAccessor.create("/" + name + "/" + WRITE_LOCK_KEY, new ZNRecord(name),
-        AccessOption.EPHEMERAL);
-
-    // Test write
-    try {
-      _bucketDataAccessor.compressedBucketWrite("/" + name, property);
-      Assert.fail("Should fail due to an already-existing lock ZNode!");
-    } catch (HelixException e) {
-      // Expect an exception
-    }
-
-    // Test read
-    try {
-      _bucketDataAccessor.compressedBucketRead("/" + name, HelixProperty.class);
-      Assert.fail("Should fail due to an already-existing lock ZNode!");
-    } catch (HelixException e) {
-      // Expect an exception
-    }
-
-    // Clean up
-    _bucketDataAccessor.compressedBucketDelete("/" + name);
   }
 
   private HelixProperty createLargeHelixProperty(String name, int numEntries) {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #509 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This diff improves parallelism and throughput for ZkBucketDataAccessor. It implements the following ideas:
1. Optimistic Concurrency Control
2. Monotonically Increasing Version Number
3. Garbage Collection of Stale Metadata
4. TTL for stale metadata

### Tests

- [x] The following tests are written for this issue:

**TestZkBucketDataAccessor**

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Tests run: 1036, Failures: 2, Errors: 0, Skipped: 3, Time elapsed: 4,911.756 s <<< FAILURE! - in TestSuite
[ERROR] testEnableCompressionResource(org.apache.helix.integration.TestEnableCompression)  Time elapsed: 300.37 s  <<< FAILURE!
org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testEnableCompressionResource() didn't finish within the time-out 300000
	at org.apache.helix.integration.TestEnableCompression.testEnableCompressionResource(TestEnableCompression.java:107)

[ERROR] testTaskPerformanceMetrics(org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics)  Time elapsed: 5.274 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics.testTaskPerformanceMetrics(TestTaskPerformanceMetrics.java:119)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:107 » ThreadTimeout Method...
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:119 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1036, Failures: 2, Errors: 0, Skipped: 3
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE

------------------------

START testEnableCompressionResource at Thu Oct 10 16:36:01 PDT 2019
START TestEnableCompression_testEnableCompressionResource at Thu Oct 10 16:36:01 PDT 2019
true: ClusterStateVerifier$BestPossAndExtViewZkVerifier(TestEnableCompression_testEnableCompressionResource@localhost:2183): wait 16988ms to verify
compressed paths:[/TestEnableCompression_testEnableCompressionResource/EXTERNALVIEW/TestResource, /TestEnableCompression_testEnableCompressionResource/IDEALSTATES/TestResource]
END TestEnableCompression_testEnableCompressionResource at Thu Oct 10 16:36:20 PDT 2019
END testEnableCompressionResource at Thu Oct 10 16:36:20 PDT 2019, took: 18859ms.
START testTaskPerformanceMetrics at Thu Oct 10 16:36:25 PDT 2019
END testTaskPerformanceMetrics at Thu Oct 10 16:36:35 PDT 2019, took: 10288ms.
Shut down zookeeper at port 2183 in thread main
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.943 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS



### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

https://github.com/apache/helix/wiki/Concurrency-and-Parallelism-for-BucketDataAccessor

### Code Quality

- [x] My diff has been formatted using helix-style.xml

