### PR TITLE
Add Java API for adding and validating resources for WAGED rebalancer

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -30,6 +30,7 @@ import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.MaintenanceSignal;
+import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
 
 /*
@@ -576,4 +577,28 @@ public interface HelixAdmin {
    * Release resources
    */
   void close();
+
+  /**
+   * Adds a resource with IdealState and ResourceConfig to be rebalanced by WAGED rebalancer with validation.
+   * @param clusterName
+   * @param idealState
+   * @param resourceConfig
+   * @return true if the resource has been added successfully. False otherwise
+   */
+  boolean addResourceWithWeight(String clusterName, IdealState idealState, ResourceConfig resourceConfig);
+
+  /**
+   * Batch-enables Waged rebalance for the names of resources given.
+   * @param clusterName
+   * @param resourceNames
+   * @return
+   */
+  boolean enableWagedRebalance(String clusterName, List<String> resourceNames);
+
+  /**
+   * Validates the resources to see if their weight configs have been set properly.
+   * @param resourceNames
+   * @return for each resource, true if the weight configs have been set properly, false otherwise
+   */
+  Map<String, Boolean> validateForWagedRebalance(String clusterName, List<String> resourceNames);
 }

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -22,6 +22,7 @@ package org.apache.helix;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.helix.model.ClusterConstraints;
 import org.apache.helix.model.ClusterConstraints.ConstraintType;
 import org.apache.helix.model.ConstraintItem;
@@ -32,6 +33,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.MaintenanceSignal;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
+
 
 /*
  * Helix cluster management
@@ -580,12 +582,17 @@ public interface HelixAdmin {
 
   /**
    * Adds a resource with IdealState and ResourceConfig to be rebalanced by WAGED rebalancer with validation.
+   * Validation includes the following:
+   * 1. Check ResourceConfig has the WEIGHT field
+   * 2. Check that all capacity keys from ClusterConfig are set up in the WEIGHT field
+   * 3. Check that all ResourceConfig's weightMap fields have all of the capacity keys
    * @param clusterName
    * @param idealState
    * @param resourceConfig
    * @return true if the resource has been added successfully. False otherwise
    */
-  boolean addResourceWithWeight(String clusterName, IdealState idealState, ResourceConfig resourceConfig);
+  boolean addResourceWithWeight(String clusterName, IdealState idealState,
+      ResourceConfig resourceConfig);
 
   /**
    * Batch-enables Waged rebalance for the names of resources given.
@@ -597,8 +604,25 @@ public interface HelixAdmin {
 
   /**
    * Validates the resources to see if their weight configs have been set properly.
+   * Validation includes the following:
+   * 1. Check ResourceConfig has the WEIGHT field
+   * 2. Check that all capacity keys from ClusterConfig are set up in the WEIGHT field
+   * 3. Check that all ResourceConfig's weightMap fields have all of the capacity keys
    * @param resourceNames
    * @return for each resource, true if the weight configs have been set properly, false otherwise
    */
-  Map<String, Boolean> validateForWagedRebalance(String clusterName, List<String> resourceNames);
+  Map<String, Boolean> validateResourcesForWagedRebalance(String clusterName,
+      List<String> resourceNames);
+
+  /**
+   * Validates the instances to ensure their weights in InstanceConfigs have been set up properly.
+   * Validation includes the following:
+   * 1. If default instance capacity is not set, check that the InstanceConfigs have the CAPACITY field
+   * 2. Check that all capacity keys defined in ClusterConfig are present in the CAPACITY field
+   * @param clusterName
+   * @param instancesNames
+   * @return
+   */
+  Map<String, Boolean> validateInstancesForWagedRebalance(String clusterName,
+      List<String> instancesNames);
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/WagedValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/WagedValidationUtil.java
@@ -1,0 +1,91 @@
+package org.apache.helix.controller.rebalancer.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.helix.HelixException;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.ResourceConfig;
+
+
+/**
+ * A util class that contains validation-related static methods for WAGED rebalancer.
+ */
+public class WagedValidationUtil {
+  /**
+   * Validates and returns instance capacities. The validation logic ensures that all required capacity keys (in ClusterConfig) are present in InstanceConfig.
+   * @param clusterConfig
+   * @param instanceConfig
+   * @return
+   */
+  public static Map<String, Integer> validateAndGetInstanceCapacity(ClusterConfig clusterConfig,
+      InstanceConfig instanceConfig) {
+    // Fetch the capacity of instance from 2 possible sources according to the following priority.
+    // 1. The instance capacity that is configured in the instance config.
+    // 2. If the default instance capacity that is configured in the cluster config contains more capacity keys, fill the capacity map with those additional values.
+    Map<String, Integer> instanceCapacity =
+        new HashMap<>(clusterConfig.getDefaultInstanceCapacityMap());
+    instanceCapacity.putAll(instanceConfig.getInstanceCapacityMap());
+
+    List<String> requiredCapacityKeys = clusterConfig.getInstanceCapacityKeys();
+    // All the required keys must exist in the instance config.
+    if (!instanceCapacity.keySet().containsAll(requiredCapacityKeys)) {
+      throw new HelixException(String.format(
+          "The required capacity keys: %s are not fully configured in the instance: %s, capacity map: %s.",
+          requiredCapacityKeys.toString(), instanceConfig.getInstanceName(),
+          instanceCapacity.toString()));
+    }
+    return instanceCapacity;
+  }
+
+  /**
+   * Validates and returns partition capacities. The validation logic ensures that all required capacity keys (from ClusterConfig) are present in the ResourceConfig for the partition.
+   * @param partitionName
+   * @param resourceConfig
+   * @param clusterConfig
+   * @return
+   */
+  public static Map<String, Integer> validateAndGetPartitionCapacity(String partitionName,
+      ResourceConfig resourceConfig, Map<String, Map<String, Integer>> capacityMap,
+      ClusterConfig clusterConfig) {
+    // Fetch the capacity of partition from 3 possible sources according to the following priority.
+    // 1. The partition capacity that is explicitly configured in the resource config.
+    // 2. Or, the default partition capacity that is configured under partition name DEFAULT_PARTITION_KEY in the resource config.
+    // 3. If the default partition capacity that is configured in the cluster config contains more capacity keys, fill the capacity map with those additional values.
+    Map<String, Integer> partitionCapacity =
+        new HashMap<>(clusterConfig.getDefaultPartitionWeightMap());
+    partitionCapacity.putAll(capacityMap.getOrDefault(partitionName,
+        capacityMap.getOrDefault(ResourceConfig.DEFAULT_PARTITION_KEY, new HashMap<>())));
+
+    List<String> requiredCapacityKeys = clusterConfig.getInstanceCapacityKeys();
+    // If any required capacity key is not configured in the resource config, fail the model creating.
+    if (!partitionCapacity.keySet().containsAll(requiredCapacityKeys)) {
+      throw new HelixException(String.format(
+          "The required capacity keys: %s are not fully configured in the resource: %s, partition: %s, weight map: %s.",
+          requiredCapacityKeys.toString(), resourceConfig.getResourceName(), partitionName,
+          partitionCapacity.toString()));
+    }
+    return partitionCapacity;
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableReplica.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableReplica.java
@@ -149,7 +149,23 @@ public class AssignableReplica implements Comparable<AssignableReplica> {
           "Invalid partition capacity configuration of resource: " + resourceConfig
               .getResourceName(), ex);
     }
+    Map<String, Integer> partitionCapacity =
+        validateAndGetPartitionCapacity(partitionName, resourceConfig, capacityMap, clusterConfig);
+    // Remove the non-required capacity items.
+    partitionCapacity.keySet().retainAll(clusterConfig.getInstanceCapacityKeys());
+    return partitionCapacity;
+  }
 
+  /**
+   * Validates and returns partition capacities. The validation logic ensures that all required capacity keys (from ClusterConfig) are present in the ResourceConfig for the partition.
+   * @param partitionName
+   * @param resourceConfig
+   * @param clusterConfig
+   * @return
+   */
+  public static Map<String, Integer> validateAndGetPartitionCapacity(String partitionName,
+      ResourceConfig resourceConfig, Map<String, Map<String, Integer>> capacityMap,
+      ClusterConfig clusterConfig) {
     // Fetch the capacity of partition from 3 possible sources according to the following priority.
     // 1. The partition capacity that is explicitly configured in the resource config.
     // 2. Or, the default partition capacity that is configured under partition name DEFAULT_PARTITION_KEY in the resource config.
@@ -167,9 +183,6 @@ public class AssignableReplica implements Comparable<AssignableReplica> {
           requiredCapacityKeys.toString(), resourceConfig.getResourceName(), partitionName,
           partitionCapacity.toString()));
     }
-    // Remove the non-required capacity items.
-    partitionCapacity.keySet().retainAll(requiredCapacityKeys);
-
     return partitionCapacity;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1680,6 +1680,17 @@ public class ZKHelixAdmin implements HelixAdmin {
       throw new HelixException("Resource name list is invalid!");
     }
 
+    // First, ensure that all instances are valid
+    HelixDataAccessor accessor =
+        new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_zkClient));
+    Builder keyBuilder = accessor.keyBuilder();
+    List<String> liveInstances = accessor.getChildNames(keyBuilder.liveInstances());
+    if (validateInstancesForWagedRebalance(clusterName, liveInstances).containsValue(false)) {
+      throw new HelixException(String
+          .format("Instance capacities haven't been configured properly for cluster %s",
+              clusterName));
+    }
+
     Map<String, Boolean> result = new HashMap<>();
     ClusterConfig clusterConfig = _configAccessor.getClusterConfig(clusterName);
     for (String resourceName : resourceNames) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1684,8 +1684,8 @@ public class ZKHelixAdmin implements HelixAdmin {
     HelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_zkClient));
     Builder keyBuilder = accessor.keyBuilder();
-    List<String> liveInstances = accessor.getChildNames(keyBuilder.liveInstances());
-    if (validateInstancesForWagedRebalance(clusterName, liveInstances).containsValue(false)) {
+    List<String> instances = accessor.getChildNames(keyBuilder.instanceConfigs());
+    if (validateInstancesForWagedRebalance(clusterName, instances).containsValue(false)) {
       throw new HelixException(String
           .format("Instance capacities haven't been configured properly for cluster %s",
               clusterName));

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1746,12 +1746,13 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     // Remove DEFAULT key
     Set<String> capacityMapSet = new HashSet<>(capacityMap.keySet());
+    boolean hasDefaultCapacity = capacityMapSet.contains(ResourceConfig.DEFAULT_PARTITION_KEY);
     capacityMapSet.remove(ResourceConfig.DEFAULT_PARTITION_KEY);
 
     // Make sure capacityMap contains all partitions defined in IdealState
     // Here, IdealState has not been rebalanced, so listFields might be null, in which case, we would get an emptyList from getPartitionSet()
     // So check using numPartitions instead
-    if (capacityMapSet.size() != idealState.getNumPartitions()) {
+    if (capacityMapSet.size() != idealState.getNumPartitions() && !hasDefaultCapacity) {
       throw new IllegalArgumentException(String.format(
           "ResourceConfig for %s does not have all partitions defined in PartitionCapacityMap!",
           idealState.getResourceName()));

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1580,7 +1580,8 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   @Override
-  public boolean addResourceWithWeight(String clusterName, IdealState idealState, ResourceConfig resourceConfig) {
+  public boolean addResourceWithWeight(String clusterName, IdealState idealState,
+      ResourceConfig resourceConfig) {
     // Null checks
     if (idealState == null) {
       throw new HelixException("IdealState is null!");
@@ -1593,12 +1594,14 @@ public class ZKHelixAdmin implements HelixAdmin {
     // Order in which a resource should be added:
     // 1. Validate the weights in ResourceConfig against ClusterConfig
     // Check that all capacity keys in ClusterConfig are set up in every partition in ResourceConfig's WEIGHT field
-    if (!validateWeightForResourceConfig(_configAccessor.getClusterConfig(clusterName), resourceConfig)) {
+    if (!validateWeightForResourceConfig(_configAccessor.getClusterConfig(clusterName),
+        resourceConfig)) {
       return false;
     }
 
     // 2. Add the resourceConfig to ZK
-    _configAccessor.setResourceConfig(clusterName, resourceConfig.getResourceName(), resourceConfig);
+    _configAccessor
+        .setResourceConfig(clusterName, resourceConfig.getResourceName(), resourceConfig);
 
     // 3. Add the idealState to ZK
     setResourceIdealState(clusterName, idealState.getResourceName(), idealState);
@@ -1620,7 +1623,8 @@ public class ZKHelixAdmin implements HelixAdmin {
       throw new HelixException("Resource name list is invalid!");
     }
 
-    HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_zkClient));
+    HelixDataAccessor accessor =
+        new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_zkClient));
     Builder keyBuilder = accessor.keyBuilder();
     List<IdealState> idealStates = accessor.getChildValues(keyBuilder.idealStates());
     List<String> nullIdealStates = new ArrayList<>();
@@ -1628,14 +1632,17 @@ public class ZKHelixAdmin implements HelixAdmin {
       if (idealStates.get(i) == null) {
         nullIdealStates.add(resourceNames.get(i));
       } else {
-        idealStates.get(i).setRebalancerClassName("org.apache.helix.controller.rebalancer.WagedRebalancer");
+        idealStates.get(i)
+            .setRebalancerClassName("org.apache.helix.controller.rebalancer.WagedRebalancer");
       }
     }
     if (!nullIdealStates.isEmpty()) {
-      throw new HelixException(String.format("Not all IdealStates exist in the cluster: %s", nullIdealStates));
+      throw new HelixException(
+          String.format("Not all IdealStates exist in the cluster: %s", nullIdealStates));
     }
     List<PropertyKey> idealStateKeys = new ArrayList<>();
-    idealStates.forEach(idealState -> idealStateKeys.add(keyBuilder.idealStates(idealState.getResourceName())));
+    idealStates.forEach(
+        idealState -> idealStateKeys.add(keyBuilder.idealStates(idealState.getResourceName())));
     boolean[] success = accessor.setChildren(idealStateKeys, idealStates);
     for (boolean s : success) {
       if (!s) {
@@ -1646,7 +1653,8 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   @Override
-  public Map<String, Boolean> validateForWagedRebalance(String clusterName, List<String> resourceNames) {
+  public Map<String, Boolean> validateForWagedRebalance(String clusterName,
+      List<String> resourceNames) {
     // Null checks
     if (clusterName == null || clusterName.isEmpty()) {
       throw new HelixException("Cluster name is invalid!");
@@ -1664,6 +1672,10 @@ public class ZKHelixAdmin implements HelixAdmin {
         continue;
       }
       ResourceConfig resourceConfig = _configAccessor.getResourceConfig(clusterName, resourceName);
+      if (resourceConfig == null || !resourceConfig.isValid()) {
+        result.put(resourceName, false);
+        continue;
+      }
       result.put(resourceName, validateWeightForResourceConfig(clusterConfig, resourceConfig));
     }
     return result;
@@ -1675,7 +1687,8 @@ public class ZKHelixAdmin implements HelixAdmin {
    * @param resourceConfig
    * @return true if ResourceConfig has all the required fields. False otherwise.
    */
-  private boolean validateWeightForResourceConfig(ClusterConfig clusterConfig, ResourceConfig resourceConfig) {
+  private boolean validateWeightForResourceConfig(ClusterConfig clusterConfig,
+      ResourceConfig resourceConfig) {
     // Check that the ResourceConfig has the WEIGHT field
     Map<String, String> weightMap = resourceConfig.getMapConfig("WEIGHT");
     if (weightMap == null || weightMap.isEmpty()) {
@@ -1692,8 +1705,8 @@ public class ZKHelixAdmin implements HelixAdmin {
       // Check that all ResourceConfig's weightMap fields have all of the capacity keys
       weightMap.forEach((partitionName, weightJson) -> capacityKeys.forEach(capacityKey -> {
         if (!weightJson.contains(capacityKey)) {
-          throw new HelixException(
-              String.format("Partition %s does not contain weight key %s!", partitionName, capacityKey));
+          throw new HelixException(String
+              .format("Partition %s does not contain weight key %s!", partitionName, capacityKey));
         }
       }));
     }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1757,7 +1757,8 @@ public class ZKHelixAdmin implements HelixAdmin {
         return true;
       }
       logger.error(
-          "ClusterConfig's default partition weight map doesn't have all the required keys!");
+          "ResourceConfig for {} is null, and ClusterConfig's default partition weight map doesn't have all the required keys!",
+          idealState.getResourceName());
       return false;
     }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
@@ -265,14 +265,14 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     Assert.assertEquals(assignableNode.getMaxCapacity(), _capacityDataMap);
   }
 
-  @Test(expectedExceptions = HelixException.class, expectedExceptionsMessageRegExp = "The required capacity keys: \\[item2, item1, item3, AdditionalCapacityKey\\] are not fully configured in the instance: testInstanceConfigId, capacity map: \\{item2=40, item1=20, item3=30\\}.")
+  @Test(expectedExceptions = HelixException.class, expectedExceptionsMessageRegExp = "The required capacity keys: \\[item2, item1, item3, AdditionalCapacityKey\\] are not fully configured in the instance: testInstanceId, capacity map: \\{item2=40, item1=20, item3=30\\}.")
   public void testIncompleteInstanceCapacity() {
     ClusterConfig testClusterConfig = new ClusterConfig("testClusterConfigId");
     List<String> requiredCapacityKeys = new ArrayList<>(_capacityDataMap.keySet());
     requiredCapacityKeys.add("AdditionalCapacityKey");
     testClusterConfig.setInstanceCapacityKeys(requiredCapacityKeys);
 
-    InstanceConfig testInstanceConfig = new InstanceConfig("testInstanceConfigId");
+    InstanceConfig testInstanceConfig = new InstanceConfig(_testInstanceId);
     testInstanceConfig.setInstanceCapacityMap(_capacityDataMap);
 
     new AssignableNode(testClusterConfig, testInstanceConfig, _testInstanceId);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
@@ -265,7 +265,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     Assert.assertEquals(assignableNode.getMaxCapacity(), _capacityDataMap);
   }
 
-  @Test(expectedExceptions = HelixException.class, expectedExceptionsMessageRegExp = "The required capacity keys: \\[item2, item1, item3, AdditionalCapacityKey\\] are not fully configured in the instance: testInstanceId, capacity map: \\{item2=40, item1=20, item3=30\\}.")
+  @Test(expectedExceptions = HelixException.class, expectedExceptionsMessageRegExp = "The required capacity keys: \\[item2, item1, item3, AdditionalCapacityKey\\] are not fully configured in the instance: testInstanceConfigId, capacity map: \\{item2=40, item1=20, item3=30\\}.")
   public void testIncompleteInstanceCapacity() {
     ClusterConfig testClusterConfig = new ClusterConfig("testClusterConfigId");
     List<String> requiredCapacityKeys = new ArrayList<>(_capacityDataMap.keySet());

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -42,6 +42,7 @@ import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.ZkUnitTestBase;
+import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.examples.MasterSlaveStateModelFactory;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ClusterConstraints;
@@ -604,7 +605,6 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
 
     admin.enableWagedRebalance(clusterName, Collections.singletonList(testResourcePrefix));
     IdealState is = admin.getResourceIdealState(clusterName, testResourcePrefix);
-    Assert.assertEquals(is.getRebalancerClassName(),
-        "org.apache.helix.controller.rebalancer.WagedRebalancer");
+    Assert.assertEquals(is.getRebalancerClassName(), WagedRebalancer.class.getName());
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -556,7 +556,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     try {
       admin.addResourceWithWeight(clusterName, idealState, resourceConfig);
       Assert.fail();
-    } catch (Exception e) {
+    } catch (HelixException e) {
       // OK since resourceConfig is empty
     }
 

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -573,11 +573,6 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
         Collections.singletonList(testResourcePrefix));
     Assert.assertEquals(validationResult.size(), 1);
     Assert.assertFalse(validationResult.get(testResourcePrefix));
-    try {
-      admin.addResourceWithWeight(clusterName, idealState, resourceConfig);
-    } catch (Exception e) {
-      // OK since ClusterConfig is empty
-    }
 
     // Add the capacity key to ClusterConfig
     HelixDataAccessor dataAccessor = new ZKHelixDataAccessor(clusterName, _baseAccessor);

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -440,7 +440,13 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   @Override
-  public Map<String, Boolean> validateForWagedRebalance(String clusterName, List<String> resourceNames) {
+  public Map<String, Boolean> validateResourcesForWagedRebalance(String clusterName, List<String> resourceNames) {
+    return null;
+  }
+
+  @Override
+  public Map<String, Boolean> validateInstancesForWagedRebalance(String clusterName,
+      List<String> instancesNames) {
     return null;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -38,6 +38,7 @@ import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.MaintenanceSignal;
+import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
 
 public class MockHelixAdmin implements HelixAdmin {
@@ -426,5 +427,20 @@ public class MockHelixAdmin implements HelixAdmin {
 
   @Override public void close() {
 
+  }
+
+  @Override
+  public boolean addResourceWithWeight(String clusterName, IdealState idealState, ResourceConfig resourceConfig) {
+    return false;
+  }
+
+  @Override
+  public boolean enableWagedRebalance(String clusterName, List<String> resourceNames) {
+    return false;
+  }
+
+  @Override
+  public Map<String, Boolean> validateForWagedRebalance(String clusterName, List<String> resourceNames) {
+    return null;
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #553 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add Java API for adding and validating resources for WAGED rebalancer. This is a set of convenience APIs provided through HelixAdmin the user could use to more easily add resources and validate them.

### Tests

- [x] The following tests are written for this issue:

testAddResourceWithWeightAndValidation
testEnableWagedRebalance

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Tests run: 1051, Failures: 3, Errors: 0, Skipped: 3, Time elapsed: 3,899.986 s <<< FAILURE! - in TestSuite
[ERROR] testEnableCompressionResource(org.apache.helix.integration.TestEnableCompression)  Time elapsed: 150.607 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.integration.TestEnableCompression.testEnableCompressionResource(TestEnableCompression.java:108)

[ERROR] testMsgTriggeredRebalance(org.apache.helix.controller.stages.TestRebalancePipeline)  Time elapsed: 11.216 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.controller.stages.TestRebalancePipeline.testMsgTriggeredRebalance(TestRebalancePipeline.java:221)

[ERROR] testIncompleteInstanceCapacity(org.apache.helix.controller.rebalancer.waged.model.TestAssignableNode)  Time elapsed: 0.016 s  <<< FAILURE!
org.testng.TestException: 

The exception was thrown with the wrong message: expected "The required capacity keys: \[item2, item1, item3, AdditionalCapacityKey\] are not fully configured in the instance: testInstanceId, capacity map: \{item2=40, item1=20, item3=30\}." but got "The required capacity keys: [item2, item1, item3, AdditionalCapacityKey] are not fully configured in the instance: testInstanceConfigId, capacity map: {item2=40, item1=20, item3=30}."
	at org.apache.helix.controller.rebalancer.waged.model.TestAssignableNode.testIncompleteInstanceCapacity(TestAssignableNode.java:278)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestAssignableNode.testIncompleteInstanceCapacity » Test 
The exception was th...
[ERROR]   TestRebalancePipeline.testMsgTriggeredRebalance:221 expected:<true> but was:<false>
[ERROR]   TestEnableCompression.testEnableCompressionResource:108 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1051, Failures: 3, Errors: 0, Skipped: 3

--------

Fixed TestAssignableNode in this PR - PASS
TestRebalancePipeline - PASS
TestEnableCompression - PASS

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml