### PR TITLE
Add typoed name DataPropagationLatencyGuage as deprecated

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientPathMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientPathMonitor.java
@@ -102,6 +102,12 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
   private HistogramDynamicMetric _readBytesGauge;
   private HistogramDynamicMetric _writeBytesGauge;
   private HistogramDynamicMetric _dataPropagationLatencyGauge;
+
+  /**
+   * @deprecated
+   * Keep it for backward-compatibility purpose.
+   */
+  @Deprecated
   private HistogramDynamicMetric _dataPropagationLatencyGuage;
 
   @Override
@@ -150,10 +156,12 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
         new HistogramDynamicMetric(PredefinedMetricDomains.DataPropagationLatencyGauge.name(),
             new Histogram(new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(),
                 TimeUnit.MILLISECONDS)));
+
+    // This is deprecated and keep it for backward-compatibility purpose.
     _dataPropagationLatencyGuage =
         new HistogramDynamicMetric(PredefinedMetricDomains.DataPropagationLatencyGuage.name(),
-        new Histogram(new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(),
-            TimeUnit.MILLISECONDS)));
+            new Histogram(new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(),
+                TimeUnit.MILLISECONDS)));
   }
 
   public ZkClientPathMonitor register() throws JMException {
@@ -171,6 +179,7 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
     attributeList.add(_readBytesGauge);
     attributeList.add(_writeBytesGauge);
     attributeList.add(_dataPropagationLatencyGauge);
+    // This is deprecated and keep it for backward-compatibility purpose.
     attributeList.add(_dataPropagationLatencyGuage);
 
     ObjectName objectName = new ObjectName(String

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientPathMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ZkClientPathMonitor.java
@@ -77,9 +77,15 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
     ReadBytesGauge,
     WriteBytesGauge,
     /*
-     * The latency between a ZK data change happening in the server side and the client side getting notification.
+     * The latency between a ZK data change happening on the server side and the client side.
      */
-    DataPropagationLatencyGauge
+    DataPropagationLatencyGauge,
+    /**
+     * @deprecated
+     * This domain name has a typo. Keep it in case its historical metric data is being used.
+     */
+    @Deprecated
+    DataPropagationLatencyGuage
   }
 
   private SimpleDynamicMetric<Long> _readCounter;
@@ -96,6 +102,7 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
   private HistogramDynamicMetric _readBytesGauge;
   private HistogramDynamicMetric _writeBytesGauge;
   private HistogramDynamicMetric _dataPropagationLatencyGauge;
+  private HistogramDynamicMetric _dataPropagationLatencyGuage;
 
   @Override
   public String getSensorName() {
@@ -143,6 +150,10 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
         new HistogramDynamicMetric(PredefinedMetricDomains.DataPropagationLatencyGauge.name(),
             new Histogram(new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(),
                 TimeUnit.MILLISECONDS)));
+    _dataPropagationLatencyGuage =
+        new HistogramDynamicMetric(PredefinedMetricDomains.DataPropagationLatencyGuage.name(),
+        new Histogram(new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(),
+            TimeUnit.MILLISECONDS)));
   }
 
   public ZkClientPathMonitor register() throws JMException {
@@ -160,6 +171,7 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
     attributeList.add(_readBytesGauge);
     attributeList.add(_writeBytesGauge);
     attributeList.add(_dataPropagationLatencyGauge);
+    attributeList.add(_dataPropagationLatencyGuage);
 
     ObjectName objectName = new ObjectName(String
         .format("%s,%s=%s", ZkClientMonitor.getObjectName(_type, _key, _instanceName).toString(),
@@ -184,6 +196,7 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
 
   public void recordDataPropagationLatency(long latency) {
     _dataPropagationLatencyGauge.updateValue(latency);
+    _dataPropagationLatencyGuage.updateValue(latency);
   }
 
   private void increaseFailureCounter(boolean isRead) {


### PR DESCRIPTION
### Issues

- [x]  My PR addresses the following Helix issues and references them in the PR title:
#512 
If we remove the typoed name DataPropagationLatencyGuage, current metrics graph may not see the metric and historical DataPropagationLatencyGuage data may be lost. To solve the problem, we need to add back DataPropagationLatencyGuage and set it as deprecated.

### Description

- [x]  Here are some details about my PR, including screenshots of any UI changes:
If we remove the typoed name DataPropagationLatencyGuage, current metrics graph may not see the metric and historical DataPropagationLatencyGuage data may be lost. To solve the problem, we need to add back DataPropagationLatencyGuage and set it as deprecated.

### Tests

- []  The following tests are written for this issue:
(List the names of added unit/integration tests)

- [x]  The following is the result of the "mvn test" command on the appropriate module:

Tests all pass.

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestPartitionLevelTransitionConstraint.test:160 expected:<true> but was:<false>
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 882, Failures: 2, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  53:55 min
[INFO] Finished at: 2019-10-21T22:41:58-07:00

END TestPartitionLevelTransitionConstraint_test at Mon Oct 21 22:47:22 PDT 2019
END test at Mon Oct 21 22:47:22 PDT 2019, took: 1650ms.
Shut down zookeeper at port 2183 in thread main
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.305 s - in org.apache.helix.integration.TestPartitionLevelTransitionConstraint
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

TestTaskPerformanceMetrics#testTaskPerformanceMetrics
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 16.152 s - in org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]

### Commits

- [x]  My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "How to write a good git commit message":
Subject is separated from body by a blank line
Subject is limited to 50 characters (not including Jira issue reference)
Subject does not end with a period
Subject uses the imperative mood ("add", not "adding")
Body wraps at 72 characters
Body explains "what" and "why", not "how"
Documentation

  In case of new functionality, my PR adds documentation in the following wiki page:
(Link the GitHub wiki you added)

### Code Quality

- [x]  My diff has been formatted using helix-style-intellij.xml