### PR TITLE
Update zkBaseDataAccessor with custom serializer support

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
@@ -257,4 +257,9 @@ public interface BaseDataAccessor<T> {
    * reset the cache if any, when session expiry happens
    */
   void reset();
+
+  /**
+   * Close the opened zkConnection
+   */
+  void close();
 }

--- a/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
@@ -259,7 +259,7 @@ public interface BaseDataAccessor<T> {
   void reset();
 
   /**
-   * Close the opened zkConnection
+   * Close the connection to the metadata store
    */
   void close();
 }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -88,8 +88,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
   private static Logger LOG = LoggerFactory.getLogger(ZkBaseDataAccessor.class);
 
   private final HelixZkClient _zkClient;
-  // onDemand zkClient for read/write non-znRecord data path;
-  // minimal change to support custom serializer
+  //ZkClient that will be lazily instantiated if there are operations for non-ZNRecord data
   private HelixZkClient _nonZNRecordZkClient = null;
 
   public ZkBaseDataAccessor(HelixZkClient zkClient) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -111,10 +111,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
    * @param zkAddress The zookeeper address
    */
   public ZkBaseDataAccessor(String zkAddress) {
-    _zkClient = SharedZkClientFactory.getInstance()
-        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
-            new HelixZkClient.ZkClientConfig()
-                .setZkSerializer(new ZNRecordSerializer()));
+    this(zkAddress, new ZNRecordSerializer());
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -1142,6 +1142,8 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
    */
   @Override
   public void close() {
-    _zkClient.close();
+    if (_zkClient != null) {
+      _zkClient.close();
+    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -46,7 +46,6 @@ import org.apache.helix.manager.zk.ZkAsyncCallbacks.GetDataCallbackHandler;
 import org.apache.helix.manager.zk.ZkAsyncCallbacks.SetDataCallbackHandler;
 import org.apache.helix.manager.zk.client.HelixZkClient;
 import org.apache.helix.manager.zk.client.SharedZkClientFactory;
-import org.apache.helix.manager.zk.zookeeper.ZkConnection;
 import org.apache.helix.store.zk.ZNode;
 import org.apache.helix.util.HelixUtil;
 import org.apache.zookeeper.CreateMode;
@@ -89,7 +88,6 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
 
   private final HelixZkClient _zkClient;
 
-  //TODO: to be deprecated for client usage
   public ZkBaseDataAccessor(HelixZkClient zkClient) {
     if (zkClient == null) {
       throw new NullPointerException("zkclient is null");
@@ -97,16 +95,26 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
     _zkClient = zkClient;
   }
 
+  /**
+   * The ZkBaseDataAccessor with custom serializer support
+   * @param zkAddress The zookeeper address
+   */
   public ZkBaseDataAccessor(String zkAddress, ZkSerializer zkSerializer) {
     _zkClient = SharedZkClientFactory.getInstance()
         .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
             new HelixZkClient.ZkClientConfig().setZkSerializer(zkSerializer));
   }
 
+  /**
+   * The default ZkBaseDataAccessor with {@link org.apache.helix.ZNRecord} as the data model;
+   * Uses {@link ZNRecordSerializer} serializer
+   * @param zkAddress The zookeeper address
+   */
   public ZkBaseDataAccessor(String zkAddress) {
     _zkClient = SharedZkClientFactory.getInstance()
         .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
-            new HelixZkClient.ZkClientConfig());
+            new HelixZkClient.ZkClientConfig()
+                .setZkSerializer(new ZNRecordSerializer()));
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -105,26 +105,27 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
    */
   private HelixZkClient getNonZNRecordZkClient() {
     if (_nonZNRecordZkClient == null) {
-      synchronized (ZkBaseDataAccessor.class) {
-        _nonZNRecordZkClient = new ZkClient.Builder().setConnection(
-            new ZkConnection(_zkClient.getServers(), ZkClient.DEFAULT_SESSION_TIMEOUT))
-            .setZkSerializer(new ZkSerializer() {
-              @Override
-              public byte[] serialize(Object data)
-                  throws ZkMarshallingError {
-                if (data instanceof byte[]) {
-                  return (byte[]) data;
+      synchronized (this) {
+        if (_nonZNRecordZkClient == null) {
+          _nonZNRecordZkClient = new ZkClient.Builder().setConnection(
+              new ZkConnection(_zkClient.getServers(), ZkClient.DEFAULT_SESSION_TIMEOUT))
+              .setZkSerializer(new ZkSerializer() {
+                @Override
+                public byte[] serialize(Object data)
+                    throws ZkMarshallingError {
+                  if (data instanceof byte[]) {
+                    return (byte[]) data;
+                  }
+                  throw new HelixException("Only support a byte array as an argument!");
                 }
-                throw new HelixException("Only support a byte array as an argument!");
-              }
 
-              @Override
-              public Object deserialize(byte[] data)
-                  throws ZkMarshallingError {
-                return data;
-              }
-            }).build();
-        return _nonZNRecordZkClient;
+                @Override
+                public Object deserialize(byte[] data)
+                    throws ZkMarshallingError {
+                  return data;
+                }
+              }).build();
+        }
       }
     }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -1136,4 +1136,12 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
   public void reset() {
     // Nothing to do
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void close() {
+    _zkClient.close();
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -98,6 +98,10 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
     _zkClient = zkClient;
   }
 
+  public HelixZkClient getZkClient() {
+    return _zkClient;
+  }
+
   /**
    * Lazy initialization is used to reduce the cost of unnecessary opened zkConnections
    * @return singleton instance of non-ZnRecord ZkClient

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -45,6 +45,7 @@ import org.apache.helix.manager.zk.ZkAsyncCallbacks.ExistsCallbackHandler;
 import org.apache.helix.manager.zk.ZkAsyncCallbacks.GetDataCallbackHandler;
 import org.apache.helix.manager.zk.ZkAsyncCallbacks.SetDataCallbackHandler;
 import org.apache.helix.manager.zk.client.HelixZkClient;
+import org.apache.helix.manager.zk.client.SharedZkClientFactory;
 import org.apache.helix.manager.zk.zookeeper.ZkConnection;
 import org.apache.helix.store.zk.ZNode;
 import org.apache.helix.util.HelixUtil;
@@ -97,9 +98,15 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
   }
 
   public ZkBaseDataAccessor(String zkAddress, ZkSerializer zkSerializer) {
-    _zkClient = new ZkClient.Builder()
-        .setConnection(new ZkConnection(zkAddress, ZkClient.DEFAULT_SESSION_TIMEOUT))
-        .setZkSerializer(zkSerializer).build();
+    _zkClient = SharedZkClientFactory.getInstance()
+        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
+            new HelixZkClient.ZkClientConfig().setZkSerializer(zkSerializer));
+  }
+
+  public ZkBaseDataAccessor(String zkAddress) {
+    _zkClient = SharedZkClientFactory.getInstance()
+        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
+            new HelixZkClient.ZkClientConfig());
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -150,7 +150,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
         // this will happen if parent node does not exist
         String parentPath = HelixUtil.getZkParentPath(path);
         try {
-          AccessResult res = doCreate(zkClient, parentPath, record, AccessOption.PERSISTENT);
+          AccessResult res = doCreate(zkClient, parentPath, null, AccessOption.PERSISTENT);
           result._pathCreated.addAll(res._pathCreated);
           RetCode rc = res._retCode;
           if (rc == RetCode.OK || rc == RetCode.NODE_EXISTS) {
@@ -373,14 +373,9 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
    * Sync create method with custom serializer support
    */
   public boolean create(String path, Object data, int options, ZkSerializer serializer) {
-    try {
-      byte[] bytes = serializer.serialize(data);
-      AccessResult result = doCreate(_nonZNRecordClient, path, bytes, options);
-      return result._retCode == RetCode.OK;
-    } catch (ZkMarshallingError ex) {
-      LOG.error("Failed to serialize the data object", ex);
-      throw ex;
-    }
+    byte[] bytes = serializer.serialize(data);
+    AccessResult result = doCreate(_nonZNRecordClient, path, bytes, options);
+    return result._retCode == RetCode.OK;
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -88,7 +88,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
   private static Logger LOG = LoggerFactory.getLogger(ZkBaseDataAccessor.class);
 
   private final HelixZkClient _zkClient;
-  // onDemand ZnRecordClient
+  // onDemand zkClient for read/write non-znRecord data path
   private HelixZkClient _nonZNRecordClient = null;
 
   public ZkBaseDataAccessor(HelixZkClient zkClient) {
@@ -367,9 +367,6 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
       if (AccessOption.isThrowExceptionIfNotExist(options)) {
         throw ex;
       }
-    } catch (ZkMarshallingError ex) {
-      LOG.error("Failed to deserialize the byte array", ex);
-      throw ex;
     }
     return content;
   }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -232,7 +232,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       try {
         cache.lockWrite();
         ZkBaseDataAccessor<T>.AccessResult result =
-            _baseAccessor.doCreate(_baseAccessor.getZkClient(), serverPath, data, options);
+            _baseAccessor.doCreate(serverPath, data, options, true);
         boolean success = (result._retCode == RetCode.OK);
 
         updateCache(cache, result._pathCreated, success, serverPath, data, ZNode.ZERO_STAT);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -820,4 +820,11 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       _zkCache.reset();
     }
   }
+
+  @Override
+  public void close() {
+    if (_zkclient != null) {
+      _zkclient.close();
+    }
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -232,7 +232,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       try {
         cache.lockWrite();
         ZkBaseDataAccessor<T>.AccessResult result =
-            _baseAccessor.doCreate(_zkclient, serverPath, data, options);
+            _baseAccessor.doCreate(serverPath, data, options);
         boolean success = (result._retCode == RetCode.OK);
 
         updateCache(cache, result._pathCreated, success, serverPath, data, ZNode.ZERO_STAT);
@@ -263,7 +263,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       if (cache != null) {
         cache.lockWrite();
         ZkBaseDataAccessor<T>.AccessResult result =
-            _baseAccessor.doSet(_baseAccessor.getZkClient(), serverPath, data, expectVersion, options);
+            _baseAccessor.doSet(serverPath, data, expectVersion, options);
         success = result._retCode == RetCode.OK;
 
         updateCache(cache, result._pathCreated, success, serverPath, data, result._stat);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -263,7 +263,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       if (cache != null) {
         cache.lockWrite();
         ZkBaseDataAccessor<T>.AccessResult result =
-            _baseAccessor.doSet(_zkclient, serverPath, data, expectVersion, options);
+            _baseAccessor.doSet(_baseAccessor.getZkClient(), serverPath, data, expectVersion, options);
         success = result._retCode == RetCode.OK;
 
         updateCache(cache, result._pathCreated, success, serverPath, data, result._stat);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -232,7 +232,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       try {
         cache.lockWrite();
         ZkBaseDataAccessor<T>.AccessResult result =
-            _baseAccessor.doCreate(serverPath, data, options);
+            _baseAccessor.doCreate(_baseAccessor.getZkClient(), serverPath, data, options);
         boolean success = (result._retCode == RetCode.OK);
 
         updateCache(cache, result._pathCreated, success, serverPath, data, ZNode.ZERO_STAT);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -232,7 +232,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       try {
         cache.lockWrite();
         ZkBaseDataAccessor<T>.AccessResult result =
-            _baseAccessor.doCreate(serverPath, data, options, true);
+            _baseAccessor.doCreate(_zkclient, serverPath, data, options);
         boolean success = (result._retCode == RetCode.OK);
 
         updateCache(cache, result._pathCreated, success, serverPath, data, ZNode.ZERO_STAT);
@@ -263,7 +263,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       if (cache != null) {
         cache.lockWrite();
         ZkBaseDataAccessor<T>.AccessResult result =
-            _baseAccessor.doSet(serverPath, data, expectVersion, options, true);
+            _baseAccessor.doSet(_zkclient, serverPath, data, expectVersion, options);
         success = result._retCode == RetCode.OK;
 
         updateCache(cache, result._pathCreated, success, serverPath, data, result._stat);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -263,7 +263,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       if (cache != null) {
         cache.lockWrite();
         ZkBaseDataAccessor<T>.AccessResult result =
-            _baseAccessor.doSet(serverPath, data, expectVersion, options);
+            _baseAccessor.doSet(serverPath, data, expectVersion, options, true);
         success = result._retCode == RetCode.OK;
 
         updateCache(cache, result._pathCreated, success, serverPath, data, result._stat);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
@@ -10,7 +10,6 @@
  */
 package org.apache.helix.manager.zk.zookeeper;
 
-import javax.management.JMException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Date;
@@ -23,6 +22,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
+import javax.management.JMException;
 
 import org.I0Itec.zkclient.DataUpdater;
 import org.I0Itec.zkclient.ExceptionUtil;
@@ -1141,6 +1141,7 @@ public class ZkClient implements Watcher {
           throw new IllegalStateException("ZkClient already closed!");
         }
         try {
+          // ERROR:
           final ZkConnection zkConnection = (ZkConnection) getConnection();
           // Validate that the connection is not null before trigger callback
           if (zkConnection == null || zkConnection.getZookeeper() == null) {
@@ -1571,6 +1572,9 @@ public class ZkClient implements Watcher {
       }
 
       started = true;
+    } catch (Exception e) {
+      LOG.error("Exception while connecting the ZooKeeper", e);
+      throw e;
     } finally {
       getEventLock().unlock();
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
@@ -10,6 +10,7 @@
  */
 package org.apache.helix.manager.zk.zookeeper;
 
+import javax.management.JMException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Date;
@@ -22,7 +23,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
-import javax.management.JMException;
 
 import org.I0Itec.zkclient.DataUpdater;
 import org.I0Itec.zkclient.ExceptionUtil;
@@ -1141,7 +1141,6 @@ public class ZkClient implements Watcher {
           throw new IllegalStateException("ZkClient already closed!");
         }
         try {
-          // ERROR:
           final ZkConnection zkConnection = (ZkConnection) getConnection();
           // Validate that the connection is not null before trigger callback
           if (zkConnection == null || zkConnection.getZookeeper() == null) {
@@ -1572,9 +1571,6 @@ public class ZkClient implements Watcher {
       }
 
       started = true;
-    } catch (Exception e) {
-      LOG.error("Exception while connecting the ZooKeeper", e);
-      throw e;
     } finally {
       getEventLock().unlock();
 

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -157,7 +157,7 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     ZNRecord record = new ZNRecord("submsg_0");
     ZkBaseDataAccessor<ZNRecord> accessor = new ZkBaseDataAccessor<ZNRecord>(_gZkClient);
 
-    AccessResult result = accessor.doSet(path, record, -1, AccessOption.PERSISTENT, true);
+    AccessResult result = accessor.doSet(_gZkClient, path, record, -1, AccessOption.PERSISTENT);
     Assert.assertEquals(result._retCode, RetCode.OK);
     Assert.assertEquals(result._pathCreated.size(), 3);
     Assert.assertTrue(result._pathCreated.contains(String.format("/%s/%s", _rootPath, "msg_0")));

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -37,7 +37,6 @@ import org.apache.helix.manager.zk.ZkBaseDataAccessor.AccessResult;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor.RetCode;
 import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
@@ -65,11 +64,6 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     if (_gZkClient.exists(path)) {
       _gZkClient.deleteRecursively(path);
     }
-  }
-
-  @AfterClass
-  public void after() {
-    int a =1;
   }
 
   @Test
@@ -163,7 +157,7 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     ZNRecord record = new ZNRecord("submsg_0");
     ZkBaseDataAccessor<ZNRecord> accessor = new ZkBaseDataAccessor<ZNRecord>(_gZkClient);
 
-    AccessResult result = accessor.doSet(path, record, -1, AccessOption.PERSISTENT);
+    AccessResult result = accessor.doSet(path, record, -1, AccessOption.PERSISTENT, true);
     Assert.assertEquals(result._retCode, RetCode.OK);
     Assert.assertEquals(result._pathCreated.size(), 3);
     Assert.assertTrue(result._pathCreated.contains(String.format("/%s/%s", _rootPath, "msg_0")));
@@ -216,12 +210,18 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
 
     ZkBaseDataAccessor<ZNRecord> accessor = new ZkBaseDataAccessor<>(_gZkClient);
 
-    String recordData = "DummyContent";
-    boolean success = accessor.create(path, recordData, AccessOption.PERSISTENT, CUSTOM_ZK_SERIALIZER);
-    Assert.assertTrue(success);
+    String content0 = "DummyContent";
+    String content1 = "ChangedContent";
+    boolean createResult = accessor.create(path, content0, AccessOption.PERSISTENT, CUSTOM_ZK_SERIALIZER);
+    Assert.assertTrue(createResult);
 
     Object data = accessor.get(path, null, AccessOption.PERSISTENT, CUSTOM_ZK_SERIALIZER);
-    Assert.assertEquals(new String((byte[]) data), "DummyContent");
+    Assert.assertEquals(new String((byte[]) data), content0);
+    boolean setResult = accessor.set(path, content1, AccessOption.PERSISTENT, 0, CUSTOM_ZK_SERIALIZER);
+    Assert.assertTrue(setResult);
+
+    data = accessor.get(path, null, AccessOption.PERSISTENT, CUSTOM_ZK_SERIALIZER);
+    Assert.assertEquals(new String((byte[]) data), content1);
 
     System.out.println("END " + testName + " at " + new Date(System.currentTimeMillis()));
   }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -37,6 +37,7 @@ import org.apache.helix.manager.zk.ZkBaseDataAccessor.AccessResult;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor.RetCode;
 import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
@@ -64,6 +65,11 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     if (_gZkClient.exists(path)) {
       _gZkClient.deleteRecursively(path);
     }
+  }
+
+  @AfterClass
+  public void afterClass() {
+    _gZkClient.close();
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -230,6 +230,9 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     createResult = defaultAccessor.create(path, new ZNRecord("test"), AccessOption.PERSISTENT);
     // The result is expected to be true
     Assert.assertTrue(createResult);
+
+    defaultAccessor.close();
+    System.out.println("END " + testName + " at " + new Date(System.currentTimeMillis()));
   }
 
   @Test
@@ -242,13 +245,15 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     String path = String.format("/%s/%s", _rootPath, "msg_0");
 
     ZkBaseDataAccessor customDataAccessor = new ZkBaseDataAccessor(ZK_ADDR, LIST_SERIALIZER);
-
     boolean createResult = customDataAccessor.create(path, new ZNRecord("test"), AccessOption.PERSISTENT);
     // The result is expected to be false because the ZnRecord is not List
     Assert.assertFalse(createResult);
     createResult = customDataAccessor.create(path, ImmutableList.of(1, 2, 3), AccessOption.PERSISTENT);
     // The result is expected to be true
     Assert.assertTrue(createResult);
+
+    customDataAccessor.close();
+    System.out.println("END " + testName + " at " + new Date(System.currentTimeMillis()));
   }
 
   @Test
@@ -275,6 +280,7 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     data = (List<Integer>) accessor.get(path, null, AccessOption.PERSISTENT);
     Assert.assertEquals(data, l1);
 
+    accessor.close();
     System.out.println("END " + testName + " at " + new Date(System.currentTimeMillis()));
   }
 

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -45,6 +45,24 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 public class TestZkBaseDataAccessor extends ZkUnitTestBase {
+  // serialize/deserialize integer list to byte array
+  private static final ZkSerializer LIST_SERIALIZER = new ZkSerializer() {
+    @Override
+    public byte[] serialize(Object o)
+        throws ZkMarshallingError {
+      List<Integer> list = (List<Integer>) o;
+      return list.stream().map(String::valueOf).collect(Collectors.joining(","))
+          .getBytes();
+    }
+
+    @Override
+    public Object deserialize(byte[] bytes)
+        throws ZkMarshallingError {
+      String string = new String(bytes);
+      return Arrays.stream(string.split(",")).map(Integer::valueOf)
+          .collect(Collectors.toList());
+    }
+  };
   String _rootPath = TestHelper.getTestClassName();
 
 
@@ -195,6 +213,45 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
   }
 
   @Test
+  public void testDefaultAccessorCreateCustomData() {
+    String className = TestHelper.getTestClassName();
+    String methodName = TestHelper.getTestMethodName();
+    String testName = className + "_" + methodName;
+    System.out.println("START " + testName + " at " + new Date(System.currentTimeMillis()));
+
+    String path = String.format("/%s/%s", _rootPath, "msg_0");
+
+    ZkBaseDataAccessor defaultAccessor = new ZkBaseDataAccessor(ZK_ADDR);
+
+    List<Integer> l0 = ImmutableList.of(1, 2, 3);
+    boolean createResult = defaultAccessor.create(path, l0, AccessOption.PERSISTENT);
+    // The result is expected to be false because the list is not ZNRecord
+    Assert.assertFalse(createResult);
+    createResult = defaultAccessor.create(path, new ZNRecord("test"), AccessOption.PERSISTENT);
+    // The result is expected to be true
+    Assert.assertTrue(createResult);
+  }
+
+  @Test
+  public void testCustomAccessorCreateZnRecord() {
+    String className = TestHelper.getTestClassName();
+    String methodName = TestHelper.getTestMethodName();
+    String testName = className + "_" + methodName;
+    System.out.println("START " + testName + " at " + new Date(System.currentTimeMillis()));
+
+    String path = String.format("/%s/%s", _rootPath, "msg_0");
+
+    ZkBaseDataAccessor customDataAccessor = new ZkBaseDataAccessor(ZK_ADDR, LIST_SERIALIZER);
+
+    boolean createResult = customDataAccessor.create(path, new ZNRecord("test"), AccessOption.PERSISTENT);
+    // The result is expected to be false because the ZnRecord is not List
+    Assert.assertFalse(createResult);
+    createResult = customDataAccessor.create(path, ImmutableList.of(1, 2, 3), AccessOption.PERSISTENT);
+    // The result is expected to be true
+    Assert.assertTrue(createResult);
+  }
+
+  @Test
   public void testSyncCreateWithCustomSerializer() {
     String className = TestHelper.getTestClassName();
     String methodName = TestHelper.getTestMethodName();
@@ -203,25 +260,7 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
 
     String path = String.format("/%s/%s", _rootPath, "msg_0");
 
-    // serialize/deserialize integer list to byte array
-    ZkSerializer listSerializer = new ZkSerializer() {
-      @Override
-      public byte[] serialize(Object o)
-          throws ZkMarshallingError {
-        List<Integer> list = (List<Integer>) o;
-        return list.stream().map(String::valueOf).collect(Collectors.joining(","))
-            .getBytes();
-      }
-
-      @Override
-      public Object deserialize(byte[] bytes)
-          throws ZkMarshallingError {
-        String string = new String(bytes);
-        return Arrays.stream(string.split(",")).map(Integer::valueOf)
-            .collect(Collectors.toList());
-      }
-    };
-    ZkBaseDataAccessor<List<Integer>> accessor = new ZkBaseDataAccessor<>(ZK_ADDR, listSerializer);
+    ZkBaseDataAccessor<List<Integer>> accessor = new ZkBaseDataAccessor<>(ZK_ADDR, LIST_SERIALIZER);
 
     List<Integer> l0 = ImmutableList.of(1, 2, 3);
     List<Integer> l1 = ImmutableList.of(4, 5, 6);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -157,7 +157,7 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     ZNRecord record = new ZNRecord("submsg_0");
     ZkBaseDataAccessor<ZNRecord> accessor = new ZkBaseDataAccessor<ZNRecord>(_gZkClient);
 
-    AccessResult result = accessor.doSet(_gZkClient, path, record, -1, AccessOption.PERSISTENT);
+    AccessResult result = accessor.doSet(path, record, -1, AccessOption.PERSISTENT);
     Assert.assertEquals(result._retCode, RetCode.OK);
     Assert.assertEquals(result._pathCreated.size(), 3);
     Assert.assertTrue(result._pathCreated.contains(String.format("/%s/%s", _rootPath, "msg_0")));
@@ -208,19 +208,19 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
 
     String path = String.format("/%s/%s", _rootPath, "msg_0");
 
-    ZkBaseDataAccessor<ZNRecord> accessor = new ZkBaseDataAccessor<>(_gZkClient);
+    ZkBaseDataAccessor<Object> accessor = new ZkBaseDataAccessor<>(ZK_ADDR, CUSTOM_ZK_SERIALIZER);
 
     String content0 = "DummyContent";
     String content1 = "ChangedContent";
-    boolean createResult = accessor.create(path, content0, AccessOption.PERSISTENT, CUSTOM_ZK_SERIALIZER);
+    boolean createResult = accessor.create(path, content0, AccessOption.PERSISTENT);
     Assert.assertTrue(createResult);
 
-    Object data = accessor.get(path, null, AccessOption.PERSISTENT, CUSTOM_ZK_SERIALIZER);
+    Object data = accessor.get(path, null, AccessOption.PERSISTENT);
     Assert.assertEquals(new String((byte[]) data), content0);
-    boolean setResult = accessor.set(path, content1, AccessOption.PERSISTENT, 0, CUSTOM_ZK_SERIALIZER);
+    boolean setResult = accessor.set(path, content1, 0, AccessOption.PERSISTENT);
     Assert.assertTrue(setResult);
 
-    data = accessor.get(path, null, AccessOption.PERSISTENT, CUSTOM_ZK_SERIALIZER);
+    data = accessor.get(path, null, AccessOption.PERSISTENT);
     Assert.assertEquals(new String((byte[]) data), content1);
 
     System.out.println("END " + testName + " at " + new Date(System.currentTimeMillis()));

--- a/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
@@ -258,6 +258,9 @@ public class MockBaseDataAccessor implements BaseDataAccessor<ZNRecord> {
     _recordMap.clear();
   }
 
+  @Override
+  public void close() { }
+
   @Override public boolean set(String path, ZNRecord record, int options, int expectVersion) {
     return set(path, record, options);
   }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#533

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
Update zkBaseDataAccessor with custom serializer support
- new constructor takes in the custom serializer as the parameter

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)
testSyncCreateWithCustomSerializer
testCustomAccessorCreateZnRecord
testDefaultAccessorCreateCustomData

- [x] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestBucketizedResource.testBounceDisableAndDrop:189 expected:<false> but was:<true>
[ERROR]   TestDrop.testBasic:113->assertEmptyCSandEV:62 expected:<true> but was:<false>
[ERROR]   TestZkConnectionLost.testLostZkConnection:140 » Helix Workflow "testLostZkConn...
[ERROR]   TestWtCacheAsyncOpMultiThread.testHappyPathZkCacheBaseDataAccessor:202 » IllegalState
[ERROR]   TestZkCacheSyncOpSingleThread.testZkCacheCallbackExternalOpNoChroot:96 » IllegalState
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 885, Failures: 6, Errors: 0, Skipped: 0
[INFO] 


The single failed test passed when running in IDE

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml