### PR TITLE
The WAGED rebalancer returns the previously calculated assignment on calculation failure

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.helix.HelixConstants;
-import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.controller.changedetector.ResourceChangeDetector;
@@ -183,7 +182,7 @@ public class WagedRebalancer {
       LOG.error("The new assignment calculation fails.", ex);
       // Record the failure in metrics.
       CountMetric rebalanceFailureCount = _metricCollector.getMetric(
-          WagedRebalancerMetricCollector.WagedRebalancerMetricNames.RebalanceFailureCount.name(),
+          WagedRebalancerMetricCollector.WagedRebalancerMetricNames.RebalanceFailureCounter.name(),
           CountMetric.class);
       rebalanceFailureCount.increaseCount(1L);
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -509,18 +509,18 @@ public class WagedRebalancer {
             LatencyMetric.class);
         stateReadLatency.startMeasuringLatency();
         currentBaseline = assignmentMetadataStore.getBaseline();
-        currentBaseline.keySet().retainAll(resources);
         stateReadLatency.endMeasuringLatency();
-      } catch (HelixException ex) {
-        LOG.error("Failed to get the current baseline assignment. Use the current states instead.",
-            ex);
-        currentBaseline = getCurrentStateAssingment(currentStateOutput, resources);
       } catch (Exception ex) {
         throw new HelixRebalanceException(
             "Failed to get the current baseline assignment because of unexpected error.",
             HelixRebalanceException.Type.INVALID_REBALANCER_STATUS, ex);
       }
     }
+    if (currentBaseline.isEmpty()) {
+      LOG.warn("The current baseline assignment record is empty. Use the current states instead.");
+      currentBaseline = getCurrentStateAssingment(currentStateOutput, resources);
+    }
+    currentBaseline.keySet().retainAll(resources);
     return currentBaseline;
   }
 
@@ -543,19 +543,19 @@ public class WagedRebalancer {
             LatencyMetric.class);
         stateReadLatency.startMeasuringLatency();
         currentBestAssignment = assignmentMetadataStore.getBestPossibleAssignment();
-        currentBestAssignment.keySet().retainAll(resources);
         stateReadLatency.endMeasuringLatency();
-      } catch (HelixException ex) {
-        LOG.error(
-            "Failed to get the current best possible assignment. Use the current states instead.",
-            ex);
-        currentBestAssignment = getCurrentStateAssingment(currentStateOutput, resources);
       } catch (Exception ex) {
         throw new HelixRebalanceException(
             "Failed to get the current best possible assignment because of unexpected error.",
             HelixRebalanceException.Type.INVALID_REBALANCER_STATUS, ex);
       }
     }
+    if (currentBestAssignment.isEmpty()) {
+      LOG.warn(
+          "The current best possible assignment record is empty. Use the current states instead.");
+      currentBestAssignment = getCurrentStateAssingment(currentStateOutput, resources);
+    }
+    currentBestAssignment.keySet().retainAll(resources);
     return currentBestAssignment;
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -51,6 +51,7 @@ import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.monitoring.metrics.MetricCollector;
 import org.apache.helix.monitoring.metrics.WagedRebalancerMetricCollector;
+import org.apache.helix.monitoring.metrics.model.CountMetric;
 import org.apache.helix.monitoring.metrics.model.LatencyMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -174,9 +175,33 @@ public class WagedRebalancer {
     LOG.info("Start computing new ideal states for resources: {}", resourceMap.keySet().toString());
     validateInput(clusterData, resourceMap);
 
-    // Calculate the target assignment based on the current cluster status.
-    Map<String, IdealState> newIdealStates =
-        computeBestPossibleStates(clusterData, resourceMap, currentStateOutput);
+    Map<String, IdealState> newIdealStates;
+    try {
+      // Calculate the target assignment based on the current cluster status.
+      newIdealStates = computeBestPossibleStates(clusterData, resourceMap, currentStateOutput);
+    } catch (HelixRebalanceException ex) {
+      LOG.error("The new assignment calculation fails.", ex);
+      // Record the failure in metrics.
+      CountMetric rebalanceFailureCount = _metricCollector.getMetric(
+          WagedRebalancerMetricCollector.WagedRebalancerMetricNames.RebalanceFailureCount.name(),
+          CountMetric.class);
+      rebalanceFailureCount.increaseCount(1l);
+
+      HelixRebalanceException.Type failureType = ex.getFailureType();
+      if (failureType.equals(HelixRebalanceException.Type.INVALID_REBALANCER_STATUS) || failureType
+          .equals(HelixRebalanceException.Type.UNKNOWN_FAILURE)) {
+        throw ex;
+      }
+
+      // If the failure is because of cluster status input or calculating failure, return the previously calculated assignment.
+      LOG.warn("Trying to return the previously calculated assignment.");
+      // Note that don't return an assignment based on the current state if there is no previously
+      // calculated result in this fallback logic.
+      Map<String, ResourceAssignment> assignmentRecord =
+          getBestPossibleAssignment(_assignmentMetadataStore, new CurrentStateOutput(),
+              resourceMap.keySet());
+      newIdealStates = convertResourceAssignment(clusterData, assignmentRecord);
+    }
 
     // Construct the new best possible states according to the current state and target assignment.
     // Note that the new ideal state might be an intermediate state between the current state and
@@ -203,7 +228,7 @@ public class WagedRebalancer {
   }
 
   // Coordinate baseline recalculation and partial rebalance according to the cluster changes.
-  private Map<String, IdealState> computeBestPossibleStates(
+  protected Map<String, IdealState> computeBestPossibleStates(
       ResourceControllerDataProvider clusterData, Map<String, Resource> resourceMap,
       final CurrentStateOutput currentStateOutput) throws HelixRebalanceException {
     getChangeDetector().updateSnapshots(clusterData);
@@ -243,45 +268,58 @@ public class WagedRebalancer {
     Map<String, ResourceAssignment> newAssignment =
         partialRebalance(clusterData, clusterChanges, resourceMap, activeNodes, currentStateOutput);
 
-    // <ResourceName, <State, Priority>>
-    Map<String, Map<String, Integer>> resourceStatePriorityMap = new HashMap<>();
-    // Convert the assignments into IdealState for the following state mapping calculation.
-    Map<String, IdealState> finalIdealStateMap = new HashMap<>();
-    for (String resourceName : newAssignment.keySet()) {
-      IdealState newIdealState;
-      try {
-        IdealState currentIdealState = clusterData.getIdealState(resourceName);
-        Map<String, Integer> statePriorityMap = clusterData
-            .getStateModelDef(currentIdealState.getStateModelDefRef()).getStatePriorityMap();
-        // Keep the priority map for the rebalance overwrite logic later.
-        resourceStatePriorityMap.put(resourceName, statePriorityMap);
-        // Create a new IdealState instance contains the new calculated assignment in the preference
-        // list.
-        newIdealState = generateIdealStateWithAssignment(resourceName, currentIdealState,
-            newAssignment.get(resourceName), statePriorityMap);
-      } catch (Exception ex) {
-        throw new HelixRebalanceException(
-            "Fail to calculate the new IdealState for resource: " + resourceName,
-            HelixRebalanceException.Type.INVALID_CLUSTER_STATUS, ex);
-      }
-      finalIdealStateMap.put(resourceName, newIdealState);
-    }
+    Map<String, IdealState> finalIdealStateMap =
+        convertResourceAssignment(clusterData, newAssignment);
 
     // The additional rebalance overwrite is required since the calculated mapping may contains
     // some delayed rebalanced assignments.
     if (!activeNodes.equals(clusterData.getEnabledLiveInstances())) {
       applyRebalanceOverwrite(finalIdealStateMap, clusterData, resourceMap, clusterChanges,
-          resourceStatePriorityMap, getBaselineAssignment(_assignmentMetadataStore,
-              currentStateOutput, resourceMap.keySet()));
+          getBaselineAssignment(_assignmentMetadataStore, currentStateOutput,
+              resourceMap.keySet()));
     }
     // Replace the assignment if user-defined preference list is configured.
     // Note the user-defined list is intentionally applied to the final mapping after calculation.
     // This is to avoid persisting it into the assignment store, which impacts the long term
     // assignment evenness and partition movements.
-    finalIdealStateMap.entrySet().stream()
-        .forEach(idealStateEntry -> applyUserDefinedPreferenceList(
+    finalIdealStateMap.entrySet().stream().forEach(
+        idealStateEntry -> applyUserDefinedPreferenceList(
             clusterData.getResourceConfig(idealStateEntry.getKey()), idealStateEntry.getValue()));
 
+    return finalIdealStateMap;
+  }
+
+  /**
+   * Convert the resource assignment map into an IdealState map.
+   */
+  private Map<String, IdealState> convertResourceAssignment(
+      ResourceControllerDataProvider clusterData, Map<String, ResourceAssignment> assignments)
+      throws HelixRebalanceException {
+    // Convert the assignments into IdealState for the following state mapping calculation.
+    Map<String, IdealState> finalIdealStateMap = new HashMap<>();
+    for (String resourceName : assignments.keySet()) {
+      try {
+        IdealState currentIdealState = clusterData.getIdealState(resourceName);
+        Map<String, Integer> statePriorityMap =
+            clusterData.getStateModelDef(currentIdealState.getStateModelDefRef())
+                .getStatePriorityMap();
+        // Create a new IdealState instance contains the new calculated assignment in the preference
+        // list.
+        IdealState newIdealState = new IdealState(resourceName);
+        // Copy the simple fields
+        newIdealState.getRecord().setSimpleFields(currentIdealState.getRecord().getSimpleFields());
+        // Sort the preference list according to state priority.
+        newIdealState.setPreferenceLists(
+            getPreferenceLists(assignments.get(resourceName), statePriorityMap));
+        // Note the state mapping in the new assignment won't be directly propagate to the map fields.
+        // The rebalancer will calculate for the final state mapping considering the current states.
+        finalIdealStateMap.put(resourceName, newIdealState);
+      } catch (Exception ex) {
+        throw new HelixRebalanceException(
+            "Fail to calculate the new IdealState for resource: " + resourceName,
+            HelixRebalanceException.Type.INVALID_CLUSTER_STATUS, ex);
+      }
+    }
     return finalIdealStateMap;
   }
 
@@ -414,23 +452,6 @@ public class WagedRebalancer {
     return CHANGE_DETECTOR_THREAD_LOCAL.get();
   }
 
-  // Generate a new IdealState based on the input newAssignment.
-  // The assignment will be propagate to the preference lists.
-  // Note that we will recalculate the states based on the current state, so there is no need to
-  // update the mapping fields in the IdealState output.
-  private IdealState generateIdealStateWithAssignment(String resourceName,
-      IdealState currentIdealState, ResourceAssignment newAssignment,
-      Map<String, Integer> statePriorityMap) {
-    IdealState newIdealState = new IdealState(resourceName);
-    // Copy the simple fields
-    newIdealState.getRecord().setSimpleFields(currentIdealState.getRecord().getSimpleFields());
-    // Sort the preference list according to state priority.
-    newIdealState.setPreferenceLists(getPreferenceLists(newAssignment, statePriorityMap));
-    // Note the state mapping in the new assignment won't be directly propagate to the map fields.
-    // The rebalancer will calculate for the final state mapping considering the current states.
-    return newIdealState;
-  }
-
   // Generate the preference lists from the state mapping based on state priority.
   private Map<String, List<String>> getPreferenceLists(ResourceAssignment newAssignment,
       Map<String, Integer> statePriorityMap) {
@@ -487,19 +508,17 @@ public class WagedRebalancer {
             LatencyMetric.class);
         stateReadLatency.startMeasuringLatency();
         currentBaseline = assignmentMetadataStore.getBaseline();
+        currentBaseline.keySet().retainAll(resources);
         stateReadLatency.endMeasuringLatency();
       } catch (HelixException ex) {
-        // Report error. and use empty mapping instead.
-        LOG.error("Failed to get the current baseline assignment.", ex);
+        LOG.error("Failed to get the current baseline assignment. Use the current states instead.",
+            ex);
+        currentBaseline = getCurrentStateAssingment(currentStateOutput, resources);
       } catch (Exception ex) {
         throw new HelixRebalanceException(
             "Failed to get the current baseline assignment because of unexpected error.",
             HelixRebalanceException.Type.INVALID_REBALANCER_STATUS, ex);
       }
-    }
-    if (currentBaseline.isEmpty()) {
-      LOG.warn("The current baseline assignment record is empty. Use the current states instead.");
-      currentBaseline = getCurrentStateAssingment(currentStateOutput, resources);
     }
     return currentBaseline;
   }
@@ -523,20 +542,18 @@ public class WagedRebalancer {
             LatencyMetric.class);
         stateReadLatency.startMeasuringLatency();
         currentBestAssignment = assignmentMetadataStore.getBestPossibleAssignment();
+        currentBestAssignment.keySet().retainAll(resources);
         stateReadLatency.endMeasuringLatency();
       } catch (HelixException ex) {
-        // Report error. and use empty mapping instead.
-        LOG.error("Failed to get the current best possible assignment.", ex);
+        LOG.error(
+            "Failed to get the current best possible assignment. Use the current states instead.",
+            ex);
+        currentBestAssignment = getCurrentStateAssingment(currentStateOutput, resources);
       } catch (Exception ex) {
         throw new HelixRebalanceException(
             "Failed to get the current best possible assignment because of unexpected error.",
             HelixRebalanceException.Type.INVALID_REBALANCER_STATUS, ex);
       }
-    }
-    if (currentBestAssignment.isEmpty()) {
-      LOG.warn(
-          "The current best possible assignment record is empty. Use the current states instead.");
-      currentBestAssignment = getCurrentStateAssingment(currentStateOutput, resources);
     }
     return currentBestAssignment;
   }
@@ -593,37 +610,32 @@ public class WagedRebalancer {
    * @param clusterData the cluster data cache.
    * @param resourceMap the rebalanaced resource map.
    * @param clusterChanges the detected cluster changes that triggeres the rebalance.
-   * @param resourceStatePriorityMap the state priority map for each resource.
    * @param baseline the baseline assignment
    */
   private void applyRebalanceOverwrite(Map<String, IdealState> idealStateMap,
       ResourceControllerDataProvider clusterData, Map<String, Resource> resourceMap,
       Map<HelixConstants.ChangeType, Set<String>> clusterChanges,
-      Map<String, Map<String, Integer>> resourceStatePriorityMap,
       Map<String, ResourceAssignment> baseline) throws HelixRebalanceException {
     Set<String> enabledLiveInstances = clusterData.getEnabledLiveInstances();
     // Note that the calculation used the baseline as the input only. This is for minimizing
     // unnecessary partition movement.
-    Map<String, ResourceAssignment> activeAssignment = calculateAssignment(clusterData,
-        clusterChanges, resourceMap, enabledLiveInstances, Collections.emptyMap(), baseline);
+    Map<String, IdealState> activeIdealStates = convertResourceAssignment(clusterData,
+        calculateAssignment(clusterData, clusterChanges, resourceMap, enabledLiveInstances,
+            Collections.emptyMap(), baseline));
     for (String resourceName : idealStateMap.keySet()) {
       IdealState is = idealStateMap.get(resourceName);
-      if (!activeAssignment.containsKey(resourceName)) {
+      if (!activeIdealStates.containsKey(resourceName)) {
         throw new HelixRebalanceException(
             "Failed to calculate the complete partition assignment with all active nodes. Cannot find the resource assignment for "
-                + resourceName,
-            HelixRebalanceException.Type.FAILED_TO_CALCULATE);
+                + resourceName, HelixRebalanceException.Type.FAILED_TO_CALCULATE);
       }
+      IdealState newActiveIdealState = activeIdealStates.get(resourceName);
       IdealState currentIdealState = clusterData.getIdealState(resourceName);
-      IdealState newActiveIdealState =
-          generateIdealStateWithAssignment(resourceName, currentIdealState,
-              activeAssignment.get(resourceName), resourceStatePriorityMap.get(resourceName));
-
-      int numReplia = currentIdealState.getReplicaCount(enabledLiveInstances.size());
-      int minActiveReplica = DelayedRebalanceUtil.getMinActiveReplica(currentIdealState, numReplia);
-      Map<String, List<String>> finalPreferenceLists =
-          DelayedRebalanceUtil.getFinalDelayedMapping(newActiveIdealState.getPreferenceLists(),
-              is.getPreferenceLists(), enabledLiveInstances, Math.min(minActiveReplica, numReplia));
+      int numReplica = currentIdealState.getReplicaCount(enabledLiveInstances.size());
+      int minActiveReplica = DelayedRebalanceUtil.getMinActiveReplica(currentIdealState, numReplica);
+      Map<String, List<String>> finalPreferenceLists = DelayedRebalanceUtil
+          .getFinalDelayedMapping(newActiveIdealState.getPreferenceLists(), is.getPreferenceLists(),
+              enabledLiveInstances, Math.min(minActiveReplica, numReplica));
 
       is.setPreferenceLists(finalPreferenceLists);
     }
@@ -640,5 +652,9 @@ public class WagedRebalancer {
         }
       }
     }
+  }
+
+  protected MetricCollector getMetricCollector() {
+    return _metricCollector;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -179,7 +179,7 @@ public class WagedRebalancer {
       // Calculate the target assignment based on the current cluster status.
       newIdealStates = computeBestPossibleStates(clusterData, resourceMap, currentStateOutput);
     } catch (HelixRebalanceException ex) {
-      LOG.error("The new assignment calculation fails.", ex);
+      LOG.error("Failed to calculate the new assignments.", ex);
       // Record the failure in metrics.
       CountMetric rebalanceFailureCount = _metricCollector.getMetric(
           WagedRebalancerMetricCollector.WagedRebalancerMetricNames.RebalanceFailureCounter.name(),

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/SimpleDynamicMetric.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/SimpleDynamicMetric.java
@@ -25,7 +25,7 @@ package org.apache.helix.monitoring.mbeans.dynamicMBeans;
  * @param <T> the type of the metric value
  */
 public class SimpleDynamicMetric<T> extends DynamicMetric<T, T> {
-  private final String _metricName;
+  protected final String _metricName;
 
   /**
    * Instantiates a new Simple dynamic metric.

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/WagedRebalancerMetricCollector.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/WagedRebalancerMetricCollector.java
@@ -20,8 +20,11 @@ package org.apache.helix.monitoring.metrics;
  */
 
 import javax.management.JMException;
+
 import org.apache.helix.monitoring.mbeans.MonitorDomainNames;
+import org.apache.helix.monitoring.metrics.implementation.RebalanceFailureCount;
 import org.apache.helix.monitoring.metrics.implementation.RebalanceLatencyGauge;
+import org.apache.helix.monitoring.metrics.model.CountMetric;
 import org.apache.helix.monitoring.metrics.model.LatencyMetric;
 
 public class WagedRebalancerMetricCollector extends MetricCollector {
@@ -38,7 +41,11 @@ public class WagedRebalancerMetricCollector extends MetricCollector {
 
     // The following latency metrics are related to AssignmentMetadataStore
     StateReadLatencyGauge,
-    StateWriteLatencyGauge
+    StateWriteLatencyGauge,
+
+    // Count of any rebalance failure.
+    // Note the rebalancer may still be able to return an assignment based on the previous record on an error.
+    RebalanceFailureCount
   }
 
   public WagedRebalancerMetricCollector(String clusterName) throws JMException {
@@ -66,15 +73,20 @@ public class WagedRebalancerMetricCollector extends MetricCollector {
         WagedRebalancerMetricNames.GlobalBaselineCalcLatencyGauge.name(), getResetIntervalInMs());
     LatencyMetric partialRebalanceLatencyGauge = new RebalanceLatencyGauge(
         WagedRebalancerMetricNames.PartialRebalanceLatencyGauge.name(), getResetIntervalInMs());
-    LatencyMetric stateReadLatencyGauge = new RebalanceLatencyGauge(
-        WagedRebalancerMetricNames.StateReadLatencyGauge.name(), getResetIntervalInMs());
-    LatencyMetric stateWriteLatencyGauge = new RebalanceLatencyGauge(
-        WagedRebalancerMetricNames.StateWriteLatencyGauge.name(), getResetIntervalInMs());
+    LatencyMetric stateReadLatencyGauge =
+        new RebalanceLatencyGauge(WagedRebalancerMetricNames.StateReadLatencyGauge.name(),
+            getResetIntervalInMs());
+    LatencyMetric stateWriteLatencyGauge =
+        new RebalanceLatencyGauge(WagedRebalancerMetricNames.StateWriteLatencyGauge.name(),
+            getResetIntervalInMs());
+    CountMetric calcFailureCount =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.RebalanceFailureCount.name());
 
     // Add metrics to WagedRebalancerMetricCollector
     addMetric(globalBaselineCalcLatencyGauge);
     addMetric(partialRebalanceLatencyGauge);
     addMetric(stateReadLatencyGauge);
     addMetric(stateWriteLatencyGauge);
+    addMetric(calcFailureCount);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/WagedRebalancerMetricCollector.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/WagedRebalancerMetricCollector.java
@@ -44,8 +44,9 @@ public class WagedRebalancerMetricCollector extends MetricCollector {
     StateWriteLatencyGauge,
 
     // Count of any rebalance failure.
-    // Note the rebalancer may still be able to return an assignment based on the previous record on an error.
-    RebalanceFailureCount
+    // Note the rebalancer may still be able to return an assignment based on the previous record
+    // on an error.
+    RebalanceFailureCounter
   }
 
   public WagedRebalancerMetricCollector(String clusterName) throws JMException {
@@ -69,10 +70,12 @@ public class WagedRebalancerMetricCollector extends MetricCollector {
    */
   private void createMetrics() {
     // Define all metrics
-    LatencyMetric globalBaselineCalcLatencyGauge = new RebalanceLatencyGauge(
-        WagedRebalancerMetricNames.GlobalBaselineCalcLatencyGauge.name(), getResetIntervalInMs());
-    LatencyMetric partialRebalanceLatencyGauge = new RebalanceLatencyGauge(
-        WagedRebalancerMetricNames.PartialRebalanceLatencyGauge.name(), getResetIntervalInMs());
+    LatencyMetric globalBaselineCalcLatencyGauge =
+        new RebalanceLatencyGauge(WagedRebalancerMetricNames.GlobalBaselineCalcLatencyGauge.name(),
+            getResetIntervalInMs());
+    LatencyMetric partialRebalanceLatencyGauge =
+        new RebalanceLatencyGauge(WagedRebalancerMetricNames.PartialRebalanceLatencyGauge.name(),
+            getResetIntervalInMs());
     LatencyMetric stateReadLatencyGauge =
         new RebalanceLatencyGauge(WagedRebalancerMetricNames.StateReadLatencyGauge.name(),
             getResetIntervalInMs());
@@ -80,7 +83,7 @@ public class WagedRebalancerMetricCollector extends MetricCollector {
         new RebalanceLatencyGauge(WagedRebalancerMetricNames.StateWriteLatencyGauge.name(),
             getResetIntervalInMs());
     CountMetric calcFailureCount =
-        new RebalanceFailureCount(WagedRebalancerMetricNames.RebalanceFailureCount.name());
+        new RebalanceFailureCount(WagedRebalancerMetricNames.RebalanceFailureCounter.name());
 
     // Add metrics to WagedRebalancerMetricCollector
     addMetric(globalBaselineCalcLatencyGauge);

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/WagedRebalancerMetricCollector.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/WagedRebalancerMetricCollector.java
@@ -43,9 +43,9 @@ public class WagedRebalancerMetricCollector extends MetricCollector {
     StateReadLatencyGauge,
     StateWriteLatencyGauge,
 
-    // Count of any rebalance failure.
-    // Note the rebalancer may still be able to return an assignment based on the previous record
-    // on an error.
+    // Count of any rebalance compute failure.
+    // Note the rebalancer may still be able to return the last known-good assignment on a rebalance
+    // compute failure. And this fallback logic won't impact this counting.
     RebalanceFailureCounter
   }
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/implementation/RebalanceFailureCount.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/implementation/RebalanceFailureCount.java
@@ -1,0 +1,18 @@
+package org.apache.helix.monitoring.metrics.implementation;
+
+import org.apache.helix.monitoring.metrics.model.CountMetric;
+
+public class RebalanceFailureCount extends CountMetric {
+  /**
+   * Instantiates a new Simple dynamic metric.
+   *
+   * @param metricName the metric name
+   */
+  public RebalanceFailureCount(String metricName) {
+    super(metricName, 0l);
+  }
+
+  public void increaseCount(long count) {
+    updateValue(getValue() + count);
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/implementation/RebalanceFailureCount.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/implementation/RebalanceFailureCount.java
@@ -9,9 +9,10 @@ public class RebalanceFailureCount extends CountMetric {
    * @param metricName the metric name
    */
   public RebalanceFailureCount(String metricName) {
-    super(metricName, 0l);
+    super(metricName, 0L);
   }
 
+  @Override
   public void increaseCount(long count) {
     updateValue(getValue() + count);
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/implementation/RebalanceLatencyGauge.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/implementation/RebalanceLatencyGauge.java
@@ -48,7 +48,6 @@ public class RebalanceLatencyGauge extends LatencyMetric {
    * the rebalancer could fail at any point, and we want it to recover gracefully by resetting the
    * internal state of this metric.
    */
-  @Override
   public void startMeasuringLatency() {
     reset();
     _startTime = System.currentTimeMillis();
@@ -57,7 +56,6 @@ public class RebalanceLatencyGauge extends LatencyMetric {
   /**
    * WARNING: this method is not thread-safe.
    */
-  @Override
   public void endMeasuringLatency() {
     if (_startTime == VALUE_NOT_SET || _endTime != VALUE_NOT_SET) {
       LOG.error(
@@ -72,33 +70,19 @@ public class RebalanceLatencyGauge extends LatencyMetric {
     reset();
   }
 
-  @Override
-  public String getMetricName() {
-    return _metricName;
-  }
-
-  @Override
-  public void reset() {
-    _startTime = VALUE_NOT_SET;
-    _endTime = VALUE_NOT_SET;
-  }
-
-  @Override
-  public String toString() {
-    return String.format("Metric %s's latency is %d", _metricName, getLastEmittedMetricValue());
-  }
-
   /**
    * Returns the most recently emitted metric value at the time of the call.
    * @return
    */
-  @Override
   public long getLastEmittedMetricValue() {
     return _lastEmittedMetricValue;
   }
 
-  @Override
-  public DynamicMetric getDynamicMetric() {
-    return this;
+  /**
+   * Resets the internal state of this metric.
+   */
+  private void reset() {
+    _startTime = VALUE_NOT_SET;
+    _endTime = VALUE_NOT_SET;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/implementation/RebalanceLatencyGauge.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/implementation/RebalanceLatencyGauge.java
@@ -22,7 +22,6 @@ package org.apache.helix.monitoring.metrics.implementation;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
 import java.util.concurrent.TimeUnit;
-import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.metrics.model.LatencyMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +47,7 @@ public class RebalanceLatencyGauge extends LatencyMetric {
    * the rebalancer could fail at any point, and we want it to recover gracefully by resetting the
    * internal state of this metric.
    */
+  @Override
   public void startMeasuringLatency() {
     reset();
     _startTime = System.currentTimeMillis();
@@ -56,6 +56,7 @@ public class RebalanceLatencyGauge extends LatencyMetric {
   /**
    * WARNING: this method is not thread-safe.
    */
+  @Override
   public void endMeasuringLatency() {
     if (_startTime == VALUE_NOT_SET || _endTime != VALUE_NOT_SET) {
       LOG.error(
@@ -74,6 +75,7 @@ public class RebalanceLatencyGauge extends LatencyMetric {
    * Returns the most recently emitted metric value at the time of the call.
    * @return
    */
+  @Override
   public long getLastEmittedMetricValue() {
     return _lastEmittedMetricValue;
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/model/CountMetric.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/model/CountMetric.java
@@ -19,23 +19,46 @@ package org.apache.helix.monitoring.metrics.model;
  * under the License.
  */
 
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
 
 /**
  * Represents a count metric and defines methods to help with calculation. A count metric gives a
  * gauge value of a certain property.
  */
-public abstract class CountMetric<V> extends SimpleDynamicMetric<V> implements Metric {
-  protected V _count;
+public abstract class CountMetric extends SimpleDynamicMetric<Long> implements Metric {
 
   /**
-   * Instantiates a new Simple dynamic metric.
+   * Instantiates a new count metric.
+   *
    * @param metricName the metric name
-   * @param metricObject the metric object
+   * @param initCount the initial count
    */
-  public CountMetric(String metricName, V metricObject) {
-    super(metricName, metricObject);
+  public CountMetric(String metricName, long initCount) {
+    super(metricName, initCount);
   }
 
-  public abstract void setCount(Object count);
+  /**
+   * Increment the metric by the input count.
+   *
+   * @param count
+   */
+  public abstract void increaseCount(long count);
+
+  public String getMetricName() {
+    return _metricName;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Metric %s's count is %d", getMetricName(), getValue());
+  }
+
+  public long getLastEmittedMetricValue() {
+    return getValue();
+  }
+
+  public DynamicMetric getDynamicMetric() {
+    return this;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/model/CountMetric.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/model/CountMetric.java
@@ -45,6 +45,7 @@ public abstract class CountMetric extends SimpleDynamicMetric<Long> implements M
    */
   public abstract void increaseCount(long count);
 
+  @Override
   public String getMetricName() {
     return _metricName;
   }
@@ -54,10 +55,12 @@ public abstract class CountMetric extends SimpleDynamicMetric<Long> implements M
     return String.format("Metric %s's count is %d", getMetricName(), getValue());
   }
 
+  @Override
   public long getLastEmittedMetricValue() {
     return getValue();
   }
 
+  @Override
   public DynamicMetric getDynamicMetric() {
     return this;
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/model/LatencyMetric.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/model/LatencyMetric.java
@@ -52,6 +52,7 @@ public abstract class LatencyMetric extends HistogramDynamicMetric implements Me
    */
   public abstract void endMeasuringLatency();
 
+  @Override
   public String getMetricName() {
     return _metricName;
   }
@@ -61,6 +62,7 @@ public abstract class LatencyMetric extends HistogramDynamicMetric implements Me
     return String.format("Metric %s's latency is %d", getMetricName(), getLastEmittedMetricValue());
   }
 
+  @Override
   public DynamicMetric getDynamicMetric() {
     return this;
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/model/LatencyMetric.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/model/LatencyMetric.java
@@ -20,6 +20,7 @@ package org.apache.helix.monitoring.metrics.model;
  */
 
 import com.codahale.metrics.Histogram;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
 import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 
 /**
@@ -38,6 +39,7 @@ public abstract class LatencyMetric extends HistogramDynamicMetric implements Me
    */
   public LatencyMetric(String metricName, Histogram metricObject) {
     super(metricName, metricObject);
+    _metricName = metricName;
   }
 
   /**
@@ -49,4 +51,17 @@ public abstract class LatencyMetric extends HistogramDynamicMetric implements Me
    * Ends measuring the latency.
    */
   public abstract void endMeasuringLatency();
+
+  public String getMetricName() {
+    return _metricName;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Metric %s's latency is %d", getMetricName(), getLastEmittedMetricValue());
+  }
+
+  public DynamicMetric getDynamicMetric() {
+    return this;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/model/Metric.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/model/Metric.java
@@ -32,11 +32,6 @@ public interface Metric {
   String getMetricName();
 
   /**
-   * Resets the internal state of this metric.
-   */
-  void reset();
-
-  /**
    * Prints the metric along with its name.
    */
   String toString();

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -265,7 +265,8 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
           "Failed to generate cluster model. Failure Type: INVALID_CLUSTER_STATUS");
     }
 
-    // The rebalance will be done with empty mapping result since there is no previously calculated assignment.
+    // The rebalance will be done with empty mapping result since there is no previously calculated
+    // assignment.
     Assert.assertTrue(
         rebalancer.computeNewIdealStates(clusterData, resourceMap, new CurrentStateOutput())
             .isEmpty());
@@ -327,13 +328,14 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
       Assert.assertEquals(ex.getFailureType(), HelixRebalanceException.Type.FAILED_TO_CALCULATE);
       Assert.assertEquals(ex.getMessage(), "Algorithm fails. Failure Type: FAILED_TO_CALCULATE");
     }
-    // But if call with the public method computeNewIdealStates(), the rebalance will return with the previous rebalance result.
+    // But if call with the public method computeNewIdealStates(), the rebalance will return with
+    // the previous rebalance result.
     Map<String, IdealState> newResult =
         rebalancer.computeNewIdealStates(clusterData, resourceMap, new CurrentStateOutput());
     Assert.assertEquals(newResult, result);
     // Ensure failure has been recorded
     Assert.assertEquals(rebalancer.getMetricCollector().getMetric(
-        WagedRebalancerMetricCollector.WagedRebalancerMetricNames.RebalanceFailureCount.name(),
+        WagedRebalancerMetricCollector.WagedRebalancerMetricNames.RebalanceFailureCounter.name(),
         CountMetric.class).getValue().longValue(), 1l);
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestDelayedWagedRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestDelayedWagedRebalance.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.helix.TestHelper;
 import org.apache.helix.integration.rebalancer.DelayedAutoRebalancer.TestDelayedAutoRebalance;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.tools.ClusterVerifiers.StrictMatchExternalViewVerifier;
@@ -39,7 +40,7 @@ public class TestDelayedWagedRebalance extends TestDelayedAutoRebalance {
     Set<String> dbNames = new HashSet<>();
     int i = 0;
     for (String stateModel : TestStateModels) {
-      dbNames.add("Test-DB-" + i++);
+      dbNames.add("Test-DB-" + TestHelper.getTestMethodName() + i++);
     }
     return new StrictMatchExternalViewVerifier.Builder(CLUSTER_NAME).setResources(dbNames)
         .setDeactivatedNodeAwareness(true).setZkAddr(ZK_ADDR).build();
@@ -47,10 +48,10 @@ public class TestDelayedWagedRebalance extends TestDelayedAutoRebalance {
 
   // create test DBs, wait it converged and return externalviews
   protected Map<String, ExternalView> createTestDBs(long delayTime) throws InterruptedException {
-    Map<String, ExternalView> externalViews = new HashMap<String, ExternalView>();
+    Map<String, ExternalView> externalViews = new HashMap<>();
     int i = 0;
     for (String stateModel : TestStateModels) {
-      String db = "Test-DB-" + i++;
+      String db = "Test-DB-" + TestHelper.getTestMethodName() + i++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
           _minActiveReplica);
       _testDBs.add(db);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestDelayedWagedRebalanceWithDisabledInstance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestDelayedWagedRebalanceWithDisabledInstance.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.helix.TestHelper;
 import org.apache.helix.integration.rebalancer.DelayedAutoRebalancer.TestDelayedAutoRebalanceWithDisabledInstance;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.tools.ClusterVerifiers.StrictMatchExternalViewVerifier;
@@ -40,7 +41,7 @@ public class TestDelayedWagedRebalanceWithDisabledInstance
     Set<String> dbNames = new HashSet<>();
     int i = 0;
     for (String stateModel : TestStateModels) {
-      dbNames.add("Test-DB-" + i++);
+      dbNames.add("Test-DB-" + TestHelper.getTestMethodName() + i++);
     }
     return new StrictMatchExternalViewVerifier.Builder(CLUSTER_NAME).setResources(dbNames)
         .setDeactivatedNodeAwareness(true).setZkAddr(ZK_ADDR).build();
@@ -48,10 +49,10 @@ public class TestDelayedWagedRebalanceWithDisabledInstance
 
   // create test DBs, wait it converged and return externalviews
   protected Map<String, ExternalView> createTestDBs(long delayTime) throws InterruptedException {
-    Map<String, ExternalView> externalViews = new HashMap<String, ExternalView>();
+    Map<String, ExternalView> externalViews = new HashMap<>();
     int i = 0;
     for (String stateModel : TestStateModels) {
-      String db = "Test-DB-" + i++;
+      String db = "Test-DB-" + TestHelper.getTestMethodName() + i++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
           _minActiveReplica);
       _testDBs.add(db);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestDelayedWagedRebalanceWithRackaware.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestDelayedWagedRebalanceWithRackaware.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.helix.TestHelper;
 import org.apache.helix.integration.rebalancer.DelayedAutoRebalancer.TestDelayedAutoRebalanceWithRackaware;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.tools.ClusterVerifiers.StrictMatchExternalViewVerifier;
@@ -39,7 +40,7 @@ public class TestDelayedWagedRebalanceWithRackaware extends TestDelayedAutoRebal
     Set<String> dbNames = new HashSet<>();
     int i = 0;
     for (String stateModel : TestStateModels) {
-      dbNames.add("Test-DB-" + i++);
+      dbNames.add("Test-DB-" + TestHelper.getTestMethodName() + i++);
     }
     return new StrictMatchExternalViewVerifier.Builder(CLUSTER_NAME).setResources(dbNames)
         .setDeactivatedNodeAwareness(true).setZkAddr(ZK_ADDR).build();
@@ -47,10 +48,10 @@ public class TestDelayedWagedRebalanceWithRackaware extends TestDelayedAutoRebal
 
   // create test DBs, wait it converged and return externalviews
   protected Map<String, ExternalView> createTestDBs(long delayTime) throws InterruptedException {
-    Map<String, ExternalView> externalViews = new HashMap<String, ExternalView>();
+    Map<String, ExternalView> externalViews = new HashMap<>();
     int i = 0;
     for (String stateModel : TestStateModels) {
-      String db = "Test-DB-" + i++;
+      String db = "Test-DB-" + TestHelper.getTestMethodName() + i++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
           _minActiveReplica);
       _testDBs.add(db);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
@@ -383,7 +383,8 @@ public class TestWagedRebalance extends ZkTestBase {
       configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
       Thread.sleep(300);
 
-      // Since the WAGED rebalancer does not partial rebalance, the assignment won't show even removed cluster level restriction
+      // Since the WAGED rebalancer does not partial rebalance, the assignment won't show even
+      // removed cluster level restriction
       Assert.assertFalse(TestHelper.verify(() -> _allDBs.stream().anyMatch(db -> {
         ExternalView ev =
             _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
@@ -108,7 +108,7 @@ public class TestWagedRebalance extends ZkTestBase {
   public void test() throws Exception {
     int i = 0;
     for (String stateModel : _testModels) {
-      String db = "Test-DB-" + i++;
+      String db = "Test-DB-test" + i++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica, _replica);
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
@@ -148,7 +148,7 @@ public class TestWagedRebalance extends ZkTestBase {
     Set<String> tags = new HashSet<String>(_nodeToTagMap.values());
     int i = 3;
     for (String tag : tags) {
-      String db = "Test-DB-" + i++;
+      String db = "Test-DB-testWithInstanceTag" + i++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db,
           BuiltInStateModelDefinitions.MasterSlave.name(), PARTITIONS, _replica, _replica);
       IdealState is =
@@ -164,7 +164,7 @@ public class TestWagedRebalance extends ZkTestBase {
 
   @Test(dependsOnMethods = "test")
   public void testChangeIdealState() throws InterruptedException {
-    String dbName = "Test-DB";
+    String dbName = "Test-DB-testChangeIdealState";
     createResourceWithWagedRebalance(CLUSTER_NAME, dbName,
         BuiltInStateModelDefinitions.MasterSlave.name(), PARTITIONS, _replica, _replica);
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, dbName, _replica);
@@ -198,7 +198,7 @@ public class TestWagedRebalance extends ZkTestBase {
 
   @Test(dependsOnMethods = "test")
   public void testDisableInstance() throws InterruptedException {
-    String dbName = "Test-DB";
+    String dbName = "Test-DB-testDisableInstance";
     createResourceWithWagedRebalance(CLUSTER_NAME, dbName,
         BuiltInStateModelDefinitions.MasterSlave.name(), PARTITIONS, _replica, _replica);
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, dbName, _replica);
@@ -254,7 +254,7 @@ public class TestWagedRebalance extends ZkTestBase {
 
     int j = 0;
     for (String stateModel : _testModels) {
-      String db = "Test-DB-" + j++;
+      String db = "Test-DB-testLackEnoughLiveInstances" + j++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
           _replica);
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
@@ -293,7 +293,7 @@ public class TestWagedRebalance extends ZkTestBase {
 
     int j = 0;
     for (String stateModel : _testModels) {
-      String db = "Test-DB-" + j++;
+      String db = "Test-DB-testLackEnoughInstances" + j++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
           _replica);
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
@@ -324,7 +324,7 @@ public class TestWagedRebalance extends ZkTestBase {
   public void testMixedRebalancerUsage() throws InterruptedException {
     int i = 0;
     for (String stateModel : _testModels) {
-      String db = "Test-DB-" + i++;
+      String db = "Test-DB-testMixedRebalancerUsage" + i++;
       if (i == 0) {
         _gSetupTool.addResourceToCluster(CLUSTER_NAME, db, PARTITIONS, stateModel,
             IdealState.RebalanceMode.FULL_AUTO + "", CrushRebalanceStrategy.class.getName());
@@ -354,12 +354,12 @@ public class TestWagedRebalance extends ZkTestBase {
       String limitedResourceName = null;
       int i = 0;
       for (String stateModel : _testModels) {
-        String db = "Test-DB-" + i++;
+        String db = "Test-DB-testMaxPartitionLimitation-" + i++;
         createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
             _replica);
         if (i == 1) {
           // The limited resource has additional limitation, so even the other resources can be assigned
-          // later, this resource will still be blocked by the max partition limitation.
+          // later in theory, this resource will still be blocked by the max partition limitation.
           limitedResourceName = db;
           IdealState idealState =
               _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
@@ -371,8 +371,8 @@ public class TestWagedRebalance extends ZkTestBase {
       }
       Thread.sleep(300);
 
-      // Since the WAGED rebalancer does not do partial rebalance, the initial assignment won't show.
-      Assert.assertFalse(TestHelper.verify(() -> _allDBs.stream().allMatch(db -> {
+      // Since the WAGED rebalancer does not partial rebalance, the initial assignment won't show.
+      Assert.assertFalse(TestHelper.verify(() -> _allDBs.stream().anyMatch(db -> {
         ExternalView ev =
             _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
         return ev != null && !ev.getPartitionSet().isEmpty();
@@ -383,20 +383,12 @@ public class TestWagedRebalance extends ZkTestBase {
       configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
       Thread.sleep(300);
 
-      // wait until any of the resources is rebalanced
-      TestHelper.verify(() -> {
-        for (String db : _allDBs) {
-          ExternalView ev =
-              _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
-          if (ev != null && !ev.getPartitionSet().isEmpty()) {
-            return true;
-          }
-        }
-        return false;
-      }, 3000);
-      ExternalView ev = _gSetupTool.getClusterManagementTool()
-          .getResourceExternalView(CLUSTER_NAME, limitedResourceName);
-      Assert.assertFalse(ev != null && !ev.getPartitionSet().isEmpty());
+      // Since the WAGED rebalancer does not partial rebalance, the assignment won't show even removed cluster level restriction
+      Assert.assertFalse(TestHelper.verify(() -> _allDBs.stream().anyMatch(db -> {
+        ExternalView ev =
+            _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
+        return ev != null && !ev.getPartitionSet().isEmpty();
+      }), 2000));
 
       // Remove the resource level limitation
       IdealState idealState = _gSetupTool.getClusterManagementTool()

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
@@ -108,7 +108,7 @@ public class TestWagedRebalance extends ZkTestBase {
   public void test() throws Exception {
     int i = 0;
     for (String stateModel : _testModels) {
-      String db = "Test-DB-test" + i++;
+      String db = "Test-DB-" + TestHelper.getTestMethodName() + i++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica, _replica);
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
@@ -148,7 +148,7 @@ public class TestWagedRebalance extends ZkTestBase {
     Set<String> tags = new HashSet<String>(_nodeToTagMap.values());
     int i = 3;
     for (String tag : tags) {
-      String db = "Test-DB-testWithInstanceTag" + i++;
+      String db = "Test-DB-" + TestHelper.getTestMethodName() + i++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db,
           BuiltInStateModelDefinitions.MasterSlave.name(), PARTITIONS, _replica, _replica);
       IdealState is =
@@ -164,7 +164,7 @@ public class TestWagedRebalance extends ZkTestBase {
 
   @Test(dependsOnMethods = "test")
   public void testChangeIdealState() throws InterruptedException {
-    String dbName = "Test-DB-testChangeIdealState";
+    String dbName = "Test-DB-" + TestHelper.getTestMethodName();
     createResourceWithWagedRebalance(CLUSTER_NAME, dbName,
         BuiltInStateModelDefinitions.MasterSlave.name(), PARTITIONS, _replica, _replica);
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, dbName, _replica);
@@ -198,7 +198,7 @@ public class TestWagedRebalance extends ZkTestBase {
 
   @Test(dependsOnMethods = "test")
   public void testDisableInstance() throws InterruptedException {
-    String dbName = "Test-DB-testDisableInstance";
+    String dbName = "Test-DB-" + TestHelper.getTestMethodName();
     createResourceWithWagedRebalance(CLUSTER_NAME, dbName,
         BuiltInStateModelDefinitions.MasterSlave.name(), PARTITIONS, _replica, _replica);
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, dbName, _replica);
@@ -254,7 +254,7 @@ public class TestWagedRebalance extends ZkTestBase {
 
     int j = 0;
     for (String stateModel : _testModels) {
-      String db = "Test-DB-testLackEnoughLiveInstances" + j++;
+      String db = "Test-DB-" + TestHelper.getTestMethodName() + j++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
           _replica);
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
@@ -293,7 +293,7 @@ public class TestWagedRebalance extends ZkTestBase {
 
     int j = 0;
     for (String stateModel : _testModels) {
-      String db = "Test-DB-testLackEnoughInstances" + j++;
+      String db = "Test-DB-" + TestHelper.getTestMethodName() + j++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
           _replica);
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
@@ -324,7 +324,7 @@ public class TestWagedRebalance extends ZkTestBase {
   public void testMixedRebalancerUsage() throws InterruptedException {
     int i = 0;
     for (String stateModel : _testModels) {
-      String db = "Test-DB-testMixedRebalancerUsage" + i++;
+      String db = "Test-DB-" + TestHelper.getTestMethodName() + i++;
       if (i == 0) {
         _gSetupTool.addResourceToCluster(CLUSTER_NAME, db, PARTITIONS, stateModel,
             IdealState.RebalanceMode.FULL_AUTO + "", CrushRebalanceStrategy.class.getName());
@@ -354,12 +354,14 @@ public class TestWagedRebalance extends ZkTestBase {
       String limitedResourceName = null;
       int i = 0;
       for (String stateModel : _testModels) {
-        String db = "Test-DB-testMaxPartitionLimitation-" + i++;
+        String db = "Test-DB-" + TestHelper.getTestMethodName() + i++;
         createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
             _replica);
         if (i == 1) {
-          // The limited resource has additional limitation, so even the other resources can be assigned
-          // later in theory, this resource will still be blocked by the max partition limitation.
+          // The limited resource has additional limitation.
+          // The other resources could have been assigned in theory if the WAGED rebalancer were
+          // not used.
+          // However, with the WAGED rebalancer, this restricted resource will block the other ones.
           limitedResourceName = db;
           IdealState idealState =
               _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
@@ -371,7 +373,8 @@ public class TestWagedRebalance extends ZkTestBase {
       }
       Thread.sleep(300);
 
-      // Since the WAGED rebalancer does not partial rebalance, the initial assignment won't show.
+      // Since the WAGED rebalancer need to finish rebalancing every resources, the initial
+      // assignment won't show.
       Assert.assertFalse(TestHelper.verify(() -> _allDBs.stream().anyMatch(db -> {
         ExternalView ev =
             _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
@@ -383,8 +386,8 @@ public class TestWagedRebalance extends ZkTestBase {
       configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
       Thread.sleep(300);
 
-      // Since the WAGED rebalancer does not partial rebalance, the assignment won't show even
-      // removed cluster level restriction
+      // Since the WAGED rebalancer need to finish rebalancing every resources, the assignment won't
+      // show even removed cluster level restriction
       Assert.assertFalse(TestHelper.verify(() -> _allDBs.stream().anyMatch(db -> {
         ExternalView ev =
             _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalanceFaultZone.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalanceFaultZone.java
@@ -110,7 +110,7 @@ public class TestWagedRebalanceFaultZone extends ZkTestBase {
   public void testZoneIsolation() throws Exception {
     int i = 0;
     for (String stateModel : _testModels) {
-      String db = "Test-DB-" + i++;
+      String db = "Test-DB-testZoneIsolation" + i++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
           _replica);
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
@@ -126,7 +126,7 @@ public class TestWagedRebalanceFaultZone extends ZkTestBase {
     Set<String> tags = new HashSet<String>(_nodeToTagMap.values());
     int i = 0;
     for (String tag : tags) {
-      String db = "Test-DB-" + i++;
+      String db = "Test-DB-testZoneIsolationWithInstanceTag" + i++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db,
           BuiltInStateModelDefinitions.MasterSlave.name(), PARTITIONS, _replica, _replica);
       IdealState is =
@@ -154,7 +154,7 @@ public class TestWagedRebalanceFaultZone extends ZkTestBase {
 
     int j = 0;
     for (String stateModel : _testModels) {
-      String db = "Test-DB-" + j++;
+      String db = "Test-DB-testLackEnoughLiveRacks" + j++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
           _replica);
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
@@ -196,7 +196,7 @@ public class TestWagedRebalanceFaultZone extends ZkTestBase {
 
     int j = 0;
     for (String stateModel : _testModels) {
-      String db = "Test-DB-" + j++;
+      String db = "Test-DB-testLackEnoughRacks" + j++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
           _replica);
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
@@ -228,7 +228,7 @@ public class TestWagedRebalanceFaultZone extends ZkTestBase {
   public void testAddZone() throws Exception {
     int i = 0;
     for (String stateModel : _testModels) {
-      String db = "Test-DB-" + i++;
+      String db = "Test-DB-testAddZone" + i++;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
           _replica);
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#507 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The WAGED rebalancer returns the previously calculated assignment on calculation failure
This is to protect the cluster assignment on a rebalancing algorithm failure. For example, the cluster is out of capacity. In this case, the rebalancer will keep using the previously calculated mapping.
Also, add the RebalanceFailureCount metric for recording the failures.

### Tests

- [x] The following tests are written for this issue:

New test cases to TestWagedRebalancer

- [x] The following is the result of the "mvn test" command on the appropriate module:
[ERROR] Failures: 
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[ERROR]   TestDeleteJobFromJobQueue.testForceDeleteJobFromJobQueue:75 » Helix Failed to ...
[ERROR]   TestTaskRebalancer.timeouts:199 expected:<true> but was:<false>
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[ERROR]   TestGetLastScheduledTaskExecInfo.testGetLastScheduledTaskExecInfo:73 expected:<COMPLETED> but was:<INIT>
[INFO] 
[ERROR] Tests run: 1044, Failures: 5, Errors: 0, Skipped: 4
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------

Re-run
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 58.973 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

NA

### Code Quality

- [x] My diff has been formatted using helix-style.xml


