### PR TITLE
Reset the WAGED rebalancer once the controller newly acquires leadership.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -191,6 +191,7 @@ public class GenericHelixController implements IdealStateChangeListener,
   // Since the stateful rebalancer needs to be lazily constructed when the HelixManager instance is
   // ready, the GenericHelixController is not constructed with a stateful rebalancer. This wrapper
   // is to avoid the complexity of handling a nullable value in the event handling process.
+  // TODO Create the required stateful rebalancer only when it is used by any resource.
   private final StatefulRebalancerRef _rebalancerRef = new StatefulRebalancerRef() {
     @Override
     protected StatefulRebalancer createRebalancer(HelixManager helixManager) {

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -1319,6 +1319,8 @@ public class GenericHelixController implements IdealStateChangeListener,
     /**
      * @return A valid rebalancer object.
      *         If the rebalancer is no longer valid, it will be reset before returning.
+     * TODO: Make rebalancer volatile or make it singleton, if this method is called in multiple
+     * TODO: threads outside the controller object.
      */
     synchronized T getRebalancer(HelixManager helixManager) {
       // Lazily initialize the stateful rebalancer instance since the GenericHelixController

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -62,6 +62,7 @@ import org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider;
 import org.apache.helix.controller.pipeline.AsyncWorkerType;
 import org.apache.helix.controller.pipeline.Pipeline;
 import org.apache.helix.controller.pipeline.PipelineRegistry;
+import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.controller.stages.AttributeName;
 import org.apache.helix.controller.stages.BestPossibleStateCalcStage;
 import org.apache.helix.controller.stages.ClusterEvent;
@@ -169,7 +170,6 @@ public class GenericHelixController implements IdealStateChangeListener,
   Timer _onDemandRebalanceTimer = null;
   AtomicReference<RebalanceTask> _nextRebalanceTask = new AtomicReference<>();
 
-
   /**
    * A cache maintained across pipelines
    */
@@ -186,6 +186,11 @@ public class GenericHelixController implements IdealStateChangeListener,
   private final Set<Pipeline.Type> _enabledPipelineTypes;
 
   private HelixManager _helixManager;
+
+  // Since the WAGED rebalancer needs to be lazily constructed, the GenericHelixController will not
+  // be constructed with a WAGED rebalancer. This wrapper is to avoid the complexity of handling a
+  // nullable value in the GenericHelixController logic.
+  private final WagedRebalancerRef _wagedRebalancerRef = new WagedRebalancerRef();
 
   /**
    * TODO: We should get rid of this once we move to:
@@ -626,6 +631,22 @@ public class GenericHelixController implements IdealStateChangeListener,
       return;
     }
 
+    // Event handling happens in a different thread from the onControllerChange processing thread.
+    // Thus, there are several possible conditions.
+    // 1. Event handled after leadership acquired. So we will have a valid rebalancer for the
+    // event processing.
+    // 2. Event handled shortly after leadership relinquished. And the rebalancer has not been
+    // marked as invalid yet. So the event will be processed the same as case one.
+    // 3. Event is leftover from the previous session, and it is handled when the controller
+    // regains the leadership. The rebalancer will be reset before being used. That is the
+    // expected behavior so as to avoid inconsistent rebalance result.
+    // 4. Event handled shortly after leadership relinquished. And the rebalancer has been marked
+    // as invalid. So we reset the rebalancer. But the later isLeader() check will return false and
+    // the pipeline will be triggered. So the reset rebalancer won't be used before the controller
+    // regains leadership.
+    event.addAttribute(AttributeName.STATEFUL_REBALANCER.name(),
+        _wagedRebalancerRef.getWagedRebalancer(manager));
+
     if (!manager.isLeader()) {
       logger.error("Cluster manager: " + manager.getInstanceName() + " is not leader for " + manager
           .getClusterName() + ". Pipeline will not be invoked");
@@ -1022,6 +1043,12 @@ public class GenericHelixController implements IdealStateChangeListener,
       _clusterStatusMonitor.setMaintenance(_inMaintenanceMode);
     } else {
       enableClusterStatusMonitor(false);
+      // Note that onControllerChange is executed in parallel with the event processing thread. It
+      // is possible that the current WAGED rebalancer object is in use for handling callback. So
+      // mark the rebalancer invalid only, instead of closing it here.
+      // This to-be-closed WAGED rebalancer will be reset later on a later event processing if
+      // the controller becomes leader again.
+      _wagedRebalancerRef.invalidRebalancer();
     }
 
     logger.info("END: GenericClusterController.onControllerChange() for cluster " + _clusterName);
@@ -1125,6 +1152,8 @@ public class GenericHelixController implements IdealStateChangeListener,
 
     enableClusterStatusMonitor(false);
 
+    _wagedRebalancerRef.closeWagedRebalancer();
+
     // TODO controller shouldn't be used in anyway after shutdown.
     // Need to record shutdown and throw Exception if the controller is used again.
   }
@@ -1202,7 +1231,6 @@ public class GenericHelixController implements IdealStateChangeListener,
     return statusFlag;
   }
 
-
   // TODO: refactor this to use common/ClusterEventProcessor.
   @Deprecated
   private class ClusterEventProcessor extends Thread {
@@ -1257,5 +1285,56 @@ public class GenericHelixController implements IdealStateChangeListener,
 
     eventThread.setDaemon(true);
     eventThread.start();
+  }
+}
+
+/**
+ * A wrapper class for the WAGED rebalancer instance.
+ */
+class WagedRebalancerRef {
+  private WagedRebalancer _rebalancer = null;
+  private boolean _isRebalancerValid = true;
+
+  private void createWagedRebalancer(HelixManager helixManager) {
+    // Create WagedRebalancer instance if it hasn't been already initialized
+    if (_rebalancer == null) {
+      _rebalancer = new WagedRebalancer(helixManager);
+      _isRebalancerValid = true;
+    }
+  }
+
+  /**
+   * Mark the current rebalancer object to be invalid, which indicates it needs to be reset before
+   * the next usage.
+   */
+  synchronized void invalidRebalancer() {
+    _isRebalancerValid = false;
+  }
+
+  /**
+   * @return A valid rebalancer object.
+   *         If the rebalancer is no longer valid, it will be reset before returning.
+   */
+  synchronized WagedRebalancer getWagedRebalancer(HelixManager helixManager) {
+    // Lazily initialize the WAGED rebalancer instance since the GenericHelixController instance is
+    // instantiated without the HelixManager information that is required.
+    createWagedRebalancer(helixManager);
+    // If the rebalance exists but has been marked as invalid (due to leadership switch), it needs
+    // to be reset before return.
+    if (!_isRebalancerValid) {
+      _rebalancer.reset();
+      _isRebalancerValid = true;
+    }
+    return _rebalancer;
+  }
+
+  /**
+   * Proactively close the rebalance object to release the resources.
+   */
+  synchronized void closeWagedRebalancer() {
+    if (_rebalancer != null) {
+      _rebalancer.close();
+      _rebalancer = null;
+    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/StatefulRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/StatefulRebalancer.java
@@ -1,0 +1,37 @@
+package org.apache.helix.controller.rebalancer;
+
+import java.util.Map;
+
+import org.apache.helix.HelixRebalanceException;
+import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.Resource;
+
+
+/**
+ * Allows one to come up with custom implementation of a stateful rebalancer.<br/>
+ */
+public interface StatefulRebalancer<T extends BaseControllerDataProvider> {
+
+  /**
+   * Reset the rebalancer to the initial state.
+   */
+  void reset();
+
+  /**
+   * Release all the resources and clean up all the rebalancer state.
+   */
+  void close();
+
+  /**
+   * Compute the new IdealStates for all the input resources. The IdealStates include both new
+   * partition assignment (in the listFiles) and the new replica state mapping (in the mapFields).
+   * @param clusterData The Cluster status data provider.
+   * @param resourceMap A map containing all the rebalancing resources.
+   * @param currentStateOutput The present Current States of the resources.
+   * @return A map of the new IdealStates with the resource name as key.
+   */
+  Map<String, IdealState> computeNewIdealStates(T clusterData, Map<String, Resource> resourceMap,
+      final CurrentStateOutput currentStateOutput) throws HelixRebalanceException;
+}

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -41,6 +41,7 @@ import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.controller.changedetector.ResourceChangeDetector;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
+import org.apache.helix.controller.rebalancer.StatefulRebalancer;
 import org.apache.helix.controller.rebalancer.internal.MappingCalculator;
 import org.apache.helix.controller.rebalancer.util.DelayedRebalanceUtil;
 import org.apache.helix.controller.rebalancer.waged.constraints.ConstraintBasedAlgorithmFactory;
@@ -70,7 +71,7 @@ import org.slf4j.LoggerFactory;
  *      Design Document
  *      </a>
  */
-public class WagedRebalancer {
+public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDataProvider> {
   private static final Logger LOG = LoggerFactory.getLogger(WagedRebalancer.class);
 
   // When any of the following change happens, the rebalancer needs to do a global rebalance which
@@ -228,7 +229,7 @@ public class WagedRebalancer {
     }
   }
 
-  // Clean up the internal cached rebalance status.
+  @Override
   public void reset() {
     if (_assignmentMetadataStore != null) {
       _assignmentMetadataStore.reset();
@@ -236,7 +237,7 @@ public class WagedRebalancer {
     _changeDetector.resetSnapshots();
   }
 
-  // Release all the resources.
+  @Override
   public void close() {
     if (_baselineCalculateExecutor != null) {
       _baselineCalculateExecutor.shutdownNow();
@@ -247,14 +248,7 @@ public class WagedRebalancer {
     _metricCollector.unregister();
   }
 
-  /**
-   * Compute the new IdealStates for all the input resources. The IdealStates include both new
-   * partition assignment (in the listFiles) and the new replica state mapping (in the mapFields).
-   * @param clusterData The Cluster status data provider.
-   * @param resourceMap A map containing all the rebalancing resources.
-   * @param currentStateOutput The present Current States of the resources.
-   * @return A map of the new IdealStates with the resource name as key.
-   */
+  @Override
   public Map<String, IdealState> computeNewIdealStates(ResourceControllerDataProvider clusterData,
       Map<String, Resource> resourceMap, final CurrentStateOutput currentStateOutput)
       throws HelixRebalanceException {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -237,6 +237,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     _changeDetector.resetSnapshots();
   }
 
+  // TODO the rebalancer should reject any other computing request after being closed.
   @Override
   public void close() {
     if (_baselineCalculateExecutor != null) {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/AttributeName.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/AttributeName.java
@@ -38,5 +38,6 @@ public enum AttributeName {
   AsyncFIFOWorkerPool,
   PipelineType,
   LastRebalanceFinishTimeStamp,
-  ControllerDataProvider
+  ControllerDataProvider,
+  STATEFUL_REBALANCER
 }

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -388,11 +388,12 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
 
     runStage(event, new CurrentStateComputationStage());
     // Note the dryrunWagedRebalancer is just for one time usage
-    DryrunWagedRebalancer dryrunWagedRebalancer = new DryrunWagedRebalancer(_zkClient.getServers(), cache.getClusterName(),
-        cache.getClusterConfig().getGlobalRebalancePreference());
+    DryrunWagedRebalancer dryrunWagedRebalancer =
+        new DryrunWagedRebalancer(_zkClient.getServers(), cache.getClusterName(),
+            cache.getClusterConfig().getGlobalRebalancePreference());
+    event.addAttribute(AttributeName.STATEFUL_REBALANCER.name(), dryrunWagedRebalancer);
     try {
-      // TODO: be caution here, should be handled statelessly.
-      runStage(event, new BestPossibleStateCalcStage(dryrunWagedRebalancer));
+      runStage(event, new BestPossibleStateCalcStage());
     } finally {
       dryrunWagedRebalancer.close();
     }

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
@@ -497,6 +497,7 @@ public class TestWagedRebalance extends ZkTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
+    // TODO remove this sleep after fix https://github.com/apache/helix/issues/526
     Thread.sleep(300);
     validate(_replica);
 
@@ -507,6 +508,7 @@ public class TestWagedRebalance extends ZkTestBase {
         BuiltInStateModelDefinitions.MasterSlave.name(), PARTITIONS, _replica, _replica);
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, moreDB, _replica);
     _allDBs.add(moreDB);
+    // TODO remove this sleep after fix https://github.com/apache/helix/issues/526
     Thread.sleep(300);
     validate(_replica);
     ExternalView oldEV =
@@ -516,6 +518,7 @@ public class TestWagedRebalance extends ZkTestBase {
     simulateSessionExpiry(_controller.getZkClient());
     // After reset done, the rebalancer will try to rebalance all the partitions since it has
     // forgotten the previous state.
+    // TODO remove this sleep after fix https://github.com/apache/helix/issues/526
     Thread.sleep(300);
     validate(_replica);
     ExternalView newEV =

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
@@ -412,12 +412,12 @@ public class TestWagedRebalance extends ZkTestBase {
   }
 
   @Test(dependsOnMethods = "test")
-  public void testNewInstances()
-      throws InterruptedException {
+  public void testNewInstances() throws InterruptedException {
     ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
     ClusterConfig clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
     clusterConfig.setGlobalRebalancePreference(ImmutableMap
-        .of(ClusterConfig.GlobalRebalancePreferenceKey.EVENNESS, 0, ClusterConfig.GlobalRebalancePreferenceKey.LESS_MOVEMENT, 10));
+        .of(ClusterConfig.GlobalRebalancePreferenceKey.EVENNESS, 0,
+            ClusterConfig.GlobalRebalancePreferenceKey.LESS_MOVEMENT, 10));
     configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
 
     int i = 0;
@@ -471,6 +471,58 @@ public class TestWagedRebalance extends ZkTestBase {
         participant.syncStop();
       }
     }
+  }
+
+  /**
+   * The stateful WAGED rebalancer will be reset while the controller regains the leadership.
+   * This test is to verify if the reset has been done and the rebalancer has forgotten any previous
+   * status after leadership switched.
+   */
+  @Test(dependsOnMethods = "test")
+  public void testRebalancerReset() throws Exception {
+    // Configure the rebalance preference so as to trigger more partition movements for evenness.
+    // This is to ensure the controller will try to move something if the rebalancer has been reset.
+    ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    ClusterConfig clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setGlobalRebalancePreference(ImmutableMap
+        .of(ClusterConfig.GlobalRebalancePreferenceKey.EVENNESS, 10,
+            ClusterConfig.GlobalRebalancePreferenceKey.LESS_MOVEMENT, 0));
+    configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    int i = 0;
+    for (String stateModel : _testModels) {
+      String db = "Test-DB-" + TestHelper.getTestMethodName() + i++;
+      createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, _replica,
+          _replica);
+      _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
+      _allDBs.add(db);
+    }
+    Thread.sleep(300);
+    validate(_replica);
+
+    // Adding one more resource. Since it is added after the other resources, the assignment is
+    // impacted because of the other resources' assignment.
+    String moreDB = "More-Test-DB";
+    createResourceWithWagedRebalance(CLUSTER_NAME, moreDB,
+        BuiltInStateModelDefinitions.MasterSlave.name(), PARTITIONS, _replica, _replica);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, moreDB, _replica);
+    _allDBs.add(moreDB);
+    Thread.sleep(300);
+    validate(_replica);
+    ExternalView oldEV =
+        _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, moreDB);
+
+    // Expire the controller session so it will reset the internal rebalancer's status.
+    simulateSessionExpiry(_controller.getZkClient());
+    // After reset done, the rebalancer will try to rebalance all the partitions since it has
+    // forgotten the previous state.
+    Thread.sleep(300);
+    validate(_replica);
+    ExternalView newEV =
+        _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, moreDB);
+
+    // To verify that the controller has moved some partitions.
+    Assert.assertFalse(newEV.equals(oldEV));
   }
 
   private void validate(int expectedReplica) {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#660 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This is to prevent any cached assignment information which is recorded during the previous session from impacting the rebalance result.
Detailed change list:
1. Move the stateful WAGED rebalancer to the GenericHelixController object instead of the rebalance stage. This is for resolving the possible race condition between the event processing thread and leader switch handling thread.
2. Adding a new test regarding leadership switch to verify that the WAGED rebalancer has been reset after the processing.

### Tests

- [x] The following tests are written for this issue:

TestWagedRebalance.testRebalancerReset

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures: 
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[ERROR]   TestZKUtil.testChildrenOperations:80 expected:<2> but was:<4>
[INFO] 
[ERROR] Tests run: 1067, Failures: 2, Errors: 0, Skipped: 0

Re-run

[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.357 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml
