### PR TITLE
Add method to wait and return established session's ID

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -699,19 +699,15 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     int retryCount = 0;
     while (retryCount < 3) {
       try {
-        // TODO: get session id from waitUntilConnected to avoid race condition
-        if (!_zkclient.waitUntilConnected(_connectionInitTimeout, TimeUnit.MILLISECONDS)) {
-          throw new ZkTimeoutException(
-              "Unable to connect to zookeeper server within timeout: " + _connectionInitTimeout
-                  + " ms.");
-        }
+        final long sessionId =
+            _zkclient.waitForEstablishedSession(_connectionInitTimeout, TimeUnit.MILLISECONDS);
         handleStateChanged(KeeperState.SyncConnected);
         /*
          * This listener is subscribed after SyncConnected and firing new session events,
          * which means this listener has not yet handled new session, so we have to handle new
          * session here just for this listener.
          */
-        handleNewSession(ZKUtil.toHexSessionId(_zkclient.getSessionId()));
+        handleNewSession(ZKUtil.toHexSessionId(sessionId));
         break;
       } catch (HelixException e) {
         LOG.error("fail to createClient.", e);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java
@@ -1368,31 +1368,41 @@ public class ZkClient implements Watcher {
     return _connection;
   }
 
+  public long waitForEstablishedSession(long timeout, TimeUnit timeUnit) {
+    validateCurrentThread();
+
+    Date deadline = new Date(System.currentTimeMillis() + timeUnit.toMillis(timeout));
+
+    LOG.debug("Waiting for keeper state: {}", KeeperState.SyncConnected);
+    acquireEventLock();
+    try {
+      waitForKeeperStateUntilDeadline(KeeperState.SyncConnected, deadline);
+      // Reading session ID before unlocking event lock is critical to guarantee the established
+      // session's ID won't change.
+      return getSessionId();
+    } finally {
+      getEventLock().unlock();
+    }
+  }
+
   public boolean waitUntilConnected(long time, TimeUnit timeUnit) throws ZkInterruptedException {
     return waitForKeeperState(KeeperState.SyncConnected, time, timeUnit);
   }
 
   public boolean waitForKeeperState(KeeperState keeperState, long time, TimeUnit timeUnit)
       throws ZkInterruptedException {
-    if (_zookeeperEventThread != null && Thread.currentThread() == _zookeeperEventThread) {
-      throw new IllegalArgumentException("Must not be done in the zookeeper event thread.");
-    }
-    Date timeout = new Date(System.currentTimeMillis() + timeUnit.toMillis(time));
+    validateCurrentThread();
+    Date deadline = new Date(System.currentTimeMillis() + timeUnit.toMillis(time));
 
     LOG.debug("Waiting for keeper state " + keeperState);
     acquireEventLock();
     try {
-      boolean stillWaiting = true;
-      while (_currentState != keeperState) {
-        if (!stillWaiting) {
-          return false;
-        }
-        stillWaiting = getEventLock().getStateChangedCondition().awaitUntil(timeout);
-      }
-      LOG.debug("State is " + (_currentState == null ? "CLOSED" : _currentState));
+      waitForKeeperStateUntilDeadline(keeperState, deadline);
+      LOG.debug("Current keeper state is {}.", _currentState == null ? "CLOSED" : _currentState);
       return true;
-    } catch (InterruptedException e) {
-      throw new ZkInterruptedException(e);
+    } catch (ZkTimeoutException e) {
+      LOG.debug("Waiting for keeper state: {} timed out in {} {}.", keeperState, time, timeUnit);
+      return false;
     } finally {
       getEventLock().unlock();
     }
@@ -2134,6 +2144,26 @@ public class ZkClient implements Watcher {
        * to remove.
        */
       return _listener.hashCode();
+    }
+  }
+
+  private void validateCurrentThread() {
+    if (_zookeeperEventThread != null && Thread.currentThread() == _zookeeperEventThread) {
+      throw new IllegalArgumentException("Must not be done in the zookeeper event thread.");
+    }
+  }
+
+  private void waitForKeeperStateUntilDeadline(KeeperState keeperState, Date deadline) {
+    try {
+      boolean stillWaiting = true;
+      while (_currentState != keeperState) {
+        if (!stillWaiting) {
+          throw new ZkTimeoutException("Waiting to be connected to ZK server has timed out.");
+        }
+        stillWaiting = getEventLock().getStateChangedCondition().awaitUntil(deadline);
+      }
+    } catch (InterruptedException e) {
+      throw new ZkInterruptedException(e);
     }
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
@@ -712,4 +712,24 @@ public class TestRawZkClient extends ZkUnitTestBase {
     // of its owner expires.
     _zkClient.delete(path);
   }
+
+  @Test
+  public void testWaitForEstablishedSession() {
+    ZkClient zkClient = new ZkClient(ZK_ADDR);
+    Assert.assertTrue(zkClient.waitForEstablishedSession(1, TimeUnit.SECONDS) != 0L);
+    TestHelper.stopZkServer(_zkServer);
+    Assert.assertTrue(zkClient.waitForKeeperState(KeeperState.Disconnected, 1, TimeUnit.SECONDS));
+
+    try {
+      zkClient.waitForEstablishedSession(3, TimeUnit.SECONDS);
+      Assert.fail("Connecting to zk server should time out and ZkTimeoutException is expected.");
+    } catch (ZkTimeoutException expected) {
+      // Because zk server is shutdown, zkClient should not connect to zk server and a
+      // ZkTimeoutException should be thrown.
+    }
+
+    zkClient.close();
+    // Recover zk server for later tests.
+    _zkServer.start();
+  }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #676 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Current zkclient's waitUntilConnected does not return a zk session ID. zkClient's getSessionId() could bring in session race condition: session A is connected in waitUntilConnected, but when zkClient.getSession() is called in zkHelixManager, session A might be already expired and so zkClient.getSession() gets session B. This session ID is critical for the firs time handling new session after zkclient is created in zkHelixManager.

Solution: add a new method waitForEstablishedSession() to wait for SynCconnected state and return the session id before unlocking the eventLock.

### Tests

- [x] The following tests are written for this issue:

testWaitForEstablishedSession

- [x] The following is the result of the "mvn test" command on the appropriate module:

Tests all pass.

[INFO] Tests run: 897, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,384.61 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 897, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  56:24 min
[INFO] Finished at: 2020-01-08T22:38:20-08:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml