### PR TITLE
Revert closing gZkClient after TestZkBaseDataAccessor afterclass method

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -40,7 +40,6 @@ import org.apache.helix.manager.zk.ZkBaseDataAccessor.AccessResult;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor.RetCode;
 import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
@@ -72,11 +71,6 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     if (_gZkClient.exists(path)) {
       _gZkClient.deleteRecursively(path);
     }
-  }
-
-  @AfterClass
-  public void afterClass() {
-    _gZkClient.close();
   }
 
   @Test


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
The introduced close gzkClient in the afterclass method in zkBaseDataAccessor will lead to the mvn test failing cause the gzkClient is in zkTestBase
### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

3705839 [ZkClient-EventThread-52503-localhost:2183] ERROR org.apache.helix.manager.zk.ZKHelixManager  - fail to connect zkserver: localhost:2183 in 60000ms. expiredSessionId: 1002923fb2f07df, clusterName: TestConsecutiveZkSessionExpiry_testDistributedController
[ERROR] Tests run: 885, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 3,720.587 s <<< FAILURE! - in TestSuite
[ERROR] testTaskPerformanceMetrics(org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics)  Time elapsed: 2.329 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.monitoring.mbeans.TestTaskPerformanceMetrics.testTaskPerformanceMetrics(TestTaskPerformanceMetrics.java:118)

[ERROR] testUserDefinedPreferenceListsInFullAuto(org.apache.helix.integration.rebalancer.TestMixedModeAutoRebalance)  Time elapsed: 3.452 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.rebalancer.TestMixedModeAutoRebalance.testUserDefinedPreferenceListsInFullAuto(TestMixedModeAutoRebalance.java:153)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR] org.apache.helix.integration.rebalancer.TestMixedModeAutoRebalance.testUserDefinedPreferenceListsInFullAuto(org.apache.helix.integration.rebalancer.TestMixedModeAutoRebalance)
[INFO]   Run 1: PASS
[INFO]   Run 2: PASS
[INFO]   Run 3: PASS
[INFO]   Run 4: PASS
[INFO]   Run 5: PASS
[INFO]   Run 6: PASS
[ERROR]   Run 7: TestMixedModeAutoRebalance.testUserDefinedPreferenceListsInFullAuto:153 expected:<true> but was:<false>
[INFO]   Run 8: PASS
[INFO] 
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 878, Failures: 2, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Helix 0.9.2-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  0.469 s]
[INFO] Apache Helix :: Core ............................... FAILURE [  01:02 h]
[INFO] Apache Helix :: Admin Webapp ....................... SKIPPED
[INFO] Apache Helix :: Restful Interface .................. SKIPPED
[INFO] Apache Helix :: HelixAgent ......................... SKIPPED
[INFO] Apache Helix :: Recipes ............................ SKIPPED
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SKIPPED
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SKIPPED
[INFO] Apache Helix :: Recipes :: distributed lock manager  SKIPPED
[INFO] Apache Helix :: Recipes :: distributed task execution SKIPPED
[INFO] Apache Helix :: Recipes :: service discovery ....... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:02 h
[INFO] Finished at: 2019-11-13T18:20:08-08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 

The failed tests are successful when running individually in IDE

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml