### PR TITLE
Fix NullPointerException in TestDisableCustomCodeRunner_test.

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/TestDisableCustomCodeRunner.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestDisableCustomCodeRunner.java
@@ -38,6 +38,7 @@ import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.participant.CustomCodeCallbackHandler;
 import org.apache.helix.participant.HelixCustomCodeRunner;
@@ -177,10 +178,17 @@ public class TestDisableCustomCodeRunner extends ZkUnitTestBase {
     Assert.assertTrue(result);
 
     // Change live-instance should not invoke any custom-code runner
-    LiveInstance fakeInstance = new LiveInstance("fakeInstance");
+    String fakeInstanceName = "fakeInstance";
+    InstanceConfig instanceConfig = new InstanceConfig(fakeInstanceName);
+    instanceConfig.setHostName("localhost");
+    instanceConfig.setPort("10000");
+    instanceConfig.setInstanceEnabled(true);
+    admin.addInstance(clusterName, instanceConfig);
+
+    LiveInstance fakeInstance = new LiveInstance(fakeInstanceName);
     fakeInstance.setSessionId("fakeSessionId");
     fakeInstance.setHelixVersion("0.6");
-    accessor.setProperty(keyBuilder.liveInstance("fakeInstance"), fakeInstance);
+    accessor.setProperty(keyBuilder.liveInstance(fakeInstanceName), fakeInstance);
     Thread.sleep(1000);
 
     for (Map.Entry<String, DummyCallback> e : callbacks.entrySet()) {
@@ -196,7 +204,7 @@ public class TestDisableCustomCodeRunner extends ZkUnitTestBase {
     }
 
     // Remove fake instance
-    accessor.removeProperty(keyBuilder.liveInstance("fakeInstance"));
+    accessor.removeProperty(keyBuilder.liveInstance(fakeInstanceName));
 
     // Re-enable custom-code runner
     admin.enableResource(clusterName, customCodeRunnerResource, true);
@@ -227,7 +235,7 @@ public class TestDisableCustomCodeRunner extends ZkUnitTestBase {
     }
 
     // Add a fake instance should invoke custom-code runner
-    accessor.setProperty(keyBuilder.liveInstance("fakeInstance"), fakeInstance);
+    accessor.setProperty(keyBuilder.liveInstance(fakeInstanceName), fakeInstance);
     Thread.sleep(1000);
     for (String instance : callbacks.keySet()) {
       DummyCallback callback = callbacks.get(instance);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #615 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In TestDisableCustomCodeRunner_test, a new fake live instance is created without an instance config, so when the cluster monitor is reporting metrics for this instance, its instance config is not found, thus a NullPointerException is thrown.

Need to add an instance config for the fake live instance. 

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAlertingRebalancerFailure.testTagSetIncorrect:174->checkResourceBestPossibleCalFailureState:310 expected:<true> but was:<false>
[ERROR] org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceTopoplogyAwareDisabled.test(org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceTopoplogyAwareDisabled)
[INFO]   Run 1: PASS
[ERROR]   Run 2: TestCrushAutoRebalanceTopoplogyAwareDisabled.test:65->TestCrushAutoRebalanceNonRack.test:159->TestCrushAutoRebalanceNonRack.validateIsolation:300 expected:<3> but was:<4>
[INFO]
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[INFO]
[ERROR] Tests run: 882, Failures: 3, Errors: 0, Skipped: 4
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:02 h
[INFO] Finished at: 2019-11-18T19:28:34-08:00

[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.501 s - in org.apache.helix.integration.TestAlertingRebalancerFailure
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.905 s
[INFO] Finished at: 2019-11-18T20:34:26-08:00

[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.794 s - in org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceTopoplogyAwareDisabled
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.802 s
[INFO] Finished at: 2019-11-18T20:35:15-08:00
[INFO] -----------------------------------------------------------------------



### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml