### PR TITLE
Use ZnRecordSerializer in ConfigAccessor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.apache.helix.manager.zk.ZKUtil;
+import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.client.HelixZkClient;
 import org.apache.helix.manager.zk.client.SharedZkClientFactory;
 import org.apache.helix.model.ClusterConfig;
@@ -75,7 +76,8 @@ public class ConfigAccessor {
 
   /**
    * Initialize an accessor with a Zookeeper client
-   * Note: it is recommended to use the other constructor instead to avoid having to create a HelixZkClient.
+   * Note: it is recommended to use the other constructor instead to avoid having to create a
+   * HelixZkClient.
    * @param zkClient
    */
   @Deprecated
@@ -85,13 +87,15 @@ public class ConfigAccessor {
   }
 
   /**
-   * Initialize a ConfigAccessor with a ZooKeeper connect string. It will use a SharedZkClient with default settings.
+   * Initialize a ConfigAccessor with a ZooKeeper connect string. It will use a SharedZkClient with
+   * default settings. Note that ZNRecordSerializer will be used for the internal ZkClient since
+   * ConfigAccessor only deals with Helix's data models like ResourceConfig.
    * @param zkAddress
    */
   public ConfigAccessor(String zkAddress) {
-    _zkClient = SharedZkClientFactory.getInstance()
-        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
-            new HelixZkClient.ZkClientConfig());
+    _zkClient = SharedZkClientFactory.getInstance().buildZkClient(
+        new HelixZkClient.ZkConnectionConfig(zkAddress),
+        new HelixZkClient.ZkClientConfig().setZkSerializer(new ZNRecordSerializer()));
     _usesExternalZkClient = false;
   }
 

--- a/helix-core/src/test/java/org/apache/helix/TestConfigAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/TestConfigAccessor.java
@@ -43,14 +43,21 @@ public class TestConfigAccessor extends ZkUnitTestBase {
         "MasterSlave", true);
 
     ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    ConfigAccessor configAccessorZkAddr = new ConfigAccessor(ZK_ADDR);
     ConfigScope clusterScope = new ConfigScopeBuilder().forCluster(clusterName).build();
 
     // cluster scope config
     String clusterConfigValue = configAccessor.get(clusterScope, "clusterConfigKey");
     Assert.assertNull(clusterConfigValue);
+    // also test with ConfigAccessor created with ZkAddr
+    clusterConfigValue = configAccessorZkAddr.get(clusterScope, "clusterConfigKey");
+    Assert.assertNull(clusterConfigValue);
 
     configAccessor.set(clusterScope, "clusterConfigKey", "clusterConfigValue");
     clusterConfigValue = configAccessor.get(clusterScope, "clusterConfigKey");
+    Assert.assertEquals(clusterConfigValue, "clusterConfigValue");
+    configAccessorZkAddr.set(clusterScope, "clusterConfigKey", "clusterConfigValue");
+    clusterConfigValue = configAccessorZkAddr.get(clusterScope, "clusterConfigKey");
     Assert.assertEquals(clusterConfigValue, "clusterConfigValue");
 
     // resource scope config
@@ -153,6 +160,8 @@ public class TestConfigAccessor extends ZkUnitTestBase {
 
     TestHelper.dropCluster(clusterName, _gZkClient);
 
+    configAccessor.close();
+    configAccessorZkAddr.close();
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
 
   }
@@ -192,6 +201,7 @@ public class TestConfigAccessor extends ZkUnitTestBase {
     Assert.assertEquals(participantConfigValue, "participantConfigValue");
 
     admin.dropCluster(clusterName);
+    configAccessor.close();
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #665 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

ConfigAccessor is a Helix API used for CRUD access of Helix's data model such as ResourceConfig, InstanceConfig, etc.. These records are represented as ZNRecord and therefore needs to be serialized and deserialized with ZnRecordSerializer. This diff fixes ConfigAccessor so that it explicitly uses ZnRecordSerializer by default.

### Tests

- [x] The following tests are written for this issue:

TestConfigAccessor.java (enhanced with creating another ConfigAccessor object with the new constructor that takes in the ZK Address)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml

