### PR TITLE
Fix NullPointerException in TestBatchMessage.

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestBatchMessage.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestBatchMessage.java
@@ -45,13 +45,16 @@ import org.testng.annotations.Test;
 
 public class TestBatchMessage extends ZkTestBase {
   class TestZkChildListener implements IZkChildListener {
-    int _maxNbOfChilds = 0;
+    int _maxNumberOfChildren = 0;
 
     @Override
-    public void handleChildChange(String parentPath, List<String> currentChilds) throws Exception {
-      System.out.println(parentPath + " has " + currentChilds.size() + " messages");
-      if (currentChilds.size() > _maxNbOfChilds) {
-        _maxNbOfChilds = currentChilds.size();
+    public void handleChildChange(String parentPath, List<String> currentChildren) {
+      if (currentChildren == null) {
+        return;
+      }
+      System.out.println(parentPath + " has " + currentChildren.size() + " messages");
+      if (currentChildren.size() > _maxNumberOfChildren) {
+        _maxNumberOfChildren = currentChildren.size();
       }
     }
 
@@ -107,7 +110,7 @@ public class TestBatchMessage extends ZkTestBase {
     Assert.assertTrue(result);
     // Change to three is because there is an extra factory registered
     // So one extra NO_OP message send
-    Assert.assertTrue(listener._maxNbOfChilds <= 3,
+    Assert.assertTrue(listener._maxNumberOfChildren <= 3,
         "Should get no more than 2 messages (O->S and S->M)");
 
     // clean up
@@ -190,7 +193,7 @@ public class TestBatchMessage extends ZkTestBase {
     Assert.assertTrue(result);
     // Change to three is because there is an extra factory registered
     // So one extra NO_OP message send
-    Assert.assertTrue(listener._maxNbOfChilds <= 3,
+    Assert.assertTrue(listener._maxNumberOfChildren <= 3,
         "Should get no more than 2 messages (O->S and S->M)");
 
     // clean up
@@ -349,7 +352,7 @@ public class TestBatchMessage extends ZkTestBase {
         ClusterStateVerifier.verifyByZkCallback(new BestPossAndExtViewZkVerifier(ZK_ADDR,
             clusterName));
     Assert.assertTrue(result);
-    Assert.assertTrue(listener._maxNbOfChilds > 16,
+    Assert.assertTrue(listener._maxNumberOfChildren > 16,
         "Should see more than 16 messages at the same time (32 O->S and 32 S->M)");
 
     // clean up


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fix #571 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

NullPointerException in TestBatchMessage when currentChildren is null and currentChildren.size() is called.
Add a null check in handleChildChange().

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 882, Failures: 2, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  57:22 min
[INFO] Finished at: 2019-11-14T18:35:23-08:00

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml