### PR TITLE
Fix NullPointerException and test failure for testDisablePartitionAndStopInstance

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
@@ -297,7 +297,8 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
   @Override
   public String toString() {
     String verifierName = getClass().getSimpleName();
-    return verifierName + "(" + _clusterName + "@" + _zkClient.getServers() + "@resources["
-        + _resources != null ? Arrays.toString(_resources.toArray()) : "" + "])";
+    return String
+        .format("%s(%s@%s@resources[%s])", verifierName, _clusterName, _zkClient.getServers(),
+            _resources != null ? Arrays.toString(_resources.toArray()) : "");
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #612 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
StrictMatchExternalViewVerifier's toString() has a bug that causes NullPointerException if _resources is null. The code fails to check if _resources is null. And NullPointerException causes testDisablePartitionAndStopInstance's failure.
https://github.com/apache/helix/blob/c98dfa056e8ff67666b90827f369d74eea8213bf/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java#L300-L301

Solution: fix the bug in StrictMatchExternalViewVerifier's toString().

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestStopWorkflow.testStopTask » ThreadTimeout Method org.testng.internal.TestN...
[ERROR]   TestWorkflowTermination.testWorkflowRunningTimeout:130->verifyWorkflowCleanup:256 expected:<true> but was:<false>
[ERROR]   TestGetLastScheduledTaskExecInfo.testGetLastScheduledTaskExecInfo:73 expected:<COMPLETED> but was:<RUNNING>
[INFO]
[ERROR] Tests run: 886, Failures: 3, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:00 h
[INFO] Finished at: 2019-11-18T12:57:36-08:00

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.52 s - in org.apache.helix.integration.task.TestStopWorkflow
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12.847 s
[INFO] Finished at: 2019-11-18T14:13:08-08:00

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.22 s - in org.apache.helix.task.TestGetLastScheduledTaskExecInfo
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12.570 s
[INFO] Finished at: 2019-11-18T14:10:16-08:00

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.976 s - in org.apache.helix.integration.task.TestWorkflowTermination
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  13.437 s
[INFO] Finished at: 2019-11-18T14:04:30-08:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml