### PR TITLE
Add support for PathBasedZkSerializer in ZkBaseDataAccessor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -102,10 +102,21 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
   }
 
   /**
-   * The ZkBaseDataAccessor with custom serializer support
+   * The ZkBaseDataAccessor with custom serializer support of ZkSerializer type.
    * @param zkAddress The zookeeper address
    */
   public ZkBaseDataAccessor(String zkAddress, ZkSerializer zkSerializer) {
+    _zkClient = SharedZkClientFactory.getInstance().buildZkClient(
+        new HelixZkClient.ZkConnectionConfig(zkAddress),
+        new HelixZkClient.ZkClientConfig().setZkSerializer(zkSerializer));
+    _usesExternalZkClient = false;
+  }
+
+  /**
+   * The ZkBaseDataAccessor with custom serializer support of PathBasedZkSerializer type.
+   * @param zkAddress The zookeeper address
+   */
+  public ZkBaseDataAccessor(String zkAddress, PathBasedZkSerializer zkSerializer) {
     _zkClient = SharedZkClientFactory.getInstance().buildZkClient(
         new HelixZkClient.ZkConnectionConfig(zkAddress),
         new HelixZkClient.ZkClientConfig().setZkSerializer(zkSerializer));


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #649

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We add a custom serializer support for ZkSerializer in ZkBaseDataAccessor. But some users might be using PathBasedZkSerializer - we need to add support for a custom PathBasedZkSerializer as well.

### Tests

- [x] The following tests are written for this issue:

No tests needed. Already covered by existing tests.

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestCardDealingAdjustmentAlgorithmV2.testAlgorithmConstructor:127 expected:<9> but was:<6>
[ERROR] org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas(org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2)
[ERROR]   Run 1: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:273 Total movements: 4 != expected 8, replica: 1
[ERROR]   Run 2: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:273 Total movements: 4 != expected 8, replica: 2
[ERROR]   Run 3: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:273 Total movements: 14 != expected 21, replica: 3
[INFO]   Run 4: PASS
[INFO]   Run 5: PASS
[INFO] 
[ERROR]   TestRebalanceRunningTask.testFixedTargetTaskAndEnabledRebalanceAndNodeAdded:298 expected:<true> but was:<false>

TestRebalanceRunningTask passed when run independently.


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml