### PR TITLE
Filter resource map with ideal states for instance capacity metrics.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -242,14 +242,14 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
         // ResourceToRebalance map also has resources from current states.
         // Only use the resources in ideal states to parse all replicas.
         Map<String, IdealState> idealStateMap = dataProvider.getIdealStates();
-        Map<String, Resource> metricResourceMap = resourceMap.entrySet().stream()
+        Map<String, Resource> resourceToMonitorMap = resourceMap.entrySet().stream()
             .filter(resourceName -> idealStateMap.containsKey(resourceName))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         Map<String, ResourceAssignment> currentStateAssignment =
-            currentStateOutput.getAssignment(metricResourceMap.keySet());
+            currentStateOutput.getAssignment(resourceToMonitorMap.keySet());
         ClusterModel clusterModel = ClusterModelProvider.generateClusterModelFromCurrentState(
-            dataProvider, metricResourceMap, currentStateAssignment);
+            dataProvider, resourceToMonitorMap, currentStateAssignment);
 
         Map<String, Double> maxUsageMap = new HashMap<>();
         for (AssignableNode node : clusterModel.getAssignableNodes().values()) {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #565 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
ResourceToReblance map also has resources from current states. Only use the resources in ideal states to parse all replicas.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestBasicSpectator.TestSpectator:57 expected:<true> but was:<false>
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1048, Failures: 3, Errors: 0, Skipped: 4
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:09 h
[INFO] Finished at: 2019-11-05T16:48:52-08:00

END TestBasicSpectator at Tue Nov 05 16:51:46 PST 2019
Shut down zookeeper at port 2183 in thread main

===============================================
Default Suite
Total tests run: 1, Failures: 0, Skips: 0

testJobQueueAutoCleanUp 
Total tests run: 1, Failures: 0, Skips: 0

START testTaskPerformanceMetrics at Tue Nov 05 16:54:11 PST 2019
Total tests run: 1, Failures: 0, Skips: 0




### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml