### PR TITLE
Stabilize the TestAlertingRebalancerFailure test

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/TestAlertingRebalancerFailure.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestAlertingRebalancerFailure.java
@@ -164,6 +164,7 @@ public class TestAlertingRebalancerFailure extends ZkStandAloneCMTestBase {
         BuiltInStateModelDefinitions.MasterSlave.name(), RebalanceMode.FULL_AUTO.name());
     ZkHelixClusterVerifier verifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
         .setZkAddr(ZK_ADDR).setResources(new HashSet<>(Collections.singleton(testDb))).build();
+    _gSetupTool.getClusterManagementTool().rebalance(CLUSTER_NAME, testDb, 3);
     Assert.assertTrue(verifier.verifyByPolling());
 
     // Verify there is no rebalance error logged


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #607  

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In this PR, the TestAlertingRebalancerFailure has been stabilized. This test was unstable because there were some race condition between two tests (cleanup of testParticipantUnavailable and start of the testTagSetIncorrect). Due to this race condition, the listfield and mapfield in the IdealState have been missing for the testTagSetIncorrect test. Hence, rebalancer does not run as expected.

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:
mvn test has been run several time to make sure TestAlertingRebalancerFailure does not fail.

Test Result 1: mvn test
[ERROR] Tests run: 886, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3,503.711 s <<< FAILURE! - in TestSuite
[ERROR] testDifferentTasks(org.apache.helix.integration.task.TestIndependentTaskRebalancer)  Time elapsed: 1.328 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.integration.task.TestIndependentTaskRebalancer.testDifferentTasks(TestIndependentTaskRebalancer.java:146)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestIndependentTaskRebalancer.testDifferentTasks:146 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 886, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  58:28 min
[INFO] Finished at: 2019-11-15T11:27:23-08:00
[INFO] ------------------------------------------------------------------------

Test Result 2: mvn test -Dtest="TestIndependentTaskRebalancer"
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.432 s - in org.apache.helix.integration.task.TestIndependentTaskRebalancer
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  19.394 s
[INFO] Finished at: 2019-11-15T13:57:59-08:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml
