### PR TITLE
Fix the context creation without config

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowDispatcher.java
@@ -209,10 +209,16 @@ public class WorkflowDispatcher extends AbstractTaskDispatcher {
   public WorkflowContext getOrInitializeWorkflowContext(String workflowName, TaskDataCache cache) {
     WorkflowContext workflowCtx = cache.getWorkflowContext(workflowName);
     if (workflowCtx == null) {
-      workflowCtx = new WorkflowContext(new ZNRecord(TaskUtil.WORKFLOW_CONTEXT_KW));
-      workflowCtx.setStartTime(System.currentTimeMillis());
-      workflowCtx.setName(workflowName);
-      LOG.debug("Workflow context is created for " + workflowName);
+      if (cache.getWorkflowConfig(workflowName) != null) {
+        workflowCtx = new WorkflowContext(new ZNRecord(TaskUtil.WORKFLOW_CONTEXT_KW));
+        workflowCtx.setStartTime(System.currentTimeMillis());
+        workflowCtx.setName(workflowName);
+        LOG.debug("Workflow context is created for " + workflowName);
+      } else {
+        // If config is null, do not initialize context
+        LOG.error("Workflow context is not created for {}. Workflow config is missing!",
+            workflowName);
+      }
     }
     return workflowCtx;
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowContextWithoutConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowContextWithoutConfig.java
@@ -90,12 +90,13 @@ public class TestWorkflowContextWithoutConfig extends TaskTestBase {
     Assert.assertNotNull(_driver.getWorkflowContext(workflowName1));
     Assert.assertNotNull(_admin.getResourceIdealState(CLUSTER_NAME, workflowName1));
 
-    // Wait until workflow is completed.
-    _driver.pollForWorkflowState(workflowName1, TaskState.COMPLETED);
-
     String idealStatePath = "/" + CLUSTER_NAME + "/IDEALSTATES/" + workflowName1;
     ZNRecord record = _manager.getHelixDataAccessor().getBaseDataAccessor().get(idealStatePath,
         null, AccessOption.PERSISTENT);
+    Assert.assertNotNull(record);
+
+    // Wait until workflow is completed.
+    _driver.pollForWorkflowState(workflowName1, TaskState.COMPLETED);
 
     // Verify that WorkflowConfig, WorkflowContext, and IdealState are removed after workflow got
     // expired.
@@ -107,7 +108,7 @@ public class TestWorkflowContextWithoutConfig extends TaskTestBase {
     }, 30 * 1000);
     Assert.assertTrue(workflowExpired);
 
-    // Write ideaState to ZooKeeper
+    // Write idealState to ZooKeeper
     _manager.getHelixDataAccessor().getBaseDataAccessor().set(idealStatePath, record,
         AccessOption.PERSISTENT);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowContextWithoutConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowContextWithoutConfig.java
@@ -1,0 +1,131 @@
+package org.apache.helix.integration.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.AccessOption;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.TestHelper;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.task.WorkflowContext;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Test to check workflow context is not created without workflow config.
+ */
+public class TestWorkflowContextWithoutConfig extends TaskTestBase {
+  private HelixAdmin _admin;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    super.beforeClass();
+    _admin = _gSetupTool.getClusterManagementTool();
+  }
+
+  @Test
+  public void testWorkflowContextWithoutConfig() throws Exception {
+    final long expiryTime = 5000L;
+    String workflowName1 = TestHelper.getTestMethodName() + "_1";
+    Workflow.Builder builder1 = new Workflow.Builder(workflowName1);
+
+    // Workflow DAG Schematic:
+    //          JOB0
+    //           /\
+    //          /  \
+    //         /    \
+    //       JOB1   JOB2
+
+    JobConfig.Builder jobBuilder1 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName1)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "1000"));
+
+    JobConfig.Builder jobBuilder2 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName1)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "1000"));
+
+    JobConfig.Builder jobBuilder3 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName1)
+        .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "1000"));
+
+    builder1.addParentChildDependency("JOB0", "JOB1");
+    builder1.addParentChildDependency("JOB0", "JOB2");
+    builder1.addJob("JOB0", jobBuilder1);
+    builder1.addJob("JOB1", jobBuilder2);
+    builder1.addJob("JOB2", jobBuilder3);
+    builder1.setExpiry(expiryTime);
+
+    _driver.start(builder1.build());
+
+    // Wait until workflow is created and IN_PROGRESS state.
+    _driver.pollForWorkflowState(workflowName1, TaskState.IN_PROGRESS);
+
+    // Check that WorkflowConfig, WorkflowContext, and IdealState are indeed created for this
+    // workflow
+    Assert.assertNotNull(_driver.getWorkflowConfig(workflowName1));
+    Assert.assertNotNull(_driver.getWorkflowContext(workflowName1));
+    Assert.assertNotNull(_admin.getResourceIdealState(CLUSTER_NAME, workflowName1));
+
+    // Wait until workflow is completed.
+    _driver.pollForWorkflowState(workflowName1, TaskState.COMPLETED);
+
+    String idealStatePath = "/" + CLUSTER_NAME + "/IDEALSTATES/" + workflowName1;
+    ZNRecord record = _manager.getHelixDataAccessor().getBaseDataAccessor().get(idealStatePath,
+        null, AccessOption.PERSISTENT);
+
+    // Verify that WorkflowConfig, WorkflowContext, and IdealState are removed after workflow got
+    // expired.
+    boolean workflowExpired = TestHelper.verify(() -> {
+      WorkflowContext wCtx = _driver.getWorkflowContext(workflowName1);
+      WorkflowConfig wCfg = _driver.getWorkflowConfig(workflowName1);
+      IdealState idealState = _admin.getResourceIdealState(CLUSTER_NAME, workflowName1);
+      return (wCtx == null && wCfg == null && idealState == null);
+    }, 30 * 1000);
+    Assert.assertTrue(workflowExpired);
+
+    // Write ideaState to ZooKeeper
+    _manager.getHelixDataAccessor().getBaseDataAccessor().set(idealStatePath, record,
+        AccessOption.PERSISTENT);
+
+    // Create and start a new workflow just to make sure pipeline runs several times and context
+    // will not be created for workflow1 again
+    String workflowName2 = TestHelper.getTestMethodName() + "_2";
+    Workflow.Builder builder2 = new Workflow.Builder(workflowName2);
+    builder2.addJob("JOB0", jobBuilder1);
+    _driver.start(builder2.build());
+    _driver.pollForWorkflowState(workflowName2, TaskState.COMPLETED);
+
+    // Verify that context is not created after IdealState is written back to ZK.
+    boolean workflowContextNotCreated = TestHelper.verify(() -> {
+      WorkflowContext wCtx = _driver.getWorkflowContext(workflowName1);
+      WorkflowConfig wCfg = _driver.getWorkflowConfig(workflowName1);
+      IdealState idealState = _admin.getResourceIdealState(CLUSTER_NAME, workflowName1);
+      return (wCtx == null && wCfg == null && idealState != null);
+    }, 30 * 1000);
+    Assert.assertTrue(workflowContextNotCreated);
+  }
+}


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #582.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

An if statement is added in the getOrInitializeWorkflowContext fucntion the checks whether config is null or not. If config is null, this function will not initialize the context.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:
A new test has been added. (TestWorkflowContextWithoutConfig)

Test Result 1: mvn test

[ERROR] Tests run: 883, Failures: 2, Errors: 0, Skipped: 1, Time elapsed: 3,435.407 s <<< FAILURE! - in TestSuite
[ERROR] testTagSetIncorrect(org.apache.helix.integration.TestAlertingRebalancerFailure)  Time elapsed: 180.079 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.integration.TestAlertingRebalancerFailure.checkResourceBestPossibleCalFailureState(TestAlertingRebalancerFailure.java:310)
	at org.apache.helix.integration.TestAlertingRebalancerFailure.testTagSetIncorrect(TestAlertingRebalancerFailure.java:174)

[ERROR] testTaskPerformanceMetrics(org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics)  Time elapsed: 2.219 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics.testTaskPerformanceMetrics(TestTaskPerformanceMetrics.java:118)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 883, Failures: 2, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  57:20 min
[INFO] Finished at: 2019-11-01T10:34:40-07:00
[INFO] ------------------------------------------------------------------------


Test Result 2: mvn test -Dtest="TestAlertingRebalancerFailure,TestTaskPerformanceMetrics"
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.918 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  24.422 s
[INFO] Finished at: 2019-11-01T11:05:16-07:00
[INFO] ------------------------------------------------------------------------



### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml