### PR TITLE
Fix workflow cleanup after expiry

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowDispatcher.java
@@ -129,8 +129,15 @@ public class WorkflowDispatcher extends AbstractTaskDispatcher {
       long expiryTime = workflowCfg.getExpiry();
       // Check if this workflow has been finished past its expiry.
       if (workflowCtx.getFinishTime() + expiryTime <= currentTime) {
-        LOG.info("Workflow " + workflow + " passed expiry time, cleaning up the workflow context.");
-        cleanupWorkflow(workflow);
+        if (workflowCtx.getWorkflowState() == TaskState.COMPLETED) {
+          LOG.info(
+              String.format("Workflow %s passed expiry time, cleaning up the workflow.", workflow));
+          cleanupWorkflow(workflow);
+        } else {
+          LOG.info(String.format(
+              "Workflow %s passed expiry time, but it does not completed successfully, skipping the clean up workflow!",
+              workflow));
+        }
       } else {
         // schedule future cleanup work
         long cleanupTime = workflowCtx.getFinishTime() + expiryTime;

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowExpiryTime.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowExpiryTime.java
@@ -1,0 +1,109 @@
+package org.apache.helix.integration.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.AccessOption;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.TestHelper;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.task.WorkflowContext;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Test to check workflow expiry time behavior.
+ */
+public class TestWorkflowExpiryTime extends TaskTestBase {
+  private HelixAdmin _admin;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    super.beforeClass();
+    _admin = _gSetupTool.getClusterManagementTool();
+  }
+
+  @Test
+  public void testFailedWorkflowExpiryTime() throws Exception {
+    final long expiryTime = 2000L;
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder builder1 = new Workflow.Builder(workflowName);
+
+    JobConfig.Builder jobBuilder1 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(
+            ImmutableMap.of(MockTask.TASK_RESULT_STATUS, TaskResult.Status.FATAL_FAILED.name()));
+
+    builder1.addJob("JOB0", jobBuilder1);
+    builder1.setExpiry(expiryTime);
+
+    _driver.start(builder1.build());
+
+    // Wait until workflow is Failed
+    _driver.pollForWorkflowState(workflowName, TaskState.FAILED);
+
+
+    // workflowIsCleanedUp should be false and workflow should not be deleted
+    boolean workflowIsCleanedUp = TestHelper.verify(() -> {
+      WorkflowContext wCtx = _driver.getWorkflowContext(workflowName);
+      WorkflowConfig wCfg = _driver.getWorkflowConfig(workflowName);
+      IdealState idealState = _admin.getResourceIdealState(CLUSTER_NAME, workflowName);
+      return (wCtx == null || wCfg == null || idealState == null);
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertFalse(workflowIsCleanedUp);
+  }
+
+  @Test
+  public void testCompletedWorkflowExpiryTime() throws Exception {
+    final long expiryTime = 2000L;
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder builder1 = new Workflow.Builder(workflowName);
+
+    JobConfig.Builder jobBuilder1 = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG)
+        .setMaxAttemptsPerTask(1).setWorkflow(workflowName)
+        .setJobCommandConfigMap(
+            ImmutableMap.of(MockTask.TASK_RESULT_STATUS, TaskResult.Status.COMPLETED.name()));
+
+    builder1.addJob("JOB0", jobBuilder1);
+    builder1.setExpiry(expiryTime);
+
+    _driver.start(builder1.build());
+
+    // Wait until workflow is Completed
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    // workflowIsCleanedUp should be true and workflow should be deleted
+    boolean workflowIsCleanedUp = TestHelper.verify(() -> {
+      WorkflowContext wCtx = _driver.getWorkflowContext(workflowName);
+      WorkflowConfig wCfg = _driver.getWorkflowConfig(workflowName);
+      IdealState idealState = _admin.getResourceIdealState(CLUSTER_NAME, workflowName);
+      return (wCtx == null && wCfg == null && idealState == null);
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(workflowIsCleanedUp);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowTimeout.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowTimeout.java
@@ -113,7 +113,7 @@ public class TestWorkflowTimeout extends TaskTestBase {
     _driver.start(workflowBuilder.build());
     // Pause the queue
     Thread.sleep(2500);
-    Assert.assertNull(_driver.getWorkflowConfig(workflowName));
-    Assert.assertNull(_driver.getJobContext(workflowName));
+    Assert.assertNotNull(_driver.getWorkflowConfig(workflowName));
+    Assert.assertNotNull(_driver.getJobContext(workflowName));
   }
 }


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #658 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In this commit, a check has been added which only, allows the completed workflows to be cleaned up after expiry time. This will allow users to investigate the failed jobs.

### Tests
- [x] The following tests are written for this issue:
TestWorkflowExpiryTime

- [x] The following is the result of the "mvn test" command on the appropriate module:
[INFO] Tests run: 889, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,593.504 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 889, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  59:59 min
[INFO] Finished at: 2019-12-13T10:11:13-08:00
[INFO] ------------------------------------------------------------------------


### Commits
- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml

