### PR TITLE
Deep copy for mapFields and listFields in ZNRecord's copy constructor.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ZNRecord.java
+++ b/helix-core/src/main/java/org/apache/helix/ZNRecord.java
@@ -20,6 +20,7 @@ package org.apache.helix;
  */
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -101,8 +102,9 @@ public class ZNRecord {
   public ZNRecord(ZNRecord record, String id) {
     this(id);
     simpleFields.putAll(record.getSimpleFields());
-    mapFields.putAll(record.getMapFields());
-    listFields.putAll(record.getListFields());
+    // Deep copy for both mapFields and listFields.
+    record.getMapFields().forEach((k, v) -> mapFields.put(k, new HashMap<>(v)));
+    record.getListFields().forEach((k, v) -> listFields.put(k, new ArrayList<>(v)));
     if (record.rawPayload != null) {
       rawPayload = new byte[record.rawPayload.length];
       System.arraycopy(record.rawPayload, 0, rawPayload, 0, record.rawPayload.length);

--- a/helix-core/src/test/java/org/apache/helix/TestZNRecord.java
+++ b/helix-core/src/test/java/org/apache/helix/TestZNRecord.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -122,5 +123,47 @@ public class TestZNRecord {
     expectMap2.put("map2Key1", "map2Value1");
     expectRecord.setMapField("mapKey2", expectMap2);
     Assert.assertEquals(record, expectRecord, "Should be equal.");
+  }
+
+  @Test
+  public void testDeepCopyConstructor() {
+    ZNRecord record = new ZNRecord("record");
+
+    // set simple field
+    record.setSimpleField("simpleKey1", "simpleValue1");
+
+    // set list field
+    List<String> list1 = new ArrayList<>();
+    list1.add("list1Value1");
+    list1.add("list1Value2");
+    record.setListField("listKey1", list1);
+
+    // set map field
+    Map<String, String> map1 = new HashMap<>();
+    map1.put("map1Key1", "map1Value1");
+    record.setMapField("mapKey1", map1);
+
+    Map<String, String> map2 = new HashMap<>();
+    map2.put("map2Key1", "map2Value1");
+    record.setMapField("mapKey2", map2);
+
+    ZNRecord newRecord = new ZNRecord(record);
+
+    // Verify initial copy results.
+    Assert.assertEquals(record.getMapFields(), newRecord.getMapFields());
+    Assert.assertEquals(record.getListFields(), newRecord.getListFields());
+    Assert.assertEquals(record, newRecord);
+
+    // Change values in original record.
+    map1.put("map1Key1", "valueChanged");
+    record.setMapField("mapKey1", map1);
+
+    list1.set(0, "valueChanged");
+    record.setListField("listKey1", list1);
+
+    // Value changes in original record should not change new record.
+    Assert.assertFalse(record.getMapFields().equals(newRecord.getMapFields()));
+    Assert.assertFalse(record.getListFields().equals(newRecord.getListFields()));
+    Assert.assertFalse(record.equals(newRecord));
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #549 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
new ZNRecord(ZNRecord record, String id) seems it wants to do a deep copy. But mapFields and listFields are not deep copied.

Change list:
1. deep copy for mapFields and listFields in ZNRecord's copy constructor.
2. Add unit test for the deep copy constructor.

### Tests

- [x] The following tests are written for this issue:

TestZNRecord.testDeepCopyConstructor

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestSyncSessionToController>ZkTestBase.beforeSuite:126 » IllegalState Zookeepe...
[INFO]
[ERROR] Tests run: 1998, Failures: 1, Errors: 0, Skipped: 1997
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:42 min
[INFO] Finished at: 2019-10-30T17:23:37-07:00


[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.142 s - in org.apache.helix.integration.TestSyncSessionToController
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml