### PR TITLE
Modify ZkUtil methods so that they accept ZkAddress as parameter

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -36,6 +36,10 @@ import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.Stat;
 
+/**
+ * Using this ZKUtil class for production purposes is NOT recommended since a lot of the static
+ * methods require a ZkClient instance to be passed in.
+ */
 public final class ZKUtil {
   private static Logger logger = LoggerFactory.getLogger(ZKUtil.class);
   private static int RETRYLIMIT = 3;
@@ -43,6 +47,13 @@ public final class ZKUtil {
   private ZKUtil() {
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param clusterName
+   * @param zkAddress
+   * @return
+   */
   public static boolean isClusterSetup(String clusterName, String zkAddress) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
     boolean result = isClusterSetup(clusterName, zkClient);
@@ -50,7 +61,6 @@ public final class ZKUtil {
     return result;
   }
 
-  @Deprecated
   public static boolean isClusterSetup(String clusterName, HelixZkClient zkClient) {
     if (clusterName == null) {
       logger.info("Fail to check cluster setup : cluster name is null!");
@@ -97,6 +107,15 @@ public final class ZKUtil {
     return isValid;
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param zkAddress
+   * @param clusterName
+   * @param instanceName
+   * @param type
+   * @return
+   */
   public static boolean isInstanceSetup(String zkAddress, String clusterName, String instanceName,
       InstanceType type) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
@@ -105,9 +124,8 @@ public final class ZKUtil {
     return result;
   }
 
-  @Deprecated
-  public static boolean isInstanceSetup(HelixZkClient zkclient, String clusterName, String instanceName,
-      InstanceType type) {
+  public static boolean isInstanceSetup(HelixZkClient zkclient, String clusterName,
+      String instanceName, InstanceType type) {
     if (type == InstanceType.PARTICIPANT || type == InstanceType.CONTROLLER_PARTICIPANT) {
       ArrayList<String> requiredPaths = new ArrayList<>();
       requiredPaths.add(PropertyPathBuilder.instanceConfig(clusterName, instanceName));
@@ -139,13 +157,19 @@ public final class ZKUtil {
     return true;
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param zkAddress
+   * @param parentPath
+   * @param list
+   */
   public static void createChildren(String zkAddress, String parentPath, List<ZNRecord> list) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
     createChildren(zkClient, parentPath, list);
     zkClient.close();
   }
 
-  @Deprecated
   public static void createChildren(HelixZkClient client, String parentPath, List<ZNRecord> list) {
     client.createPersistent(parentPath, true);
     if (list != null) {
@@ -155,13 +179,19 @@ public final class ZKUtil {
     }
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param zkAddress
+   * @param parentPath
+   * @param nodeRecord
+   */
   public static void createChildren(String zkAddress, String parentPath, ZNRecord nodeRecord) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
     createChildren(zkClient, parentPath, nodeRecord);
     zkClient.close();
   }
 
-  @Deprecated
   public static void createChildren(HelixZkClient client, String parentPath, ZNRecord nodeRecord) {
     client.createPersistent(parentPath, true);
 
@@ -170,13 +200,19 @@ public final class ZKUtil {
     client.createPersistent(temp, nodeRecord);
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param zkAddress
+   * @param parentPath
+   * @param list
+   */
   public static void dropChildren(String zkAddress, String parentPath, List<ZNRecord> list) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
     dropChildren(zkClient, parentPath, list);
     zkClient.close();
   }
 
-  @Deprecated
   public static void dropChildren(HelixZkClient client, String parentPath, List<ZNRecord> list) {
     // TODO: check if parentPath exists
     if (list != null) {
@@ -186,13 +222,19 @@ public final class ZKUtil {
     }
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param zkAddress
+   * @param parentPath
+   * @param nodeRecord
+   */
   public static void dropChildren(String zkAddress, String parentPath, ZNRecord nodeRecord) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
     dropChildren(zkClient, parentPath, nodeRecord);
     zkClient.close();
   }
 
-  @Deprecated
   public static void dropChildren(HelixZkClient client, String parentPath, ZNRecord nodeRecord) {
     // TODO: check if parentPath exists
     String id = nodeRecord.getId();
@@ -200,6 +242,13 @@ public final class ZKUtil {
     client.deleteRecursively(temp);
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param zkAddress
+   * @param path
+   * @return
+   */
   public static List<ZNRecord> getChildren(String zkAddress, String path) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
     List<ZNRecord> result = getChildren(zkClient, path);
@@ -207,7 +256,6 @@ public final class ZKUtil {
     return result;
   }
 
-  @Deprecated
   public static List<ZNRecord> getChildren(HelixZkClient client, String path) {
     // parent watch will be set by zkClient
     List<String> children = client.getChildren(path);
@@ -231,6 +279,14 @@ public final class ZKUtil {
     return childRecords;
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param zkAddress
+   * @param path
+   * @param record
+   * @param mergeOnUpdate
+   */
   public static void updateIfExists(String zkAddress, String path, final ZNRecord record,
       boolean mergeOnUpdate) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
@@ -238,7 +294,6 @@ public final class ZKUtil {
     zkClient.close();
   }
 
-  @Deprecated
   public static void updateIfExists(HelixZkClient client, String path, final ZNRecord record,
       boolean mergeOnUpdate) {
     if (client.exists(path)) {
@@ -252,6 +307,15 @@ public final class ZKUtil {
     }
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param zkAddress
+   * @param path
+   * @param record
+   * @param persistent
+   * @param mergeOnUpdate
+   */
   public static void createOrMerge(String zkAddress, String path, final ZNRecord record,
       final boolean persistent, final boolean mergeOnUpdate) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
@@ -259,7 +323,6 @@ public final class ZKUtil {
     zkClient.close();
   }
 
-  @Deprecated
   public static void createOrMerge(HelixZkClient client, String path, final ZNRecord record,
       final boolean persistent, final boolean mergeOnUpdate) {
     int retryCount = 0;
@@ -296,6 +359,15 @@ public final class ZKUtil {
     }
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param zkAddress
+   * @param path
+   * @param record
+   * @param persistent
+   * @param mergeOnUpdate
+   */
   public static void createOrUpdate(String zkAddress, String path, final ZNRecord record,
       final boolean persistent, final boolean mergeOnUpdate) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
@@ -310,7 +382,8 @@ public final class ZKUtil {
       try {
         if (client.exists(path)) {
           DataUpdater<ZNRecord> updater = new DataUpdater<ZNRecord>() {
-            @Override public ZNRecord update(ZNRecord currentData) {
+            @Override
+            public ZNRecord update(ZNRecord currentData) {
               if (currentData != null && mergeOnUpdate) {
                 currentData.update(record);
                 return currentData;
@@ -332,6 +405,15 @@ public final class ZKUtil {
     }
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param zkAddress
+   * @param path
+   * @param record
+   * @param persistent
+   * @param mergeOnUpdate
+   */
   public static void asyncCreateOrMerge(String zkAddress, String path, final ZNRecord record,
       final boolean persistent, final boolean mergeOnUpdate) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
@@ -339,7 +421,6 @@ public final class ZKUtil {
     zkClient.close();
   }
 
-  @Deprecated
   public static void asyncCreateOrMerge(HelixZkClient client, String path, final ZNRecord record,
       final boolean persistent, final boolean mergeOnUpdate) {
     try {
@@ -375,6 +456,14 @@ public final class ZKUtil {
     }
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param zkAddress
+   * @param path
+   * @param record
+   * @param persistent
+   */
   public static void createOrReplace(String zkAddress, String path, final ZNRecord record,
       final boolean persistent) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
@@ -382,7 +471,6 @@ public final class ZKUtil {
     zkClient.close();
   }
 
-  @Deprecated
   public static void createOrReplace(HelixZkClient client, String path, final ZNRecord record,
       final boolean persistent) {
     int retryCount = 0;
@@ -409,6 +497,13 @@ public final class ZKUtil {
     }
   }
 
+  /**
+   * Note: this method will create a dedicated ZkClient on the fly. Creating and closing a
+   * ZkConnection is a costly operation - use it at your own risk!
+   * @param zkAddress
+   * @param path
+   * @param recordTosubtract
+   */
   public static void subtract(String zkAddress, final String path,
       final ZNRecord recordTosubtract) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
@@ -416,7 +511,6 @@ public final class ZKUtil {
     zkClient.close();
   }
 
-  @Deprecated
   public static void subtract(HelixZkClient client, final String path,
       final ZNRecord recordTosubtract) {
     int retryCount = 0;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -29,6 +29,7 @@ import org.apache.helix.HelixException;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.ZNRecord;
+import org.apache.helix.manager.zk.client.DedicatedZkClientFactory;
 import org.apache.helix.manager.zk.client.HelixZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,14 @@ public final class ZKUtil {
   private ZKUtil() {
   }
 
+  public static boolean isClusterSetup(String clusterName, String zkAddress) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    boolean result = isClusterSetup(clusterName, zkClient);
+    zkClient.close();
+    return result;
+  }
+
+  @Deprecated
   public static boolean isClusterSetup(String clusterName, HelixZkClient zkClient) {
     if (clusterName == null) {
       logger.info("Fail to check cluster setup : cluster name is null!");
@@ -88,6 +97,15 @@ public final class ZKUtil {
     return isValid;
   }
 
+  public static boolean isInstanceSetup(String zkAddress, String clusterName, String instanceName,
+      InstanceType type) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    boolean result = isInstanceSetup(zkClient, clusterName, instanceName, type);
+    zkClient.close();
+    return result;
+  }
+
+  @Deprecated
   public static boolean isInstanceSetup(HelixZkClient zkclient, String clusterName, String instanceName,
       InstanceType type) {
     if (type == InstanceType.PARTICIPANT || type == InstanceType.CONTROLLER_PARTICIPANT) {
@@ -121,6 +139,13 @@ public final class ZKUtil {
     return true;
   }
 
+  public static void createChildren(String zkAddress, String parentPath, List<ZNRecord> list) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    createChildren(zkClient, parentPath, list);
+    zkClient.close();
+  }
+
+  @Deprecated
   public static void createChildren(HelixZkClient client, String parentPath, List<ZNRecord> list) {
     client.createPersistent(parentPath, true);
     if (list != null) {
@@ -130,6 +155,13 @@ public final class ZKUtil {
     }
   }
 
+  public static void createChildren(String zkAddress, String parentPath, ZNRecord nodeRecord) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    createChildren(zkClient, parentPath, nodeRecord);
+    zkClient.close();
+  }
+
+  @Deprecated
   public static void createChildren(HelixZkClient client, String parentPath, ZNRecord nodeRecord) {
     client.createPersistent(parentPath, true);
 
@@ -138,6 +170,13 @@ public final class ZKUtil {
     client.createPersistent(temp, nodeRecord);
   }
 
+  public static void dropChildren(String zkAddress, String parentPath, List<ZNRecord> list) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    dropChildren(zkClient, parentPath, list);
+    zkClient.close();
+  }
+
+  @Deprecated
   public static void dropChildren(HelixZkClient client, String parentPath, List<ZNRecord> list) {
     // TODO: check if parentPath exists
     if (list != null) {
@@ -147,6 +186,13 @@ public final class ZKUtil {
     }
   }
 
+  public static void dropChildren(String zkAddress, String parentPath, ZNRecord nodeRecord) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    dropChildren(zkClient, parentPath, nodeRecord);
+    zkClient.close();
+  }
+
+  @Deprecated
   public static void dropChildren(HelixZkClient client, String parentPath, ZNRecord nodeRecord) {
     // TODO: check if parentPath exists
     String id = nodeRecord.getId();
@@ -154,6 +200,14 @@ public final class ZKUtil {
     client.deleteRecursively(temp);
   }
 
+  public static List<ZNRecord> getChildren(String zkAddress, String path) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    List<ZNRecord> result = getChildren(zkClient, path);
+    zkClient.close();
+    return result;
+  }
+
+  @Deprecated
   public static List<ZNRecord> getChildren(HelixZkClient client, String path) {
     // parent watch will be set by zkClient
     List<String> children = client.getChildren(path);
@@ -177,6 +231,14 @@ public final class ZKUtil {
     return childRecords;
   }
 
+  public static void updateIfExists(String zkAddress, String path, final ZNRecord record,
+      boolean mergeOnUpdate) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    updateIfExists(zkClient, path, record, mergeOnUpdate);
+    zkClient.close();
+  }
+
+  @Deprecated
   public static void updateIfExists(HelixZkClient client, String path, final ZNRecord record,
       boolean mergeOnUpdate) {
     if (client.exists(path)) {
@@ -190,6 +252,14 @@ public final class ZKUtil {
     }
   }
 
+  public static void createOrMerge(String zkAddress, String path, final ZNRecord record,
+      final boolean persistent, final boolean mergeOnUpdate) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    createOrMerge(zkClient, path, record, persistent, mergeOnUpdate);
+    zkClient.close();
+  }
+
+  @Deprecated
   public static void createOrMerge(HelixZkClient client, String path, final ZNRecord record,
       final boolean persistent, final boolean mergeOnUpdate) {
     int retryCount = 0;
@@ -226,6 +296,13 @@ public final class ZKUtil {
     }
   }
 
+  public static void createOrUpdate(String zkAddress, String path, final ZNRecord record,
+      final boolean persistent, final boolean mergeOnUpdate) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    createOrUpdate(zkClient, path, record, persistent, mergeOnUpdate);
+    zkClient.close();
+  }
+
   public static void createOrUpdate(HelixZkClient client, String path, final ZNRecord record,
       final boolean persistent, final boolean mergeOnUpdate) {
     int retryCount = 0;
@@ -255,6 +332,14 @@ public final class ZKUtil {
     }
   }
 
+  public static void asyncCreateOrMerge(String zkAddress, String path, final ZNRecord record,
+      final boolean persistent, final boolean mergeOnUpdate) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    asyncCreateOrMerge(zkClient, path, record, persistent, mergeOnUpdate);
+    zkClient.close();
+  }
+
+  @Deprecated
   public static void asyncCreateOrMerge(HelixZkClient client, String path, final ZNRecord record,
       final boolean persistent, final boolean mergeOnUpdate) {
     try {
@@ -290,6 +375,14 @@ public final class ZKUtil {
     }
   }
 
+  public static void createOrReplace(String zkAddress, String path, final ZNRecord record,
+      final boolean persistent) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    createOrReplace(zkClient, path, record, persistent);
+    zkClient.close();
+  }
+
+  @Deprecated
   public static void createOrReplace(HelixZkClient client, String path, final ZNRecord record,
       final boolean persistent) {
     int retryCount = 0;
@@ -316,6 +409,14 @@ public final class ZKUtil {
     }
   }
 
+  public static void subtract(String zkAddress, final String path,
+      final ZNRecord recordTosubtract) {
+    HelixZkClient zkClient = getHelixZkClient(zkAddress);
+    subtract(zkClient, path, recordTosubtract);
+    zkClient.close();
+  }
+
+  @Deprecated
   public static void subtract(HelixZkClient client, final String path,
       final ZNRecord recordTosubtract) {
     int retryCount = 0;
@@ -341,6 +442,19 @@ public final class ZKUtil {
         logger.warn("Exception trying to createOrReplace " + path + ". Will retry.", e);
       }
     }
+  }
 
+  /**
+   * Returns a dedicated ZkClient.
+   * @return
+   */
+  private static HelixZkClient getHelixZkClient(String zkAddr) {
+    if (zkAddr == null || zkAddr.isEmpty()) {
+      throw new HelixException("ZK Address given is either null or empty!");
+    }
+    HelixZkClient.ZkClientConfig clientConfig = new HelixZkClient.ZkClientConfig();
+    clientConfig.setZkSerializer(new ZNRecordSerializer());
+    return DedicatedZkClientFactory.getInstance()
+        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddr), clientConfig);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKUtil.java
@@ -28,6 +28,7 @@ import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.ZkUnitTestBase;
+import org.apache.helix.manager.zk.client.HelixZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.AssertJUnit;
@@ -47,10 +48,10 @@ public class TestZKUtil extends ZkUnitTestBase {
     result = ZKUtil.isClusterSetup(null, _gZkClient);
     AssertJUnit.assertFalse(result);
 
-    result = ZKUtil.isClusterSetup(null, null);
+    result = ZKUtil.isClusterSetup(null, (HelixZkClient) null);
     AssertJUnit.assertFalse(result);
 
-    result = ZKUtil.isClusterSetup(clusterName, null);
+    result = ZKUtil.isClusterSetup(clusterName, (HelixZkClient) null);
     AssertJUnit.assertFalse(result);
 
     TestHelper.setupEmptyCluster(_gZkClient, clusterName);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #605 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Replace methods in ZkUtil so that it does not require HelixZkClient

This is so that the users of ZkUtil do not have to create HelixZkClient to use the utility methods.

### Tests

- [x] The following tests are written for this issue:

Covered by TestZKUtil.java

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestCardDealingAdjustmentAlgorithmV2.testAlgorithmConstructor:128 expected:<9> but was:<6>
[ERROR] org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas(org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2)
[ERROR]   Run 1: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:274 Total movements: 4 != expected 8, replica: 1
[ERROR]   Run 2: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:274 Total movements: 4 != expected 8, replica: 2
[ERROR]   Run 3: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:274 Total movements: 14 != expected 21, replica: 3
[INFO]   Run 4: PASS
[INFO]   Run 5: PASS
[INFO] 
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 882, Failures: 3, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  56:42 min
[INFO] Finished at: 2019-11-15T00:20:58-08:00

-----------------
Both pass when run individually.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml