### PR TITLE
Revert "Deep copy for mapFields and listFields in ZNRecord's copy constructor. (#552)"

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ZNRecord.java
+++ b/helix-core/src/main/java/org/apache/helix/ZNRecord.java
@@ -20,7 +20,6 @@ package org.apache.helix;
  */
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -102,9 +101,8 @@ public class ZNRecord {
   public ZNRecord(ZNRecord record, String id) {
     this(id);
     simpleFields.putAll(record.getSimpleFields());
-    // Deep copy for both mapFields and listFields.
-    record.getMapFields().forEach((k, v) -> mapFields.put(k, new HashMap<>(v)));
-    record.getListFields().forEach((k, v) -> listFields.put(k, new ArrayList<>(v)));
+    mapFields.putAll(record.getMapFields());
+    listFields.putAll(record.getListFields());
     if (record.rawPayload != null) {
       rawPayload = new byte[record.rawPayload.length];
       System.arraycopy(record.rawPayload, 0, rawPayload, 0, record.rawPayload.length);

--- a/helix-core/src/test/java/org/apache/helix/TestZNRecord.java
+++ b/helix-core/src/test/java/org/apache/helix/TestZNRecord.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -123,47 +122,5 @@ public class TestZNRecord {
     expectMap2.put("map2Key1", "map2Value1");
     expectRecord.setMapField("mapKey2", expectMap2);
     Assert.assertEquals(record, expectRecord, "Should be equal.");
-  }
-
-  @Test
-  public void testDeepCopyConstructor() {
-    ZNRecord record = new ZNRecord("record");
-
-    // set simple field
-    record.setSimpleField("simpleKey1", "simpleValue1");
-
-    // set list field
-    List<String> list1 = new ArrayList<>();
-    list1.add("list1Value1");
-    list1.add("list1Value2");
-    record.setListField("listKey1", list1);
-
-    // set map field
-    Map<String, String> map1 = new HashMap<>();
-    map1.put("map1Key1", "map1Value1");
-    record.setMapField("mapKey1", map1);
-
-    Map<String, String> map2 = new HashMap<>();
-    map2.put("map2Key1", "map2Value1");
-    record.setMapField("mapKey2", map2);
-
-    ZNRecord newRecord = new ZNRecord(record);
-
-    // Verify initial copy results.
-    Assert.assertEquals(record.getMapFields(), newRecord.getMapFields());
-    Assert.assertEquals(record.getListFields(), newRecord.getListFields());
-    Assert.assertEquals(record, newRecord);
-
-    // Change values in original record.
-    map1.put("map1Key1", "valueChanged");
-    record.setMapField("mapKey1", map1);
-
-    list1.set(0, "valueChanged");
-    record.setListField("listKey1", list1);
-
-    // Value changes in original record should not change new record.
-    Assert.assertFalse(record.getMapFields().equals(newRecord.getMapFields()));
-    Assert.assertFalse(record.getListFields().equals(newRecord.getListFields()));
-    Assert.assertFalse(record.equals(newRecord));
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #566 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Revert "Deep copy for mapFields and listFields in ZNRecord's copy constructor. (#552)
This reverts commit 2a335cf73ac65b53fd2b06c6b1ee8c70553d30b1.

The copy constructor in ZNRecord is critical. It may cause potential concurrency problems like race condition in other methods. To be safe, we don't want deep copy.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestZkConnectionLost.testLostZkConnection:140 » Helix Workflow "testLostZkConn...
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 882, Failures: 2, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  54:21 min
[INFO] Finished at: 2019-11-04T17:07:05-08:00

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 30.935 s - in org.apache.helix.integration.TestZkConnectionLost
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  35.563 s
[INFO] Finished at: 2019-11-04T18:21:46-08:00


[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.388 s - in org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS





### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml