### PR TITLE
Add close() to ClusterSetup to avoid ZkClient leak

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterSetup.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterSetup.java
@@ -134,7 +134,7 @@ public class ClusterSetup {
   public static final String setConstraint = "setConstraint";
   public static final String removeConstraint = "removeConstraint";
 
-  static Logger _logger = LoggerFactory.getLogger(ClusterSetup.class);
+  private static final Logger _logger = LoggerFactory.getLogger(ClusterSetup.class);
   private final String _zkServerAddress;
   private final HelixZkClient _zkClient;
   // true if ZkBaseDataAccessor was instantiated with a HelixZkClient, false otherwise


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #628 628

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

ClusterSetup is a helper class that's used for cluster-related operations. This class is missing a close() method users could call to prevent ZkClient/ZkConnection leak. This commit adds close() method.


### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] testStopTask(org.apache.helix.integration.task.TestStopWorkflow)  Time elapsed: 300.009 s  <<< FAILURE!
org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testStopTask() didn't finish within the time-out 300000

[ERROR] testComputeMappingForDifferentReplicas(org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2)  Time elapsed: 0.024 s  <<< FAILURE!
java.lang.AssertionError: Total movements: 4 != expected 8, replica: 1
	at org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas(TestCardDealingAdjustmentAlgorithmV2.java:273)

[ERROR] testComputeMappingForDifferentReplicas(org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2)  Time elapsed: 0.024 s  <<< FAILURE!
java.lang.AssertionError: Total movements: 4 != expected 8, replica: 2
	at org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas(TestCardDealingAdjustmentAlgorithmV2.java:273)

[ERROR] testComputeMappingForDifferentReplicas(org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2)  Time elapsed: 0.022 s  <<< FAILURE!
java.lang.AssertionError: Total movements: 14 != expected 21, replica: 3
	at org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas(TestCardDealingAdjustmentAlgorithmV2.java:273)

[ERROR] testAlgorithmConstructor(org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2)  Time elapsed: 0.023 s  <<< FAILURE!
java.lang.AssertionError: expected:<9> but was:<6>
	at org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2.testAlgorithmConstructor(TestCardDealingAdjustmentAlgorithmV2.java:127)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestCardDealingAdjustmentAlgorithmV2.testAlgorithmConstructor:127 expected:<9> but was:<6>
[ERROR] org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas(org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2)
[ERROR]   Run 1: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:273 Total movements: 4 != expected 8, replica: 1
[ERROR]   Run 2: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:273 Total movements: 4 != expected 8, replica: 2
[ERROR]   Run 3: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:273 Total movements: 14 != expected 21, replica: 3
[INFO]   Run 4: PASS
[INFO]   Run 5: PASS
[INFO] 
[ERROR]   TestStopWorkflow.testStopTask » ThreadTimeout Method org.testng.internal.TestN...
[INFO] 
[ERROR] Tests run: 883, Failures: 3, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE

-----
Both tests passed when run individually.
[INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.807 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS



### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml