### PR TITLE
Fix incorrect formula in the comment for measuring baseline divergence

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/ResourceUsageCalculator.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/ResourceUsageCalculator.java
@@ -82,7 +82,7 @@ public class ResourceUsageCalculator {
    *       }
    *    }
    * }
-   * baseline divergence = (matched: 1) / (doesn't match: 3) = 1/3 ~= 0.333
+   * baseline divergence = (matched: 1) / (total(matched + doesn't match): 3) = 1/3 ~= 0.333
    * @param baseline baseline assignment
    * @param bestPossibleAssignment best possible assignment
    * @return double value range at [0.0, 1.0]


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fix formula error in the comment for measuring baseline divergence.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fix formula error in the comment for measuring baseline divergence.

### Tests

- [x] The following tests are written for this issue:

None.

- [x] The following is the result of the "mvn test" command on the appropriate module:

mvn build

### Commits

- [ ] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml