### PR TITLE
Patch zkClient leakage fix #656

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -56,8 +56,12 @@ public final class ZKUtil {
    */
   public static boolean isClusterSetup(String clusterName, String zkAddress) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    boolean result = isClusterSetup(clusterName, zkClient);
-    zkClient.close();
+    boolean result;
+    try {
+      result = isClusterSetup(clusterName, zkClient);
+    } finally {
+      zkClient.close();
+    }
     return result;
   }
 
@@ -119,8 +123,12 @@ public final class ZKUtil {
   public static boolean isInstanceSetup(String zkAddress, String clusterName, String instanceName,
       InstanceType type) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    boolean result = isInstanceSetup(zkClient, clusterName, instanceName, type);
-    zkClient.close();
+    boolean result;
+    try {
+      result = isInstanceSetup(zkClient, clusterName, instanceName, type);
+    } finally {
+      zkClient.close();
+    }
     return result;
   }
 
@@ -166,8 +174,11 @@ public final class ZKUtil {
    */
   public static void createChildren(String zkAddress, String parentPath, List<ZNRecord> list) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    createChildren(zkClient, parentPath, list);
-    zkClient.close();
+    try {
+      createChildren(zkClient, parentPath, list);
+    } finally {
+      zkClient.close();
+    }
   }
 
   public static void createChildren(HelixZkClient client, String parentPath, List<ZNRecord> list) {
@@ -188,8 +199,11 @@ public final class ZKUtil {
    */
   public static void createChildren(String zkAddress, String parentPath, ZNRecord nodeRecord) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    createChildren(zkClient, parentPath, nodeRecord);
-    zkClient.close();
+    try {
+      createChildren(zkClient, parentPath, nodeRecord);
+    } finally {
+      zkClient.close();
+    }
   }
 
   public static void createChildren(HelixZkClient client, String parentPath, ZNRecord nodeRecord) {
@@ -209,8 +223,11 @@ public final class ZKUtil {
    */
   public static void dropChildren(String zkAddress, String parentPath, List<ZNRecord> list) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    dropChildren(zkClient, parentPath, list);
-    zkClient.close();
+    try {
+      dropChildren(zkClient, parentPath, list);
+    } finally {
+      zkClient.close();
+    }
   }
 
   public static void dropChildren(HelixZkClient client, String parentPath, List<ZNRecord> list) {
@@ -231,8 +248,11 @@ public final class ZKUtil {
    */
   public static void dropChildren(String zkAddress, String parentPath, ZNRecord nodeRecord) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    dropChildren(zkClient, parentPath, nodeRecord);
-    zkClient.close();
+    try {
+      dropChildren(zkClient, parentPath, nodeRecord);
+    } finally {
+      zkClient.close();
+    }
   }
 
   public static void dropChildren(HelixZkClient client, String parentPath, ZNRecord nodeRecord) {
@@ -251,8 +271,12 @@ public final class ZKUtil {
    */
   public static List<ZNRecord> getChildren(String zkAddress, String path) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    List<ZNRecord> result = getChildren(zkClient, path);
-    zkClient.close();
+    List<ZNRecord> result;
+    try {
+      result = getChildren(zkClient, path);
+    } finally {
+      zkClient.close();
+    }
     return result;
   }
 
@@ -290,8 +314,11 @@ public final class ZKUtil {
   public static void updateIfExists(String zkAddress, String path, final ZNRecord record,
       boolean mergeOnUpdate) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    updateIfExists(zkClient, path, record, mergeOnUpdate);
-    zkClient.close();
+    try {
+      updateIfExists(zkClient, path, record, mergeOnUpdate);
+    } finally {
+      zkClient.close();
+    }
   }
 
   public static void updateIfExists(HelixZkClient client, String path, final ZNRecord record,
@@ -319,8 +346,11 @@ public final class ZKUtil {
   public static void createOrMerge(String zkAddress, String path, final ZNRecord record,
       final boolean persistent, final boolean mergeOnUpdate) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    createOrMerge(zkClient, path, record, persistent, mergeOnUpdate);
-    zkClient.close();
+    try {
+      createOrMerge(zkClient, path, record, persistent, mergeOnUpdate);
+    } finally {
+      zkClient.close();
+    }
   }
 
   public static void createOrMerge(HelixZkClient client, String path, final ZNRecord record,
@@ -371,8 +401,11 @@ public final class ZKUtil {
   public static void createOrUpdate(String zkAddress, String path, final ZNRecord record,
       final boolean persistent, final boolean mergeOnUpdate) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    createOrUpdate(zkClient, path, record, persistent, mergeOnUpdate);
-    zkClient.close();
+    try {
+      createOrUpdate(zkClient, path, record, persistent, mergeOnUpdate);
+    } finally {
+      zkClient.close();
+    }
   }
 
   public static void createOrUpdate(HelixZkClient client, String path, final ZNRecord record,
@@ -417,8 +450,11 @@ public final class ZKUtil {
   public static void asyncCreateOrMerge(String zkAddress, String path, final ZNRecord record,
       final boolean persistent, final boolean mergeOnUpdate) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    asyncCreateOrMerge(zkClient, path, record, persistent, mergeOnUpdate);
-    zkClient.close();
+    try {
+      asyncCreateOrMerge(zkClient, path, record, persistent, mergeOnUpdate);
+    } finally {
+      zkClient.close();
+    }
   }
 
   public static void asyncCreateOrMerge(HelixZkClient client, String path, final ZNRecord record,
@@ -467,8 +503,11 @@ public final class ZKUtil {
   public static void createOrReplace(String zkAddress, String path, final ZNRecord record,
       final boolean persistent) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    createOrReplace(zkClient, path, record, persistent);
-    zkClient.close();
+    try {
+      createOrReplace(zkClient, path, record, persistent);
+    } finally {
+      zkClient.close();
+    }
   }
 
   public static void createOrReplace(HelixZkClient client, String path, final ZNRecord record,
@@ -507,8 +546,11 @@ public final class ZKUtil {
   public static void subtract(String zkAddress, final String path,
       final ZNRecord recordTosubtract) {
     HelixZkClient zkClient = getHelixZkClient(zkAddress);
-    subtract(zkClient, path, recordTosubtract);
-    zkClient.close();
+    try {
+      subtract(zkClient, path, recordTosubtract);
+    } finally {
+      zkClient.close();
+    }
   }
 
   public static void subtract(HelixZkClient client, final String path,

--- a/helix-core/src/main/java/org/apache/helix/tools/MessagePoster.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/MessagePoster.java
@@ -35,14 +35,18 @@ public class MessagePoster {
   public void post(String zkServer, Message message, String clusterName, String instanceName) {
     HelixZkClient client = SharedZkClientFactory.getInstance().buildZkClient(new HelixZkClient.ZkConnectionConfig(
         zkServer));
-    client.setZkSerializer(new ZNRecordSerializer());
-    String path = PropertyPathBuilder.instanceMessage(clusterName, instanceName, message.getId());
-    client.delete(path);
-    ZNRecord record = client.readData(PropertyPathBuilder.liveInstance(clusterName, instanceName));
-    message.setTgtSessionId(record.getSimpleField(LiveInstanceProperty.SESSION_ID.toString()));
-    message.setTgtName(record.getId());
-    // System.out.println(message);
-    client.createPersistent(path, message.getRecord());
+    try {
+      client.setZkSerializer(new ZNRecordSerializer());
+      String path = PropertyPathBuilder.instanceMessage(clusterName, instanceName, message.getId());
+      client.delete(path);
+      ZNRecord record = client.readData(PropertyPathBuilder.liveInstance(clusterName, instanceName));
+      message.setTgtSessionId(record.getSimpleField(LiveInstanceProperty.SESSION_ID.toString()));
+      message.setTgtName(record.getId());
+      // System.out.println(message);
+      client.createPersistent(path, message.getRecord());
+    } finally {
+      client.close();
+    }
   }
 
   public void postFaultInjectionMessage(String zkServer, String clusterName, String instanceName,

--- a/helix-core/src/main/java/org/apache/helix/tools/commandtools/ZKDumper.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/commandtools/ZKDumper.java
@@ -142,20 +142,24 @@ public class ZKDumper {
     String fsPath = cmd.getOptionValue("fspath");
 
     ZKDumper zkDump = new ZKDumper(zkAddress);
-    if (download) {
-      if (cmd.hasOption("addSuffix")) {
-        zkDump.suffix = cmd.getOptionValue("addSuffix");
+    try {
+      if (download) {
+        if (cmd.hasOption("addSuffix")) {
+          zkDump.suffix = cmd.getOptionValue("addSuffix");
+        }
+        zkDump.download(zkPath, fsPath + zkPath);
       }
-      zkDump.download(zkPath, fsPath + zkPath);
-    }
-    if (upload) {
-      if (cmd.hasOption("removeSuffix")) {
-        zkDump.removeSuffix = true;
+      if (upload) {
+        if (cmd.hasOption("removeSuffix")) {
+          zkDump.removeSuffix = true;
+        }
+        zkDump.upload(zkPath, fsPath);
       }
-      zkDump.upload(zkPath, fsPath);
-    }
-    if (del) {
-      zkDump.delete(zkPath);
+      if (del) {
+        zkDump.delete(zkPath);
+      }
+    } finally {
+      zkDump.close();
     }
   }
 
@@ -230,5 +234,9 @@ public class ZKDumper {
       }
       out.close();
     }
+  }
+
+  public void close() {
+    client.close();
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #656 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

During some of the instantiations of zkClient, the closing of the clients are not guaranteed due to the possible exceptions being thrown before the closing of the clients; in those cases, zkClient leakage happens. I'm adding "try finally" clauses to guard against zkClient leakage in these cases.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Tests run: 887, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 3,312.299 s <<< FAILURE! - in TestSuite
[ERROR] testEnableCompressionResource(org.apache.helix.integration.TestEnableCompression)  Time elapsed: 122.785 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.integration.TestEnableCompression.testEnableCompressionResource(TestEnableCompression.java:108)

[ERROR] testMissingTopStateDurationMonitoring(org.apache.helix.integration.controller.TestControllerLeadershipChange)  Time elapsed: 4.12 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.integration.controller.TestControllerLeadershipChange.testMissingTopStateDurationMonitoring(TestControllerLeadershipChange.java:120)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:108 expected:<true> but was:<false>
[ERROR]   TestControllerLeadershipChange.testMissingTopStateDurationMonitoring:120 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 887, Failures: 2, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  55:16 min
[INFO] Finished at: 2019-12-13T16:11:21-08:00
[INFO] ------------------------------------------------------------------------

Rerun failed tests:
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.117 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  35.669 s
[INFO] Finished at: 2019-12-16T16:11:42-08:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml