### PR TITLE
Use a copy of the new best possible assignment for measuring baseline divergence

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -401,11 +401,17 @@ public class WagedRebalancer {
 
     // Asynchronously report baseline divergence metric before persisting to metadata store,
     // just in case if persisting fails, we still have the metric.
+    // To avoid changes of the new assignment and make it safe when being used to measure baseline
+    // divergence, use a deep copy of the new assignment.
+    Map<String, ResourceAssignment> newAssignmentCopy = new HashMap<>();
+    for (Map.Entry<String, ResourceAssignment> entry : newAssignment.entrySet()) {
+      newAssignmentCopy.put(entry.getKey(), new ResourceAssignment(entry.getValue().getRecord()));
+    }
     BaselineDivergenceGauge baselineDivergenceGauge = _metricCollector.getMetric(
         WagedRebalancerMetricCollector.WagedRebalancerMetricNames.BaselineDivergenceGauge.name(),
         BaselineDivergenceGauge.class);
     baselineDivergenceGauge.asyncMeasureAndUpdateValue(clusterData.getAsyncTasksThreadPool(),
-        currentBaseline, newAssignment);
+        currentBaseline, newAssignmentCopy);
 
     if (_assignmentMetadataStore != null) {
       try {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #541 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The new assignment is really critical in waged rebalancer. If there is any potential changes in measure baseline divergence, waged rebalancer may not work correctly. 
To avoid changes of the new assignment and make it safe when being used to measure baseline
divergence, use a copy of the new assignment.

### Tests

- [ ] The following tests are written for this issue:

No test added.

- [x] The following is the result of the "mvn test" command on the appropriate module:
mvn test in helix-core

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestMixedModeAutoRebalance.testUserDefinedPreferenceListsInFullAutoWithErrors:219->ZkTestBase.validateMinActiveAndTopStateReplica:460 Test-DB_3 missing MASTER replica expected:<true> but was:<false>
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[ERROR]   TestGetLastScheduledTaskExecInfo.testGetLastScheduledTaskExecInfo:73 expected:<COMPLETED> but was:<RUNNING>
[INFO]
[ERROR] Tests run: 1045, Failures: 3, Errors: 0, Skipped: 4

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.569 s - in org.apache.helix.task.TestGetLastScheduledTaskExecInfo
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0


[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.514 s - in org.apache.helix.integration.rebalancer.TestMixedModeAutoRebalance
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.514 s - in org.apache.helix.integration.rebalancer.TestMixedModeAutoRebalance
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0




mvn build

[INFO] Reactor Summary for Apache Helix 0.9.2-SNAPSHOT:
[INFO]
[INFO] Apache Helix ....................................... SUCCESS [  0.946 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [ 12.238 s]
[INFO] Apache Helix :: Admin Webapp ....................... SUCCESS [  1.552 s]
[INFO] Apache Helix :: Restful Interface .................. SUCCESS [  3.230 s]
[INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  0.751 s]
[INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.021 s]
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  0.577 s]
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  0.670 s]
[INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  0.571 s]
[INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  0.610 s]
[INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  0.545 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml