### PR TITLE
Add a ZkAddress-based constructor for ConfigAccessor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -810,4 +810,13 @@ public class ConfigAccessor {
       ZKUtil.createOrUpdate(_zkClient, zkPath, instanceConfig.getRecord(), true, true);
     }
   }
+
+  /**
+   * Closes the ZkClient.
+   */
+  public void close() {
+    if (_zkClient != null) {
+      _zkClient.close();
+    }
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -810,8 +810,4 @@ public class ConfigAccessor {
       ZKUtil.createOrUpdate(_zkClient, zkPath, instanceConfig.getRecord(), true, true);
     }
   }
-
-  public void close() {
-
-  }
 }

--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -69,6 +69,9 @@ public class ConfigAccessor {
   }
 
   private final HelixZkClient _zkClient;
+  // true if ConfigAccessor was instantiated with a HelixZkClient, false otherwise
+  // This is used for close() to determine how ConfigAccessor should close the underlying ZkClient
+  private boolean _usesExternalZkClient;
 
   /**
    * Initialize an accessor with a Zookeeper client
@@ -77,6 +80,7 @@ public class ConfigAccessor {
    */
   public ConfigAccessor(HelixZkClient zkClient) {
     this._zkClient = zkClient;
+    this._usesExternalZkClient = true;
   }
 
   /**
@@ -87,6 +91,7 @@ public class ConfigAccessor {
     this._zkClient = SharedZkClientFactory.getInstance()
         .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
             new HelixZkClient.ZkClientConfig());
+    this._usesExternalZkClient = false;
   }
 
   /**
@@ -815,7 +820,7 @@ public class ConfigAccessor {
    * Closes the ZkClient.
    */
   public void close() {
-    if (_zkClient != null) {
+    if (_zkClient != null && !_usesExternalZkClient) {
       _zkClient.close();
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -71,7 +71,7 @@ public class ConfigAccessor {
   private final HelixZkClient _zkClient;
   // true if ConfigAccessor was instantiated with a HelixZkClient, false otherwise
   // This is used for close() to determine how ConfigAccessor should close the underlying ZkClient
-  private boolean _usesExternalZkClient;
+  private final boolean _usesExternalZkClient;
 
   /**
    * Initialize an accessor with a Zookeeper client
@@ -79,8 +79,8 @@ public class ConfigAccessor {
    * @param zkClient
    */
   public ConfigAccessor(HelixZkClient zkClient) {
-    this._zkClient = zkClient;
-    this._usesExternalZkClient = true;
+    _zkClient = zkClient;
+    _usesExternalZkClient = true;
   }
 
   /**
@@ -88,10 +88,10 @@ public class ConfigAccessor {
    * @param zkAddress
    */
   public ConfigAccessor(String zkAddress) {
-    this._zkClient = SharedZkClientFactory.getInstance()
+    _zkClient = SharedZkClientFactory.getInstance()
         .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
             new HelixZkClient.ZkClientConfig());
-    this._usesExternalZkClient = false;
+    _usesExternalZkClient = false;
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -29,6 +29,7 @@ import java.util.TreeMap;
 
 import org.apache.helix.manager.zk.ZKUtil;
 import org.apache.helix.manager.zk.client.HelixZkClient;
+import org.apache.helix.manager.zk.client.SharedZkClientFactory;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ConfigScope;
 import org.apache.helix.model.HelixConfigScope;
@@ -67,14 +68,25 @@ public class ConfigAccessor {
     // @formatter:on
   }
 
-  private final HelixZkClient zkClient;
+  private final HelixZkClient _zkClient;
 
   /**
    * Initialize an accessor with a Zookeeper client
+   * Note: it is recommended to use the other constructor instead to avoid having to create a HelixZkClient.
    * @param zkClient
    */
   public ConfigAccessor(HelixZkClient zkClient) {
-    this.zkClient = zkClient;
+    this._zkClient = zkClient;
+  }
+
+  /**
+   * Initialize a ConfigAccessor with a ZooKeeper connect string. It will use a SharedZkClient with default settings.
+   * @param zkAddress
+   */
+  public ConfigAccessor(String zkAddress) {
+    this._zkClient = SharedZkClientFactory.getInstance()
+        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
+            new HelixZkClient.ZkClientConfig());
   }
 
   /**
@@ -107,14 +119,14 @@ public class ConfigAccessor {
     // String value = null;
     Map<String, String> map = new HashMap<String, String>();
     String clusterName = scope.getClusterName();
-    if (!ZKUtil.isClusterSetup(clusterName, zkClient)) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("cluster " + clusterName + " is not setup yet");
     }
 
     String scopeStr = scope.getScopeStr();
     String[] splits = scopeStr.split("\\|");
 
-    ZNRecord record = zkClient.readData(splits[0], true);
+    ZNRecord record = _zkClient.readData(splits[0], true);
 
     if (record != null) {
       if (splits.length == 1) {
@@ -198,11 +210,11 @@ public class ConfigAccessor {
 
   private ZNRecord getConfigZnRecord(HelixConfigScope scope) {
     String clusterName = scope.getClusterName();
-    if (!ZKUtil.isClusterSetup(clusterName, zkClient)) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("fail to get configs. cluster " + clusterName + " is not setup yet");
     }
 
-    return zkClient.readData(scope.getZkPath(), true);
+    return _zkClient.readData(scope.getZkPath(), true);
   }
 
   /**
@@ -233,14 +245,14 @@ public class ConfigAccessor {
     }
 
     String clusterName = scope.getClusterName();
-    if (!ZKUtil.isClusterSetup(clusterName, zkClient)) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("cluster: " + clusterName + " is NOT setup.");
     }
 
     if (scope.getScope() == ConfigScopeProperty.PARTICIPANT) {
       String scopeStr = scope.getScopeStr();
       String instanceName = scopeStr.substring(scopeStr.lastIndexOf('/') + 1);
-      if (!ZKUtil.isInstanceSetup(zkClient, scope.getClusterName(), instanceName,
+      if (!ZKUtil.isInstanceSetup(_zkClient, scope.getClusterName(), instanceName,
           InstanceType.PARTICIPANT)) {
         throw new HelixException("instance: " + instanceName + " is NOT setup in cluster: "
             + clusterName);
@@ -267,7 +279,7 @@ public class ConfigAccessor {
         update.getMapField(splits[1]).put(key, value);
       }
     }
-    ZKUtil.createOrMerge(zkClient, splits[0], update, true, true);
+    ZKUtil.createOrMerge(_zkClient, splits[0], update, true, true);
   }
 
   /**
@@ -296,12 +308,12 @@ public class ConfigAccessor {
     }
 
     String clusterName = scope.getClusterName();
-    if (!ZKUtil.isClusterSetup(clusterName, zkClient)) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("fail to set config. cluster: " + clusterName + " is NOT setup.");
     }
 
     if (scope.getType() == ConfigScopeProperty.PARTICIPANT) {
-      if (!ZKUtil.isInstanceSetup(zkClient, scope.getClusterName(), scope.getParticipantName(),
+      if (!ZKUtil.isInstanceSetup(_zkClient, scope.getClusterName(), scope.getParticipantName(),
           InstanceType.PARTICIPANT)) {
         throw new HelixException("fail to set config. instance: " + scope.getParticipantName()
             + " is NOT setup in cluster: " + clusterName);
@@ -318,7 +330,7 @@ public class ConfigAccessor {
       update.setMapField(mapKey, keyValueMap);
     }
 
-    ZKUtil.createOrMerge(zkClient, zkPath, update, true, true);
+    ZKUtil.createOrMerge(_zkClient, zkPath, update, true, true);
   }
 
   /**
@@ -346,7 +358,7 @@ public class ConfigAccessor {
     }
 
     String clusterName = scope.getClusterName();
-    if (!ZKUtil.isClusterSetup(clusterName, zkClient)) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("cluster " + clusterName + " is not setup yet");
     }
 
@@ -370,7 +382,7 @@ public class ConfigAccessor {
       }
     }
 
-    ZKUtil.subtract(zkClient, splits[0], update);
+    ZKUtil.subtract(_zkClient, splits[0], update);
   }
 
   /**
@@ -396,7 +408,7 @@ public class ConfigAccessor {
     }
 
     String clusterName = scope.getClusterName();
-    if (!ZKUtil.isClusterSetup(clusterName, zkClient)) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("fail to remove. cluster " + clusterName + " is not setup yet");
     }
 
@@ -417,7 +429,7 @@ public class ConfigAccessor {
       }
     }
 
-    ZKUtil.subtract(zkClient, zkPath, update);
+    ZKUtil.subtract(_zkClient, zkPath, update);
   }
 
   /**
@@ -434,12 +446,12 @@ public class ConfigAccessor {
     }
 
     String clusterName = scope.getClusterName();
-    if (!ZKUtil.isClusterSetup(clusterName, zkClient)) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("fail to remove. cluster " + clusterName + " is not setup yet");
     }
 
     String zkPath = scope.getZkPath();
-    ZKUtil.subtract(zkClient, zkPath, recordToRemove);
+    ZKUtil.subtract(_zkClient, zkPath, recordToRemove);
   }
 
   /**
@@ -458,7 +470,7 @@ public class ConfigAccessor {
     }
 
     try {
-      if (!ZKUtil.isClusterSetup(clusterName, zkClient)) {
+      if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
         LOG.error("cluster " + clusterName + " is not setup yet");
         return Collections.emptyList();
       }
@@ -470,9 +482,9 @@ public class ConfigAccessor {
       String[] splits = scopeStr.split("\\|");
       List<String> retKeys = null;
       if (splits.length == 1) {
-        retKeys = zkClient.getChildren(splits[0]);
+        retKeys = _zkClient.getChildren(splits[0]);
       } else {
-        ZNRecord record = zkClient.readData(splits[0]);
+        ZNRecord record = _zkClient.readData(splits[0]);
 
         if (splits[1].startsWith("SIMPLEKEYS")) {
           retKeys = new ArrayList<String>(record.getSimpleFields().keySet());
@@ -507,7 +519,7 @@ public class ConfigAccessor {
       return null;
     }
 
-    if (!ZKUtil.isClusterSetup(scope.getClusterName(), zkClient)) {
+    if (!ZKUtil.isClusterSetup(scope.getClusterName(), _zkClient)) {
       LOG.error("fail to getKeys. cluster " + scope.getClusterName() + " is not setup yet");
       return Collections.emptyList();
     }
@@ -517,7 +529,7 @@ public class ConfigAccessor {
     List<String> retKeys = null;
 
     if (scope.isFullKey()) {
-      ZNRecord record = zkClient.readData(zkPath);
+      ZNRecord record = _zkClient.readData(zkPath);
       if (mapKey == null) {
         retKeys = new ArrayList<String>(record.getSimpleFields().keySet());
       } else {
@@ -525,10 +537,10 @@ public class ConfigAccessor {
       }
     } else {
       if (scope.getType() == ConfigScopeProperty.PARTITION) {
-        ZNRecord record = zkClient.readData(zkPath);
+        ZNRecord record = _zkClient.readData(zkPath);
         retKeys = new ArrayList<String>(record.getMapFields().keySet());
       } else {
-        retKeys = zkClient.getChildren(zkPath);
+        retKeys = _zkClient.getChildren(zkPath);
       }
     }
 
@@ -546,7 +558,7 @@ public class ConfigAccessor {
    * @return
    */
   public ClusterConfig getClusterConfig(String clusterName) {
-    if (!ZKUtil.isClusterSetup(clusterName, zkClient)) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("fail to get config. cluster: " + clusterName + " is NOT setup.");
     }
 
@@ -617,7 +629,7 @@ public class ConfigAccessor {
 
 
   private void updateClusterConfig(String clusterName, ClusterConfig clusterConfig, boolean overwrite) {
-    if (!ZKUtil.isClusterSetup(clusterName, zkClient)) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("fail to update config. cluster: " + clusterName + " is NOT setup.");
     }
 
@@ -626,9 +638,9 @@ public class ConfigAccessor {
     String zkPath = scope.getZkPath();
 
     if (overwrite) {
-      ZKUtil.createOrReplace(zkClient, zkPath, clusterConfig.getRecord(), true);
+      ZKUtil.createOrReplace(_zkClient, zkPath, clusterConfig.getRecord(), true);
     } else {
-      ZKUtil.createOrUpdate(zkClient, zkPath, clusterConfig.getRecord(), true, true);
+      ZKUtil.createOrUpdate(_zkClient, zkPath, clusterConfig.getRecord(), true, true);
     }
   }
 
@@ -694,7 +706,7 @@ public class ConfigAccessor {
 
   private void updateResourceConfig(String clusterName, String resourceName,
       ResourceConfig resourceConfig, boolean overwrite) {
-    if (!ZKUtil.isClusterSetup(clusterName, zkClient)) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("fail to setup config. cluster: " + clusterName + " is NOT setup.");
     }
 
@@ -704,9 +716,9 @@ public class ConfigAccessor {
     String zkPath = scope.getZkPath();
 
     if (overwrite) {
-      ZKUtil.createOrReplace(zkClient, zkPath, resourceConfig.getRecord(), true);
+      ZKUtil.createOrReplace(_zkClient, zkPath, resourceConfig.getRecord(), true);
     } else {
-      ZKUtil.createOrUpdate(zkClient, zkPath, resourceConfig.getRecord(), true, true);
+      ZKUtil.createOrUpdate(_zkClient, zkPath, resourceConfig.getRecord(), true, true);
     }
   }
 
@@ -719,7 +731,7 @@ public class ConfigAccessor {
    * @return
    */
   public InstanceConfig getInstanceConfig(String clusterName, String instanceName) {
-    if (!ZKUtil.isInstanceSetup(zkClient, clusterName, instanceName, InstanceType.PARTICIPANT)) {
+    if (!ZKUtil.isInstanceSetup(_zkClient, clusterName, instanceName, InstanceType.PARTICIPANT)) {
       throw new HelixException(
           "fail to get config. instance: " + instanceName + " is NOT setup in cluster: "
               + clusterName);
@@ -777,7 +789,7 @@ public class ConfigAccessor {
 
   private void updateInstanceConfig(String clusterName, String instanceName,
       InstanceConfig instanceConfig, boolean overwrite) {
-    if (!ZKUtil.isClusterSetup(clusterName, zkClient)) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("fail to setup config. cluster: " + clusterName + " is NOT setup.");
     }
 
@@ -786,16 +798,20 @@ public class ConfigAccessor {
             .forParticipant(instanceName).build();
     String zkPath = scope.getZkPath();
 
-    if (!zkClient.exists(zkPath)) {
+    if (!_zkClient.exists(zkPath)) {
       throw new HelixException(
           "updateInstanceConfig failed. Given InstanceConfig does not already exist. instance: "
               + instanceName);
     }
 
     if (overwrite) {
-      ZKUtil.createOrReplace(zkClient, zkPath, instanceConfig.getRecord(), true);
+      ZKUtil.createOrReplace(_zkClient, zkPath, instanceConfig.getRecord(), true);
     } else {
-      ZKUtil.createOrUpdate(zkClient, zkPath, instanceConfig.getRecord(), true, true);
+      ZKUtil.createOrUpdate(_zkClient, zkPath, instanceConfig.getRecord(), true, true);
     }
+  }
+
+  public void close() {
+
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -78,6 +78,7 @@ public class ConfigAccessor {
    * Note: it is recommended to use the other constructor instead to avoid having to create a HelixZkClient.
    * @param zkClient
    */
+  @Deprecated
   public ConfigAccessor(HelixZkClient zkClient) {
     _zkClient = zkClient;
     _usesExternalZkClient = true;
@@ -817,7 +818,7 @@ public class ConfigAccessor {
   }
 
   /**
-   * Closes the ZkClient.
+   * Closes ConfigAccessor: closes the stateful resources including the ZkClient.
    */
   public void close() {
     if (_zkClient != null && !_usesExternalZkClient) {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #591 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In order to allow users to not take on the burden of creating an instance of HelixZkClient to use Helix data access APIs (like ConfigAccessor), we need to add a constructor that takes in a ZK connect string instead.

This approach has advantages such as 1) the user doesn't have to maintain the lifecycle of the ZkClient 2) add a layer of indirection between ZK and the user where Helix logic could be injected.

Also close() is added so that the user could close after use.

### Tests

- [x] The following tests are written for this issue:

ConfigAccessor is covered by existing integration tests such as TestConfigAccessor.

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestCardDealingAdjustmentAlgorithmV2.testAlgorithmConstructor:128 expected:<9> but was:<6>
[ERROR] org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas(org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2)
[ERROR]   Run 1: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:274 Total movements: 4 != expected 8, replica: 1
[ERROR]   Run 2: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:274 Total movements: 4 != expected 8, replica: 2
[ERROR]   Run 3: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:274 Total movements: 14 != expected 21, replica: 3
[INFO]   Run 4: PASS
[INFO]   Run 5: PASS
[INFO] 
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 882, Failures: 3, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  57:54 min
[INFO] Finished at: 2019-11-15T11:57:50-08:00

--------------

The tests pass when run individually.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml