### PR TITLE
Add new constructors and close() to Helix API

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -90,12 +90,16 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   private final HelixZkClient _zkClient;
   private final ConfigAccessor _configAccessor;
+  // true if ZKHelixAdmin was instantiated with a HelixZkClient, false otherwise
+  // This is used for close() to determine how ZKHelixAdmin should close the underlying ZkClient
+  private boolean _usesExternalZkClient;
 
   private static Logger logger = LoggerFactory.getLogger(ZKHelixAdmin.class);
 
   public ZKHelixAdmin(HelixZkClient zkClient) {
     _zkClient = zkClient;
     _configAccessor = new ConfigAccessor(zkClient);
+    _usesExternalZkClient = true;
   }
 
   public ZKHelixAdmin(String zkAddress) {
@@ -107,6 +111,7 @@ public class ZKHelixAdmin implements HelixAdmin {
         .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress), clientConfig);
     _zkClient.waitUntilConnected(timeOutInSec, TimeUnit.SECONDS);
     _configAccessor = new ConfigAccessor(_zkClient);
+    _usesExternalZkClient = false;
   }
 
   @Override
@@ -1571,11 +1576,13 @@ public class ZKHelixAdmin implements HelixAdmin {
     return instances;
   }
 
+  /**
+   * Closes the ZkClient only if it was generated internally.
+   */
   @Override
   public void close() {
-    if (_zkClient != null) {
+    if (_zkClient != null && !_usesExternalZkClient) {
       _zkClient.close();
     }
   }
-
 }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -92,10 +92,11 @@ public class ZKHelixAdmin implements HelixAdmin {
   private final ConfigAccessor _configAccessor;
   // true if ZKHelixAdmin was instantiated with a HelixZkClient, false otherwise
   // This is used for close() to determine how ZKHelixAdmin should close the underlying ZkClient
-  private boolean _usesExternalZkClient;
+  private final boolean _usesExternalZkClient;
 
   private static Logger logger = LoggerFactory.getLogger(ZKHelixAdmin.class);
 
+  @Deprecated
   public ZKHelixAdmin(HelixZkClient zkClient) {
     _zkClient = zkClient;
     _configAccessor = new ConfigAccessor(zkClient);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -105,9 +105,10 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
    * @param zkAddress The zookeeper address
    */
   public ZkBaseDataAccessor(String zkAddress, ZkSerializer zkSerializer) {
-    _zkClient = SharedZkClientFactory.getInstance()
-        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
-            new HelixZkClient.ZkClientConfig().setZkSerializer(zkSerializer));
+    _zkClient = SharedZkClientFactory.getInstance().buildZkClient(
+        new HelixZkClient.ZkConnectionConfig(zkAddress),
+        new HelixZkClient.ZkClientConfig().setZkSerializer(zkSerializer));
+    _usesExternalZkClient = false;
   }
 
   /**
@@ -1147,7 +1148,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
    */
   @Override
   public void close() {
-    if (_zkClient != null) {
+    if (_zkClient != null && !_usesExternalZkClient) {
       _zkClient.close();
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -87,12 +87,17 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
   private static Logger LOG = LoggerFactory.getLogger(ZkBaseDataAccessor.class);
 
   private final HelixZkClient _zkClient;
+  // true if ZkBaseDataAccessor was instantiated with a HelixZkClient, false otherwise
+  // This is used for close() to determine how ZkBaseDataAccessor should close the underlying
+  // ZkClient
+  private boolean _usesExternalZkClient;
 
   public ZkBaseDataAccessor(HelixZkClient zkClient) {
     if (zkClient == null) {
       throw new NullPointerException("zkclient is null");
     }
     _zkClient = zkClient;
+    _usesExternalZkClient = true;
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -90,8 +90,9 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
   // true if ZkBaseDataAccessor was instantiated with a HelixZkClient, false otherwise
   // This is used for close() to determine how ZkBaseDataAccessor should close the underlying
   // ZkClient
-  private boolean _usesExternalZkClient;
+  private final boolean _usesExternalZkClient;
 
+  @Deprecated
   public ZkBaseDataAccessor(HelixZkClient zkClient) {
     if (zkClient == null) {
       throw new NullPointerException("zkclient is null");

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -69,7 +69,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
   private final ReentrantLock _eventLock = new ReentrantLock();
   private ZkCacheEventThread _eventThread;
 
-  private HelixZkClient _zkclient = null;
+  private HelixZkClient _zkClient = null;
 
   public ZkCacheBaseDataAccessor(ZkBaseDataAccessor<T> baseAccessor, List<String> wtCachePaths) {
     this(baseAccessor, null, wtCachePaths, null);
@@ -115,11 +115,11 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
     clientConfig.setZkSerializer(serializer)
         .setMonitorType(monitorType)
         .setMonitorKey(monitorkey);
-    _zkclient = SharedZkClientFactory.getInstance()
+    _zkClient = SharedZkClientFactory.getInstance()
         .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress), clientConfig);
 
-    _zkclient.waitUntilConnected(HelixZkClient.DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
-    _baseAccessor = new ZkBaseDataAccessor<>(_zkclient);
+    _zkClient.waitUntilConnected(HelixZkClient.DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
+    _baseAccessor = new ZkBaseDataAccessor<>(_zkClient);
 
     if (chrootPath == null || chrootPath.equals("/")) {
       _chrootPath = null;
@@ -786,9 +786,9 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
     try {
       _eventLock.lockInterruptibly();
 
-      if (_zkclient != null) {
-        _zkclient.close();
-        _zkclient = null;
+      if (_zkClient != null) {
+        _zkClient.close();
+        _zkClient = null;
       }
 
       if (_eventThread == null) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -823,8 +823,8 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
 
   @Override
   public void close() {
-    if (_zkclient != null) {
-      _zkclient.close();
+    if (_zkClient != null) {
+      _zkClient.close();
     }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/HelixClusterVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/HelixClusterVerifier.java
@@ -37,4 +37,9 @@ public interface HelixClusterVerifier {
    *  @return true if succeed, false if not.
    */
   boolean verify();
+
+  /**
+   * Close the underlying metadata store connection.
+   */
+  void close();
 }

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
@@ -51,7 +51,7 @@ public abstract class ZkHelixClusterVerifier
   // true if ZkHelixClusterVerifier was instantiated with a HelixZkClient, false otherwise
   // This is used for close() to determine how ZkHelixClusterVerifier should close the underlying
   // ZkClient
-  private boolean _usesExternalZkClient;
+  private final boolean _usesExternalZkClient;
   protected final String _clusterName;
   protected final HelixDataAccessor _accessor;
   protected final PropertyKey.Builder _keyBuilder;


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #593 
Resolves #594 
Resolves #595 
Resolves #596 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In order to allow users to avoid having to create, manage, and close a HelixZkClient instance when using Helix data access APIs, we add new constructors and close() methods. The new constructors will allow for instantiation purely based on a ZkAddress, and internally, either Shared or Dedicated HelixZkClient will be used.

Also, the close() method ensures that we only close if we generated a ZkClient internally. External ZkClients, we can't close arbitrarily because they could be used in other active Helix APIs.

### Tests

- [x] The following tests are written for this issue:

No additional tests required - no new logic added.

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures:
[ERROR]   TestCardDealingAdjustmentAlgorithmV2.testAlgorithmConstructor:128 expected:<9> but was:<6>
[ERROR] org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas(org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2)
[ERROR]   Run 1: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:274 Total movements: 4 != expected 8, replica: 1
[ERROR]   Run 2: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:274 Total movements: 4 != expected 8, replica: 2
[ERROR]   Run 3: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:274 Total movements: 14 != expected 21, replica: 3
[INFO]   Run 4: PASS
[INFO]   Run 5: PASS
[INFO]
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 882, Failures: 3, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  57:28 min
[INFO] Finished at: 2019-11-14T19:44:05-08:00

------
Two tests pass when run individually.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml