### PR TITLE
Set helix style to only wrap if long for throws.

### DIFF
--- a/helix-style-intellij.xml
+++ b/helix-style-intellij.xml
@@ -61,7 +61,7 @@
   <option name="CALL_PARAMETERS_WRAP" value="5" />
   <option name="METHOD_PARAMETERS_WRAP" value="5" />
   <option name="THROWS_LIST_WRAP" value="1" />
-  <option name="THROWS_KEYWORD_WRAP" value="2" />
+  <option name="THROWS_KEYWORD_WRAP" value="1" />
   <option name="WRAP_COMMENTS" value="true" />
   <XML>
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
@@ -98,7 +98,7 @@
     <option name="METHOD_PARAMETERS_WRAP" value="1" />
     <option name="RESOURCE_LIST_WRAP" value="1" />
     <option name="THROWS_LIST_WRAP" value="1" />
-    <option name="THROWS_KEYWORD_WRAP" value="2" />
+    <option name="THROWS_KEYWORD_WRAP" value="1" />
     <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
     <option name="BINARY_OPERATION_WRAP" value="1" />
     <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #633 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently throws key word is wrapped to next line. We want it to be wrapped if long.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml