### PR TITLE
Refine the rebalance scope calculating logic in the WAGED rebalancer.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeDetector.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeDetector.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 public class ResourceChangeDetector implements ChangeDetector {
   private static final Logger LOG = LoggerFactory.getLogger(ResourceChangeDetector.class.getName());
 
-  private final boolean _ignoreHelixSourceChange;
+  private final boolean _ignoreControllerGeneratedFields;
   private ResourceChangeSnapshot _oldSnapshot; // snapshot for previous pipeline run
   private ResourceChangeSnapshot _newSnapshot; // snapshot for this pipeline run
 
@@ -51,9 +51,9 @@ public class ResourceChangeDetector implements ChangeDetector {
   private Map<HelixConstants.ChangeType, Collection<String>> _addedItems = new HashMap<>();
   private Map<HelixConstants.ChangeType, Collection<String>> _removedItems = new HashMap<>();
 
-  public ResourceChangeDetector(boolean ignoreHelixSourceChange) {
+  public ResourceChangeDetector(boolean ignoreControllerGeneratedFields) {
     _newSnapshot = new ResourceChangeSnapshot();
-    _ignoreHelixSourceChange = ignoreHelixSourceChange;
+    _ignoreControllerGeneratedFields = ignoreControllerGeneratedFields;
   }
 
   public ResourceChangeDetector() {
@@ -141,7 +141,7 @@ public class ResourceChangeDetector implements ChangeDetector {
   public synchronized void updateSnapshots(ResourceControllerDataProvider dataProvider) {
     // If there are changes, update internal states
     _oldSnapshot = new ResourceChangeSnapshot(_newSnapshot);
-    _newSnapshot = new ResourceChangeSnapshot(dataProvider, _ignoreHelixSourceChange);
+    _newSnapshot = new ResourceChangeSnapshot(dataProvider, _ignoreControllerGeneratedFields);
     dataProvider.clearRefreshedChangeTypes();
 
     // Invalidate cached computation

--- a/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeSnapshot.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeSnapshot.java
@@ -69,7 +69,7 @@ class ResourceChangeSnapshot {
    *
    * @param dataProvider
    * @param ignoreControllerGeneratedFields if true, the snapshot won't record any changes that is
-   *                                        modifying by the controller.
+   *                                        being modified by the controller.
    */
   ResourceChangeSnapshot(ResourceControllerDataProvider dataProvider,
       boolean ignoreControllerGeneratedFields) {

--- a/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeSnapshot.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeSnapshot.java
@@ -74,11 +74,11 @@ class ResourceChangeSnapshot {
     _instanceConfigMap = new HashMap<>(dataProvider.getInstanceConfigMap());
     _idealStateMap = new HashMap<>(dataProvider.getIdealStates());
     for (String resourceName : _idealStateMap.keySet()) {
-      IdealState orgIdealState = _idealStateMap.get(resourceName);
-      if (orgIdealState.getRebalanceMode().equals(IdealState.RebalanceMode.FULL_AUTO)) {
-        IdealState trimmedIdealState = new IdealState(orgIdealState.getRecord());
+      IdealState originalIdealState = _idealStateMap.get(resourceName);
+      if (originalIdealState.getRebalanceMode().equals(IdealState.RebalanceMode.FULL_AUTO)) {
+        IdealState trimmedIdealState = new IdealState(originalIdealState.getRecord());
         // For FullAuto resources, map fields and list fields in the IdealStates is not user's input.
-        // So there is no need to detect any change in these 2 scopes.
+        // So there is no need to detect any change in these two fields.
         trimmedIdealState.getRecord().setListFields(Collections.emptyMap());
         trimmedIdealState.getRecord().setMapFields(Collections.emptyMap());
         _idealStateMap.put(resourceName, trimmedIdealState);

--- a/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeSnapshot.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeSnapshot.java
@@ -19,6 +19,7 @@ package org.apache.helix.controller.changedetector;
  * under the License.
  */
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -72,6 +73,17 @@ class ResourceChangeSnapshot {
     _changedTypes = new HashSet<>(dataProvider.getRefreshedChangeTypes());
     _instanceConfigMap = new HashMap<>(dataProvider.getInstanceConfigMap());
     _idealStateMap = new HashMap<>(dataProvider.getIdealStates());
+    for (String resourceName : _idealStateMap.keySet()) {
+      IdealState orgIdealState = _idealStateMap.get(resourceName);
+      if (orgIdealState.getRebalanceMode().equals(IdealState.RebalanceMode.FULL_AUTO)) {
+        IdealState trimmedIdealState = new IdealState(orgIdealState.getRecord());
+        // For FullAuto resources, map fields and list fields in the IdealStates is not user's input.
+        // So there is no need to detect any change in these 2 scopes.
+        trimmedIdealState.getRecord().setListFields(Collections.emptyMap());
+        trimmedIdealState.getRecord().setMapFields(Collections.emptyMap());
+        _idealStateMap.put(resourceName, trimmedIdealState);
+      }
+    }
     _resourceConfigMap = new HashMap<>(dataProvider.getResourceConfigMap());
     _liveInstances = new HashMap<>(dataProvider.getLiveInstances());
     _clusterConfig = dataProvider.getClusterConfig();

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -69,6 +69,7 @@ public class WagedRebalancer {
   // contains 1. baseline recalculate, 2. partial rebalance that is based on the new baseline.
   private static final Set<HelixConstants.ChangeType> GLOBAL_REBALANCE_REQUIRED_CHANGE_TYPES =
       ImmutableSet.of(HelixConstants.ChangeType.RESOURCE_CONFIG,
+          HelixConstants.ChangeType.IDEAL_STATE,
           HelixConstants.ChangeType.CLUSTER_CONFIG, HelixConstants.ChangeType.INSTANCE_CONFIG);
   // The cluster change detector is a stateful object.
   // Make it static to avoid unnecessary reinitialization.
@@ -254,8 +255,6 @@ public class WagedRebalancer {
     if (clusterChanges.keySet().stream()
         .anyMatch(GLOBAL_REBALANCE_REQUIRED_CHANGE_TYPES::contains)) {
       refreshBaseline(clusterData, clusterChanges, resourceMap, currentStateOutput);
-      // Inject a cluster config change for large scale partial rebalance once the baseline changed.
-      clusterChanges.putIfAbsent(HelixConstants.ChangeType.CLUSTER_CONFIG, Collections.emptySet());
     }
 
     Set<String> activeNodes = DelayedRebalanceUtil.getActiveNodes(clusterData.getAllInstances(),

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -448,7 +448,7 @@ public class WagedRebalancer {
 
   private ResourceChangeDetector getChangeDetector() {
     if (CHANGE_DETECTOR_THREAD_LOCAL.get() == null) {
-      CHANGE_DETECTOR_THREAD_LOCAL.set(new ResourceChangeDetector());
+      CHANGE_DETECTOR_THREAD_LOCAL.set(new ResourceChangeDetector(true));
     }
     return CHANGE_DETECTOR_THREAD_LOCAL.get();
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -77,7 +77,7 @@ public class ClusterModelProvider {
         new HashMap<>(); // <instanceName, replica set>
     Set<AssignableReplica> toBeAssignedReplicas =
         findToBeAssignedReplicas(replicaMap, clusterChanges, activeInstances,
-            bestPossibleAssignment, allocatedReplicas);
+            dataProvider.getLiveInstances().keySet(), bestPossibleAssignment, allocatedReplicas);
 
     // Update the allocated replicas to the assignable nodes.
     assignableNodes.stream().forEach(node -> node.assignInitBatch(
@@ -97,14 +97,13 @@ public class ClusterModelProvider {
    * Find the minimum set of replicas that need to be reassigned.
    * A replica needs to be reassigned if one of the following condition is true:
    * 1. Cluster topology (the cluster config / any instance config) has been updated.
-   * 2. The baseline assignment has been updated.
-   * 3. The resource config has been updated.
-   * 4. The resource idealstate has been updated. TODO remove this condition when all resource configurations are migrated to resource config.
-   * 5. If the current best possible assignment does not contain the partition's valid assignment.
+   * 2. The resource config has been updated.
+   * 3. If the current best possible assignment does not contain the partition's valid assignment.
    *
    * @param replicaMap             A map contains all the replicas grouped by resource name.
    * @param clusterChanges         A map contains all the important metadata updates that happened after the previous rebalance.
-   * @param activeInstances        All the instances that are alive and enabled.
+   * @param activeInstances        All the instances that are alive and enabled according to the delay rebalance configuration.
+   * @param liveInstances          All the instances that are alive.
    * @param bestPossibleAssignment The current best possible assignment.
    * @param allocatedReplicas      Return the allocated replicas grouped by the target instance name.
    * @return The replicas that need to be reassigned.
@@ -112,12 +111,18 @@ public class ClusterModelProvider {
   private static Set<AssignableReplica> findToBeAssignedReplicas(
       Map<String, Set<AssignableReplica>> replicaMap,
       Map<HelixConstants.ChangeType, Set<String>> clusterChanges, Set<String> activeInstances,
-      Map<String, ResourceAssignment> bestPossibleAssignment,
+      Set<String> liveInstances, Map<String, ResourceAssignment> bestPossibleAssignment,
       Map<String, Set<AssignableReplica>> allocatedReplicas) {
     Set<AssignableReplica> toBeAssignedReplicas = new HashSet<>();
+
+    // newly connected nodes = changed liveInstance nodes & currently active instances.
+    Set<String> newlyConnectedNodes = clusterChanges
+        .getOrDefault(HelixConstants.ChangeType.LIVE_INSTANCE, Collections.emptySet());
+    newlyConnectedNodes.retainAll(liveInstances);
     if (clusterChanges.containsKey(HelixConstants.ChangeType.CLUSTER_CONFIG) || clusterChanges
-        .containsKey(HelixConstants.ChangeType.INSTANCE_CONFIG)) {
-      // If the cluster topology has been modified, need to reassign all replicas
+        .containsKey(HelixConstants.ChangeType.INSTANCE_CONFIG) || !newlyConnectedNodes.isEmpty()) {
+      // 1. If the cluster topology has been modified, need to reassign all replicas.
+      // 2. If any node was re-connect, need to reassign all replicas for balance.
       toBeAssignedReplicas
           .addAll(replicaMap.values().stream().flatMap(Set::stream).collect(Collectors.toSet()));
     } else {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -102,8 +102,8 @@ public class ClusterModelProvider {
    *
    * @param replicaMap             A map contains all the replicas grouped by resource name.
    * @param clusterChanges         A map contains all the important metadata updates that happened after the previous rebalance.
-   * @param activeInstances        All the instances that are alive and enabled according to the delay rebalance configuration.
-   * @param liveInstances          All the instances that are alive.
+   * @param activeInstances        All the instances that are live and enabled according to the delay rebalance configuration.
+   * @param liveInstances          All the instances that are live.
    * @param bestPossibleAssignment The current best possible assignment.
    * @param allocatedReplicas      Return the allocated replicas grouped by the target instance name.
    * @return The replicas that need to be reassigned.
@@ -116,7 +116,7 @@ public class ClusterModelProvider {
     Set<AssignableReplica> toBeAssignedReplicas = new HashSet<>();
 
     // A newly connected node = A new LiveInstance znode (or session Id updated) & the
-    // corresponding instance is alive.
+    // corresponding instance is live.
     // TODO: The assumption here is that if the LiveInstance znode is created or it's session Id is
     // TODO: updated, we need to call algorithm for moving some partitions to this new node.
     // TODO: However, if the liveInstance znode is changed because of some other reason, it will be

--- a/helix-core/src/test/java/org/apache/helix/controller/changedetector/TestResourceChangeDetector.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/changedetector/TestResourceChangeDetector.java
@@ -345,8 +345,8 @@ public class TestResourceChangeDetector extends ZkTestBase {
   /**
    * Modify IdealState mapping fields for a FULL_AUTO resource and see if detector detects.
    */
-  @Test//(dependsOnMethods = "testNoChange")
-  public void testIgnoreHelixSourceChange() {
+  @Test(dependsOnMethods = "testNoChange")
+  public void testIgnoreControllerGeneratedFields() {
     // Modify cluster config and IdealState to ensure the mapping field of the IdealState will be
     // considered as the fields that are modified by Helix logic.
     ClusterConfig clusterConfig = _dataAccessor.getProperty(_keyBuilder.clusterConfig());

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -42,6 +42,7 @@ import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceAssignment;
+import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.monitoring.metrics.WagedRebalancerMetricCollector;
 import org.apache.helix.monitoring.metrics.model.CountMetric;
 import org.mockito.Mockito;
@@ -347,7 +348,6 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
 
     // Note that this test relies on the MockRebalanceAlgorithm implementation. The mock algorithm
     // won't propagate any existing assignment from the cluster model.
-
     _metadataStore.clearMetadataStore();
     WagedRebalancer rebalancer =
         new WagedRebalancer(_metadataStore, _algorithm, new DelayedAutoRebalancer());
@@ -379,13 +379,13 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
 
     // 2. rebalance with one ideal state changed only
     String changedResourceName = _resourceNames.get(0);
-    // Create a new cluster data cache to simulate cluster change
-    clusterData = setupClusterDataCache();
     when(clusterData.getRefreshedChangeTypes())
-        .thenReturn(Collections.singleton(HelixConstants.ChangeType.IDEAL_STATE));
-    IdealState is = clusterData.getIdealState(changedResourceName);
-    // Update the tag so the ideal state will be marked as changed.
-    is.setInstanceGroupTag("newTag");
+        .thenReturn(Collections.singleton(HelixConstants.ChangeType.RESOURCE_CONFIG));
+    ResourceConfig config = new ResourceConfig(clusterData.getResourceConfig(changedResourceName).getRecord());
+    // Update the config so the resource will be marked as changed.
+    config.putSimpleConfig("foo", "bar");
+    when(clusterData.getResourceConfig(changedResourceName)).thenReturn(config);
+    clusterData.getResourceConfigMap().put(changedResourceName, config);
 
     // Although the input contains 2 resources, the rebalancer shall only call the algorithm to
     // rebalance the changed one.

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -377,7 +377,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
         _metadataStore.getBestPossibleAssignment();
     Assert.assertEquals(bestPossibleAssignment, algorithmResult);
 
-    // 2. rebalance with one ideal state changed only
+    // 2. rebalance with one resource changed in the Resource Config znode only
     String changedResourceName = _resourceNames.get(0);
     when(clusterData.getRefreshedChangeTypes())
         .thenReturn(Collections.singleton(HelixConstants.ChangeType.RESOURCE_CONFIG));

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
@@ -162,6 +162,10 @@ public abstract class AbstractTestClusterModel {
     testResourceConfigResource2.setPartitionCapacityMap(
         Collections.singletonMap(ResourceConfig.DEFAULT_PARTITION_KEY, capacityDataMapResource2));
     when(testCache.getResourceConfig("Resource2")).thenReturn(testResourceConfigResource2);
+    Map<String, ResourceConfig> configMap = new HashMap<>();
+    configMap.put("Resource1", testResourceConfigResource1);
+    configMap.put("Resource2", testResourceConfigResource2);
+    when(testCache.getResourceConfigMap()).thenReturn(configMap);
 
     // 6. Define mock state model
     for (BuiltInStateModelDefinitions bsmd : BuiltInStateModelDefinitions.values()) {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#518 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Refine the rebalance scope calculating logic in the WAGED rebalancer.
1. Ignore the IdealState mapping/listing fields if the resource is in FULL_AUTO mode.
2. On IdealState change, the resource shall be fully rebalanced since some filter conditions might be changed. Such as instance tag.
3. Live instance change (node newly connected) shall trigger full rebalance so partitions will be re-assigned to the new node.
4. A new baseline calculation no longer triggers all the replicas in the cluster to be rebalanced by default. The partial rebalance method will determine the scope based on the real change type.
5. Modify the related test cases.

### Tests

- [x] The following tests are written for this issue:

The changed logic is covered by existing tests.

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures: 
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[ERROR]   TestGetLastScheduledTaskExecInfo.testGetLastScheduledTaskExecInfo:73 expected:<COMPLETED> but was:<RUNNING>
[INFO] 
[ERROR] Tests run: 1043, Failures: 3, Errors: 0, Skipped: 3
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------

Rerun and these 3 tests pass.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

NA

### Code Quality

- [x] My diff has been formatted using helix-style.xml