### PR TITLE
Change change detector to a regular field in the WAGED rebalancer instead of static threadlocal.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -283,7 +283,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
       }
     }
 
-    // Create MetricCollector ThreadLocal if it hasn't been already initialized
+    // Create WagedRebalancer ThreadLocal if it hasn't been already initialized
     if (WAGED_REBALANCER_THREAD_LOCAL.get() == null) {
       WAGED_REBALANCER_THREAD_LOCAL
           .set(new WagedRebalancer(helixManager, preferences, METRIC_COLLECTOR_THREAD_LOCAL.get()));

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -430,10 +430,10 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
 
     // Verify that only the changed resource has been included in the calculation.
     validateRebalanceResult(Collections.emptyMap(), newIdealStates, newAlgorithmResult);
-    // There is nothing changes the baseline since only current state changed.
+    // There should be no changes in the baseline since only the currentStates changed
     baseline = _metadataStore.getBaseline();
     Assert.assertEquals(baseline, algorithmResult);
-    // The best possible assignment has been updated as long as computeNewIdealStates() is called.
+    // The BestPossible assignment should have been updated since computeNewIdealStates() should have been called.
     bestPossibleAssignment = _metadataStore.getBestPossibleAssignment();
     Assert.assertEquals(bestPossibleAssignment, newAlgorithmResult);
 
@@ -447,10 +447,10 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     newAlgorithmResult = _algorithm.getRebalanceResult();
     // Verify that both resource has been included in the calculation.
     validateRebalanceResult(resourceMap, newIdealStates, newAlgorithmResult);
-    // There is nothing changes the baseline.
+    // There should not be any changes in the baseline.
     baseline = _metadataStore.getBaseline();
     Assert.assertEquals(baseline, algorithmResult);
-    // The best possible assignment has been updated as long as computeNewIdealStates() is called.
+    // The BestPossible assignment should have been updated since computeNewIdealStates() should have been called.
     bestPossibleAssignment = _metadataStore.getBestPossibleAssignment();
     Assert.assertEquals(bestPossibleAssignment, newAlgorithmResult);
   }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
@@ -123,6 +123,8 @@ public class TestWagedRebalancerMetrics extends AbstractTestClusterModel {
     // Cluster config change will trigger baseline recalculation and partial rebalance.
     when(clusterData.getRefreshedChangeTypes())
         .thenReturn(Collections.singleton(HelixConstants.ChangeType.CLUSTER_CONFIG));
+    // Update the config so the cluster config will be marked as changed.
+    clusterData.getClusterConfig().getRecord().setSimpleField("foo", "bar");
 
     rebalancer.computeBestPossibleStates(clusterData, resourceMap, new CurrentStateOutput());
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
@@ -123,7 +123,7 @@ public class TestWagedRebalancerMetrics extends AbstractTestClusterModel {
     // Cluster config change will trigger baseline recalculation and partial rebalance.
     when(clusterData.getRefreshedChangeTypes())
         .thenReturn(Collections.singleton(HelixConstants.ChangeType.CLUSTER_CONFIG));
-    // Update the config so the cluster config will be marked as changed.
+    // Add a field to the cluster config so the cluster config will be marked as changed in the change detector.
     clusterData.getClusterConfig().getRecord().setSimpleField("foo", "bar");
 
     rebalancer.computeBestPossibleStates(clusterData, resourceMap, new CurrentStateOutput());


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#540 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The rebalance has been modified to be a thread-local object. So there is no need to keep the change detector as thread-local. This may cause a potential problem.
In addition, in order to avoid resource leakage, implement the finalize method of the WagedRebalancer to close all connections.

### Tests

- [x] The following tests are written for this issue:

TestWagedRebalancer

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures: 
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp Â» ThreadTimeout Method org.testng....
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[ERROR]   TestAssignableInstanceManager.testGetAssignableInstanceMap:114 expected:<true> but was:<false>
[ERROR]   TestGetLastScheduledTaskExecInfo.testGetLastScheduledTaskExecInfo:73 expected:<COMPLETED> but was:<RUNNING>
[INFO] 
[ERROR] Tests run: 1045, Failures: 4, Errors: 0, Skipped: 3
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] -----------------------------------------------------------------------

Rurun

[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.752 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

NA

### Code Quality

- [x] My diff has been formatted using helix-style.xml