### PR TITLE
Change ClusterConfig.setDefaultCapacityMap to be private.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -763,7 +763,7 @@ public class ClusterConfig extends HelixProperty {
     return Collections.emptyMap();
   }
 
-  public void setDefaultCapacityMap(ClusterConfigProperty capacityPropertyType,
+  private void setDefaultCapacityMap(ClusterConfigProperty capacityPropertyType,
       Map<String, Integer> capacityDataMap) throws IllegalArgumentException {
     if (capacityDataMap == null) {
       throw new IllegalArgumentException("Default capacity data is null");


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX")

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Hide this internal interface before merging into master.

### Tests

- [x] The following tests are written for this issue:

NA

- [x] The following is the result of the "mvn test" command on the appropriate module:

mvn build done

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml