### PR TITLE
Improve the algorithm so it prioritizes the assignment to the idle nodes when the constraint evaluation results are the same

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -122,13 +122,9 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
           if (scoreCompareResult == 0) {
             // If the evaluation scores of 2 nodes are the same, the algorithm assigns the replica
             // to the idle node first.
-            boolean isNodeOneIdle = !busyInstances.contains(nodeEntry1.getKey().getInstanceName());
-            boolean isNodeTwoIdle = !busyInstances.contains(nodeEntry2.getKey().getInstanceName());
-            if (isNodeOneIdle != isNodeTwoIdle) {
-              return isNodeOneIdle ? 1 : -1;
-            } else {
-              return 0;
-            }
+            int idleScore1 = busyInstances.contains(nodeEntry1.getKey().getInstanceName()) ? 0 : 1;
+            int idleScore2 = busyInstances.contains(nodeEntry2.getKey().getInstanceName()) ? 0 : 1;
+            return idleScore1 - idleScore2;
           } else {
             return scoreCompareResult;
           }
@@ -219,6 +215,10 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
     return orderedAssignableReplicas;
   }
 
+  /**
+   * @param assignments A collection of resource replicas assignment.
+   * @return A set of instance names that have at least one replica assigned in the input assignments.
+   */
   private Set<String> getBusyInstances(Collection<ResourceAssignment> assignments) {
     return assignments.stream().flatMap(
         resourceAssignment -> resourceAssignment.getRecord().getMapFields().values().stream()

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -20,6 +20,7 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
  */
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,18 +63,22 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
   }
 
   @Override
-  public OptimalAssignment calculate(ClusterModel clusterModel) throws HelixRebalanceException {
+  public OptimalAssignment calculate(ClusterModel clusterModel)
+      throws HelixRebalanceException {
     OptimalAssignment optimalAssignment = new OptimalAssignment();
     List<AssignableNode> nodes = new ArrayList<>(clusterModel.getAssignableNodes().values());
+    Set<String> busyInstances =
+        getBusyInstances(clusterModel.getContext().getBestPossibleAssignment().values());
     // Sort the replicas so the input is stable for the greedy algorithm.
     // For the other algorithm implementation, this sorting could be unnecessary.
     for (AssignableReplica replica : getOrderedAssignableReplica(clusterModel)) {
       Optional<AssignableNode> maybeBestNode =
-          getNodeWithHighestPoints(replica, nodes, clusterModel.getContext(), optimalAssignment);
+          getNodeWithHighestPoints(replica, nodes, clusterModel.getContext(), busyInstances,
+              optimalAssignment);
       // stop immediately if any replica cannot find best assignable node
       if (optimalAssignment.hasAnyFailure()) {
-        String errorMessage = String.format(
-            "Unable to find any available candidate node for partition %s; Fail reasons: %s",
+        String errorMessage = String
+            .format("Unable to find any available candidate node for partition %s; Fail reasons: %s",
             replica.getPartitionName(), optimalAssignment.getFailures());
         throw new HelixRebalanceException(errorMessage,
             HelixRebalanceException.Type.FAILED_TO_CALCULATE);
@@ -88,7 +93,7 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
 
   private Optional<AssignableNode> getNodeWithHighestPoints(AssignableReplica replica,
       List<AssignableNode> assignableNodes, ClusterContext clusterContext,
-      OptimalAssignment optimalAssignment) {
+      Set<String> busyInstances, OptimalAssignment optimalAssignment) {
     Map<AssignableNode, List<HardConstraint>> hardConstraintFailures = new ConcurrentHashMap<>();
     List<AssignableNode> candidateNodes = assignableNodes.parallelStream().filter(candidateNode -> {
       boolean isValid = true;
@@ -113,14 +118,12 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
     return candidateNodes.parallelStream().map(node -> new HashMap.SimpleEntry<>(node,
         getAssignmentNormalizedScore(node, replica, clusterContext)))
         .max((nodeEntry1, nodeEntry2) -> {
-          int scoreCompareResult =  nodeEntry1.getValue().compareTo(nodeEntry2.getValue());
+          int scoreCompareResult = nodeEntry1.getValue().compareTo(nodeEntry2.getValue());
           if (scoreCompareResult == 0) {
             // If the evaluation scores of 2 nodes are the same, the algorithm assigns the replica
             // to the idle node first.
-            boolean isNodeOneIdle =
-                clusterContext.isNodeIdle(nodeEntry1.getKey().getInstanceName());
-            boolean isNodeTwoIdle =
-                clusterContext.isNodeIdle(nodeEntry2.getKey().getInstanceName());
+            boolean isNodeOneIdle = !busyInstances.contains(nodeEntry1.getKey().getInstanceName());
+            boolean isNodeTwoIdle = !busyInstances.contains(nodeEntry2.getKey().getInstanceName());
             if (isNodeOneIdle != isNodeTwoIdle) {
               return isNodeOneIdle ? 1 : -1;
             } else {
@@ -214,5 +217,12 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
       }
     });
     return orderedAssignableReplicas;
+  }
+
+  private Set<String> getBusyInstances(Collection<ResourceAssignment> assignments) {
+    return assignments.stream().flatMap(
+        resourceAssignment -> resourceAssignment.getRecord().getMapFields().values().stream()
+            .flatMap(instanceStateMap -> instanceStateMap.keySet().stream())
+            .collect(Collectors.toSet()).stream()).collect(Collectors.toSet());
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
@@ -51,8 +51,6 @@ public class ClusterContext {
   private final Map<String, ResourceAssignment> _baselineAssignment;
   // <ResourceName, ResourceAssignment contains the best possible assignment>
   private final Map<String, ResourceAssignment> _bestPossibleAssignment;
-  // The instances that have at least one replica assigned in the best possible assignment.
-  private final Set<String> _busyInstances;
 
   /**
    * Construct the cluster context based on the current instance status.
@@ -106,15 +104,6 @@ public class ClusterContext {
     _estimatedMaxTopStateCount = estimateAvgReplicaCount(totalTopStateReplicas, instanceCount);
     _baselineAssignment = baselineAssignment;
     _bestPossibleAssignment = bestPossibleAssignment;
-
-    _busyInstances = _bestPossibleAssignment.values().stream().flatMap(
-        resourceAssignment -> resourceAssignment.getRecord().getMapFields().values().stream()
-            .flatMap(instanceStateMap -> instanceStateMap.keySet().stream())
-            .collect(Collectors.toSet()).stream()).collect(Collectors.toSet());
-  }
-
-  public boolean isNodeIdle(String instanceName) {
-    return !_busyInstances.contains(instanceName);
   }
 
   public Map<String, ResourceAssignment> getBaselineAssignment() {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#650 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This is to get rid of the randomness when the constraint-based evaluation result is a tie. Usually, when the algorithm picks up the nodes with the same score randomly, more partition movements will be triggered. A better strategy is filling the idle nodes (AKA the newly added nodes first). So those assignments won't cause a chain reaction that the other partition placements have to be altered.

### Tests

- [x] The following tests are written for this issue:

We are using the same correctness based tests to cover this logic change.
For the performance-related tests, we will do that in the long run test later. The report will be provided by then.

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures: 
[ERROR]   TestCardDealingAdjustmentAlgorithmV2.testAlgorithmConstructor:128 expected:<9> but was:<6>
[ERROR] org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas(org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2)
[ERROR]   Run 1: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:274 Total movements: 4 != expected 8, replica: 1
[ERROR]   Run 2: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:274 Total movements: 4 != expected 8, replica: 2
[ERROR]   Run 3: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:274 Total movements: 14 != expected 21, replica: 3
[INFO]   Run 4: PASS
[INFO]   Run 5: PASS
[INFO] 
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[ERROR]   TestZKUtil.testChildrenOperations:78 expected:<2> but was:<3>
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:118 expected:<true> but was:<false>
[ERROR]   TestGetLastScheduledTaskExecInfo.testGetLastScheduledTaskExecInfo:63->setupTasks:115 NullPointer
[INFO] 
[ERROR] Tests run: 1048, Failures: 6, Errors: 0, Skipped: 3

Re-run:
[INFO] Tests run: 40, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.635 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 40, Failures: 0, Errors: 0, Skipped: 0

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

TBD, we will conclude the detail design soon after the algorithm has been tested and finalized.

### Code Quality

- [x] My diff has been formatted using helix-style.xml