### PR TITLE
Refine the WAGED rebalancer to minimize the partial rebalance workload.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeDetector.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeDetector.java
@@ -24,6 +24,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Sets;
 import org.apache.helix.HelixConstants;
@@ -172,5 +174,21 @@ public class ResourceChangeDetector implements ChangeDetector {
     return _removedItems.computeIfAbsent(changeType,
         changedItems -> getRemovedItems(determinePropertyMapByType(changeType, _oldSnapshot),
             determinePropertyMapByType(changeType, _newSnapshot)));
+  }
+
+  /**
+   * @return A map contains all the changed items that are categorized by the change types.
+   */
+  public Map<HelixConstants.ChangeType, Set<String>> getAllChanges() {
+    return getChangeTypes().stream()
+        .collect(Collectors.toMap(changeType -> changeType, changeType -> {
+          Set<String> itemKeys = new HashSet<>();
+          itemKeys.addAll(getAdditionsByType(changeType));
+          itemKeys.addAll(getChangesByType(changeType));
+          itemKeys.addAll(getRemovalsByType(changeType));
+          return itemKeys;
+        })).entrySet().stream().filter(changeEntry -> !changeEntry.getValue().isEmpty()).collect(
+            Collectors
+                .toMap(changeEntry -> changeEntry.getKey(), changeEntry -> changeEntry.getValue()));
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -94,6 +94,8 @@ public class WagedRebalancer {
   private final LatencyMetric _stateReadLatency;
   private final BaselineDivergenceGauge _baselineDivergenceGauge;
 
+  // Note, the rebalance algorithm field is mutable so it should not be directly referred except for
+  // the public method computeNewIdealStates.
   private RebalanceAlgorithm _rebalanceAlgorithm;
   private Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> _preference =
       NOT_CONFIGURED_PREFERENCE;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -420,7 +420,7 @@ public class WagedRebalancer {
             HelixRebalanceException.Type.INVALID_CLUSTER_STATUS, ex);
       }
 
-      refreshBaseline(clusterModel, algorithm);
+      calculateAndUpdateBaseline(clusterModel, algorithm);
     }
   }
 
@@ -430,7 +430,7 @@ public class WagedRebalancer {
    * @param algorithm
    * @throws HelixRebalanceException
    */
-  private void refreshBaseline(ClusterModel clusterModel, RebalanceAlgorithm algorithm)
+  private void calculateAndUpdateBaseline(ClusterModel clusterModel, RebalanceAlgorithm algorithm)
       throws HelixRebalanceException {
     LOG.info("Start calculating the new baseline.");
     _globalBaselineCalcCounter.increment(1L);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -391,16 +391,7 @@ public class WagedRebalancer {
     _changeDetector.updateSnapshots(clusterData);
     // Get all the changed items' information. Filter for the items that have content changed.
     final Map<HelixConstants.ChangeType, Set<String>> clusterChanges =
-        _changeDetector.getChangeTypes().stream()
-            .collect(Collectors.toMap(changeType -> changeType, changeType -> {
-              Set<String> itemKeys = new HashSet<>();
-              itemKeys.addAll(_changeDetector.getAdditionsByType(changeType));
-              itemKeys.addAll(_changeDetector.getChangesByType(changeType));
-              itemKeys.addAll(_changeDetector.getRemovalsByType(changeType));
-              return itemKeys;
-            })).entrySet().stream().filter(changeEntry -> !changeEntry.getValue().isEmpty())
-            .collect(Collectors
-                .toMap(changeEntry -> changeEntry.getKey(), changeEntry -> changeEntry.getValue()));
+        _changeDetector.getAllChanges();
 
     if (clusterChanges.keySet().stream()
         .anyMatch(GLOBAL_REBALANCE_REQUIRED_CHANGE_TYPES::contains)) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -19,11 +19,13 @@ package org.apache.helix.controller.rebalancer.waged.model;
  * under the License.
  */
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -43,7 +45,41 @@ import org.apache.helix.model.StateModelDefinition;
  */
 public class ClusterModelProvider {
 
+  private enum RebalanceScopeType {
+    // Set the rebalance scope to cover the difference between the current assignment and the
+    // Baseline assignment only.
+    PARTIAL,
+    // Set the rebalance scope to cover all replicas that need relocation based on the cluster
+    // changes.
+    GLOBAL
+  }
+
   /**
+   * Generate a new Cluster Model object according to the current cluster status for partial
+   * rebalance. The rebalance scope is configured for recovering the missing replicas only.
+   * @param dataProvider           The controller's data cache.
+   * @param resourceMap            The full list of the resources to be rebalanced. Note that any
+   *                               resources that are not in this list will be removed from the
+   *                               final assignment.
+   * @param activeInstances        The active instances that will be used in the calculation.
+   *                               Note this list can be different from the real active node list
+   *                               according to the rebalancer logic.
+   * @param baselineAssignment     The persisted Baseline assignment.
+   * @param bestPossibleAssignment The persisted Best Possible assignment that was generated in the
+   *                               previous rebalance.
+   * @return
+   */
+  public static ClusterModel generateClusterModelForPartialRebalance(
+      ResourceControllerDataProvider dataProvider, Map<String, Resource> resourceMap,
+      Set<String> activeInstances, Map<String, ResourceAssignment> baselineAssignment,
+      Map<String, ResourceAssignment> bestPossibleAssignment) {
+    return generateClusterModel(dataProvider, resourceMap, activeInstances, Collections.emptyMap(),
+        baselineAssignment, bestPossibleAssignment, RebalanceScopeType.PARTIAL);
+  }
+
+  /**
+   * Generate a new Cluster Model object according to the current cluster status for the Baseline
+   * calculation. The rebalance scope is determined according to the cluster changes.
    * @param dataProvider           The controller's data cache.
    * @param resourceMap            The full list of the resources to be rebalanced. Note that any
    *                               resources that are not in this list will be removed from the
@@ -55,13 +91,56 @@ public class ClusterModelProvider {
    * @param baselineAssignment     The persisted Baseline assignment.
    * @param bestPossibleAssignment The persisted Best Possible assignment that was generated in the
    *                               previous rebalance.
-   * @return Generate a new Cluster Model object according to the current cluster status.
+   * @return the new cluster model
    */
-  public static ClusterModel generateClusterModel(ResourceControllerDataProvider dataProvider,
+  public static ClusterModel generateClusterModelForBaseline(
+      ResourceControllerDataProvider dataProvider, Map<String, Resource> resourceMap,
+      Set<String> activeInstances, Map<HelixConstants.ChangeType, Set<String>> clusterChanges,
+      Map<String, ResourceAssignment> baselineAssignment,
+      Map<String, ResourceAssignment> bestPossibleAssignment) {
+    return generateClusterModel(dataProvider, resourceMap, activeInstances, clusterChanges,
+        baselineAssignment, bestPossibleAssignment, RebalanceScopeType.GLOBAL);
+  }
+
+  /**
+   * Generate a cluster model based on the current state output and data cache. The rebalance scope
+   * is configured for recovering the missing replicas only.
+   * @param dataProvider           The controller's data cache.
+   * @param resourceMap            The full list of the resources to be rebalanced. Note that any
+   *                               resources that are not in this list will be removed from the
+   *                               final assignment.
+   * @param existingAssignment The resource assignment built from current state output.
+   * @return the new cluster model
+   */
+  public static ClusterModel generateClusterModelFromExistingAssignment(
+      ResourceControllerDataProvider dataProvider, Map<String, Resource> resourceMap,
+      Map<String, ResourceAssignment> existingAssignment) {
+    return generateClusterModel(dataProvider, resourceMap, dataProvider.getEnabledLiveInstances(),
+        Collections.emptyMap(), Collections.emptyMap(), existingAssignment,
+        RebalanceScopeType.GLOBAL);
+  }
+
+  /**
+   * Generate a new Cluster Model object according to the current cluster status.
+   * @param dataProvider           The controller's data cache.
+   * @param resourceMap            The full list of the resources to be rebalanced. Note that any
+   *                               resources that are not in this list will be removed from the
+   *                               final assignment.
+   * @param activeInstances        The active instances that will be used in the calculation.
+   *                               Note this list can be different from the real active node list
+   *                               according to the rebalancer logic.
+   * @param clusterChanges         All the cluster changes that happened after the previous rebalance.
+   * @param baselineAssignment     The persisted Baseline assignment.
+   * @param bestPossibleAssignment The persisted Best Possible assignment that was generated in the
+   *                               previous rebalance.
+   * @param scopeType              Specify how to determine the rebalance scope.
+   * @return the new cluster model
+   */
+  private static ClusterModel generateClusterModel(ResourceControllerDataProvider dataProvider,
       Map<String, Resource> resourceMap, Set<String> activeInstances,
       Map<HelixConstants.ChangeType, Set<String>> clusterChanges,
       Map<String, ResourceAssignment> baselineAssignment,
-      Map<String, ResourceAssignment> bestPossibleAssignment) {
+      Map<String, ResourceAssignment> bestPossibleAssignment, RebalanceScopeType scopeType) {
     // Construct all the assignable nodes and initialize with the allocated replicas.
     Set<AssignableNode> assignableNodes =
         parseAllNodes(dataProvider.getClusterConfig(), dataProvider.getInstanceConfigMap(),
@@ -75,9 +154,24 @@ public class ClusterModelProvider {
     // Check if the replicas need to be reassigned.
     Map<String, Set<AssignableReplica>> allocatedReplicas =
         new HashMap<>(); // <instanceName, replica set>
-    Set<AssignableReplica> toBeAssignedReplicas =
-        findToBeAssignedReplicas(replicaMap, clusterChanges, activeInstances,
-            dataProvider.getLiveInstances().keySet(), bestPossibleAssignment, allocatedReplicas);
+    Set<AssignableReplica> toBeAssignedReplicas;
+    switch (scopeType) {
+      case GLOBAL:
+        toBeAssignedReplicas = findToBeAssignedReplicasByClusterChanges(replicaMap, activeInstances,
+            dataProvider.getLiveInstances().keySet(), clusterChanges, bestPossibleAssignment,
+            allocatedReplicas);
+        break;
+      case PARTIAL:
+        // For partial rebalance, new partitions that are not in the Baseline won't be rebalanced.
+        // Filter to remove the replicas that are not in the Baseline from the replica map.
+        removeUnknownReplicas(replicaMap, baselineAssignment);
+        toBeAssignedReplicas =
+            findToBeAssignedReplicasByComparingBaseline(replicaMap, activeInstances,
+                baselineAssignment, bestPossibleAssignment, allocatedReplicas);
+        break;
+      default:
+        throw new HelixException("Unknown rebalance scope type: " + scopeType);
+    }
 
     // Update the allocated replicas to the assignable nodes.
     assignableNodes.parallelStream().forEach(node -> node.assignInitBatch(
@@ -93,42 +187,126 @@ public class ClusterModelProvider {
     return new ClusterModel(context, toBeAssignedReplicas, assignableNodes);
   }
 
-  /**
-   * Generate a cluster model based on the current state output and data cache.
-   * @param dataProvider           The controller's data cache.
-   * @param resourceMap            The full list of the resources to be rebalanced. Note that any
-   *                               resources that are not in this list will be removed from the
-   *                               final assignment.
-   * @param currentStateAssignment The resource assignment built from current state output.
-   * @return A cluster model based on the current state and data cache.
-   */
-  public static ClusterModel generateClusterModelFromCurrentState(
-      ResourceControllerDataProvider dataProvider,
-      Map<String, Resource> resourceMap,
-      Map<String, ResourceAssignment> currentStateAssignment) {
-    return generateClusterModel(dataProvider, resourceMap, dataProvider.getEnabledLiveInstances(),
-        Collections.emptyMap(), Collections.emptyMap(), currentStateAssignment);
+  // Filter the replicas map so only the replicas that have been allocated in the existing
+  // assignmentMap remain in the map.
+  private static void removeUnknownReplicas(Map<String, Set<AssignableReplica>> replicaMap,
+      Map<String, ResourceAssignment> assignmentMap) {
+    replicaMap.entrySet().parallelStream().forEach(replicaSetEntry -> {
+      // <partition, <state, instances set>>
+      Map<String, Map<String, Set<String>>> stateInstanceMap =
+          getStateInstanceMap(assignmentMap.get(replicaSetEntry.getKey()));
+      // Iterate the replicas of the resource to find the ones that require reallocating.
+      Iterator<AssignableReplica> replicaIter = replicaSetEntry.getValue().iterator();
+      while (replicaIter.hasNext()) {
+        AssignableReplica replica = replicaIter.next();
+        Set<String> validInstances =
+            stateInstanceMap.getOrDefault(replica.getPartitionName(), Collections.emptyMap())
+                .getOrDefault(replica.getReplicaState(), Collections.emptySet());
+        if (validInstances.isEmpty()) {
+          // Removing by comparing with the baseline assignment.
+          replicaIter.remove();
+        } else {
+          // Cleanup the state map record, so the selected instance won't be picked up again for
+          // the other replica checkup.
+          validInstances.remove(validInstances.iterator().next());
+        }
+      }
+    });
   }
 
   /**
-   * Find the minimum set of replicas that need to be reassigned.
+   * Find the minimum set of replicas that need to be reassigned by comparing with the Baseline
+   * assignment.
+   * A replica needs to be reassigned if one of the following conditions is true:
+   * 1. The assignments in the Baseline and the Best possible assignment are different. And the
+   * assignment in the Baseline is valid. So it is worthwhile to move it.
+   * 2. The assignments is not in the Baseline or the Best possible assignment.
+   * Otherwise, the rebalancer just keeps the current Best possible assignment allocation.
+   *
+   * @param replicaMap             A map contains all the replicas grouped by resource name.
+   * @param activeInstances        All the instances that are live and enabled according to the delay rebalance configuration.
+   * @param baselineAssignment     The baseline assignment.
+   * @param bestPossibleAssignment The current best possible assignment.
+   * @param allocatedReplicas      Return the allocated replicas grouped by the target instance name.
+   * @return The replicas that need to be reassigned.
+   */
+  private static Set<AssignableReplica> findToBeAssignedReplicasByComparingBaseline(
+      Map<String, Set<AssignableReplica>> replicaMap, Set<String> activeInstances,
+      Map<String, ResourceAssignment> baselineAssignment,
+      Map<String, ResourceAssignment> bestPossibleAssignment,
+      Map<String, Set<AssignableReplica>> allocatedReplicas) {
+    Set<AssignableReplica> toBeAssignedReplicas = new HashSet<>();
+    // check each resource to identify the allocated replicas and to-be-assigned replicas.
+    for (String resourceName : replicaMap.keySet()) {
+      // <partition, <state, instances set>>
+      Map<String, Map<String, Set<String>>> baselinePartitionStateMap =
+          getValidStateInstanceMap(baselineAssignment.get(resourceName), activeInstances);
+      Map<String, Map<String, Set<String>>> bestPossiblePartitionStateMap =
+          getValidStateInstanceMap(bestPossibleAssignment.get(resourceName), activeInstances);
+      // Iterate the replicas of the resource to find the ones that require reallocating.
+      for (AssignableReplica replica : replicaMap.get(resourceName)) {
+        String partitionName = replica.getPartitionName();
+        String replicaState = replica.getReplicaState();
+        // Find the allocation in the baseline
+        Set<String> baselineAllocations =
+            baselinePartitionStateMap.getOrDefault(partitionName, Collections.emptyMap())
+                .getOrDefault(replicaState, Collections.emptySet());
+        Set<String> bestPossibleAllocations =
+            bestPossiblePartitionStateMap.getOrDefault(partitionName, Collections.emptyMap())
+                .getOrDefault(replicaState, Collections.emptySet());
+
+        // Compare between the baseline and best possible assignments.
+        List<String> commonAllocations = new ArrayList<>(bestPossibleAllocations);
+        commonAllocations.retainAll(baselineAllocations);
+        if (!commonAllocations.isEmpty()) {
+          // 1. If the partition is allocated at the same location in both baseline and best possible
+          // assignment, there is no need to reassign it.
+          String allocatedInstance = commonAllocations.get(0);
+          allocatedReplicas.computeIfAbsent(allocatedInstance, key -> new HashSet<>()).add(replica);
+          // clean up the record to prevent the same location being processed again.
+          baselineAllocations.remove(allocatedInstance);
+          bestPossibleAllocations.remove(allocatedInstance);
+        } else if (!baselineAllocations.isEmpty()) {
+          // 2. If the partition is allocated at an active instance in the Baseline but the
+          // allocation does not exist in the best possible assignment, try to rebalance it.
+          toBeAssignedReplicas.add(replica);
+          // clean up the baseline record to prevent the same location being picked up again.
+          baselineAllocations.remove(baselineAllocations.iterator().next());
+        } else if (!bestPossibleAllocations.isEmpty()) {
+          // 3. If the partition is allocated at an active instance in the best possible assignment
+          // only, there is no need to rebalance it.
+          String allocatedInstance = bestPossibleAllocations.iterator().next();
+          allocatedReplicas.computeIfAbsent(allocatedInstance, key -> new HashSet<>()).add(replica);
+          // clean up the record to prevent the same location being processed again.
+          bestPossibleAllocations.remove(allocatedInstance);
+        } else {
+          // 4. If the partition is completely new, rebalance it.
+          toBeAssignedReplicas.add(replica);
+        }
+      }
+    }
+    return toBeAssignedReplicas;
+  }
+
+  /**
+   * Find the minimum set of replicas that need to be reassigned according to the cluster change.
    * A replica needs to be reassigned if one of the following condition is true:
    * 1. Cluster topology (the cluster config / any instance config) has been updated.
    * 2. The resource config has been updated.
    * 3. If the current best possible assignment does not contain the partition's valid assignment.
    *
    * @param replicaMap             A map contains all the replicas grouped by resource name.
-   * @param clusterChanges         A map contains all the important metadata updates that happened after the previous rebalance.
    * @param activeInstances        All the instances that are live and enabled according to the delay rebalance configuration.
    * @param liveInstances          All the instances that are live.
-   * @param bestPossibleAssignment The current best possible assignment.
+   * @param clusterChanges         A map contains all the important metadata updates that happened after the previous rebalance.
+   * @param currentAssignment      The current replica assignment.
    * @param allocatedReplicas      Return the allocated replicas grouped by the target instance name.
    * @return The replicas that need to be reassigned.
    */
-  private static Set<AssignableReplica> findToBeAssignedReplicas(
-      Map<String, Set<AssignableReplica>> replicaMap,
-      Map<HelixConstants.ChangeType, Set<String>> clusterChanges, Set<String> activeInstances,
-      Set<String> liveInstances, Map<String, ResourceAssignment> bestPossibleAssignment,
+  private static Set<AssignableReplica> findToBeAssignedReplicasByClusterChanges(
+      Map<String, Set<AssignableReplica>> replicaMap, Set<String> activeInstances,
+      Set<String> liveInstances, Map<HelixConstants.ChangeType, Set<String>> clusterChanges,
+      Map<String, ResourceAssignment> currentAssignment,
       Map<String, Set<AssignableReplica>> allocatedReplicas) {
     Set<AssignableReplica> toBeAssignedReplicas = new HashSet<>();
 
@@ -159,33 +337,29 @@ public class ClusterModelProvider {
             .getOrDefault(HelixConstants.ChangeType.RESOURCE_CONFIG, Collections.emptySet())
             .contains(resourceName) || clusterChanges
             .getOrDefault(HelixConstants.ChangeType.IDEAL_STATE, Collections.emptySet())
-            .contains(resourceName) || !bestPossibleAssignment.containsKey(resourceName)) {
+            .contains(resourceName) || !currentAssignment.containsKey(resourceName)) {
           toBeAssignedReplicas.addAll(replicas);
           continue; // go to check next resource
         } else {
           // check for every best possible assignments to identify if the related replicas need to reassign.
-          ResourceAssignment assignment = bestPossibleAssignment.get(resourceName);
-          // <partition, <instance, state>>
-          Map<String, Map<String, String>> stateMap = assignment.getMappedPartitions().stream()
-              .collect(Collectors.toMap(partition -> partition.getPartitionName(),
-                  partition -> new HashMap<>(assignment.getReplicaMap(partition))));
+          // <partition, <state, instances list>>
+          Map<String, Map<String, Set<String>>> stateMap =
+              getValidStateInstanceMap(currentAssignment.get(resourceName), activeInstances);
           for (AssignableReplica replica : replicas) {
             // Find any ACTIVE instance allocation that has the same state with the replica
-            Optional<Map.Entry<String, String>> instanceNameOptional =
-                stateMap.getOrDefault(replica.getPartitionName(), Collections.emptyMap()).entrySet()
-                    .stream().filter(instanceStateMap ->
-                    instanceStateMap.getValue().equals(replica.getReplicaState()) && activeInstances
-                        .contains(instanceStateMap.getKey())).findAny();
-            // 3. if no such an instance in the bestPossible assignment, need to reassign the replica
-            if (!instanceNameOptional.isPresent()) {
+            Set<String> validInstances =
+                stateMap.getOrDefault(replica.getPartitionName(), Collections.emptyMap())
+                    .getOrDefault(replica.getReplicaState(), Collections.emptySet());
+            if (validInstances.isEmpty()) {
+              // 3. if no such an instance in the bestPossible assignment, need to reassign the replica
               toBeAssignedReplicas.add(replica);
               continue; // go to check the next replica
             } else {
-              String instanceName = instanceNameOptional.get().getKey();
-              // * cleanup the best possible state map record,
+              Iterator<String> iter = validInstances.iterator();
+              // * cleanup the best possible assignment allocation record after one is picked up.
               // * so the selected instance won't be picked up again for the another replica check
-              stateMap.getOrDefault(replica.getPartitionName(), Collections.emptyMap())
-                  .remove(instanceName);
+              String instanceName = iter.next();
+              iter.remove();
               // the current best possible assignment for this replica is valid,
               // add to the allocated replica list.
               allocatedReplicas.computeIfAbsent(instanceName, key -> new HashSet<>()).add(replica);
@@ -195,6 +369,33 @@ public class ClusterModelProvider {
       }
     }
     return toBeAssignedReplicas;
+  }
+
+  // <partition, <state, instances set>>
+  private static Map<String, Map<String, Set<String>>> getValidStateInstanceMap(
+      ResourceAssignment assignment, Set<String> activeInstances) {
+    Map<String, Map<String, Set<String>>> stateInstanceMap = getStateInstanceMap(assignment);
+    // Filter to remove all invalid allocations that are not on the active instances.
+    stateInstanceMap.values().stream().forEach(stateMap -> stateMap.values().stream()
+        .forEach(instanceSet -> instanceSet.retainAll(activeInstances)));
+    return stateInstanceMap;
+  }
+
+  // <partition, <state, instances set>>
+  private static Map<String, Map<String, Set<String>>> getStateInstanceMap(
+      ResourceAssignment assignment) {
+    if (assignment == null) {
+      return Collections.emptyMap();
+    }
+    return assignment.getMappedPartitions().stream()
+        .collect(Collectors.toMap(partition -> partition.getPartitionName(), partition -> {
+          Map<String, Set<String>> stateInstanceMap = new HashMap<>();
+          assignment.getReplicaMap(partition).entrySet().stream().forEach(
+              stateMapEntry -> stateInstanceMap
+                  .computeIfAbsent(stateMapEntry.getValue(), key -> new HashSet<>())
+                  .add(stateMapEntry.getKey()));
+          return stateInstanceMap;
+        }));
   }
 
   /**
@@ -207,10 +408,10 @@ public class ClusterModelProvider {
    */
   private static Set<AssignableNode> parseAllNodes(ClusterConfig clusterConfig,
       Map<String, InstanceConfig> instanceConfigMap, Set<String> activeInstances) {
-    return activeInstances.parallelStream().map(
-        instanceName -> new AssignableNode(clusterConfig, instanceConfigMap.get(instanceName),
-            instanceName))
-        .collect(Collectors.toSet());
+    return activeInstances.parallelStream()
+        .filter(instance -> instanceConfigMap.containsKey(instance)).map(
+            instanceName -> new AssignableNode(clusterConfig, instanceConfigMap.get(instanceName),
+                instanceName)).collect(Collectors.toSet());
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -254,7 +254,7 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
 
         Map<String, ResourceAssignment> currentStateAssignment =
             currentStateOutput.getAssignment(resourceToMonitorMap.keySet());
-        ClusterModel clusterModel = ClusterModelProvider.generateClusterModelFromCurrentState(
+        ClusterModel clusterModel = ClusterModelProvider.generateClusterModelFromExistingAssignment(
             dataProvider, resourceToMonitorMap, currentStateAssignment);
 
         Map<String, Double> maxUsageMap = new HashMap<>();

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -37,6 +37,7 @@ import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.pipeline.Stage;
 import org.apache.helix.controller.pipeline.StageContext;
 import org.apache.helix.controller.rebalancer.waged.AssignmentMetadataStore;
+import org.apache.helix.controller.rebalancer.waged.RebalanceAlgorithm;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.controller.rebalancer.waged.constraints.ConstraintBasedAlgorithmFactory;
 import org.apache.helix.controller.stages.AttributeName;
@@ -430,7 +431,7 @@ class DryrunWagedRebalancer extends WagedRebalancer {
   @Override
   protected Map<String, ResourceAssignment> computeBestPossibleAssignment(
       ResourceControllerDataProvider clusterData, Map<String, Resource> resourceMap,
-      Set<String> activeNodes, CurrentStateOutput currentStateOutput)
+      Set<String> activeNodes, CurrentStateOutput currentStateOutput, RebalanceAlgorithm algorithm)
       throws HelixRebalanceException {
     return getBestPossibleAssignment(getAssignmentMetadataStore(), currentStateOutput,
         resourceMap.keySet());

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -414,45 +414,45 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
     return verifierName + "(" + _clusterName + "@" + _zkClient + "@resources["
        + (_resources != null ? Arrays.toString(_resources.toArray()) : "") + "])";
   }
-}
 
-/**
- * A Dryrun WAGED rebalancer that only calculates the assignment based on the cluster status but
- * never update the rebalancer assignment metadata.
- * This rebalacer is used in the verifiers or tests.
- */
-class DryrunWagedRebalancer extends WagedRebalancer {
-  DryrunWagedRebalancer(String metadataStoreAddrs, String clusterName,
-      Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> preferences) {
-    super(new ReadOnlyAssignmentMetadataStore(metadataStoreAddrs, clusterName),
-        ConstraintBasedAlgorithmFactory.getInstance(preferences));
+  /**
+   * A Dryrun WAGED rebalancer that only calculates the assignment based on the cluster status but
+   * never update the rebalancer assignment metadata.
+   * This rebalacer is used in the verifiers or tests.
+   */
+  private class DryrunWagedRebalancer extends WagedRebalancer {
+    DryrunWagedRebalancer(String metadataStoreAddrs, String clusterName,
+        Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> preferences) {
+      super(new ReadOnlyAssignmentMetadataStore(metadataStoreAddrs, clusterName),
+          ConstraintBasedAlgorithmFactory.getInstance(preferences));
+    }
+
+    @Override
+    protected Map<String, ResourceAssignment> computeBestPossibleAssignment(
+        ResourceControllerDataProvider clusterData, Map<String, Resource> resourceMap,
+        Set<String> activeNodes, CurrentStateOutput currentStateOutput, RebalanceAlgorithm algorithm)
+        throws HelixRebalanceException {
+      return getBestPossibleAssignment(getAssignmentMetadataStore(), currentStateOutput,
+          resourceMap.keySet());
+    }
   }
 
-  @Override
-  protected Map<String, ResourceAssignment> computeBestPossibleAssignment(
-      ResourceControllerDataProvider clusterData, Map<String, Resource> resourceMap,
-      Set<String> activeNodes, CurrentStateOutput currentStateOutput, RebalanceAlgorithm algorithm)
-      throws HelixRebalanceException {
-    return getBestPossibleAssignment(getAssignmentMetadataStore(), currentStateOutput,
-        resourceMap.keySet());
-  }
-}
+  private class ReadOnlyAssignmentMetadataStore extends AssignmentMetadataStore {
+    ReadOnlyAssignmentMetadataStore(String metadataStoreAddrs, String clusterName) {
+      super(new ZkBucketDataAccessor(metadataStoreAddrs), clusterName);
+    }
 
-class ReadOnlyAssignmentMetadataStore extends AssignmentMetadataStore {
-  ReadOnlyAssignmentMetadataStore(String metadataStoreAddrs, String clusterName) {
-    super(new ZkBucketDataAccessor(metadataStoreAddrs), clusterName);
-  }
+    @Override
+    public void persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
+      // Update the in-memory reference only
+      _globalBaseline = globalBaseline;
+    }
 
-  @Override
-  public void persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
-    // Update the in-memory reference only
-    _globalBaseline = globalBaseline;
-  }
-
-  @Override
-  public void persistBestPossibleAssignment(
-      Map<String, ResourceAssignment> bestPossibleAssignment) {
-    // Update the in-memory reference only
-    _bestPossibleAssignment = bestPossibleAssignment;
+    @Override
+    public void persistBestPossibleAssignment(
+        Map<String, ResourceAssignment> bestPossibleAssignment) {
+      // Update the in-memory reference only
+      _bestPossibleAssignment = bestPossibleAssignment;
+    }
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModelProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModelProvider.java
@@ -101,7 +101,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     ClusterModel clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
         _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
-        _instances, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+        _instances, Collections.emptyMap(), Collections.emptyMap());
     // There should be no existing assignment.
     Assert.assertFalse(clusterModel.getContext().getAssignmentForFaultZoneMap().values().stream()
         .anyMatch(resourceMap -> !resourceMap.isEmpty()));
@@ -122,7 +122,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
         _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
-        _instances, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+        _instances, Collections.emptyMap(), Collections.emptyMap());
     // Shall have 2 resources and 12 replicas after fault zone adjusted.
     Assert.assertEquals(clusterModel.getAssignableReplicaMap().size(), 2);
     Assert.assertTrue(clusterModel.getAssignableReplicaMap().values().stream()
@@ -132,8 +132,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
         _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
-        Collections.singleton(_testInstanceId), Collections.emptyMap(), Collections.emptyMap(),
-        Collections.emptyMap());
+        Collections.singleton(_testInstanceId), Collections.emptyMap(), Collections.emptyMap());
     // Have only one instance
     Assert.assertEquals(
         clusterModel.getAssignableNodes().values().stream().map(AssignableNode::getInstanceName)
@@ -146,17 +145,16 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
         _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
-        Collections.emptySet(), Collections.emptyMap(), Collections.emptyMap(),
-        Collections.emptyMap());
+        Collections.emptySet(), Collections.emptyMap(), Collections.emptyMap());
     // Have only one instance
     Assert.assertEquals(clusterModel.getAssignableNodes().size(), 0);
-    // Shall have 0 assignable replicas because there is 0 valid node.
+    // Shall have 0 assignable replicas because there are 0 valid nodes.
     Assert.assertTrue(clusterModel.getAssignableReplicaMap().values().stream()
         .allMatch(replicaSet -> replicaSet.isEmpty()));
 
-    // 4. test with best possible assignment
-    // Mock a best possible assignment based on the current states.
-    Map<String, ResourceAssignment> bestPossibleAssignment = new HashMap<>();
+    // 4. test with baseline assignment
+    // Mock a baseline assignment based on the current states.
+    Map<String, ResourceAssignment> baselineAssignment = new HashMap<>();
     for (String resource : _resourceNames) {
       // <partition, <instance, state>>
       Map<String, Map<String, String>> assignmentMap = new HashMap<>();
@@ -169,7 +167,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
         ResourceAssignment assignment = new ResourceAssignment(resource);
         assignmentMap.keySet().stream().forEach(partition -> assignment
             .addReplicaMap(new Partition(partition), assignmentMap.get(partition)));
-        bestPossibleAssignment.put(resource, assignment);
+        baselineAssignment.put(resource, assignment);
       }
     }
 
@@ -177,7 +175,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
         _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
-        _instances, Collections.emptyMap(), Collections.emptyMap(), bestPossibleAssignment);
+        _instances, Collections.emptyMap(), baselineAssignment);
     // There should be 4 existing assignments in total (each resource has 2) in the specified instance
     Assert.assertTrue(clusterModel.getContext().getAssignmentForFaultZoneMap().values().stream()
         .allMatch(resourceMap -> resourceMap.values().stream()
@@ -195,7 +193,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
         _instances,
         Collections.singletonMap(HelixConstants.ChangeType.CLUSTER_CONFIG, Collections.emptySet()),
-        Collections.emptyMap(), bestPossibleAssignment);
+        baselineAssignment);
     // There should be no existing assignment since the topology change invalidates all existing assignment
     Assert.assertTrue(clusterModel.getContext().getAssignmentForFaultZoneMap().values().stream()
         .allMatch(resourceMap -> resourceMap.isEmpty()));
@@ -213,8 +211,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
         _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
         _instances, Collections.singletonMap(HelixConstants.ChangeType.RESOURCE_CONFIG,
-            Collections.singleton(changedResourceName)), Collections.emptyMap(),
-        bestPossibleAssignment);
+            Collections.singleton(changedResourceName)), baselineAssignment);
     // There should be no existing assignment for all the resource except for resource2
     Assert.assertEquals(clusterModel.getContext().getAssignmentForFaultZoneMap().size(), 1);
     Map<String, Set<String>> resourceAssignmentMap =
@@ -245,8 +242,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
         _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
-        limitedActiveInstances, Collections.emptyMap(), Collections.emptyMap(),
-        bestPossibleAssignment);
+        limitedActiveInstances, Collections.emptyMap(), baselineAssignment);
     // There should be no existing assignment.
     Assert.assertFalse(clusterModel.getContext().getAssignmentForFaultZoneMap().values().stream()
         .anyMatch(resourceMap -> !resourceMap.isEmpty()));

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModelProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModelProvider.java
@@ -98,7 +98,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
   public void testGenerateClusterModel() throws IOException {
     ResourceControllerDataProvider testCache = setupClusterDataCache();
     // 1. test generating a cluster model with empty assignment
-    ClusterModel clusterModel = ClusterModelProvider.generateClusterModel(testCache,
+    ClusterModel clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
         _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
         _instances, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
@@ -119,7 +119,8 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     // Adjust instance fault zone, so they have different fault zones.
     testCache.getInstanceConfigMap().values().stream()
         .forEach(config -> config.setZoneId(config.getInstanceName()));
-    clusterModel = ClusterModelProvider.generateClusterModel(testCache, _resourceNames.stream()
+    clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
+        _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
         _instances, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
     // Shall have 2 resources and 12 replicas after fault zone adjusted.
@@ -128,7 +129,8 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
         .allMatch(replicaSet -> replicaSet.size() == 12));
 
     // 2. test with only one active node
-    clusterModel = ClusterModelProvider.generateClusterModel(testCache, _resourceNames.stream()
+    clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
+        _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
         Collections.singleton(_testInstanceId), Collections.emptyMap(), Collections.emptyMap(),
         Collections.emptyMap());
@@ -141,13 +143,14 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
         .allMatch(replicaSet -> replicaSet.size() == 4));
 
     // 3. test with no active instance
-    clusterModel = ClusterModelProvider.generateClusterModel(testCache, _resourceNames.stream()
+    clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
+        _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
         Collections.emptySet(), Collections.emptyMap(), Collections.emptyMap(),
         Collections.emptyMap());
     // Have only one instance
     Assert.assertEquals(clusterModel.getAssignableNodes().size(), 0);
-    // Shall have 0 assignable replicas because there is only n0 valid node.
+    // Shall have 0 assignable replicas because there is 0 valid node.
     Assert.assertTrue(clusterModel.getAssignableReplicaMap().values().stream()
         .allMatch(replicaSet -> replicaSet.isEmpty()));
 
@@ -171,7 +174,8 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     }
 
     // Generate a cluster model based on the best possible assignment
-    clusterModel = ClusterModelProvider.generateClusterModel(testCache, _resourceNames.stream()
+    clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
+        _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
         _instances, Collections.emptyMap(), Collections.emptyMap(), bestPossibleAssignment);
     // There should be 4 existing assignments in total (each resource has 2) in the specified instance
@@ -186,10 +190,12 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
         .allMatch(replicaSet -> replicaSet.size() == 10));
 
     // 5. test with best possible assignment but cluster topology is changed
-    clusterModel = ClusterModelProvider.generateClusterModel(testCache, _resourceNames.stream()
+    clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
+        _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
-        _instances, Collections.singletonMap(HelixConstants.ChangeType.CLUSTER_CONFIG,
-            Collections.emptySet()), Collections.emptyMap(), bestPossibleAssignment);
+        _instances,
+        Collections.singletonMap(HelixConstants.ChangeType.CLUSTER_CONFIG, Collections.emptySet()),
+        Collections.emptyMap(), bestPossibleAssignment);
     // There should be no existing assignment since the topology change invalidates all existing assignment
     Assert.assertTrue(clusterModel.getContext().getAssignmentForFaultZoneMap().values().stream()
         .allMatch(resourceMap -> resourceMap.isEmpty()));
@@ -203,7 +209,8 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     // 6. test with best possible assignment and one resource config change
     // Generate a cluster model based on the same best possible assignment, but resource1 config is changed
     String changedResourceName = _resourceNames.get(0);
-    clusterModel = ClusterModelProvider.generateClusterModel(testCache, _resourceNames.stream()
+    clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
+        _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
         _instances, Collections.singletonMap(HelixConstants.ChangeType.RESOURCE_CONFIG,
             Collections.singleton(changedResourceName)), Collections.emptyMap(),
@@ -221,9 +228,8 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     }
     // Only the first instance will have 2 assignment from resource2.
     for (String instance : _instances) {
-      Assert
-          .assertEquals(clusterModel.getAssignableNodes().get(instance).getAssignedReplicaCount(),
-              instance.equals(_testInstanceId) ? 2 : 0);
+      Assert.assertEquals(clusterModel.getAssignableNodes().get(instance).getAssignedReplicaCount(),
+          instance.equals(_testInstanceId) ? 2 : 0);
     }
     // Shall have 2 resources and 12 replicas
     Assert.assertEquals(clusterModel.getAssignableReplicaMap().keySet().size(), 2);
@@ -236,7 +242,8 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     // Generate a cluster model based on the best possible assignment, but the assigned node is disabled
     Set<String> limitedActiveInstances = new HashSet<>(_instances);
     limitedActiveInstances.remove(_testInstanceId);
-    clusterModel = ClusterModelProvider.generateClusterModel(testCache, _resourceNames.stream()
+    clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
+        _resourceNames.stream()
             .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
         limitedActiveInstances, Collections.emptyMap(), Collections.emptyMap(),
         bestPossibleAssignment);
@@ -253,6 +260,121 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     Assert.assertEquals(clusterModel.getAssignableReplicaMap().size(), 2);
     Assert.assertTrue(clusterModel.getAssignableReplicaMap().values().stream()
         .allMatch(replicaSet -> replicaSet.size() == 8));
+  }
 
+  @Test (dependsOnMethods = "testGenerateClusterModel")
+  public void testGenerateClusterModelForPartialRebalance() throws IOException {
+    ResourceControllerDataProvider testCache = setupClusterDataCache();
+    // 1. test generating a cluster model with empty assignment
+    ClusterModel clusterModel = ClusterModelProvider
+        .generateClusterModelForPartialRebalance(testCache, _resourceNames.stream()
+                .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
+            _instances, Collections.emptyMap(), Collections.emptyMap());
+    // There should be no existing assignment.
+    Assert.assertFalse(clusterModel.getContext().getAssignmentForFaultZoneMap().values().stream()
+        .anyMatch(resourceMap -> !resourceMap.isEmpty()));
+    Assert.assertFalse(clusterModel.getAssignableNodes().values().stream()
+        .anyMatch(node -> node.getAssignedReplicaCount() != 0));
+    // Have all 3 instances
+    Assert.assertEquals(
+        clusterModel.getAssignableNodes().values().stream().map(AssignableNode::getInstanceName)
+            .collect(Collectors.toSet()), _instances);
+    // Shall have 0 resources and 0 replicas since the baseline is empty. The partial rebalance
+    // should not rebalance any replica.
+    Assert.assertEquals(clusterModel.getAssignableReplicaMap().size(), 0);
+
+    // Adjust instance fault zone, so they have different fault zones.
+    testCache.getInstanceConfigMap().values().stream()
+        .forEach(config -> config.setZoneId(config.getInstanceName()));
+
+    // 2. test with a pair of identical best possible assignment and baseline assignment
+    // Mock a best possible assignment based on the current states.
+    Map<String, ResourceAssignment> bestPossibleAssignment = new HashMap<>();
+    for (String resource : _resourceNames) {
+      // <partition, <instance, state>>
+      Map<String, Map<String, String>> assignmentMap = new HashMap<>();
+      CurrentState cs = testCache.getCurrentState(_testInstanceId, _sessionId).get(resource);
+      if (cs != null) {
+        for (Map.Entry<String, String> stateEntry : cs.getPartitionStateMap().entrySet()) {
+          assignmentMap.computeIfAbsent(stateEntry.getKey(), k -> new HashMap<>())
+              .put(_testInstanceId, stateEntry.getValue());
+        }
+        ResourceAssignment assignment = new ResourceAssignment(resource);
+        assignmentMap.keySet().stream().forEach(partition -> assignment
+            .addReplicaMap(new Partition(partition), assignmentMap.get(partition)));
+        bestPossibleAssignment.put(resource, assignment);
+      }
+    }
+    Map<String, ResourceAssignment> baseline = new HashMap<>(bestPossibleAssignment);
+    // Generate a cluster model for partial rebalance
+    clusterModel = ClusterModelProvider.generateClusterModelForPartialRebalance(testCache,
+        _resourceNames.stream()
+            .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
+        _instances, baseline, bestPossibleAssignment);
+    // There should be 4 existing assignments in total (each resource has 2) in the specified instance
+    Assert.assertTrue(clusterModel.getContext().getAssignmentForFaultZoneMap().values().stream()
+        .allMatch(resourceMap -> resourceMap.values().stream()
+            .allMatch(partitionSet -> partitionSet.size() == 2)));
+    Assert.assertEquals(
+        clusterModel.getAssignableNodes().get(_testInstanceId).getAssignedReplicaCount(), 4);
+    // Since the best possible matches the baseline, no replica needs to be reassigned.
+    Assert.assertEquals(clusterModel.getAssignableReplicaMap().size(), 0);
+
+    // 3. test with inactive instance in the baseline and the best possible assignment
+    Set<String> partialInstanceList = new HashSet<>(_instances);
+    partialInstanceList.remove(_testInstanceId);
+    clusterModel = ClusterModelProvider.generateClusterModelForPartialRebalance(testCache,
+        _resourceNames.stream()
+            .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
+        partialInstanceList, baseline, bestPossibleAssignment);
+    // Have the other 2 active instances
+    Assert.assertEquals(clusterModel.getAssignableNodes().size(), 2);
+    // All the replicas in the existing assignment should be rebalanced.
+    Assert.assertEquals(clusterModel.getAssignableReplicaMap().size(), 2);
+    Assert.assertTrue(clusterModel.getAssignableReplicaMap().values().stream()
+        .allMatch(replicaSet -> replicaSet.size() == 2));
+    // Shall have 0 assigned replicas
+    Assert.assertTrue(clusterModel.getAssignableNodes().values().stream()
+        .allMatch(assignableNode -> assignableNode.getAssignedReplicaCount() == 0));
+
+    // 4. test with one resource that is only in the baseline
+    String resourceInBaselineOnly = _resourceNames.get(0);
+    Map<String, ResourceAssignment> partialBestPossibleAssignment =
+        new HashMap<>(bestPossibleAssignment);
+    partialBestPossibleAssignment.remove(resourceInBaselineOnly);
+    // Generate a cluster mode with the adjusted best possible assignment
+    clusterModel = ClusterModelProvider.generateClusterModelForPartialRebalance(testCache,
+        _resourceNames.stream()
+            .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
+        _instances, baseline, partialBestPossibleAssignment);
+    // There should be 2 existing assignments in total in the specified instance
+    Assert.assertTrue(clusterModel.getContext().getAssignmentForFaultZoneMap().values().stream()
+        .allMatch(resourceMap -> resourceMap.values().stream()
+            .allMatch(partitionSet -> partitionSet.size() == 2)));
+    // Only the replicas of one resource require rebalance
+    Assert.assertEquals(
+        clusterModel.getAssignableNodes().get(_testInstanceId).getAssignedReplicaCount(), 2);
+    Assert.assertEquals(clusterModel.getAssignableReplicaMap().size(), 1);
+    Assert.assertTrue(clusterModel.getAssignableReplicaMap().containsKey(resourceInBaselineOnly));
+    Assert.assertTrue(clusterModel.getAssignableReplicaMap().values().stream()
+        .allMatch(replicaSet -> replicaSet.size() == 2));
+
+    // 5. test with one resource only in the best possible assignment
+    String resourceInBestPossibleOnly = _resourceNames.get(1);
+    Map<String, ResourceAssignment> partialBaseline = new HashMap<>(baseline);
+    partialBaseline.remove(resourceInBestPossibleOnly);
+    // Generate a cluster model with the adjusted baseline
+    clusterModel = ClusterModelProvider.generateClusterModelForPartialRebalance(testCache,
+        _resourceNames.stream()
+            .collect(Collectors.toMap(resource -> resource, resource -> new Resource(resource))),
+        _instances, partialBaseline, bestPossibleAssignment);
+    // There should be 2 existing assignments in total and all of them require rebalance.
+    Assert.assertTrue(clusterModel.getContext().getAssignmentForFaultZoneMap().values().stream()
+        .allMatch(resourceMap -> resourceMap.values().stream()
+            .allMatch(partitionSet -> partitionSet.size() == 2)));
+    Assert.assertEquals(
+        clusterModel.getAssignableNodes().get(_testInstanceId).getAssignedReplicaCount(), 2);
+    // No need to rebalance the replicas that are not in the baseline yet.
+    Assert.assertEquals(clusterModel.getAssignableReplicaMap().size(), 0);
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#563 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Prerequisite of #632 

Split the cluster module calculation method so that different rebalance logic can have different rebalance scope calculation logic.
Also, refine the WAGED rebalancer logic to reduce duplicate code.

This PR implements the designed workflow that is described in this chart: https://github.com/jiajunwang/Helix-design-pics/blob/master/Coordinator.png without the async part. The async logic will be applied in the following PR.

### Tests

- [x] The following tests are written for this issue:

TestWagedRebalancer
TestClusterModelProvider.java

- [ ] The following is the result of the "mvn test" command on the appropriate module:

Please refer to #632 's test result.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

https://github.com/apache/helix/wiki/Weight-aware-Globally-Evenly-distributed-Rebalancer

### Code Quality

- [x] My diff has been formatted using helix-style.xml
