### PR TITLE
Fix NullPointerException for testCustomCodeRunner.

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/TestHelixCustomCodeRunner.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestHelixCustomCodeRunner.java
@@ -20,18 +20,14 @@ package org.apache.helix.integration;
  */
 
 import java.util.Date;
+
 import org.apache.helix.HelixConstants.ChangeType;
-import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.NotificationContext;
-import org.apache.helix.PropertyKey.Builder;
 import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
-import org.apache.helix.manager.zk.ZKHelixDataAccessor;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.model.LiveInstance;
 import org.apache.helix.participant.CustomCodeCallbackHandler;
 import org.apache.helix.participant.HelixCustomCodeRunner;
 import org.apache.helix.tools.ClusterStateVerifier;
@@ -123,11 +119,8 @@ public class TestHelixCustomCodeRunner extends ZkTestBase {
     for (int i = 0; i < nodeNb; i++) {
       participants[i].syncStop();
     }
-    HelixDataAccessor accessor =
-        new ZKHelixDataAccessor(_clusterName, new ZkBaseDataAccessor<>(_gZkClient));
-    Builder keyBuilder = accessor.keyBuilder();
-    accessor.removeProperty(keyBuilder.liveInstance("localhost_1000"));
-    TestHelper.dropCluster(_clusterName, _gZkClient);
+    deleteLiveInstances(_clusterName);
+    deleteCluster(_clusterName);
 
     System.out.println("END " + _clusterName + " at " + new Date(System.currentTimeMillis()));
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/TestHelixCustomCodeRunner.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestHelixCustomCodeRunner.java
@@ -109,15 +109,11 @@ public class TestHelixCustomCodeRunner extends ZkTestBase {
     Assert.assertTrue(_callback._isCallbackInvoked);
     _callback._isCallbackInvoked = false;
 
-    // add a new live instance
-    HelixDataAccessor accessor =
-        new ZKHelixDataAccessor(_clusterName, new ZkBaseDataAccessor<>(_gZkClient));
-    Builder keyBuilder = accessor.keyBuilder();
-
-    LiveInstance newLiveIns = new LiveInstance("newLiveInstance");
-    newLiveIns.setHelixVersion("0.6.0");
-    newLiveIns.setSessionId("randomSessionId");
-    accessor.setProperty(keyBuilder.liveInstance("newLiveInstance"), newLiveIns);
+    // add a new live instance and its instance config.
+    // instance name: localhost_1000
+    int[] newLiveInstance = new int[]{1000};
+    setupInstances(_clusterName, newLiveInstance);
+    setupLiveInstances(_clusterName, newLiveInstance);
 
     Thread.sleep(1000); // wait for the CALLBACK type callback to finish
     Assert.assertTrue(_callback._isCallbackInvoked);
@@ -127,7 +123,10 @@ public class TestHelixCustomCodeRunner extends ZkTestBase {
     for (int i = 0; i < nodeNb; i++) {
       participants[i].syncStop();
     }
-    accessor.removeProperty(keyBuilder.liveInstance("newLiveInstance"));
+    HelixDataAccessor accessor =
+        new ZKHelixDataAccessor(_clusterName, new ZkBaseDataAccessor<>(_gZkClient));
+    Builder keyBuilder = accessor.keyBuilder();
+    accessor.removeProperty(keyBuilder.liveInstance("localhost_1000"));
     TestHelper.dropCluster(_clusterName, _gZkClient);
 
     System.out.println("END " + _clusterName + " at " + new Date(System.currentTimeMillis()));


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #572 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The new live instance doesn't have its instance config. This causes NullPointerException when monitor is trying to get the instance config.
Instance config is needed for the new live instance.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 882, Failures: 2, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  57:22 min
[INFO] Finished at: 2019-11-14T18:35:23-08:00
### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml