### PR TITLE
Add new WAGED rebalancer config item "GLOBAL_REBALANCE_ASYNC_MODE".

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -83,8 +83,13 @@ public class ClusterConfig extends HelixProperty {
     DISABLED_INSTANCES,
 
     // Specifies job types and used for quota allocation
-    QUOTA_TYPES,
+    QUOTA_TYPES
+  }
 
+  /**
+   * Configurable characteristics of the WAGED rebalancer.
+   */
+  public enum WagedRebalancerConfigProperty {
     // The required instance capacity keys for resource partition assignment calculation.
     INSTANCE_CAPACITY_KEYS,
     // The default instance capacity if no capacity is configured in the Instance Config node.
@@ -94,7 +99,15 @@ public class ClusterConfig extends HelixProperty {
     // The preference of the rebalance result.
     // EVENNESS - Evenness of the resource utilization, partition, and top state distribution.
     // LESS_MOVEMENT - the tendency of keeping the current assignment instead of moving the partition for optimal assignment.
-    REBALANCE_PREFERENCE
+    REBALANCE_PREFERENCE,
+    // Specify if the WAGED rebalancer should asynchronously perform global rebalance.
+    // Note that asynchronous calculation will reduce the rebalance delay but may cause more
+    // partition movements. This is because the partial rebalance will be preformed with an stale
+    // baseline. The rebalance result would be an intermediate one and could be changed again when
+    // a new baseline is calculated.
+    //
+    // Default to be true.
+    GLOBAL_REBALANCE_ASYNC_MODE
   }
 
   public enum GlobalRebalancePreferenceKey {
@@ -121,6 +134,7 @@ public class ClusterConfig extends HelixProperty {
           .put(GlobalRebalancePreferenceKey.LESS_MOVEMENT, 1).build();
   private final static int MAX_REBALANCE_PREFERENCE = 10;
   private final static int MIN_REBALANCE_PREFERENCE = 0;
+  private final static boolean DEFAULT_GLOBAL_REBALANCE_ASYNC_MODE_ENABLED = true;
 
   /**
    * Instantiate for a specific cluster
@@ -690,14 +704,15 @@ public class ClusterConfig extends HelixProperty {
     if (capacityKeys == null || capacityKeys.isEmpty()) {
       throw new IllegalArgumentException("The input instance capacity key list is empty.");
     }
-    _record.setListField(ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name(), capacityKeys);
+    _record.setListField(WagedRebalancerConfigProperty.INSTANCE_CAPACITY_KEYS.name(), capacityKeys);
   }
 
   /**
    * @return The required Instance Capacity Keys. If not configured, return an empty list.
    */
   public List<String> getInstanceCapacityKeys() {
-    List<String> capacityKeys = _record.getListField(ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name());
+    List<String> capacityKeys =
+        _record.getListField(WagedRebalancerConfigProperty.INSTANCE_CAPACITY_KEYS.name());
     if (capacityKeys == null) {
       return Collections.emptyList();
     }
@@ -710,7 +725,7 @@ public class ClusterConfig extends HelixProperty {
    * @return data map if it exists, or empty map
    */
   public Map<String, Integer> getDefaultInstanceCapacityMap() {
-    return getDefaultCapacityMap(ClusterConfigProperty.DEFAULT_INSTANCE_CAPACITY_MAP);
+    return getDefaultCapacityMap(WagedRebalancerConfigProperty.DEFAULT_INSTANCE_CAPACITY_MAP);
   }
 
   /**
@@ -726,7 +741,8 @@ public class ClusterConfig extends HelixProperty {
    */
   public void setDefaultInstanceCapacityMap(Map<String, Integer> capacityDataMap)
       throws IllegalArgumentException {
-    setDefaultCapacityMap(ClusterConfigProperty.DEFAULT_INSTANCE_CAPACITY_MAP, capacityDataMap);
+    setDefaultCapacityMap(WagedRebalancerConfigProperty.DEFAULT_INSTANCE_CAPACITY_MAP,
+        capacityDataMap);
   }
 
   /**
@@ -735,7 +751,7 @@ public class ClusterConfig extends HelixProperty {
    * @return data map if it exists, or empty map
    */
   public Map<String, Integer> getDefaultPartitionWeightMap() {
-    return getDefaultCapacityMap(ClusterConfigProperty.DEFAULT_PARTITION_WEIGHT_MAP);
+    return getDefaultCapacityMap(WagedRebalancerConfigProperty.DEFAULT_PARTITION_WEIGHT_MAP);
   }
 
   /**
@@ -751,11 +767,13 @@ public class ClusterConfig extends HelixProperty {
    */
   public void setDefaultPartitionWeightMap(Map<String, Integer> weightDataMap)
       throws IllegalArgumentException {
-    setDefaultCapacityMap(ClusterConfigProperty.DEFAULT_PARTITION_WEIGHT_MAP, weightDataMap);
+    setDefaultCapacityMap(WagedRebalancerConfigProperty.DEFAULT_PARTITION_WEIGHT_MAP,
+        weightDataMap);
   }
 
-  private Map<String, Integer> getDefaultCapacityMap(ClusterConfigProperty capacityPropertyType) {
-    Map<String, String> capacityData = _record.getMapField(capacityPropertyType.name());
+  private Map<String, Integer> getDefaultCapacityMap(
+      WagedRebalancerConfigProperty rebalancerConfigProperty) {
+    Map<String, String> capacityData = _record.getMapField(rebalancerConfigProperty.name());
     if (capacityData != null) {
       return capacityData.entrySet().stream().collect(
           Collectors.toMap(entry -> entry.getKey(), entry -> Integer.parseInt(entry.getValue())));
@@ -763,7 +781,7 @@ public class ClusterConfig extends HelixProperty {
     return Collections.emptyMap();
   }
 
-  private void setDefaultCapacityMap(ClusterConfigProperty capacityPropertyType,
+  private void setDefaultCapacityMap(WagedRebalancerConfigProperty rebalancerConfigProperty,
       Map<String, Integer> capacityDataMap) throws IllegalArgumentException {
     if (capacityDataMap == null) {
       throw new IllegalArgumentException("Default capacity data is null");
@@ -777,7 +795,7 @@ public class ClusterConfig extends HelixProperty {
       }
       data.put(entry.getKey(), Integer.toString(entry.getValue()));
     });
-    _record.setMapField(capacityPropertyType.name(), data);
+    _record.setMapField(rebalancerConfigProperty.name(), data);
   }
 
   /**
@@ -798,7 +816,7 @@ public class ClusterConfig extends HelixProperty {
       preferenceMap.put(entry.getKey().name(), Integer.toString(entry.getValue()));
     });
 
-    _record.setMapField(ClusterConfigProperty.REBALANCE_PREFERENCE.name(), preferenceMap);
+    _record.setMapField(WagedRebalancerConfigProperty.REBALANCE_PREFERENCE.name(), preferenceMap);
   }
 
   /**
@@ -806,7 +824,7 @@ public class ClusterConfig extends HelixProperty {
    */
   public Map<GlobalRebalancePreferenceKey, Integer> getGlobalRebalancePreference() {
     Map<String, String> preferenceStrMap =
-        _record.getMapField(ClusterConfigProperty.REBALANCE_PREFERENCE.name());
+        _record.getMapField(WagedRebalancerConfigProperty.REBALANCE_PREFERENCE.name());
     if (preferenceStrMap != null && !preferenceStrMap.isEmpty()) {
       Map<GlobalRebalancePreferenceKey, Integer> preference = new HashMap<>();
       for (GlobalRebalancePreferenceKey key : GlobalRebalancePreferenceKey.values()) {
@@ -820,6 +838,19 @@ public class ClusterConfig extends HelixProperty {
     }
     // If configuration is not complete, return the default one.
     return DEFAULT_GLOBAL_REBALANCE_PREFERENCE;
+  }
+
+  /**
+   * Set the asynchronous global rebalance mode.
+   * @param isAsync true if the global rebalance should be performed asynchronously
+   */
+  public void setGlobalRebalanceAsyncMode(boolean isAsync) {
+    _record.setBooleanField(WagedRebalancerConfigProperty.GLOBAL_REBALANCE_ASYNC_MODE.name(), isAsync);
+  }
+
+  public boolean isGlobalRebalanceAsyncModeEnabled() {
+    return _record.getBooleanField(WagedRebalancerConfigProperty.GLOBAL_REBALANCE_ASYNC_MODE.name(),
+        DEFAULT_GLOBAL_REBALANCE_ASYNC_MODE_ENABLED);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
@@ -19,16 +19,16 @@ package org.apache.helix.model;
  * under the License.
  */
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.ZNRecord;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import static org.apache.helix.model.ClusterConfig.GlobalRebalancePreferenceKey.EVENNESS;
 import static org.apache.helix.model.ClusterConfig.GlobalRebalancePreferenceKey.LESS_MOVEMENT;
@@ -41,8 +41,8 @@ public class TestClusterConfig {
 
     ClusterConfig testConfig = new ClusterConfig("testId");
     testConfig.getRecord()
-        .setListField(ClusterConfig.ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name(), keys);
-
+        .setListField(ClusterConfig.WagedRebalancerConfigProperty.INSTANCE_CAPACITY_KEYS.name(),
+            keys);
     Assert.assertEquals(testConfig.getInstanceCapacityKeys(), keys);
   }
 
@@ -60,7 +60,7 @@ public class TestClusterConfig {
     testConfig.setInstanceCapacityKeys(keys);
 
     Assert.assertEquals(keys, testConfig.getRecord()
-        .getListField(ClusterConfig.ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name()));
+        .getListField(ClusterConfig.WagedRebalancerConfigProperty.INSTANCE_CAPACITY_KEYS.name()));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
@@ -82,7 +82,8 @@ public class TestClusterConfig {
 
     ClusterConfig testConfig = new ClusterConfig("testId");
     testConfig.getRecord()
-        .setMapField(ClusterConfig.ClusterConfigProperty.REBALANCE_PREFERENCE.name(), mapFieldData);
+        .setMapField(ClusterConfig.WagedRebalancerConfigProperty.REBALANCE_PREFERENCE.name(),
+            mapFieldData);
 
     Assert.assertEquals(testConfig.getGlobalRebalancePreference(), preference);
   }
@@ -116,7 +117,7 @@ public class TestClusterConfig {
     testConfig.setGlobalRebalancePreference(preference);
 
     Assert.assertEquals(testConfig.getRecord()
-            .getMapField(ClusterConfig.ClusterConfigProperty.REBALANCE_PREFERENCE.name()),
+            .getMapField(ClusterConfig.WagedRebalancerConfigProperty.REBALANCE_PREFERENCE.name()),
         mapFieldData);
   }
 
@@ -138,7 +139,7 @@ public class TestClusterConfig {
         ImmutableMap.of("item1", "1", "item2", "2", "item3", "3");
 
     ZNRecord rec = new ZNRecord("testId");
-    rec.setMapField(ClusterConfig.ClusterConfigProperty.DEFAULT_INSTANCE_CAPACITY_MAP.name(),
+    rec.setMapField(ClusterConfig.WagedRebalancerConfigProperty.DEFAULT_INSTANCE_CAPACITY_MAP.name(),
         capacityDataMapString);
     ClusterConfig testConfig = new ClusterConfig(rec);
 
@@ -162,8 +163,9 @@ public class TestClusterConfig {
     ClusterConfig testConfig = new ClusterConfig("testConfig");
     testConfig.setDefaultInstanceCapacityMap(capacityDataMap);
 
-    Assert.assertEquals(testConfig.getRecord().getMapField(ClusterConfig.ClusterConfigProperty.
-        DEFAULT_INSTANCE_CAPACITY_MAP.name()), capacityDataMapString);
+    Assert.assertEquals(
+        testConfig.getRecord().getMapField(ClusterConfig.WagedRebalancerConfigProperty.
+            DEFAULT_INSTANCE_CAPACITY_MAP.name()), capacityDataMapString);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Default capacity data is null")
@@ -193,7 +195,7 @@ public class TestClusterConfig {
         ImmutableMap.of("item1", "1", "item2", "2", "item3", "3");
 
     ZNRecord rec = new ZNRecord("testId");
-    rec.setMapField(ClusterConfig.ClusterConfigProperty.DEFAULT_PARTITION_WEIGHT_MAP.name(),
+    rec.setMapField(ClusterConfig.WagedRebalancerConfigProperty.DEFAULT_PARTITION_WEIGHT_MAP.name(),
         weightDataMapString);
     ClusterConfig testConfig = new ClusterConfig(rec);
 
@@ -217,8 +219,9 @@ public class TestClusterConfig {
     ClusterConfig testConfig = new ClusterConfig("testConfig");
     testConfig.setDefaultPartitionWeightMap(weightDataMap);
 
-    Assert.assertEquals(testConfig.getRecord().getMapField(ClusterConfig.ClusterConfigProperty.
-        DEFAULT_PARTITION_WEIGHT_MAP.name()), weightDataMapString);
+    Assert.assertEquals(
+        testConfig.getRecord().getMapField(ClusterConfig.WagedRebalancerConfigProperty.
+            DEFAULT_PARTITION_WEIGHT_MAP.name()), weightDataMapString);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Default capacity data is null")
@@ -238,5 +241,22 @@ public class TestClusterConfig {
 
     ClusterConfig testConfig = new ClusterConfig("testConfig");
     testConfig.setDefaultPartitionWeightMap(weightDataMap);
+  }
+
+  @Test
+  public void testAsyncGlobalRebalanceOption() {
+    ClusterConfig testConfig = new ClusterConfig("testConfig");
+    // Default value is true.
+    Assert.assertEquals(testConfig.isGlobalRebalanceAsyncModeEnabled(), true);
+    // Test get the option
+    testConfig.getRecord()
+        .setBooleanField(ClusterConfig.WagedRebalancerConfigProperty.GLOBAL_REBALANCE_ASYNC_MODE.name(),
+            false);
+    Assert.assertEquals(testConfig.isGlobalRebalanceAsyncModeEnabled(), false);
+    // Test set the option
+    testConfig.setGlobalRebalanceAsyncMode(true);
+    Assert.assertEquals(testConfig.getRecord()
+        .getBooleanField(ClusterConfig.WagedRebalancerConfigProperty.GLOBAL_REBALANCE_ASYNC_MODE.name(),
+            false), true);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
@@ -41,8 +41,8 @@ public class TestClusterConfig {
 
     ClusterConfig testConfig = new ClusterConfig("testId");
     testConfig.getRecord()
-        .setListField(ClusterConfig.WagedRebalancerConfigProperty.INSTANCE_CAPACITY_KEYS.name(),
-            keys);
+        .setListField(ClusterConfig.ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name(), keys);
+
     Assert.assertEquals(testConfig.getInstanceCapacityKeys(), keys);
   }
 
@@ -60,7 +60,7 @@ public class TestClusterConfig {
     testConfig.setInstanceCapacityKeys(keys);
 
     Assert.assertEquals(keys, testConfig.getRecord()
-        .getListField(ClusterConfig.WagedRebalancerConfigProperty.INSTANCE_CAPACITY_KEYS.name()));
+        .getListField(ClusterConfig.ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name()));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
@@ -82,8 +82,7 @@ public class TestClusterConfig {
 
     ClusterConfig testConfig = new ClusterConfig("testId");
     testConfig.getRecord()
-        .setMapField(ClusterConfig.WagedRebalancerConfigProperty.REBALANCE_PREFERENCE.name(),
-            mapFieldData);
+        .setMapField(ClusterConfig.ClusterConfigProperty.REBALANCE_PREFERENCE.name(), mapFieldData);
 
     Assert.assertEquals(testConfig.getGlobalRebalancePreference(), preference);
   }
@@ -117,7 +116,7 @@ public class TestClusterConfig {
     testConfig.setGlobalRebalancePreference(preference);
 
     Assert.assertEquals(testConfig.getRecord()
-            .getMapField(ClusterConfig.WagedRebalancerConfigProperty.REBALANCE_PREFERENCE.name()),
+            .getMapField(ClusterConfig.ClusterConfigProperty.REBALANCE_PREFERENCE.name()),
         mapFieldData);
   }
 
@@ -139,7 +138,7 @@ public class TestClusterConfig {
         ImmutableMap.of("item1", "1", "item2", "2", "item3", "3");
 
     ZNRecord rec = new ZNRecord("testId");
-    rec.setMapField(ClusterConfig.WagedRebalancerConfigProperty.DEFAULT_INSTANCE_CAPACITY_MAP.name(),
+    rec.setMapField(ClusterConfig.ClusterConfigProperty.DEFAULT_INSTANCE_CAPACITY_MAP.name(),
         capacityDataMapString);
     ClusterConfig testConfig = new ClusterConfig(rec);
 
@@ -163,9 +162,8 @@ public class TestClusterConfig {
     ClusterConfig testConfig = new ClusterConfig("testConfig");
     testConfig.setDefaultInstanceCapacityMap(capacityDataMap);
 
-    Assert.assertEquals(
-        testConfig.getRecord().getMapField(ClusterConfig.WagedRebalancerConfigProperty.
-            DEFAULT_INSTANCE_CAPACITY_MAP.name()), capacityDataMapString);
+    Assert.assertEquals(testConfig.getRecord().getMapField(ClusterConfig.ClusterConfigProperty.
+        DEFAULT_INSTANCE_CAPACITY_MAP.name()), capacityDataMapString);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Default capacity data is null")
@@ -195,7 +193,7 @@ public class TestClusterConfig {
         ImmutableMap.of("item1", "1", "item2", "2", "item3", "3");
 
     ZNRecord rec = new ZNRecord("testId");
-    rec.setMapField(ClusterConfig.WagedRebalancerConfigProperty.DEFAULT_PARTITION_WEIGHT_MAP.name(),
+    rec.setMapField(ClusterConfig.ClusterConfigProperty.DEFAULT_PARTITION_WEIGHT_MAP.name(),
         weightDataMapString);
     ClusterConfig testConfig = new ClusterConfig(rec);
 
@@ -219,9 +217,8 @@ public class TestClusterConfig {
     ClusterConfig testConfig = new ClusterConfig("testConfig");
     testConfig.setDefaultPartitionWeightMap(weightDataMap);
 
-    Assert.assertEquals(
-        testConfig.getRecord().getMapField(ClusterConfig.WagedRebalancerConfigProperty.
-            DEFAULT_PARTITION_WEIGHT_MAP.name()), weightDataMapString);
+    Assert.assertEquals(testConfig.getRecord().getMapField(ClusterConfig.ClusterConfigProperty.
+        DEFAULT_PARTITION_WEIGHT_MAP.name()), weightDataMapString);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Default capacity data is null")
@@ -250,13 +247,13 @@ public class TestClusterConfig {
     Assert.assertEquals(testConfig.isGlobalRebalanceAsyncModeEnabled(), true);
     // Test get the option
     testConfig.getRecord()
-        .setBooleanField(ClusterConfig.WagedRebalancerConfigProperty.GLOBAL_REBALANCE_ASYNC_MODE.name(),
+        .setBooleanField(ClusterConfig.ClusterConfigProperty.GLOBAL_REBALANCE_ASYNC_MODE.name(),
             false);
     Assert.assertEquals(testConfig.isGlobalRebalanceAsyncModeEnabled(), false);
     // Test set the option
     testConfig.setGlobalRebalanceAsyncMode(true);
     Assert.assertEquals(testConfig.getRecord()
-        .getBooleanField(ClusterConfig.WagedRebalancerConfigProperty.GLOBAL_REBALANCE_ASYNC_MODE.name(),
+        .getBooleanField(ClusterConfig.ClusterConfigProperty.GLOBAL_REBALANCE_ASYNC_MODE.name(),
             false), true);
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -25,11 +25,14 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.helix.TestHelper;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.InstanceConfig;
@@ -38,11 +41,6 @@ import org.apache.helix.rest.server.util.JerseyUriRequestBuilder;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 public class TestInstancesAccessor extends AbstractTestClass {
   private final static String CLUSTER_NAME = "TestCluster_0";
@@ -181,7 +179,8 @@ public class TestInstancesAccessor extends AbstractTestClass {
     // Empty out ClusterConfig's weight key setting for testing
     ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
     clusterConfig.getRecord().setListField(
-        ClusterConfig.ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name(), new ArrayList<>());
+        ClusterConfig.WagedRebalancerConfigProperty.INSTANCE_CAPACITY_KEYS.name(),
+        new ArrayList<>());
     _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
     // Issue a validate call
     String body = new JerseyUriRequestBuilder("clusters/{}/instances?command=validateWeight")

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -25,14 +25,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.apache.helix.TestHelper;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.InstanceConfig;
@@ -41,6 +38,11 @@ import org.apache.helix.rest.server.util.JerseyUriRequestBuilder;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 public class TestInstancesAccessor extends AbstractTestClass {
   private final static String CLUSTER_NAME = "TestCluster_0";
@@ -179,8 +181,7 @@ public class TestInstancesAccessor extends AbstractTestClass {
     // Empty out ClusterConfig's weight key setting for testing
     ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
     clusterConfig.getRecord().setListField(
-        ClusterConfig.WagedRebalancerConfigProperty.INSTANCE_CAPACITY_KEYS.name(),
-        new ArrayList<>());
+        ClusterConfig.ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name(), new ArrayList<>());
     _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
     // Issue a validate call
     String body = new JerseyUriRequestBuilder("clusters/{}/instances?command=validateWeight")


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#563 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Prerequisite of #632 

This option will be used by the WAGED rebalancer to determine if the global rebalance should be performed asynchronously.
Also, refine the other WAGED rebalancer configuration items so they are separately categorized.

### Tests

- [x] The following tests are written for this issue:

TestClusterConfig

- [ ] The following is the result of the "mvn test" command on the appropriate module:

Please refer to #632 's test result.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

NA

### Code Quality

- [x] My diff has been formatted using helix-style.xml
