### PR TITLE
Add resource partition weight gauge

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/ResourceUsageCalculator.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/ResourceUsageCalculator.java
@@ -142,4 +142,97 @@ public class ResourceUsageCalculator {
     return numTotalBestPossibleReplicas == 0 ? 1.0d
         : (1.0d - (double) numMatchedReplicas / (double) numTotalBestPossibleReplicas);
   }
+
+  /**
+   * Calculates average partition weight per capacity key for a resource config. Example as below:
+   * Input =
+   * {
+   *   "partition1": {
+   *     "capacity1": 20,
+   *     "capacity2": 40
+   *   },
+   *   "partition2": {
+   *     "capacity1": 30,
+   *     "capacity2": 50
+   *   },
+   *   "partition3": {
+   *     "capacity1": 16,
+   *     "capacity2": 30
+   *   }
+   * }
+   *
+   * Total weight for key "capacity1" = 20 + 30 + 16 = 66;
+   * Total weight for key "capacity2" = 40 + 50 + 30 = 120;
+   * Total partitions = 3;
+   * Average partition weight for "capacity1" = 66 / 3 = 22;
+   * Average partition weight for "capacity2" = 120 / 3 = 40;
+   *
+   * Output =
+   * {
+   *   "capacity1": 22,
+   *   "capacity2": 40
+   * }
+   *
+   * @param partitionCapacityMap A map of partition capacity:
+   *        <PartitionName or DEFAULT_PARTITION_KEY, <Capacity Key, Capacity Number>>
+   * @return A map of partition weight: capacity key -> average partition weight
+   */
+  public static Map<String, Integer> calculateAveragePartitionWeight(
+      Map<String, Map<String, Integer>> partitionCapacityMap) {
+    Map<String, PartitionWeightCounterEntry> countPartitionWeightMap =
+        aggregatePartitionWeight(partitionCapacityMap);
+
+    // capacity key -> average partition weight
+    Map<String, Integer> averagePartitionWeightMap = new HashMap<>();
+
+    // Calculate average partition weight for each capacity key.
+    // Per capacity key level:
+    // average partition weight = (total partition weight) / (number of partitions)
+    for (Map.Entry<String, PartitionWeightCounterEntry> entry
+        : countPartitionWeightMap.entrySet()) {
+      String capacityKey = entry.getKey();
+      PartitionWeightCounterEntry weightEntry = entry.getValue();
+      int averageWeight = weightEntry.getWeight() / weightEntry.getPartitions();
+      averagePartitionWeightMap.put(capacityKey, averageWeight);
+    }
+
+    return averagePartitionWeightMap;
+  }
+
+  /*
+   * Aggregates partition weight for each capacity key.
+   */
+  private static Map<String, PartitionWeightCounterEntry> aggregatePartitionWeight(
+      Map<String, Map<String, Integer>> partitionCapacityMap) {
+    // capacity key -> [number of partitions, total weight per capacity key]
+    Map<String, PartitionWeightCounterEntry> countPartitionWeightMap = new HashMap<>();
+
+    partitionCapacityMap.values().forEach(partitionCapacityEntry ->
+        partitionCapacityEntry.forEach((capacityKey, weight) -> countPartitionWeightMap
+            .computeIfAbsent(capacityKey, counterEntry -> new PartitionWeightCounterEntry())
+            .increase(1, weight)));
+
+    return countPartitionWeightMap;
+  }
+
+  /*
+   * Represents total number of partitions and total partition weight for a capacity key.
+   */
+  private static class PartitionWeightCounterEntry {
+    private int partitions;
+    private int weight;
+
+    private int getPartitions() {
+      return partitions;
+    }
+
+    private int getWeight() {
+      return weight;
+    }
+
+    private void increase(int partitions, int weight) {
+      this.partitions += partitions;
+      this.weight += weight;
+    }
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -507,7 +507,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
    *                         capacity key -> average partition weight
    */
   public void updatePartitionWeight(String resourceName, Map<String, Integer> averageWeightMap) {
-    ResourceMonitor monitor = _resourceMonitorMap.get(resourceName);
+    ResourceMonitor monitor = getOrCreateResourceMonitor(resourceName);
     if (monitor == null) {
       LOG.warn("Failed to update partition weight metric for resource: {} because resource monitor"
           + " is not created.", resourceName);
@@ -538,7 +538,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     }
   }
 
-  ResourceMonitor getOrCreateResourceMonitor(String resourceName) {
+  private ResourceMonitor getOrCreateResourceMonitor(String resourceName) {
     try {
       if (!_resourceMonitorMap.containsKey(resourceName)) {
         synchronized (_resourceMonitorMap) {

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -497,6 +497,25 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     }
   }
 
+  /**
+   * Updates metrics of average partition weight per capacity key for a resource. If a resource
+   * monitor is not yet existed for this resource, a new resource monitor will be created for this
+   * resource.
+   *
+   * @param resourceName The resource name for which partition weight is updated
+   * @param averageWeightMap A map of average partition weight of each capacity key:
+   *                         capacity key -> average partition weight
+   */
+  public void updatePartitionWeight(String resourceName, Map<String, Integer> averageWeightMap) {
+    ResourceMonitor monitor = _resourceMonitorMap.get(resourceName);
+    if (monitor == null) {
+      LOG.warn("Failed to update partition weight metric for resource: {} because resource monitor"
+          + " is not created.", resourceName);
+      return;
+    }
+    monitor.updatePartitionWeightStats(averageWeightMap);
+  }
+
   public void updateMissingTopStateDurationStats(String resourceName, long totalDuration,
       long helixLatency, boolean isGraceful, boolean succeeded) {
     ResourceMonitor resourceMonitor = getOrCreateResourceMonitor(resourceName);
@@ -519,7 +538,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     }
   }
 
-  private ResourceMonitor getOrCreateResourceMonitor(String resourceName) {
+  ResourceMonitor getOrCreateResourceMonitor(String resourceName) {
     try {
       if (!_resourceMonitorMap.containsKey(resourceName)) {
         synchronized (_resourceMonitorMap) {

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -50,6 +50,8 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     INTERMEDIATE_STATE_CAL_FAILED
   }
 
+  private static final String GAUGE_METRIC_SUFFIX = "Gauge";
+
   // Gauges
   private SimpleDynamicMetric<Long> _numOfPartitions;
   private SimpleDynamicMetric<Long> _numOfPartitionsInExternalView;
@@ -385,11 +387,10 @@ public class ResourceMonitor extends DynamicMBeanProvider {
 
       // Capacity keys are changed, so capacity attribute map needs to be updated.
       _dynamicCapacityMetricsMap.clear();
-      final String gaugeMetricSuffix = "Gauge";
       for (Map.Entry<String, Integer> entry : partitionWeightMap.entrySet()) {
         String capacityKey = entry.getKey();
         _dynamicCapacityMetricsMap.put(capacityKey,
-            new SimpleDynamicMetric<>(capacityKey + gaugeMetricSuffix, (long) entry.getValue()));
+            new SimpleDynamicMetric<>(capacityKey + GAUGE_METRIC_SUFFIX, (long) entry.getValue()));
       }
     }
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -19,18 +19,19 @@ package org.apache.helix.monitoring.mbeans;
  * under the License.
  */
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import javax.management.JMException;
 import javax.management.ObjectName;
 
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
+import com.google.common.collect.Lists;
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -83,31 +84,13 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   private final String _clusterName;
   private final ObjectName _initObjectName;
 
+  // A map of dynamic capacity Gauges. The map's keys could change.
+  private final Map<String, SimpleDynamicMetric<Long>> _dynamicCapacityMetricsMap;
+
   @Override
-  public ResourceMonitor register() throws JMException {
-    List<DynamicMetric<?, ?>> attributeList = new ArrayList<>();
-    attributeList.add(_numOfPartitions);
-    attributeList.add(_numOfPartitionsInExternalView);
-    attributeList.add(_numOfErrorPartitions);
-    attributeList.add(_numNonTopStatePartitions);
-    attributeList.add(_numLessMinActiveReplicaPartitions);
-    attributeList.add(_numLessReplicaPartitions);
-    attributeList.add(_numPendingRecoveryRebalancePartitions);
-    attributeList.add(_numPendingLoadRebalancePartitions);
-    attributeList.add(_numRecoveryRebalanceThrottledPartitions);
-    attributeList.add(_numLoadRebalanceThrottledPartitions);
-    attributeList.add(_externalViewIdealStateDiff);
-    attributeList.add(_successfulTopStateHandoffDurationCounter);
-    attributeList.add(_successTopStateHandoffCounter);
-    attributeList.add(_failedTopStateHandoffCounter);
-    attributeList.add(_maxSinglePartitionTopStateHandoffDuration);
-    attributeList.add(_partitionTopStateHandoffDurationGauge);
-    attributeList.add(_partitionTopStateHandoffHelixLatencyGauge);
-    attributeList.add(_partitionTopStateNonGracefulHandoffDurationGauge);
-    attributeList.add(_totalMessageReceived);
-    attributeList.add(_numPendingStateTransitions);
-    attributeList.add(_rebalanceState);
-    doRegister(attributeList, _initObjectName);
+  public DynamicMBeanProvider register() throws JMException {
+    doRegister(buildAttributeList(), _initObjectName);
+
     return this;
   }
 
@@ -116,10 +99,12 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   }
 
   @SuppressWarnings("unchecked")
-  public ResourceMonitor(String clusterName, String resourceName, ObjectName objectName) {
+  public ResourceMonitor(String clusterName, String resourceName, ObjectName objectName)
+      throws JMException {
     _clusterName = clusterName;
     _resourceName = resourceName;
     _initObjectName = objectName;
+    _dynamicCapacityMetricsMap = new ConcurrentHashMap<>();
 
     _externalViewIdealStateDiff = new SimpleDynamicMetric("DifferenceWithIdealStateGauge", 0L);
     _numLoadRebalanceThrottledPartitions =
@@ -382,6 +367,37 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     _numLoadRebalanceThrottledPartitions.updateValue(numLoadRebalanceThrottledPartitions);
   }
 
+  /**
+   * Updates partition weight metric. If the partition capacity keys are changed, all MBean
+   * attributes will be updated accordingly: old capacity keys will be replaced with new capacity
+   * keys in MBean server.
+   *
+   * @param partitionWeightMap A map of partition weight: capacity key -> partition weight
+   */
+  void updatePartitionWeightStats(Map<String, Integer> partitionWeightMap) {
+    synchronized (_dynamicCapacityMetricsMap) {
+      if (_dynamicCapacityMetricsMap.keySet().equals(partitionWeightMap.keySet())) {
+        for (Map.Entry<String, Integer> entry : partitionWeightMap.entrySet()) {
+          _dynamicCapacityMetricsMap.get(entry.getKey()).updateValue((long) entry.getValue());
+        }
+        return;
+      }
+
+      // Capacity keys are changed, so capacity attribute map needs to be updated.
+      _dynamicCapacityMetricsMap.clear();
+      final String gaugeMetricSuffix = "Gauge";
+      for (Map.Entry<String, Integer> entry : partitionWeightMap.entrySet()) {
+        String capacityKey = entry.getKey();
+        _dynamicCapacityMetricsMap.put(capacityKey,
+            new SimpleDynamicMetric<>(capacityKey + gaugeMetricSuffix, (long) entry.getValue()));
+      }
+    }
+
+    // Update all MBean attributes.
+    updateAttributesInfo(buildAttributeList(),
+        "Resource monitor for resource: " + getResourceName());
+  }
+
   public void setRebalanceState(RebalanceStatus state) {
     _rebalanceState.updateValue(state.name());
   }
@@ -427,5 +443,35 @@ public class ResourceMonitor extends DynamicMBeanProvider {
       _maxSinglePartitionTopStateHandoffDuration.updateValue(0L);
       _lastResetTime = System.currentTimeMillis();
     }
+  }
+
+  private List<DynamicMetric<?, ?>> buildAttributeList() {
+    List<DynamicMetric<?, ?>> attributeList = Lists.newArrayList(
+        _numOfPartitions,
+        _numOfPartitionsInExternalView,
+        _numOfErrorPartitions,
+        _numNonTopStatePartitions,
+        _numLessMinActiveReplicaPartitions,
+        _numLessReplicaPartitions,
+        _numPendingRecoveryRebalancePartitions,
+        _numPendingLoadRebalancePartitions,
+        _numRecoveryRebalanceThrottledPartitions,
+        _numLoadRebalanceThrottledPartitions,
+        _externalViewIdealStateDiff,
+        _successfulTopStateHandoffDurationCounter,
+        _successTopStateHandoffCounter,
+        _failedTopStateHandoffCounter,
+        _maxSinglePartitionTopStateHandoffDuration,
+        _partitionTopStateHandoffDurationGauge,
+        _partitionTopStateHandoffHelixLatencyGauge,
+        _partitionTopStateNonGracefulHandoffDurationGauge,
+        _totalMessageReceived,
+        _numPendingStateTransitions,
+        _rebalanceState
+    );
+
+    attributeList.addAll(_dynamicCapacityMetricsMap.values());
+
+    return attributeList;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/util/TestResourceUsageCalculator.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/util/TestResourceUsageCalculator.java
@@ -60,6 +60,22 @@ public class TestResourceUsageCalculator {
         0.0d);
   }
 
+  @Test
+  public void testCalculateAveragePartitionWeight() {
+    Map<String, Map<String, Integer>> partitionCapacityMap = ImmutableMap.of(
+        "partition1", ImmutableMap.of("capacity1", 20, "capacity2", 40),
+        "partition2", ImmutableMap.of("capacity1", 30, "capacity2", 50),
+        "partition3", ImmutableMap.of("capacity1", 16, "capacity2", 30));
+
+    Map<String, Integer> averageCapacityWeightMap =
+        ResourceUsageCalculator.calculateAveragePartitionWeight(partitionCapacityMap);
+    Map<String, Integer> expectedAverageWeightMap =
+        ImmutableMap.of("capacity1", 22, "capacity2", 40);
+
+    Assert.assertNotNull(averageCapacityWeightMap);
+    Assert.assertEquals(averageCapacityWeightMap, expectedAverageWeightMap);
+  }
+
   private Map<String, ResourceAssignment> buildResourceAssignment(
       Map<String, Map<String, Map<String, String>>> resourceMap) {
     Map<String, ResourceAssignment> assignment = new HashMap<>();
@@ -78,7 +94,7 @@ public class TestResourceUsageCalculator {
   }
 
   @DataProvider(name = "TestMeasureBaselineDivergenceInput")
-  public Object[][] loadTestMeasureBaselineDivergenceInput() {
+  private Object[][] loadTestMeasureBaselineDivergenceInput() {
     final String[] params =
         new String[]{"baseline", "someMatchBestPossible", "noMatchBestPossible"};
     return TestInputLoader

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -401,85 +401,11 @@ public class TestClusterStatusMonitor {
     Assert.assertFalse(_server.isRegistered(clusterMonitorObjName),
         "Failed to unregister ClusterStatusMonitor.");
     for (String instance : maxUsageMap.keySet()) {
-      String instanceBeanName = String
-          .format("%s,%s=%s", monitor.clusterBeanName(), ClusterStatusMonitor.INSTANCE_DN_KEY,
-              instance);
+      String instanceBeanName =
+          String.format("%s,%s=%s", monitor.clusterBeanName(), ClusterStatusMonitor.INSTANCE_DN_KEY, instance);
       ObjectName instanceObjectName = monitor.getObjectName(instanceBeanName);
       Assert.assertFalse(_server.isRegistered(instanceObjectName),
           "Failed to unregister instance monitor for instance: " + instance);
-    }
-  }
-
-  @Test
-  public void testUpdatePartitionWeight()
-      throws IOException, MalformedObjectNameException, AttributeNotFoundException, MBeanException,
-             ReflectionException, InstanceNotFoundException {
-    String clusterName = TestHelper.getTestMethodName();
-    Map<String, Map<String, Integer>> partitionWeightMap = ImmutableMap.of(
-        "resource1", ImmutableMap.of("capacity1", 20, "capacity2", 40),
-        "resource2", ImmutableMap.of("capacity1", 30, "capacity2", 50));
-
-    // Setup cluster status monitor.
-    ClusterStatusMonitor monitor = new ClusterStatusMonitor(clusterName);
-    monitor.active();
-    ObjectName clusterMonitorObjName = monitor.getObjectName(monitor.clusterBeanName());
-
-    Assert.assertTrue(_server.isRegistered(clusterMonitorObjName));
-
-    // Register resource monitor. Otherwise, updatePartitionWeight() would fail.
-    partitionWeightMap.keySet().forEach(resourceName -> {
-      try {
-        monitor.getOrCreateResourceMonitor(resourceName).register();
-      } catch (JMException e) {
-        Assert.fail("Resource monitor could not register to MBean server.");
-      }
-    });
-
-    // Update Metrics
-    partitionWeightMap.forEach(monitor::updatePartitionWeight);
-
-    verifyPartitionWeightMetrics(monitor, partitionWeightMap);
-
-    // Change capacity keys: "capacity2" -> "capacity3"
-    partitionWeightMap = ImmutableMap.of(
-        "resource1", ImmutableMap.of("capacity1", 20, "capacity3", 60),
-        "resource2", ImmutableMap.of("capacity1", 30, "capacity3", 80));
-
-    // Update metrics.
-    partitionWeightMap.forEach(monitor::updatePartitionWeight);
-
-    // Verify results.
-    verifyPartitionWeightMetrics(monitor, partitionWeightMap);
-
-    // "capacity2" metric should not exist in MBean server.
-    String removedAttribute = "capacity2Gauge";
-    for (Map.Entry<String, Map<String, Integer>> entry : partitionWeightMap.entrySet()) {
-      String resourceName = entry.getKey();
-      String beanName = String
-          .format("%s,%s=%s", monitor.clusterBeanName(), ClusterStatusMonitor.RESOURCE_DN_KEY,
-              resourceName);
-      ObjectName objectName = monitor.getObjectName(beanName);
-
-      try {
-        _server.getAttribute(objectName, removedAttribute);
-        Assert.fail("AttributeNotFoundException should be thrown because attribute [capacity2Gauge]"
-            + " is removed.");
-      } catch (AttributeNotFoundException expected) {
-        // AttributeNotFoundException is expected because attribute [capacity2Gauge] is removed.
-      }
-    }
-
-    // Reset monitor.
-    monitor.reset();
-    Assert.assertFalse(_server.isRegistered(clusterMonitorObjName),
-        "Failed to unregister ClusterStatusMonitor.");
-    for (String resourceName : partitionWeightMap.keySet()) {
-      String beanName = String
-          .format("%s,%s=%s", monitor.clusterBeanName(), ClusterStatusMonitor.RESOURCE_DN_KEY,
-              resourceName);
-      ObjectName objectName = monitor.getObjectName(beanName);
-      Assert.assertFalse(_server.isRegistered(objectName),
-          "Failed to unregister instance monitor for instance: " + resourceName);
     }
   }
 
@@ -506,29 +432,6 @@ public class TestClusterStatusMonitor {
         String attributeName = capacityKey + "Gauge";
         Assert.assertEquals((long) _server.getAttribute(instanceObjectName, attributeName),
             (long) instanceCapacityMap.get(instance).get(capacityKey));
-      }
-    }
-  }
-
-  private void verifyPartitionWeightMetrics(ClusterStatusMonitor monitor,
-      Map<String, Map<String, Integer>> expectedPartitionWeightMap)
-      throws MalformedObjectNameException, IOException, AttributeNotFoundException, MBeanException,
-             ReflectionException, InstanceNotFoundException {
-    final String gaugeMetricSuffix = "Gauge";
-    for (Map.Entry<String, Map<String, Integer>> entry : expectedPartitionWeightMap.entrySet()) {
-      String resourceName = entry.getKey();
-      String beanName = String
-          .format("%s,%s=%s", monitor.clusterBeanName(), ClusterStatusMonitor.RESOURCE_DN_KEY,
-              resourceName);
-      ObjectName objectName = monitor.getObjectName(beanName);
-
-      // Resource monitor for this resource is already registered.
-      Assert.assertTrue(_server.isRegistered(objectName));
-
-      for (Map.Entry<String, Integer> capacityEntry : entry.getValue().entrySet()) {
-        String attributeName = capacityEntry.getKey() + gaugeMetricSuffix;
-        Assert.assertEquals((long) _server.getAttribute(objectName, attributeName),
-            (long) capacityEntry.getValue());
       }
     }
   }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestResourceMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestResourceMonitor.java
@@ -55,171 +55,175 @@ public class TestResourceMonitor {
   @Test()
   public void testReportData() throws JMException {
     final int n = 5;
-    ResourceMonitor monitor = new ResourceMonitor(_clusterName, _dbName, new ObjectName("testDomain:key=value"));
+    ResourceMonitor monitor =
+        new ResourceMonitor(_clusterName, _dbName, new ObjectName("testDomain:key=value"));
     monitor.register();
 
-    List<String> instances = new ArrayList<>();
-    for (int i = 0; i < n; i++) {
-      String instance = "localhost_" + (12918 + i);
-      instances.add(instance);
-    }
-
-    ZNRecord idealStateRecord = DefaultIdealStateCalculator
-        .calculateIdealState(instances, _partitions, _replicas - 1, _dbName, "MASTER", "SLAVE");
-    IdealState idealState = new IdealState(deepCopyZNRecord(idealStateRecord));
-    idealState.setMinActiveReplicas(_replicas - 1);
-    ExternalView externalView = new ExternalView(deepCopyZNRecord(idealStateRecord));
-    StateModelDefinition stateModelDef =
-        BuiltInStateModelDefinitions.MasterSlave.getStateModelDefinition();
-
-    monitor.updateResourceState(externalView, idealState, stateModelDef);
-
-    Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), 0);
-    Assert.assertEquals(monitor.getErrorPartitionGauge(), 0);
-    Assert.assertEquals(monitor.getExternalViewPartitionGauge(), _partitions);
-    Assert.assertEquals(monitor.getPartitionGauge(), _partitions);
-    Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), 0);
-    Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), 0);
-    Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0);
-    Assert.assertEquals(monitor.getBeanName(), _clusterName + " " + _dbName);
-
-    int errorCount = 5;
-    Random r = new Random();
-    int start = r.nextInt(_partitions - errorCount - 1);
-    for (int i = start; i < start + errorCount; i++) {
-      String partition = _dbName + "_" + i;
-      Map<String, String> map = externalView.getStateMap(partition);
-      for (String key : map.keySet()) {
-        if (map.get(key).equalsIgnoreCase("SLAVE")) {
-          map.put(key, "ERROR");
-          break;
-        }
+    try {
+      List<String> instances = new ArrayList<>();
+      for (int i = 0; i < n; i++) {
+        String instance = "localhost_" + (12918 + i);
+        instances.add(instance);
       }
-      externalView.setStateMap(partition, map);
-    }
 
-    monitor.updateResourceState(externalView, idealState, stateModelDef);
+      ZNRecord idealStateRecord = DefaultIdealStateCalculator
+          .calculateIdealState(instances, _partitions, _replicas - 1, _dbName, "MASTER", "SLAVE");
+      IdealState idealState = new IdealState(deepCopyZNRecord(idealStateRecord));
+      idealState.setMinActiveReplicas(_replicas - 1);
+      ExternalView externalView = new ExternalView(deepCopyZNRecord(idealStateRecord));
+      StateModelDefinition stateModelDef =
+          BuiltInStateModelDefinitions.MasterSlave.getStateModelDefinition();
 
-    Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), errorCount);
-    Assert.assertEquals(monitor.getErrorPartitionGauge(), errorCount);
-    Assert.assertEquals(monitor.getExternalViewPartitionGauge(), _partitions);
-    Assert.assertEquals(monitor.getPartitionGauge(), _partitions);
-    Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), 0);
-    Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), errorCount);
-    Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0);
+      monitor.updateResourceState(externalView, idealState, stateModelDef);
 
-    int lessMinActiveReplica = 6;
-    externalView = new ExternalView(deepCopyZNRecord(idealStateRecord));
-    start = r.nextInt(_partitions - lessMinActiveReplica - 1);
-    for (int i = start; i < start + lessMinActiveReplica; i++) {
-      String partition = _dbName + "_" + i;
-      Map<String, String> map = externalView.getStateMap(partition);
-      Iterator<String> it = map.keySet().iterator();
-      int flag = 0;
-      while (it.hasNext()) {
-        String key = it.next();
-        if (map.get(key).equalsIgnoreCase("SLAVE")) {
-          if (flag++ % 2 == 0) {
-            map.put(key, "OFFLINE");
-          } else {
-            it.remove();
+      Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), 0);
+      Assert.assertEquals(monitor.getErrorPartitionGauge(), 0);
+      Assert.assertEquals(monitor.getExternalViewPartitionGauge(), _partitions);
+      Assert.assertEquals(monitor.getPartitionGauge(), _partitions);
+      Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), 0);
+      Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), 0);
+      Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0);
+      Assert.assertEquals(monitor.getBeanName(), _clusterName + " " + _dbName);
+
+      int errorCount = 5;
+      Random r = new Random();
+      int start = r.nextInt(_partitions - errorCount - 1);
+      for (int i = start; i < start + errorCount; i++) {
+        String partition = _dbName + "_" + i;
+        Map<String, String> map = externalView.getStateMap(partition);
+        for (String key : map.keySet()) {
+          if (map.get(key).equalsIgnoreCase("SLAVE")) {
+            map.put(key, "ERROR");
+            break;
           }
         }
+        externalView.setStateMap(partition, map);
       }
-      externalView.setStateMap(partition, map);
-    }
 
-    monitor.updateResourceState(externalView, idealState, stateModelDef);
+      monitor.updateResourceState(externalView, idealState, stateModelDef);
 
-    Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), lessMinActiveReplica);
-    Assert.assertEquals(monitor.getErrorPartitionGauge(), 0);
-    Assert.assertEquals(monitor.getExternalViewPartitionGauge(), _partitions);
-    Assert.assertEquals(monitor.getPartitionGauge(), _partitions);
-    Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), lessMinActiveReplica);
-    Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), lessMinActiveReplica);
-    Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0);
+      Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), errorCount);
+      Assert.assertEquals(monitor.getErrorPartitionGauge(), errorCount);
+      Assert.assertEquals(monitor.getExternalViewPartitionGauge(), _partitions);
+      Assert.assertEquals(monitor.getPartitionGauge(), _partitions);
+      Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), 0);
+      Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), errorCount);
+      Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0);
 
-    int lessReplica = 4;
-    externalView = new ExternalView(deepCopyZNRecord(idealStateRecord));
-    start = r.nextInt(_partitions - lessReplica - 1);
-    for (int i = start; i < start + lessReplica; i++) {
-      String partition = _dbName + "_" + i;
-      Map<String, String> map = externalView.getStateMap(partition);
-      int flag = 0;
-      Iterator<String> it = map.keySet().iterator();
-      while (it.hasNext()) {
-        String key = it.next();
-        if (map.get(key).equalsIgnoreCase("SLAVE")) {
-          if (flag++ % 2 == 0) {
-            map.put(key, "OFFLINE");
-          } else {
-            it.remove();
+      int lessMinActiveReplica = 6;
+      externalView = new ExternalView(deepCopyZNRecord(idealStateRecord));
+      start = r.nextInt(_partitions - lessMinActiveReplica - 1);
+      for (int i = start; i < start + lessMinActiveReplica; i++) {
+        String partition = _dbName + "_" + i;
+        Map<String, String> map = externalView.getStateMap(partition);
+        Iterator<String> it = map.keySet().iterator();
+        int flag = 0;
+        while (it.hasNext()) {
+          String key = it.next();
+          if (map.get(key).equalsIgnoreCase("SLAVE")) {
+            if (flag++ % 2 == 0) {
+              map.put(key, "OFFLINE");
+            } else {
+              it.remove();
+            }
           }
-          break;
         }
+        externalView.setStateMap(partition, map);
       }
-      externalView.setStateMap(partition, map);
-    }
 
-    monitor.updateResourceState(externalView, idealState, stateModelDef);
+      monitor.updateResourceState(externalView, idealState, stateModelDef);
 
-    Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), lessReplica);
-    Assert.assertEquals(monitor.getErrorPartitionGauge(), 0);
-    Assert.assertEquals(monitor.getExternalViewPartitionGauge(), _partitions);
-    Assert.assertEquals(monitor.getPartitionGauge(), _partitions);
-    Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), 0);
-    Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), lessReplica);
-    Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0);
+      Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), lessMinActiveReplica);
+      Assert.assertEquals(monitor.getErrorPartitionGauge(), 0);
+      Assert.assertEquals(monitor.getExternalViewPartitionGauge(), _partitions);
+      Assert.assertEquals(monitor.getPartitionGauge(), _partitions);
+      Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), lessMinActiveReplica);
+      Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), lessMinActiveReplica);
+      Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0);
 
-    int missTopState = 7;
-    externalView = new ExternalView(deepCopyZNRecord(idealStateRecord));
-    start = r.nextInt(_partitions - missTopState - 1);
-    for (int i = start; i < start + missTopState; i++) {
-      String partition = _dbName + "_" + i;
-      Map<String, String> map = externalView.getStateMap(partition);
-      int flag = 0;
-      for (String key : map.keySet()) {
-        if (map.get(key).equalsIgnoreCase("MASTER")) {
-          if (flag++ % 2 == 0) {
-            map.put(key, "OFFLINE");
-          } else {
-            map.remove(key);
+      int lessReplica = 4;
+      externalView = new ExternalView(deepCopyZNRecord(idealStateRecord));
+      start = r.nextInt(_partitions - lessReplica - 1);
+      for (int i = start; i < start + lessReplica; i++) {
+        String partition = _dbName + "_" + i;
+        Map<String, String> map = externalView.getStateMap(partition);
+        int flag = 0;
+        Iterator<String> it = map.keySet().iterator();
+        while (it.hasNext()) {
+          String key = it.next();
+          if (map.get(key).equalsIgnoreCase("SLAVE")) {
+            if (flag++ % 2 == 0) {
+              map.put(key, "OFFLINE");
+            } else {
+              it.remove();
+            }
+            break;
           }
-          break;
         }
+        externalView.setStateMap(partition, map);
       }
-      externalView.setStateMap(partition, map);
+
+      monitor.updateResourceState(externalView, idealState, stateModelDef);
+
+      Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), lessReplica);
+      Assert.assertEquals(monitor.getErrorPartitionGauge(), 0);
+      Assert.assertEquals(monitor.getExternalViewPartitionGauge(), _partitions);
+      Assert.assertEquals(monitor.getPartitionGauge(), _partitions);
+      Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), 0);
+      Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), lessReplica);
+      Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0);
+
+      int missTopState = 7;
+      externalView = new ExternalView(deepCopyZNRecord(idealStateRecord));
+      start = r.nextInt(_partitions - missTopState - 1);
+      for (int i = start; i < start + missTopState; i++) {
+        String partition = _dbName + "_" + i;
+        Map<String, String> map = externalView.getStateMap(partition);
+        int flag = 0;
+        for (String key : map.keySet()) {
+          if (map.get(key).equalsIgnoreCase("MASTER")) {
+            if (flag++ % 2 == 0) {
+              map.put(key, "OFFLINE");
+            } else {
+              map.remove(key);
+            }
+            break;
+          }
+        }
+        externalView.setStateMap(partition, map);
+      }
+
+      monitor.updateResourceState(externalView, idealState, stateModelDef);
+
+      Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), missTopState);
+      Assert.assertEquals(monitor.getErrorPartitionGauge(), 0);
+      Assert.assertEquals(monitor.getExternalViewPartitionGauge(), _partitions);
+      Assert.assertEquals(monitor.getPartitionGauge(), _partitions);
+      Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), 0);
+      Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), missTopState);
+      Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), missTopState);
+
+      Assert.assertEquals(monitor.getNumPendingStateTransitionGauge(), 0);
+      // test pending state transition message report and read
+      int messageCount = new Random().nextInt(_partitions) + 1;
+      monitor.updatePendingStateTransitionMessages(messageCount);
+      Assert.assertEquals(monitor.getNumPendingStateTransitionGauge(), messageCount);
+
+      Assert.assertEquals(monitor.getRebalanceState(),
+          ResourceMonitor.RebalanceStatus.UNKNOWN.name());
+      monitor.setRebalanceState(ResourceMonitor.RebalanceStatus.NORMAL);
+      Assert
+          .assertEquals(monitor.getRebalanceState(), ResourceMonitor.RebalanceStatus.NORMAL.name());
+      monitor.setRebalanceState(ResourceMonitor.RebalanceStatus.BEST_POSSIBLE_STATE_CAL_FAILED);
+      Assert.assertEquals(monitor.getRebalanceState(),
+          ResourceMonitor.RebalanceStatus.BEST_POSSIBLE_STATE_CAL_FAILED.name());
+      monitor.setRebalanceState(ResourceMonitor.RebalanceStatus.INTERMEDIATE_STATE_CAL_FAILED);
+      Assert.assertEquals(monitor.getRebalanceState(),
+          ResourceMonitor.RebalanceStatus.INTERMEDIATE_STATE_CAL_FAILED.name());
+    } finally {
+      // Has to unregister this monitor to clean up. Otherwise, later tests may be affected and fail.
+      monitor.unregister();
     }
-
-    monitor.updateResourceState(externalView, idealState, stateModelDef);
-
-    Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), missTopState);
-    Assert.assertEquals(monitor.getErrorPartitionGauge(), 0);
-    Assert.assertEquals(monitor.getExternalViewPartitionGauge(), _partitions);
-    Assert.assertEquals(monitor.getPartitionGauge(), _partitions);
-    Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), 0);
-    Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), missTopState);
-    Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), missTopState);
-
-    Assert.assertEquals(monitor.getNumPendingStateTransitionGauge(), 0);
-    // test pending state transition message report and read
-    int messageCount = new Random().nextInt(_partitions) + 1;
-    monitor.updatePendingStateTransitionMessages(messageCount);
-    Assert.assertEquals(monitor.getNumPendingStateTransitionGauge(), messageCount);
-
-    Assert
-        .assertEquals(monitor.getRebalanceState(), ResourceMonitor.RebalanceStatus.UNKNOWN.name());
-    monitor.setRebalanceState(ResourceMonitor.RebalanceStatus.NORMAL);
-    Assert.assertEquals(monitor.getRebalanceState(), ResourceMonitor.RebalanceStatus.NORMAL.name());
-    monitor.setRebalanceState(ResourceMonitor.RebalanceStatus.BEST_POSSIBLE_STATE_CAL_FAILED);
-    Assert.assertEquals(monitor.getRebalanceState(),
-        ResourceMonitor.RebalanceStatus.BEST_POSSIBLE_STATE_CAL_FAILED.name());
-    monitor.setRebalanceState(ResourceMonitor.RebalanceStatus.INTERMEDIATE_STATE_CAL_FAILED);
-    Assert.assertEquals(monitor.getRebalanceState(),
-        ResourceMonitor.RebalanceStatus.INTERMEDIATE_STATE_CAL_FAILED.name());
-
-    // Has to unregister this monitor to clean up. Otherwise, later tests may be affected and fail.
-    monitor.unregister();
   }
 
   @Test
@@ -232,37 +236,39 @@ public class TestResourceMonitor {
         new ResourceMonitor(clusterName, resource, resourceObjectName);
     monitor.register();
 
-    Map<String, Map<String, Integer>> partitionWeightMap =
-        ImmutableMap.of(resource, ImmutableMap.of("capacity1", 20, "capacity2", 40));
-
-    // Update Metrics
-    partitionWeightMap.values().forEach(monitor::updatePartitionWeightStats);
-
-    verifyPartitionWeightMetrics(mBeanServer, resourceObjectName, partitionWeightMap);
-
-    // Change capacity keys: "capacity2" -> "capacity3"
-    partitionWeightMap =
-        ImmutableMap.of(resource, ImmutableMap.of("capacity1", 20, "capacity3", 60));
-
-    // Update metrics.
-    partitionWeightMap.values().forEach(monitor::updatePartitionWeightStats);
-
-    // Verify results.
-    verifyPartitionWeightMetrics(mBeanServer, resourceObjectName, partitionWeightMap);
-
-    // "capacity2" metric should not exist in MBean server.
-    String removedAttribute = "capacity2Gauge";
     try {
-      mBeanServer.getAttribute(resourceObjectName, removedAttribute);
-      Assert.fail("AttributeNotFoundException should be thrown because attribute [capacity2Gauge]"
-          + " is removed.");
-    } catch (AttributeNotFoundException expected) {
-    }
+      Map<String, Map<String, Integer>> partitionWeightMap =
+          ImmutableMap.of(resource, ImmutableMap.of("capacity1", 20, "capacity2", 40));
 
-    // Reset monitor.
-    monitor.unregister();
-    Assert.assertFalse(mBeanServer.isRegistered(resourceObjectName),
-        "Failed to unregister resource monitor.");
+      // Update Metrics
+      partitionWeightMap.values().forEach(monitor::updatePartitionWeightStats);
+
+      verifyPartitionWeightMetrics(mBeanServer, resourceObjectName, partitionWeightMap);
+
+      // Change capacity keys: "capacity2" -> "capacity3"
+      partitionWeightMap =
+          ImmutableMap.of(resource, ImmutableMap.of("capacity1", 20, "capacity3", 60));
+
+      // Update metrics.
+      partitionWeightMap.values().forEach(monitor::updatePartitionWeightStats);
+
+      // Verify results.
+      verifyPartitionWeightMetrics(mBeanServer, resourceObjectName, partitionWeightMap);
+
+      // "capacity2" metric should not exist in MBean server.
+      String removedAttribute = "capacity2Gauge";
+      try {
+        mBeanServer.getAttribute(resourceObjectName, removedAttribute);
+        Assert.fail("AttributeNotFoundException should be thrown because attribute [capacity2Gauge]"
+            + " is removed.");
+      } catch (AttributeNotFoundException expected) {
+      }
+    } finally {
+      // Reset monitor.
+      monitor.unregister();
+      Assert.assertFalse(mBeanServer.isRegistered(resourceObjectName),
+          "Failed to unregister resource monitor.");
+    }
   }
 
   /**
@@ -308,6 +314,7 @@ public class TestResourceMonitor {
       for (Map.Entry<String, Integer> capacityEntry : entry.getValue().entrySet()) {
         String attributeName = capacityEntry.getKey() + gaugeMetricSuffix;
         try {
+          // Wait until the attribute is already registered to mbean server.
           Assert.assertTrue(TestHelper.verify(
               () -> !mBeanServer.getAttributes(objectName, new String[]{attributeName}).isEmpty(),
               2000));


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #685

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We would like to monitor the usage of each capacity for the resource partitions: gauge of the average partition weight for each CAPACITY key.

### Tests

- [x] The following tests are written for this issue:

- testUpdatePartitionWeight
- testCalculateAveragePartitionWeight

- [x] The following is the result of the "mvn test" command on the appropriate module:
```
[INFO] Results:
[INFO]
[WARNING] Tests run: 1063, Failures: 0, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:05 h
[INFO] Finished at: 2020-01-21T19:15:51-08:00
[INFO] ------------------------------------------------------------------------

 ./scripts/runSingleTest.sh TestDelayedAutoRebalanceWithDisabledInstance 1

[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 44.566 s - in org.apache.helix.integration.rebalancer.DelayedAutoRebalancer.TestDelayedAutoRebalanceWithDisabledInstance
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  49.406 s
[INFO] Finished at: 2020-01-22T10:48:30-08:00
[INFO] ------------------------------------------------------------------------

./scripts/runSingleTest.sh org.apache.helix.integration.rebalancer.DelayedAutoRebalancer.Test* 1

[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 110.733 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:55 min
[INFO] Finished at: 2020-01-22T10:51:51-08:00
[INFO] ------------------------------------------------------------------------
```



### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml