### PR TITLE
Add the new Rebalancer monitor domain to the active domain list.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/InstanceType.java
+++ b/helix-core/src/main/java/org/apache/helix/InstanceType.java
@@ -36,7 +36,8 @@ public enum InstanceType {
   CONTROLLER(new String[] {
       MonitorDomainNames.ClusterStatus.name(),
       MonitorDomainNames.HelixZkClient.name(),
-      MonitorDomainNames.HelixCallback.name()
+      MonitorDomainNames.HelixCallback.name(),
+      MonitorDomainNames.Rebalancer.name()
   }),
 
   PARTICIPANT(new String[] {
@@ -51,7 +52,8 @@ public enum InstanceType {
       MonitorDomainNames.HelixZkClient.name(),
       MonitorDomainNames.HelixCallback.name(),
       MonitorDomainNames.HelixThreadPoolExecutor.name(),
-      MonitorDomainNames.CLMParticipantReport.name()
+      MonitorDomainNames.CLMParticipantReport.name(),
+      MonitorDomainNames.Rebalancer.name()
   }),
 
   SPECTATOR(new String[] {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#402 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add the new Rebalancer monitor domain to the active domain list.
So the apps depend on Helix lib will pick up the right MBeans.

### Tests

- [x] The following tests are written for this issue:

NA

- [ ] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures: 
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[ERROR]   TestGetLastScheduledTaskExecInfo.testGetLastScheduledTaskExecInfo:70 expected:<1572379747084> but was:<1572379745816>
[INFO] 
[ERROR] Tests run: 1045, Failures: 2, Errors: 0, Skipped: 3
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------

Rerun and they passed.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

NA

### Code Quality

- [x] My diff has been formatted using helix-style.xml