### PR TITLE
Add ZooKeeperAccessor to helix-rest

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/common/ServletType.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/common/ServletType.java
@@ -21,21 +21,27 @@ package org.apache.helix.rest.common;
 
 import org.apache.helix.rest.server.resources.helix.AbstractHelixResource;
 import org.apache.helix.rest.server.resources.metadata.NamespacesAccessor;
+import org.apache.helix.rest.server.resources.zookeeper.ZooKeeperAccessor;
+
 
 public enum ServletType {
   /**
    * Servlet serving default API endpoints (/admin/v2/clusters/...)
    */
   DEFAULT_SERVLET(HelixRestNamespace.DEFAULT_NAMESPACE_PATH_SPEC,
-      new String[] { AbstractHelixResource.class.getPackage().getName(),
-          NamespacesAccessor.class.getPackage().getName()
+      new String[] {
+          AbstractHelixResource.class.getPackage().getName(),
+          NamespacesAccessor.class.getPackage().getName(),
+          ZooKeeperAccessor.class.getPackage().getName()
       }),
 
   /**
    * Servlet serving namespaced API endpoints (/admin/v2/namespaces/{namespaceName})
    */
   COMMON_SERVLET("/namespaces/%s/*",
-      new String[] { AbstractHelixResource.class.getPackage().getName(),
+      new String[] {
+          AbstractHelixResource.class.getPackage().getName(),
+          ZooKeeperAccessor.class.getPackage().getName()
       });
 
   private final String _servletPathSpecTemplate;

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
@@ -138,7 +138,8 @@ public class ServerContext {
           @Override
           public byte[] serialize(Object o)
               throws ZkMarshallingError {
-            throw new UnsupportedOperationException("serialize() is not supported yet!");
+            // TODO: Support serialize for write methods if necessary
+            throw new UnsupportedOperationException("serialize() is not supported.");
           }
 
           @Override

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
@@ -48,6 +48,7 @@ public class ServerContext {
   private ClusterSetup _clusterSetup;
   private ConfigAccessor _configAccessor;
   // A lazily-initialized base data accessor that reads/writes byte array to ZK
+  // TODO: Only read (deserialize) is supported at this time. This baseDataAccessor should support write (serialize) as needs arise
   private volatile ZkBaseDataAccessor<byte[]> _byteArrayZkBaseDataAccessor;
   // 1 Cluster name will correspond to 1 helix data accessor
   private final Map<String, HelixDataAccessor> _helixDataAccessorPool;

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/AbstractHelixResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/AbstractHelixResource.java
@@ -78,7 +78,7 @@ public class AbstractHelixResource extends AbstractResource {
   }
 
   protected ZkBaseDataAccessor<byte[]> getByteArrayDataAccessor() {
-    return getServerContext().getByteArrayBaseDataAccessor();
+    return getServerContext().getByteArrayZkBaseDataAccessor();
   }
 
   protected static ZNRecord toZNRecord(String data)

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
@@ -30,6 +30,7 @@ import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.rest.server.resources.zookeeper.ZooKeeperAccessor;
 import org.codehaus.jackson.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,8 +56,8 @@ public class PropertyStoreAccessor extends AbstractHelixResource {
   public Response getPropertyByPath(@PathParam("clusterId") String clusterId,
       @PathParam("path") String path) {
     path = "/" + path;
-    if (!isPathValid(path)) {
-      LOG.info("The propertyStore path {} is invalid for cluster {}", path, clusterId);
+    if (!ZooKeeperAccessor.isPathValid(path)) {
+      LOG.error("The propertyStore path {} is invalid for cluster {}", path, clusterId);
       return badRequest(
           "Invalid path string. Valid path strings use slash as the directory separator and names the location of ZNode");
     }
@@ -76,19 +77,5 @@ public class PropertyStoreAccessor extends AbstractHelixResource {
       throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
           .entity(String.format("The property store path %s doesn't exist", recordPath)).build());
     }
-  }
-
-  /**
-   * Valid matches:
-   * /
-   * /abc
-   * /abc/abc/abc/abc
-   * Invalid matches:
-   * null or empty string
-   * /abc/
-   * /abc/abc/abc/abc/
-   **/
-  private static boolean isPathValid(String path) {
-    return path.matches("^/|(/[\\w-]+)+$");
   }
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
@@ -57,7 +57,7 @@ public class PropertyStoreAccessor extends AbstractHelixResource {
       @PathParam("path") String path) {
     path = "/" + path;
     if (!ZooKeeperAccessor.isPathValid(path)) {
-      LOG.error("The propertyStore path {} is invalid for cluster {}", path, clusterId);
+      LOG.info("The propertyStore path {} is invalid for cluster {}", path, clusterId);
       return badRequest(
           "Invalid path string. Valid path strings use slash as the directory separator and names the location of ZNode");
     }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
@@ -1,0 +1,29 @@
+package org.apache.helix.rest.server.resources.zookeeper;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * ZooKeeperAccessor provides methods for accessing ZooKeeper resources (ZNodes).
+ * It provides basic ZooKeeper features supported by ZkClient.
+ */
+public class ZooKeeperAccessor {
+
+
+}

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
@@ -19,11 +19,122 @@ package org.apache.helix.rest.server.resources.zookeeper;
  * under the License.
  */
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import org.apache.helix.AccessOption;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.rest.common.ContextPropertyKeys;
+import org.apache.helix.rest.server.ServerContext;
+import org.apache.helix.rest.server.resources.AbstractResource;
+import org.apache.helix.rest.server.resources.helix.ClusterAccessor;
+import org.codehaus.jackson.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
 /**
  * ZooKeeperAccessor provides methods for accessing ZooKeeper resources (ZNodes).
  * It provides basic ZooKeeper features supported by ZkClient.
  */
-public class ZooKeeperAccessor {
+@Path("/zookeeper")
+public class ZooKeeperAccessor extends AbstractResource {
+  private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperAccessor.class.getName());
 
+  private ServerContext _serverContext =
+      (ServerContext) _application.getProperties().get(ContextPropertyKeys.SERVER_CONTEXT.name());
+  private ZkBaseDataAccessor<byte[]> _zkBaseDataAccessor =
+      _serverContext.getByteArrayZkBaseDataAccessor();
 
+  @GET
+  @Path("{path: .+}")
+  public Response get(@PathParam("path") String path)
+
+  /**
+   * Checks if a ZNode exists in the given path.
+   * @param path
+   * @return true if a ZNode exists, false otherwise
+   */
+  @GET
+  @Path("exists/{path: .+}")
+  public Response exists(@PathParam("path") String path) {
+    if (!isPathValid(path)) {
+      String errMsg = "exists(): The given path {} is not a valid ZooKeeper path!" + path;
+      LOG.error(errMsg);
+      return badRequest(errMsg);
+    }
+
+    boolean exists = _zkBaseDataAccessor.exists(path, AccessOption.PERSISTENT);
+    return JSONRepresentation(exists);
+  }
+
+  /**
+   * Reads the given path from ZooKeeper and returns the binary data for the ZNode.
+   * @param path
+   * @return binary data in the ZNode
+   */
+  @GET
+  @Path("getData/{path: .+}")
+  public Response getData(@PathParam("path") String path) {
+    if (!isPathValid(path)) {
+      String errMsg = "getData(): The given path {} is not a valid ZooKeeper path!" + path;
+      LOG.error(errMsg);
+      return badRequest(errMsg);
+    }
+
+    if (_zkBaseDataAccessor.exists(path, AccessOption.PERSISTENT)) {
+      byte[] bytes = _zkBaseDataAccessor.get(path, null, AccessOption.PERSISTENT);
+      return JSONRepresentation(bytes);
+    } else {
+      throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
+          .entity(String.format("The ZNode at path %s does not exist", path)).build());
+    }
+  }
+
+  /**
+   * Returns a list of children ZNode names given the path for the parent ZNode.
+   * @param path
+   * @return list of child ZNodes
+   */
+  @GET
+  @Path("getChildren/{path: .+}")
+  public Response getChildren(@PathParam("path") String path) {
+    if (!isPathValid(path)) {
+      String errMsg = "getChildren(): The given path {} is not a valid ZooKeeper path!" + path;
+      LOG.error(errMsg);
+      return badRequest(errMsg);
+    }
+
+    if (_zkBaseDataAccessor.exists(path, AccessOption.PERSISTENT)) {
+      List<String> children = _zkBaseDataAccessor.getChildNames(path, AccessOption.PERSISTENT);
+      return JSONRepresentation(children);
+    } else {
+      throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
+          .entity(String.format("The ZNode at path %s does not exist", path)).build());
+    }
+  }
+
+  /**
+   * Validates whether a given path string is a valid ZK path.
+   *
+   * Valid matches:
+   * /
+   * /abc
+   * /abc/abc/abc/abc
+   * Invalid matches:
+   * null or empty string
+   * /abc/
+   * /abc/abc/abc/abc/
+   **/
+  public static boolean isPathValid(String path) {
+    return path.matches("^/|(/[\\w-]+)+$");
+  }
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
@@ -89,8 +89,9 @@ public class ZooKeeperAccessor extends AbstractResource {
       case getChildren:
         return getChildren(path);
       default:
-        LOG.error("Unsupported command: " + commandStr);
-        return badRequest("Unsupported command: " + commandStr);
+        String errMsg = "Unsupported command: " + commandStr;
+        LOG.error(errMsg);
+        return badRequest(errMsg);
     }
   }
 
@@ -127,8 +128,9 @@ public class ZooKeeperAccessor extends AbstractResource {
               ImmutableMap.of(ZooKeeperCommand.getStringData.name(), new String(bytes));
           return JSONRepresentation(stringResult);
         default:
-          LOG.error("Unsupported command : " + command);
-          return badRequest("Unsupported command : " + command);
+          String errMsg = "Unsupported command: " + command;
+          LOG.error(errMsg);
+          return badRequest(errMsg);
       }
     } else {
       throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
@@ -19,6 +19,8 @@ package org.apache.helix.rest.server.resources.zookeeper;
  * under the License.
  */
 
+import java.io.UnsupportedEncodingException;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.GET;
@@ -115,10 +117,15 @@ public class ZooKeeperAccessor extends AbstractResource {
 
     if (_zkBaseDataAccessor.exists(path, AccessOption.PERSISTENT)) {
       byte[] bytes = _zkBaseDataAccessor.get(path, null, AccessOption.PERSISTENT);
+      String s = new String(bytes);
+
       switch (command) {
         case getBinaryData:
           Map<String, byte[]> binaryResult =
               ImmutableMap.of(ZooKeeperCommand.getBinaryData.name(), bytes);
+          // Note: this serialization (using ObjectMapper) will convert this byte[] into
+          // a Base64 String! The REST client (user) must convert the resulting String back into
+          // a byte[] using Base64.
           return JSONRepresentation(binaryResult);
         case getStringData:
           Map<String, String> stringResult =

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPropertyStoreAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPropertyStoreAccessor.java
@@ -64,7 +64,7 @@ public class TestPropertyStoreAccessor extends AbstractTestClass {
         return new String(bytes);
       }
     });
-    // initially prepare the datas in different paths
+    // initially prepare the data in different paths
     Assert
         .assertTrue(_customDataAccessor.create(CUSTOM_PATH, TEST_CONTENT, AccessOption.PERSISTENT));
     Assert.assertTrue(_baseAccessor.create(ZNRECORD_PATH, TEST_ZNRECORD, AccessOption.PERSISTENT));

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
@@ -1,0 +1,93 @@
+package org.apache.helix.rest.server;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.I0Itec.zkclient.exception.ZkMarshallingError;
+import org.I0Itec.zkclient.serialize.ZkSerializer;
+import org.apache.helix.AccessOption;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.rest.server.util.JerseyUriRequestBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestZooKeeperAccessor extends AbstractTestClass {
+
+  private ZkBaseDataAccessor<byte[]> _testBaseDataAccessor;
+
+
+  @BeforeClass
+  public void beforeClass() {
+    _testBaseDataAccessor = new ZkBaseDataAccessor<>(ZK_ADDR, new ZkSerializer() {
+      @Override
+      public byte[] serialize(Object o)
+          throws ZkMarshallingError {
+        return o.toString().getBytes();
+      }
+
+      @Override
+      public Object deserialize(byte[] bytes)
+          throws ZkMarshallingError {
+        return new String(bytes);
+      }
+    });
+  }
+
+  @AfterClass
+  public void afterClass() {
+    _testBaseDataAccessor.close();
+  }
+
+  @Test
+  public void testExists() {
+    String path = "/path";
+    Assert.assertFalse(_testBaseDataAccessor.exists(path, AccessOption.PERSISTENT));
+
+    // Create a ZNode and check again
+    String content = "testExists";
+    Assert.assertTrue(_testBaseDataAccessor.create(path, content.getBytes(), AccessOption.PERSISTENT));
+    Assert.assertTrue(_testBaseDataAccessor.exists(path, AccessOption.PERSISTENT));
+
+    String data = new JerseyUriRequestBuilder("zookeeper/exists{}").format(path)
+        .isBodyReturnExpected(true).get(this);
+
+    // Clean up
+    _testBaseDataAccessor.remove(path, AccessOption.PERSISTENT);
+  }
+
+  @Test
+  public void testGetData() {
+    String path = "path";
+    String content = "testGetData";
+
+    // First, write data
+    _testBaseDataAccessor.create(path, content.getBytes(), AccessOption.PERSISTENT);
+
+    String data = new JerseyUriRequestBuilder("zookeeper/getData{}").format(path)
+        .isBodyReturnExpected(true).get(this);
+  }
+
+  @Test
+  public void testGetChildren() {
+
+  }
+}

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
@@ -67,7 +67,7 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
     Assert.assertTrue(_testBaseDataAccessor.create(path, content.getBytes(), AccessOption.PERSISTENT));
     Assert.assertTrue(_testBaseDataAccessor.exists(path, AccessOption.PERSISTENT));
 
-    String data = new JerseyUriRequestBuilder("zookeeper/exists{}").format(path)
+    String data = new JerseyUriRequestBuilder("zookeeper{}?command=exists").format(path)
         .isBodyReturnExpected(true).get(this);
 
     // Clean up

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
@@ -73,7 +73,7 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
         .isBodyReturnExpected(true).get(this);
     result = OBJECT_MAPPER.readValue(data, HashMap.class);
     Assert.assertTrue(result.containsKey("exists"));
-    Assert.assertEquals(result.get("exists"), Boolean.FALSE);
+    Assert.assertFalse(result.get("exists"));
 
     // Create a ZNode and check again
     String content = "testExists";
@@ -85,7 +85,7 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
         .isBodyReturnExpected(true).get(this);
     result = OBJECT_MAPPER.readValue(data, HashMap.class);
     Assert.assertTrue(result.containsKey("exists"));
-    Assert.assertEquals(result.get("exists"), Boolean.TRUE);
+    Assert.assertTrue(result.get("exists"));
 
     // Clean up
     _testBaseDataAccessor.remove(path, AccessOption.PERSISTENT);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #667 
Fixes #668 
Fixes #669 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In order to provide basic ZkClient functionalities (CRUD) in helix-rest, we want to add a ZooKeeperAccessor class that supports endpoints like get(), getChildren(), and exists().

Changelist:
1. Fix the double-checked locking idiom for byte array ZkBaseDataAccessor
2. Add ZooKeeperAccessor
3. Add tests

### Tests

- [x] The following tests are written for this issue:

TestZooKeeperAccessor.java

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 93, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.96 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 93, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  27.300 s
[INFO] Finished at: 2020-01-13T10:02:47-08:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml