### PR TITLE
add Helix cloud interface and implementation skeleton methods

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/api/cloud/CloudInstanceInformation.java
+++ b/helix-core/src/main/java/org/apache/helix/api/cloud/CloudInstanceInformation.java
@@ -1,0 +1,40 @@
+package org.apache.helix.api.cloud;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Generic interface for cloud instance information
+ */
+public interface CloudInstanceInformation {
+  /**
+   * Get the the value of a specific cloud instance field by name
+   * @return the value of the field
+   */
+  String get(String key);
+
+  /**
+   * The enum contains all the required cloud instance field in Helix
+   */
+  enum CloudInstanceField {
+    INSTANCE_NAME,
+    FAULT_DOMAIN,
+    INSTANCE_SET_NAME
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/api/cloud/CloudInstanceInformationProcessor.java
+++ b/helix-core/src/main/java/org/apache/helix/api/cloud/CloudInstanceInformationProcessor.java
@@ -1,0 +1,41 @@
+package org.apache.helix.api.cloud;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+
+
+/**
+ * Generic interface to fetch and parse cloud instance information
+ */
+public interface CloudInstanceInformationProcessor<T extends Object> {
+
+  /**
+   * Get the raw cloud instance information
+   * @return raw cloud instance information
+   */
+  List<T> fetchCloudInstanceInformation();
+
+  /**
+   * Parse the raw cloud instance information in responses and compose required cloud instance information
+   * @return required cloud instance information
+   */
+  CloudInstanceInformation parseCloudInstanceInformation(List<T> responses);
+}

--- a/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformation.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformation.java
@@ -1,0 +1,77 @@
+package org.apache.helix.cloud.azure;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Map;
+
+import org.apache.helix.api.cloud.CloudInstanceInformation;
+
+
+public class AzureCloudInstanceInformation implements CloudInstanceInformation {
+  private Map<String, String> _cloudInstanceInfoMap;
+
+  /**
+   * Instantiate the AzureCloudInstanceInformation using each field individually.
+   * Users should use AzureCloudInstanceInformation.Builder to create information.
+   * @param cloudInstanceInfoMap
+   */
+  protected AzureCloudInstanceInformation(Map<String, String> cloudInstanceInfoMap) {
+    _cloudInstanceInfoMap = cloudInstanceInfoMap;
+  }
+
+  @Override
+  public String get(String key) {
+    return _cloudInstanceInfoMap.get(key);
+  }
+
+  public static class Builder {
+    private Map<String, String> _cloudInstanceInfoMap = null;
+
+    public AzureCloudInstanceInformation build() {
+      return new AzureCloudInstanceInformation(_cloudInstanceInfoMap);
+    }
+
+    /**
+     * Default constructor
+     */
+    public Builder() {
+    }
+
+    public Builder setInstanceName(String v) {
+      _cloudInstanceInfoMap.put(CloudInstanceField.INSTANCE_NAME.name(), v);
+      return this;
+    }
+
+    public Builder setFaultDomain(String v) {
+      _cloudInstanceInfoMap.put(CloudInstanceField.FAULT_DOMAIN.name(), v);
+      return this;
+    }
+
+    public Builder setInstanceSetName(String v) {
+      _cloudInstanceInfoMap.put(CloudInstanceField.INSTANCE_SET_NAME.name(), v);
+      return this;
+    }
+
+    public Builder setCloudInstanceInfoField(String key, String value) {
+      _cloudInstanceInfoMap.put(key, value);
+      return this;
+    }
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformationProcessor.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformationProcessor.java
@@ -1,0 +1,56 @@
+package org.apache.helix.cloud.azure;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.helix.api.cloud.CloudInstanceInformationProcessor;
+
+
+public class AzureCloudInstanceInformationProcessor implements CloudInstanceInformationProcessor<String> {
+
+  public AzureCloudInstanceInformationProcessor() {
+  }
+
+  /**
+   * fetch the raw Azure cloud instance information
+   * @return raw Azure cloud instance information
+   */
+  @Override
+  public List<String> fetchCloudInstanceInformation() {
+    List<String> response = new ArrayList<>();
+    //TODO: implement the fetching logic
+    return response;
+  }
+
+  /**
+   * Parse raw Azure cloud instance information.
+   * @return required azure cloud instance information
+   */
+  @Override
+  public AzureCloudInstanceInformation parseCloudInstanceInformation(List<String> responses) {
+    AzureCloudInstanceInformation azureCloudInstanceInformation = null;
+    //TODO: implement the parsing logic
+    return azureCloudInstanceInformation;
+  }
+}
+
+


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
issue:[599](https://github.com/apache/helix/issues/599)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
We plan to support participant auto registration to the cluster for scalability and robustness reason. In this PR, there are interfaces for fetching and parsing cloud information, and some skeleton code for the implementation.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Tests run: 882, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3,152.768 s <<< FAILURE! - in TestSuite
[ERROR] testTaskPerformanceMetrics(org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics)  Time elapsed: 2.16 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics.testTaskPerformanceMetrics(TestTaskPerformanceMetrics.java:118)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 882, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Helix 0.9.2-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  0.388 s]
[INFO] Apache Helix :: Core ............................... FAILURE [52:36 min]
[INFO] Apache Helix :: Admin Webapp ....................... SKIPPED
[INFO] Apache Helix :: Restful Interface .................. SKIPPED
[INFO] Apache Helix :: HelixAgent ......................... SKIPPED
[INFO] Apache Helix :: Recipes ............................ SKIPPED
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SKIPPED
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SKIPPED
[INFO] Apache Helix :: Recipes :: distributed lock manager  SKIPPED
[INFO] Apache Helix :: Recipes :: distributed task execution SKIPPED
[INFO] Apache Helix :: Recipes :: service discovery ....... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  52:37 min
[INFO] Finished at: 2019-11-13T10:12:30-08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/mnzhang/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :helix-core

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml