### PR TITLE
Fix name typo for DataPropagationLatencyGuage.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientPathMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientPathMonitor.java
@@ -79,7 +79,7 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
     /*
      * The latency between a ZK data change happening in the server side and the client side getting notification.
      */
-    DataPropagationLatencyGuage
+    DataPropagationLatencyGauge
   }
 
   private SimpleDynamicMetric<Long> _readCounter;
@@ -140,7 +140,7 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
         new Histogram(
             new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
     _dataPropagationLatencyGauge =
-        new HistogramDynamicMetric(PredefinedMetricDomains.DataPropagationLatencyGuage.name(),
+        new HistogramDynamicMetric(PredefinedMetricDomains.DataPropagationLatencyGauge.name(),
             new Histogram(new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(),
                 TimeUnit.MILLISECONDS)));
   }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
@@ -298,7 +298,7 @@ public class TestRawZkClient extends ZkUnitTestBase {
     zkClient.process(new WatchedEvent(Watcher.Event.EventType.NodeDataChanged, null, TEST_PATH));
     Assert.assertTrue(callbackFinish.await(10, TimeUnit.SECONDS));
     Assert.assertTrue(
-        (long) beanServer.getAttribute(rootname, "DataPropagationLatencyGuage.Max") >= waitTime);
+        (long) beanServer.getAttribute(rootname, "DataPropagationLatencyGauge.Max") >= waitTime);
 
     _zkClient.delete(TEST_PATH);
   }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
@@ -141,15 +141,16 @@ public class TestZkClientMonitor {
     Assert.assertTrue(
         (long) _beanServer.getAttribute(instancesName, "WriteTotalLatencyCounter") >= 10);
 
-    monitor
-        .recordDataPropagationLatency("TEST/INSTANCES/node_1/CURRENTSTATES/session_1/Resource", 5);
-    Assert
-        .assertEquals((long) _beanServer.getAttribute(rootName, "DataPropagationLatencyGuage.Max"), 5);
+    monitor.recordDataPropagationLatency("TEST/INSTANCES/node_1/CURRENTSTATES/session_1/Resource",
+        5);
+    String dataPropagationLatencyGaugeAttr =
+        ZkClientPathMonitor.PredefinedMetricDomains.DataPropagationLatencyGauge.name() + ".Max";
+    Assert.assertEquals((long) _beanServer.getAttribute(rootName, dataPropagationLatencyGaugeAttr),
+        5);
     Assert.assertEquals(
-        (long) _beanServer.getAttribute(currentStateName, "DataPropagationLatencyGuage.Max"), 5);
-    Assert
-        .assertEquals((long) _beanServer.getAttribute(idealStateName, "DataPropagationLatencyGuage.Max"),
-            0);
+        (long) _beanServer.getAttribute(currentStateName, dataPropagationLatencyGaugeAttr), 5);
+    Assert.assertEquals(
+        (long) _beanServer.getAttribute(idealStateName, dataPropagationLatencyGaugeAttr), 0);
   }
 
   @Test
@@ -159,6 +160,8 @@ public class TestZkClientMonitor {
     final String TEST_TAG = "test_tag_x";
     final String TEST_KEY = "test_key_x";
     final String TEST_INSTANCE = "test_instance_x";
+    String dataPropagationLatencyGaugeAttr =
+        ZkClientPathMonitor.PredefinedMetricDomains.DataPropagationLatencyGauge.name() + ".Max";
 
     ZkClientMonitor monitor = new ZkClientMonitor(TEST_TAG, TEST_KEY, TEST_INSTANCE, false, null);
     monitor.register();
@@ -168,14 +171,14 @@ public class TestZkClientMonitor {
     monitor
         .recordDataPropagationLatency("TEST/INSTANCES/node_1/CURRENTSTATES/session_1/Resource", 5);
     Assert
-        .assertEquals((long) _beanServer.getAttribute(rootName, "DataPropagationLatencyGuage.Max"),
+        .assertEquals((long) _beanServer.getAttribute(rootName, dataPropagationLatencyGaugeAttr),
             5);
     // The reservoir length is 10 ms, so the prev max of 5 is not valid anymore.
     Thread.sleep(10);
     monitor
         .recordDataPropagationLatency("TEST/INSTANCES/node_1/CURRENTSTATES/session_1/Resource", 4);
     Assert
-        .assertEquals((long) _beanServer.getAttribute(rootName, "DataPropagationLatencyGuage.Max"),
+        .assertEquals((long) _beanServer.getAttribute(rootName, dataPropagationLatencyGaugeAttr),
             4);
   }
 }


### PR DESCRIPTION
### Issues

- [x]  My PR addresses the following Helix issues and references them in the PR title:
#513 

### Description

- [x]  Here are some details about my PR, including screenshots of any UI changes:
(Write a concise description including what, why, how)
Fix name typo so helix client/product has a clearer understanding of the metric name.

### Tests

- []  The following tests are written for this issue:
(List the names of added unit/integration tests)

- []  The following is the result of the "mvn test" command on the appropriate module:
(Copy & paste the result of "mvn test")

Tests all pass.

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestDisableResource.testDisableResourceInSemiAutoMode:107 expected:<true> but was:<false>
[ERROR]   TestRawZkClient.afterClass:67 » Zk org.apache.zookeeper.KeeperException$NotEmp...
[ERROR]   TestRawZkClient.testZkClientMonitor:301 NullPointer
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[ERROR]   TestZkClientMonitor.testCounter:147 NullPointer
[ERROR]   TestZkClientMonitor.testCustomizedResetInterval:171 NullPointer
[INFO]
[ERROR] Tests run: 883, Failures: 6, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  54:10 min
[INFO] Finished at: 2019-10-16T16:08:48-07:00

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.913 s - in org.apache.helix.integration.TestDisableResource
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12.251 s
[INFO] Finished at: 2019-10-16T22:16:30-07:00
[INFO] ------------------------------------------------------------------------

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 16.1 s - in org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  20.725 s
[INFO] Finished at: 2019-10-16T22:19:26-07:00

[INFO] Running org.apache.helix.monitoring.mbeans.TestZkClientMonitor
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.311 s - in org.apache.helix.monitoring.mbeans.TestZkClientMonitor
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.146 s
[INFO] Finished at: 2019-10-16T22:35:03-07:00

[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.792 s - in org.apache.helix.manager.zk.TestRawZkClient
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  22.981 s
[INFO] Finished at: 2019-10-16T22:36:33-07:00


### Commits

- [x]  My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "How to write a good git commit message":
Subject is separated from body by a blank line
Subject is limited to 50 characters (not including Jira issue reference)
Subject does not end with a period
Subject uses the imperative mood ("add", not "adding")
Body wraps at 72 characters
Body explains "what" and "why", not "how"
Documentation

  In case of new functionality, my PR adds documentation in the following wiki page:
(Link the GitHub wiki you added)

### Code Quality

- [x]  My diff has been formatted using helix-style-intellij.xml