### PR TITLE
Mitigate controller leadership switch latency - improve leader -> standby

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -352,10 +352,8 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
 
     // This allows the listener to work with one change at a time
     synchronized (_manager) {
-      if (logger.isInfoEnabled()) {
-        logger.info(Thread.currentThread().getId() + " START:INVOKE " + _path + " listener:"
-            + _listener + " type: " + type);
-      }
+      logger.info(Thread.currentThread().getId() + " START:INVOKE " + _path + " listener:"
+          + _listener + " type: " + type);
 
       if (!_expectTypes.contains(type)) {
         logger.warn("Callback handler received event in wrong order. Listener: " + _listener
@@ -460,32 +458,32 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
   }
 
   private void subscribeChildChange(String path, NotificationContext.Type callbackType) {
+    String instanceName = _manager.getInstanceName();
     if (callbackType == NotificationContext.Type.INIT
         || callbackType == NotificationContext.Type.CALLBACK) {
-      if (logger.isDebugEnabled()) {
-        logger.debug(_manager.getInstanceName() + " subscribes child-change. path: " + path
-            + ", listener: " + _listener);
-      }
+      logger.info("{} subscribes child-change on path: {}, listener: {}, callbackType: {}",
+          instanceName, _path, _listener, callbackType);
       _zkClient.subscribeChildChanges(path, this);
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
-      logger.info(_manager.getInstanceName() + " unsubscribe child-change. path: " + path
-          + ", listener: " + _listener);
+      logger.info(
+          "{} unsubscribes child-change on path: {}, listener: {}, callbackType: {}",
+          instanceName, _path, _listener, callbackType);
 
       _zkClient.unsubscribeChildChanges(path, this);
     }
   }
 
   private void subscribeDataChange(String path, NotificationContext.Type callbackType) {
+    String instanceName = _manager.getInstanceName();
     if (callbackType == NotificationContext.Type.INIT
         || callbackType == NotificationContext.Type.CALLBACK) {
-      if (logger.isDebugEnabled()) {
-        logger.debug(_manager.getInstanceName() + " subscribe data-change. path: " + path
-            + ", listener: " + _listener);
-      }
+      logger.info("{} subscribes data-change on path: {}, listener: {}, callbackType: {}",
+          instanceName, _path, _listener, callbackType);
       _zkClient.subscribeDataChanges(path, this);
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
-      logger.info(_manager.getInstanceName() + " unsubscribe data-change. path: " + path
-          + ", listener: " + _listener);
+      logger
+          .info("{} unsubscribes data-change on path: {}, listener: {}, callbackType: {}",
+              instanceName, _path, _listener, callbackType);
 
       _zkClient.unsubscribeDataChanges(path, this);
     }
@@ -501,9 +499,9 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
 
   private void subscribeForChanges(NotificationContext.Type callbackType, String path,
       boolean watchChild) {
-    logger
-        .info("Subscribing changes listener on path: {}, callbackType: {}, listener: {}, isWatchChild: {}",
-            path, callbackType, _listener, watchChild);
+    logger.info(
+        "START:INVOKE subscribing changes listener on path: {}, callbackType: {}, listener: {}, isWatchChild: {}",
+        path, callbackType, _listener, watchChild);
 
     long start = System.currentTimeMillis();
     if (_eventTypes.contains(EventType.NodeDataChanged)
@@ -568,7 +566,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
     }
 
     long end = System.currentTimeMillis();
-    logger.info("Subscribing to path:" + path + " took:" + (end - start));
+    logger.info("END:INVOKE Subscribe all listeners to path: {}, took: {}ms", path, end - start);
   }
 
   public EventType[] getEventTypes() {
@@ -721,7 +719,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
    * *Caution*: currently it's only used during disconnecting from ZK and the
    * listeners unsubscription will be taken care by zkClient directly
    */
-  void closeCallbackProcessor() {
+  void closeBatchCallbackProcessor() {
     _ready = false;
     synchronized (this) {
       if (_batchCallbackProcessor != null) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -116,7 +116,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
   private HelixCallbackMonitor _monitor;
 
   // TODO: make this be per _manager or per _listener instaed of per callbackHandler -- Lei
-  public CallbackProcessor _batchCallbackProcessor;
+  private CallbackProcessor _batchCallbackProcessor;
   private boolean _watchChild = true; // Whether we should subscribe to the child znode's data
                                       // change.
 
@@ -165,7 +165,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
     }
   }
 
-  public class CallbackProcessor
+  class CallbackProcessor
       extends DedupEventProcessor<NotificationContext.Type, NotificationContext> {
     private CallbackHandler _handler;
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import javax.management.JMException;
 
@@ -806,7 +805,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
 
       synchronized (this) {
         if (_leaderElectionHandler != null) {
-          _leaderElectionHandler.closeCallbackProcessor();
+          _leaderElectionHandler.closeBatchCallbackProcessor();
         }
         if (_controller != null) {
           _controller = null;
@@ -824,8 +823,9 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
           _dataAccessor.getBaseDataAccessor().reset();
         }
         for (CallbackHandler handler : _handlers) {
-          handler.closeCallbackProcessor();
+          handler.closeBatchCallbackProcessor();
         }
+        _handlers.clear();
       }
       _sessionStartTime = null;
       LOG.info("Cluster manager: " + _instanceName + " disconnected");

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/client/HelixZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/client/HelixZkClient.java
@@ -79,6 +79,12 @@ public interface HelixZkClient {
   @Deprecated
   void unsubscribeStateChanges(org.I0Itec.zkclient.IZkStateListener listener);
 
+  /**
+   * Unsubscribe all listeners including
+   * - all {@link IZkStateListener}
+   * - all {@link IZkDataListener}
+   * - all {@link IZkChildListener}
+   */
   void unsubscribeAll();
 
   // data access


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#661 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

- The code change will skip the getChildren() request on listener's removal, and the zkClient's unsubscribeAll will be used instead of unsubscribing a single path;
- It also includes some log optimization works.

### Tests
- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)
`testControllerConnectThenSessionExpire` in `TestControllerLeaderhshipChange`

- [x] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")
[ERROR] Tests run: 890, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 3,909.929 s <<< FAILURE! - in TestSuite
[ERROR] testDeleteStoppingStuckWorkflowForcefully(org.apache.helix.integration.task.TestForceDeleteWorkflow)  Time elapsed: 60.645 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.integration.task.TestForceDeleteWorkflow.testDeleteStoppingStuckWorkflowForcefully(TestForceDeleteWorkflow.java:279)

[ERROR] testForceDeleteJobFromJobQueue(org.apache.helix.integration.task.TestDeleteJobFromJobQueue)  Time elapsed: 0.498 s  <<< FAILURE!
org.apache.helix.HelixException: Failed to delete job: testForceDeleteJobFromJobQueue_job2 from queue: testForceDeleteJobFromJobQueue
	at org.apache.helix.integration.task.TestDeleteJobFromJobQueue.testForceDeleteJobFromJobQueue(TestDeleteJobFromJobQueue.java:75)

[ERROR] testStateTransitionTimeoutByClusterLevel(org.apache.helix.integration.paticipant.TestStateTransitionTimeoutWithResource)  Time elapsed: 38.119 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.integration.paticipant.TestStateTransitionTimeoutWithResource.testStateTransitionTimeoutByClusterLevel(TestStateTransitionTimeoutWithResource.java:196)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestStateTransitionTimeoutWithResource.testStateTransitionTimeoutByClusterLevel:196 expected:<true> but was:<false>
[ERROR]   TestDeleteJobFromJobQueue.testForceDeleteJobFromJobQueue:75 » Helix Failed to ...
[ERROR]   TestForceDeleteWorkflow.testDeleteStoppingStuckWorkflowForcefully:279 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 890, Failures: 3, Errors: 0, Skipped: 0

Failed tests get passed running individually in IDE

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml