### PR TITLE
Change calculation for baseline divergence.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/ResourceUsageCalculator.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/ResourceUsageCalculator.java
@@ -141,6 +141,6 @@ public class ResourceUsageCalculator {
     }
 
     return numTotalBestPossibleReplicas == 0 ? 1.0d
-        : (1.0d -  (double) numMatchedReplicas / (double) numTotalBestPossibleReplicas);
+        : (1.0d - (double) numMatchedReplicas / (double) numTotalBestPossibleReplicas);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/ResourceUsageCalculator.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/ResourceUsageCalculator.java
@@ -82,7 +82,9 @@ public class ResourceUsageCalculator {
    *       }
    *    }
    * }
-   * baseline divergence = (matched: 1) / (total(matched + doesn't match): 3) = 1/3 ~= 0.333
+   * baseline divergence = (doesn't match: 2) / (total(matched + doesn't match): 3) = 2/3 ~= 0.66667
+   * If divergence == 1.0, all are different(no match); divergence == 0.0, no difference.
+   *
    * @param baseline baseline assignment
    * @param bestPossibleAssignment best possible assignment
    * @return double value range at [0.0, 1.0]
@@ -138,7 +140,7 @@ public class ResourceUsageCalculator {
       }
     }
 
-    return numTotalBestPossibleReplicas == 0 ? 0.0d
-        : (double) numMatchedReplicas / (double) numTotalBestPossibleReplicas;
+    return numTotalBestPossibleReplicas == 0 ? 1.0d
+        : (1.0d -  (double) numMatchedReplicas / (double) numTotalBestPossibleReplicas);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/util/TestResourceUsageCalculator.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/util/TestResourceUsageCalculator.java
@@ -45,19 +45,19 @@ public class TestResourceUsageCalculator {
 
     // Empty best possible assignment.
     Assert.assertEquals(ResourceUsageCalculator
-        .measureBaselineDivergence(baselineAssignment, Collections.emptyMap()), 0.0d);
+        .measureBaselineDivergence(baselineAssignment, Collections.emptyMap()), 1.0d);
     // Empty baseline assignment.
     Assert.assertEquals(ResourceUsageCalculator
-        .measureBaselineDivergence(Collections.emptyMap(), noMatchBestPossibleAssignment), 0.0d);
+        .measureBaselineDivergence(Collections.emptyMap(), noMatchBestPossibleAssignment), 1.0d);
 
     Assert.assertEquals(ResourceUsageCalculator
-        .measureBaselineDivergence(baselineAssignment, noMatchBestPossibleAssignment), 0.0d);
+        .measureBaselineDivergence(baselineAssignment, noMatchBestPossibleAssignment), 1.0d);
     Assert.assertEquals(ResourceUsageCalculator
             .measureBaselineDivergence(baselineAssignment, someMatchBestPossibleAssignment),
-        (double) 1 / (double) 3);
+        (1.0d - (double) 1 / (double) 3));
     Assert.assertEquals(
         ResourceUsageCalculator.measureBaselineDivergence(baselineAssignment, baselineAssignment),
-        1.0d);
+        0.0d);
   }
 
   private Map<String, ResourceAssignment> buildResourceAssignment(

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
@@ -138,7 +138,7 @@ public class TestWagedRebalancerMetrics extends AbstractTestClusterModel {
     // Wait for asyncReportBaselineDivergenceGauge to complete and verify.
     Assert.assertTrue(TestHelper.verify(() -> (double) metricCollector.getMetric(
         WagedRebalancerMetricCollector.WagedRebalancerMetricNames.BaselineDivergenceGauge.name(),
-        RatioMetric.class).getLastEmittedMetricValue() == 1.0d, TestHelper.WAIT_DURATION));
+        RatioMetric.class).getLastEmittedMetricValue() == 0.0d, TestHelper.WAIT_DURATION));
   }
 
   @Override


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #587 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In current BaselineDivergenceGauge, value 0 means no match, 1 means all matched.
Because of divergence, we need to reverse this: 0 -> no difference, 1 -> all are different.
This PR addresses this fix.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[ERROR]   TestGetLastScheduledTaskExecInfo.testGetLastScheduledTaskExecInfo:70 expected:<1573678321675> but was:<1573678320630>
[INFO]
[ERROR] Tests run: 1049, Failures: 4, Errors: 0, Skipped: 5
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:12 h
[INFO] Finished at: 2019-11-13T12:55:12-08:00

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml