### PR TITLE
Fix handleNewSession creating ephemeral node with expired session

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -112,7 +112,7 @@ public class ParticipantManager {
   public void handleNewSession() throws Exception {
     // Check participant's session is still valid.
     // If not, skip handling new session for this participant.
-    final String zkClientHexSession = _zkclient.getHexSessionId();
+    final String zkClientHexSession = ZKUtil.toHexSessionId(_zkclient.getSessionId());
     if (!zkClientHexSession.equals(_sessionId)) {
       LOG.warn("Skip handling new session for participant. There is a session mismatch: "
               + "participant manager session = {}, zk client session = {}", _sessionId,

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -108,6 +108,16 @@ public class ParticipantManager {
    * @throws Exception if any exception occurs
    */
   public void handleNewSession() throws Exception {
+    // Check participant's session is still valid.
+    // If not, stop to handle new session for this participant.
+    final String zkClientHexSession = _zkclient.getHexSessionId();
+    if (!zkClientHexSession.equals(_sessionId)) {
+      throw new HelixException(
+          "Failed to handle new session for participant. There is a session mismatch: "
+              + "participant manager session = " + _sessionId + ", zk client session = "
+              + zkClientHexSession);
+    }
+
     joinCluster();
 
     /**
@@ -193,7 +203,7 @@ public class ParticipantManager {
         LOG.info("LiveInstance created, path: " + liveInstancePath + ", sessionId: " + liveInstance.getEphemeralOwner());
       } catch (ZkSessionMismatchedException e) {
         throw new HelixException(
-            "Failed to create live instance, path: " + liveInstancePath + ", session: "
+            "Failed to create live instance, path: " + liveInstancePath + ", expected session: "
                 + _sessionId, e);
       } catch (ZkNodeExistsException e) {
         LOG.warn("found another instance with same instanceName: " + _instanceName + " in cluster "

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -23,10 +23,8 @@ import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.I0Itec.zkclient.DataUpdater;
-import org.I0Itec.zkclient.exception.ZkNodeExistsException;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
@@ -51,7 +49,6 @@ import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.participant.statemachine.ScheduledTaskStateModelFactory;
-import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,14 +107,14 @@ public class ParticipantManager {
    * @throws Exception if any exception occurs
    */
   public void handleNewSession() throws Exception {
-    // Check participant's session is still valid.
+    // Check zk session of this participant is still valid.
     // If not, skip handling new session for this participant.
     final String zkClientHexSession = ZKUtil.toHexSessionId(_zkclient.getSessionId());
     if (!zkClientHexSession.equals(_sessionId)) {
-      LOG.warn("Skip handling new session for participant. There is a session mismatch: "
-              + "participant manager session = {}, zk client session = {}", _sessionId,
-          zkClientHexSession);
-      return;
+      throw new HelixException(
+          "Failed to handle new session for participant. There is a session mismatch: "
+              + "participant manager session = " + _sessionId + ", zk client session = "
+              + zkClientHexSession);
     }
 
     joinCluster();

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -205,9 +205,9 @@ public class ParticipantManager {
         LOG.info("LiveInstance created, path: {}, sessionId: {}", liveInstancePath,
             liveInstance.getEphemeralOwner());
       } catch (ZkSessionMismatchedException e) {
-          throw new HelixException(
-              "Failed to create live instance, path: " + liveInstancePath + ", expected session: "
-                  + _sessionId, e);
+        throw new HelixException(
+            "Failed to create live instance, path: " + liveInstancePath + ". Caused by: "
+                + e.getMessage());
       } catch (ZkNodeExistsException e) {
         LOG.warn("Found another instance with same instance name: {} in cluster: {}", _instanceName,
             _clusterName);
@@ -248,14 +248,14 @@ public class ParticipantManager {
             liveInstance.getEphemeralOwner());
       } catch (ZkSessionMismatchedException e) {
         throw new HelixException(
-            "Failed to create live instance, path: " + liveInstancePath + ", expected session: "
-                + _sessionId, e);
+            "Failed to create live instance, path: " + liveInstancePath + ". Caused by: "
+                + e.getMessage());
       } catch (ZkNodeExistsException e) {
-        throw new HelixException(
-            "Failed to create live instance because instance = " + _instanceName
-                + " already has a live-instance in cluster: " + _clusterName, e);
+        throw new HelixException("Failed to create live instance because instance: " + _instanceName
+            + " already has a live-instance in cluster: " + _clusterName + ". Path is: "
+            + liveInstancePath);
       } catch (Exception e) {
-        throw new HelixException("Failed to create live instance.", e);
+        throw new HelixException("Failed to create live instance. " + e.getMessage());
       }
     }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -98,13 +98,6 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
   public static final int DEFAULT_MAX_DISCONNECT_THRESHOLD = 600; // Default to be a large number
   private static final int DEFAULT_WAIT_CONNECTED_TIMEOUT = 10 * 1000;  // wait until connected for up to 10 seconds.
 
-  /*
-   * Before the new zookeeper object is connected to the zookeeper service and its session is
-   * established, its session id is 0.
-   * This is a string representation of zero session id in hexadecimal notation.
-   */
-  private static final String ZERO_HEX_SESSION_ID = "0";
-
   protected final String _zkAddress;
   private final String _clusterName;
   private final String _instanceName;
@@ -718,7 +711,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
          * which means this listener has not yet handled new session, so we have to handle new
          * session here just for this listener.
          */
-        handleNewSession(_zkclient.getHexSessionId());
+        handleNewSession(ZKUtil.toHexSessionId(_zkclient.getSessionId()));
         break;
       } catch (HelixException e) {
         LOG.error("fail to createClient.", e);
@@ -1000,13 +993,13 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
         continue;
       }
 
-      _sessionId = _zkclient.getHexSessionId();
+      _sessionId = ZKUtil.toHexSessionId(_zkclient.getSessionId());
 
       /**
        * at the time we read session-id, zkconnection might be lost again
        * wait until we get a non-zero session-id
        */
-    } while (!isConnected || ZERO_HEX_SESSION_ID.equals(_sessionId));
+    } while (!isConnected || "0".equals(_sessionId));
 
     LOG.info("Handling new session, session id: " + _sessionId + ", instance: " + _instanceName
         + ", instanceTye: " + _instanceType + ", cluster: " + _clusterName);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -706,7 +706,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     int retryCount = 0;
     while (retryCount < 3) {
       try {
-        // TODO: might be better to create a new method to return session id in waitUntilConnected.
+        // TODO: get session id from waitUntilConnected to avoid synchronized
         synchronized (this) {
           if (!_zkclient.waitUntilConnected(_connectionInitTimeout, TimeUnit.MILLISECONDS)) {
             throw new ZkTimeoutException(
@@ -714,7 +714,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
                     + " ms.");
           }
           handleStateChanged(KeeperState.SyncConnected);
-          handleNewSession(_zkclient.getHexSessionId(_zkclient.getSessionId()));
+          handleNewSession(_zkclient.getHexSessionId());
         }
         break;
       } catch (HelixException e) {
@@ -997,7 +997,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
         continue;
       }
 
-      _sessionId = _zkclient.getHexSessionId(_zkclient.getSessionId());
+      _sessionId = _zkclient.getHexSessionId();
 
       /**
        * at the time we read session-id, zkconnection might be lost again

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -1119,7 +1119,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
   }
 
   /**
-   * Called after the zookeeper session has expired and a new session has been established. This method
+   * Called after zookeeper session has expired and a new session has been established. This method
    * may cause session race condition when creating ephemeral nodes. Internally, this method calls
    * {@link #handleNewSession(String)} with a null value as the sessionId parameter, which results
    * in later creating the ephemeral node in the session of the latest zk connection.

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -713,6 +713,11 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
                   + " ms.");
         }
         handleStateChanged(KeeperState.SyncConnected);
+        /*
+         * This listener is subscribed after SyncConnected and firing new session events,
+         * which means this listener has not yet handled new session, so we have to handle new
+         * session here just for this listener.
+         */
         handleNewSession(_zkclient.getHexSessionId());
         break;
       } catch (HelixException e) {
@@ -1172,6 +1177,13 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
       return;
     }
 
+    /*
+     * When a null session id is passed in, we will take current session's id for following
+     * operations. Please note that current session might not be the one we expect to handle,
+     * because the one we expect might be already expired when the zk event is waiting in the
+     * event queue. Why we use current session here is for backward compatibility with the old
+     * method handleNewSession().
+     */
     if (sessionId == null) {
       sessionId = getSessionId();
       LOG.warn("Session id: <null> is passed in. Current session id: {} will be used.", sessionId);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -1165,7 +1165,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
      * so performance is expected to improve.
      */
     if (sessionId != null && !getSessionId().equals(sessionId)) {
-      LOG.info("Session is expired and not handled. Expected: {}. Actual: {}.", sessionId,
+      LOG.warn("Session is expired and not handled. Expected: {}. Actual: {}.", sessionId,
           getSessionId());
       return;
     }
@@ -1179,7 +1179,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
      */
     if (sessionId == null) {
       sessionId = getSessionId();
-      LOG.warn("Session id: <null> is passed in. Current session id: {} will be used.", sessionId);
+      LOG.debug("Session id: <null> is passed in. Current session id: {} will be used.", sessionId);
     }
 
     LOG.info("Handle new session, instance: {}, type: {}, session id: {}.", _instanceName,

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -539,6 +539,16 @@ public final class ZKUtil {
   }
 
   /**
+   * Converts a session id in hexadecimal notation from a long type session id.
+   * Ex. 1000a5ceb930004 is returned.
+   *
+   * @return String representation of session id in hexadecimal notation.
+   */
+  public static String toHexSessionId(long sessionId) {
+    return Long.toHexString(sessionId);
+  }
+
+  /**
    * Returns a dedicated ZkClient.
    * @return
    */

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkSessionMismatchedException.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkSessionMismatchedException.java
@@ -1,0 +1,30 @@
+package org.apache.helix.manager.zk;
+
+import org.I0Itec.zkclient.exception.ZkException;
+import org.apache.zookeeper.KeeperException;
+
+
+/**
+ * Exception thrown when an action is taken by an expected zk session which
+ * does not match the actual zk session.
+ */
+public class ZkSessionMismatchedException extends ZkException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ZkSessionMismatchedException() {
+        super();
+    }
+
+    public ZkSessionMismatchedException(KeeperException cause) {
+        super(cause);
+    }
+
+    public ZkSessionMismatchedException(String message, KeeperException cause) {
+        super(message, cause);
+    }
+
+    public ZkSessionMismatchedException(String message) {
+        super(message);
+    }
+}

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkSessionMismatchedException.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkSessionMismatchedException.java
@@ -12,18 +12,6 @@ public class ZkSessionMismatchedException extends ZkException {
 
     private static final long serialVersionUID = 1L;
 
-    public ZkSessionMismatchedException() {
-        super();
-    }
-
-    public ZkSessionMismatchedException(KeeperException cause) {
-        super(cause);
-    }
-
-    public ZkSessionMismatchedException(String message, KeeperException cause) {
-        super(message, cause);
-    }
-
     public ZkSessionMismatchedException(String message) {
         super(message);
     }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/client/HelixZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/client/HelixZkClient.java
@@ -187,13 +187,13 @@ public interface HelixZkClient {
   long getSessionId();
 
   /**
-   * Gets a session id in hexadecimal notation from a session id in long type.
-   * Ex. 0x1000a5ceb930004 is returned.
+   * Gets the zookeeper's session id of this zk client in hexadecimal notation.
+   * This session could be valid, expired, or "0"(initial value before zk session is established).
+   * Ex. 1000a5ceb930004 is returned.
    *
-   * @param sessionId session id in long type
    * @return String representation of session id in hexadecimal notation.
    */
-  String getHexSessionId(long sessionId);
+  String getHexSessionId();
 
   void close();
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/client/HelixZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/client/HelixZkClient.java
@@ -97,19 +97,33 @@ public interface HelixZkClient {
 
   void createEphemeral(final String path);
 
+  void createEphemeral(final String path, final String sessionId);
+
   void createEphemeral(final String path, final List<ACL> acl);
+
+  void createEphemeral(final String path, final List<ACL> acl, final String sessionId);
 
   String create(final String path, Object data, final CreateMode mode);
 
-  String create(final String path, Object datat, final List<ACL> acl, final CreateMode mode);
+  String create(final String path, Object data, final List<ACL> acl, final CreateMode mode);
 
   void createEphemeral(final String path, final Object data);
 
+  void createEphemeral(final String path, final Object data, final String sessionId);
+
   void createEphemeral(final String path, final Object data, final List<ACL> acl);
+
+  void createEphemeral(final String path, final Object data, final List<ACL> acl,
+      final String sessionId);
 
   String createEphemeralSequential(final String path, final Object data);
 
   String createEphemeralSequential(final String path, final Object data, final List<ACL> acl);
+
+  String createEphemeralSequential(final String path, final Object data, final String sessionId);
+
+  String createEphemeralSequential(final String path, final Object data, final List<ACL> acl,
+      final String sessionId);
 
   List<String> getChildren(String path);
 
@@ -171,6 +185,15 @@ public interface HelixZkClient {
   String getServers();
 
   long getSessionId();
+
+  /**
+   * Gets a session id in hexadecimal notation from a session id in long type.
+   * Ex. 0x1000a5ceb930004 is returned.
+   *
+   * @param sessionId session id in long type
+   * @return String representation of session id in hexadecimal notation.
+   */
+  String getHexSessionId(long sessionId);
 
   void close();
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/client/HelixZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/client/HelixZkClient.java
@@ -105,7 +105,7 @@ public interface HelixZkClient {
 
   String create(final String path, Object data, final CreateMode mode);
 
-  String create(final String path, Object data, final List<ACL> acl, final CreateMode mode);
+  String create(final String path, Object datat, final List<ACL> acl, final CreateMode mode);
 
   void createEphemeral(final String path, final Object data);
 
@@ -185,15 +185,6 @@ public interface HelixZkClient {
   String getServers();
 
   long getSessionId();
-
-  /**
-   * Gets the zookeeper's session id of this zk client in hexadecimal notation.
-   * This session could be valid, expired, or "0"(initial value before zk session is established).
-   * Ex. 1000a5ceb930004 is returned.
-   *
-   * @return String representation of session id in hexadecimal notation.
-   */
-  String getHexSessionId();
 
   void close();
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
@@ -87,7 +87,7 @@ public class ZkClient implements Watcher {
   // When a new zookeeper instance is created in reconnect, its session id is not yet valid before
   // the zookeeper session is established(SyncConnected). To avoid session race condition in
   // handling new session, the new session event is only fired after SyncConnected. Meanwhile,
-  // SyncConnected state is also received when re-open the zk connection. So to avoid firing
+  // SyncConnected state is also received when re-opening the zk connection. So to avoid firing
   // new session event more than once, this flag is used to check.
   // It is set to false right after the new zookeeper instance is created in reconnect before the
   // session is established. And set it to true once the new session event is fired the first time.

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
@@ -84,7 +84,15 @@ public class ZkClient implements Watcher {
   private KeeperState _currentState;
   private final ZkLock _zkEventLock = new ZkLock();
 
+  // When a new zookeeper instance is created in reconnect, its session id is not yet valid before
+  // the zookeeper session is established(SyncConnected). To avoid session race condition in
+  // handling new session, the new session event is only fired after SyncConnected. Meanwhile,
+  // SyncConnected state is also received when re-open the zk connection. So to avoid firing
+  // new session event more than once, this flag is used to check.
+  // It is set to false right after the new zookeeper instance is created in reconnect before the
+  // session is established. And set it to true once the new session event is fired the first time.
   private boolean _isNewSessionEventFired;
+
   private boolean _shutdownTriggered;
   private ZkEventThread _eventThread;
   // TODO PVo remove this later
@@ -1424,7 +1432,11 @@ public class ZkClient implements Watcher {
     }
     try {
       while (true) {
-        KeeperException retryCause = null;
+        // Because ConnectionLossException and SessionExpiredException are caught but not thrown,
+        // we don't know what causes retry. This is used to record which one of the two exceptions
+        // causes retry in ZkTimeoutException.
+        // This also helps the test testConnectionLossWhileCreateEphemeral.
+        KeeperException retryCause;
 
         if (isClosed()) {
           throw new IllegalStateException("ZkClient already closed!");

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
@@ -939,8 +939,6 @@ public class ZkClient implements Watcher {
         if (event.getState() == KeeperState.Expired) {
           getEventLock().getZNodeEventCondition().signalAll();
           getEventLock().getDataChangedCondition().signalAll();
-          // We also have to notify all listeners that something might have changed
-          fireAllEvents();
         }
       }
       if (znodeChanged) {
@@ -1093,6 +1091,13 @@ public class ZkClient implements Watcher {
          * when SyncConnected events are received.
          */
         _isNewSessionEventFired = true;
+
+        /*
+         * With this first SyncConnected state, we just get connected to zookeeper service after
+         * reconnecting when the session expired. Because previous session expired, we also have to
+         * notify all listeners that something might have changed.
+         */
+        fireAllEvents();
       }
     } else if (event.getState() == KeeperState.Expired) {
       reconnectOnExpiring();

--- a/helix-core/src/test/java/org/apache/helix/ZkTestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/ZkTestHelper.java
@@ -202,7 +202,7 @@ public class ZkTestHelper {
 
     String newSessionId = Long.toHexString(curZookeeper.getSessionId());
     LOG.info("After session expiry. sessionId: " + newSessionId + ", zk: " + curZookeeper);
-    Assert.assertNotSame(newSessionId, oldSessionId, "Fail to expire current session, zk: "
+    Assert.assertFalse(newSessionId.equals(oldSessionId), "Fail to expire current session, zk: "
         + curZookeeper);
   }
 

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestHandleNewSession.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestHandleNewSession.java
@@ -229,7 +229,7 @@ public class TestHandleNewSession extends ZkTestBase {
      * Session S1 would not create a live instance. Instead, only S2 creates a live instance.
      */
     for (int i = 0; i < 2; i++) {
-      final String lastSessionId = manager.getZkClient().getHexSessionId();
+      final String lastSessionId = ZKUtil.toHexSessionId(manager.getZkClient().getSessionId());
       try {
         // Lock zk event processing to simulate a long backlog queue.
         ((ZkClient) manager.getZkClient()).getEventLock().lockInterruptibly();
@@ -249,7 +249,7 @@ public class TestHandleNewSession extends ZkTestBase {
       // Wait until the ZkClient has got a new session.
       Assert.assertTrue(TestHelper.verify(() -> {
         try {
-          final String sessionId = manager.getZkClient().getHexSessionId();
+          final String sessionId = ZKUtil.toHexSessionId(manager.getZkClient().getSessionId());
           return !"0".equals(sessionId) && !sessionId.equals(lastSessionId);
         } catch (HelixException ex) {
           return false;
@@ -278,7 +278,7 @@ public class TestHandleNewSession extends ZkTestBase {
 
     // From now on, the live instance is created.
     // The latest(the final new one) session id that is valid.
-    final String latestSessionId = manager.getZkClient().getHexSessionId();
+    final String latestSessionId = ZKUtil.toHexSessionId(manager.getZkClient().getSessionId());
 
     Assert.assertTrue(TestHelper.verify(() -> {
       // Newly created live instance should be created by the latest session
@@ -369,9 +369,8 @@ public class TestHandleNewSession extends ZkTestBase {
           ZkTestHelper.asyncExpireSession(manager.getZkClient());
 
           // Wait and verify the new session S2 is established.
-          TestHelper
-              .verify(() -> !((manager.getZkClient().getHexSessionId()).equals(lastSessionId)),
-                  3000L);
+          TestHelper.verify(() -> !((ZKUtil.toHexSessionId(manager.getZkClient().getSessionId()))
+              .equals(lastSessionId)), 3000L);
         } catch (Exception ignored) {
           // Ignored.
         } finally {
@@ -396,7 +395,7 @@ public class TestHandleNewSession extends ZkTestBase {
         // 6. S2 is valid and creates live instance.
         manager.proceedResetHandlers();
 
-        final String latestSessionId = manager.getZkClient().getHexSessionId();
+        final String latestSessionId = ZKUtil.toHexSessionId(manager.getZkClient().getSessionId());
 
         TestHelper.verify(() -> {
           // Newly created live instance should be created by the latest session
@@ -446,7 +445,7 @@ public class TestHandleNewSession extends ZkTestBase {
 
     // From now on, the live instance is already created by S2.
     // The latest(the final new one S2) session id that is valid.
-    final String latestSessionId = manager.getZkClient().getHexSessionId();
+    final String latestSessionId = ZKUtil.toHexSessionId(manager.getZkClient().getSessionId());
 
     Assert.assertTrue(TestHelper.verify(() -> {
       // Newly created live instance should be created by the latest session

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestHandleNewSession.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestHandleNewSession.java
@@ -422,7 +422,7 @@ public class TestHandleNewSession extends ZkTestBase {
       ZkTestHelper.asyncExpireSession(manager.getZkClient());
       // 3. S1 spends a long time resetting handlers during this period.
 
-      // Wait and verify the zookeeper is alive.
+      // Wait and verify the zookeeper is closed.
       Assert.assertTrue(TestHelper.verify(
           () -> !((ZkClient) manager.getZkClient()).getConnection().getZookeeperState().isAlive(),
           3000L));

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
@@ -507,8 +507,15 @@ public class TestRawZkClient extends ZkUnitTestBase {
     }
 
     // Verify the node is created and its data is correct.
-    Assert.assertTrue(_zkClient.exists(path));
-    Assert.assertEquals(_zkClient.readData(path), data);
+    Stat stat = new Stat();
+    String nodeData = _zkClient.readData(path, stat, true);
+
+    Assert.assertNotNull(nodeData, "Failed to create ephemeral node: " + path);
+    Assert.assertEquals(nodeData, data, "Data is not correct.");
+    Assert.assertTrue(stat.getEphemeralOwner() != 0L,
+        "Ephemeral owner should NOT be zero because the node is an ephemeral node.");
+    Assert.assertEquals(ZKUtil.toHexSessionId(stat.getEphemeralOwner()), originalSessionId,
+        "Ephemeral node is created by an unexpected session");
   }
 
   /*

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
@@ -575,6 +575,8 @@ public class TestRawZkClient extends ZkUnitTestBase {
       Assert.fail("Ephemeral node should not be created by the expired session.");
     } catch (ZkSessionMismatchedException expected) {
       // Expected because there is a session mismatch.
+    } catch (Exception unexpected) {
+      Assert.fail("Should not have thrown exception: " + unexpected);
     }
 
     // Verify the node is not created.

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
@@ -516,6 +516,10 @@ public class TestRawZkClient extends ZkUnitTestBase {
         "Ephemeral owner should NOT be zero because the node is an ephemeral node.");
     Assert.assertEquals(ZKUtil.toHexSessionId(stat.getEphemeralOwner()), originalSessionId,
         "Ephemeral node is created by an unexpected session");
+
+    // Delete the node to clean up, otherwise, the ephemeral node would be existed
+    // until the session of its owner expires.
+    _zkClient.delete(path);
   }
 
   /*
@@ -701,5 +705,9 @@ public class TestRawZkClient extends ZkUnitTestBase {
         "Ephemeral owner should NOT be zero because the node is an ephemeral node.");
     Assert.assertEquals(ZKUtil.toHexSessionId(stat.getEphemeralOwner()), expectedSessionId,
         "Ephemeral node is created by an unexpected session");
+
+    // Delete the node to clean up, otherwise, the ephemeral node would be existed until the session
+    // of its owner expires.
+    _zkClient.delete(path);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
@@ -150,8 +150,8 @@ public class TestRawZkClient extends ZkUnitTestBase {
     for (int i = 0; i < 3; i++) {
       ZkTestHelper.expireSession(_zkClient);
       long newSessionId = _zkClient.getSessionId();
-      Assert.assertTrue(newSessionId > lastSessionId,
-          "New session id should be greater than expired session id.");
+      Assert.assertTrue(newSessionId != lastSessionId,
+          "New session id should not equal to expired session id.");
       lastSessionId = newSessionId;
     }
   }
@@ -561,8 +561,8 @@ public class TestRawZkClient extends ZkUnitTestBase {
     // Wait until the ZkClient has got a new session.
     Assert.assertTrue(TestHelper.verify(() -> {
       try {
-        // New session id should be greater than expired session id.
-        return _zkClient.getSessionId() > originalSessionId;
+        // New session id should not equal to expired session id.
+        return _zkClient.getSessionId() != originalSessionId;
       } catch (HelixException ex) {
         return false;
       }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
@@ -488,7 +488,7 @@ public class TestRawZkClient extends ZkUnitTestBase {
         "MasterSlave",
         true); // do rebalance
 
-    final String originalSessionId = _zkClient.getHexSessionId();
+    final String originalSessionId = ZKUtil.toHexSessionId(_zkClient.getSessionId());
     final String path = "/" + methodName;
     final String data = "Hello Helix";
 
@@ -549,7 +549,7 @@ public class TestRawZkClient extends ZkUnitTestBase {
         true); // do rebalance
 
     final long originalSessionId = _zkClient.getSessionId();
-    final String originalHexSessionId = _zkClient.getHexSessionId();
+    final String originalHexSessionId = ZKUtil.toHexSessionId(originalSessionId);
     final String path = "/" + methodName;
 
     // Verify the node is not existed.
@@ -597,7 +597,7 @@ public class TestRawZkClient extends ZkUnitTestBase {
         .setOperationRetryTimeout(3000L) // 3 seconds
         .build();
 
-    final String expectedSessionId = zkClient.getHexSessionId();
+    final String expectedSessionId = ZKUtil.toHexSessionId(zkClient.getSessionId());
     final String path = "/" + methodName;
     final String data = "data";
 
@@ -656,7 +656,7 @@ public class TestRawZkClient extends ZkUnitTestBase {
   public void testRetryUntilConnectedAfterConnectionLoss() throws Exception {
     final String methodName = TestHelper.getTestMethodName();
 
-    final String expectedSessionId = _zkClient.getHexSessionId();
+    final String expectedSessionId = ZKUtil.toHexSessionId(_zkClient.getSessionId());
     final String path = "/" + methodName;
     final String data = "data";
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #641 

When a storage node's network adapter has issues, network connection is lost, which causes around 5-10 Zookeeper sessions to become expired. Reconnect events are created after the expiration. Eventually this node has 40 minutes busy resetting the storage node's StateModel while helix controller regards this node as online, so helix does not move partitions mastership to other storage node. This caused 40 minutes down time for users of these partitions.

Root cause is zk session race condition:
Zk session may become expired and change before creating a live instance. So when a live instance(ephemeral node) is being created, if the expected session is expired, we should NOT create the ephemeral node.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Change list:
1. Change API `create()` in ZkClient to accept zk sessionId as a parameter. Add a new public API createEphemeral(final String path, final Object data, final String sessionId) to create a session aware ephemeral node.
2. Fire a new session event only right after the first SyncConnected is received.
3. Change code logic to handle new session operations that need to be completed in the expected session.

Some other comments from @lei-xia : https://github.com/pkuwm/helix/pull/1

### Tests

- [x] The following tests are written for this issue:
TestHandleNewSession.testDiscardExpiredSessions
TestHandleNewSession.testSessionExpiredWhenResetHandlers
TestRawZkClient.testConnectionLossWhileCreateEphemeral
TestRawZkClient.testCreateEphemeralWithMismatchedSession
TestRawZkClient.testCreateEphemeralWithValidSession
TestRawZkClient.testRetryUntilConnectedAfterConnectionLoss

- [x] The following is the result of the "mvn test" command on the appropriate module:

mvn test at helix-core. 

[INFO] Tests run: 896, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,339.05 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 896, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  55:43 min
[INFO] Finished at: 2020-01-05T14:19:20-08:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml