### PR TITLE
Removed useless znodes to resolve dependency between test methods in TestZKUtil

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKUtil.java
@@ -37,6 +37,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+
 public class TestZKUtil extends ZkUnitTestBase {
   private static Logger LOG = LoggerFactory.getLogger(TestZKUtil.class);
 
@@ -98,6 +99,7 @@ public class TestZKUtil extends ZkUnitTestBase {
     AssertJUnit.assertTrue(_gZkClient.exists(path));
     record = _gZkClient.readData(path);
     AssertJUnit.assertEquals("id4", record.getId());
+    _gZkClient.delete(path);
   }
 
   @Test()
@@ -109,12 +111,14 @@ public class TestZKUtil extends ZkUnitTestBase {
     ZKUtil.subtract(_gZkClient, path, record);
     record = _gZkClient.readData(path);
     AssertJUnit.assertNull(record.getSimpleField("key1"));
+    _gZkClient.delete(path);
   }
 
   @Test()
   public void testNullChildren() {
     String path = PropertyPathBuilder.instanceConfig(clusterName, "id6");
     ZKUtil.createChildren(_gZkClient, path, (List<ZNRecord>) null);
+    _gZkClient.delete(path);
   }
 
   @Test()
@@ -134,14 +138,18 @@ public class TestZKUtil extends ZkUnitTestBase {
     record = _gZkClient.readData(path);
     AssertJUnit.assertEquals(Arrays.asList("value1", "value2"), record.getListField("list"));
 
-    Map<String, String> map = new HashMap<String, String>() {{put("k1", "v1");}};
+    Map<String, String> map = new HashMap<String, String>() {{
+      put("k1", "v1");
+    }};
     record.setMapField("map", map);
     ZKUtil.createOrMerge(_gZkClient, path, record, true, true);
     record = _gZkClient.readData(path);
     AssertJUnit.assertEquals(map, record.getMapField("map"));
 
     record = new ZNRecord("id7");
-    Map<String, String> map2 = new HashMap<String, String>() {{put("k2", "v2");}};
+    Map<String, String> map2 = new HashMap<String, String>() {{
+      put("k2", "v2");
+    }};
     record.setMapField("map", map2);
     ZKUtil.createOrMerge(_gZkClient, path, record, true, true);
     record = _gZkClient.readData(path);
@@ -149,6 +157,7 @@ public class TestZKUtil extends ZkUnitTestBase {
       put("k1", "v1");
       put("k2", "v2");
     }}, record.getMapField("map"));
+    _gZkClient.delete(path);
   }
 
   @Test()
@@ -162,6 +171,7 @@ public class TestZKUtil extends ZkUnitTestBase {
     ZKUtil.createOrReplace(_gZkClient, path, record, true);
     record = _gZkClient.readData(path);
     AssertJUnit.assertEquals("id9", record.getId());
+    _gZkClient.delete(path);
   }
 
   @Test()
@@ -186,20 +196,24 @@ public class TestZKUtil extends ZkUnitTestBase {
     record = _gZkClient.readData(path);
     AssertJUnit.assertEquals(list2, record.getListField("list"));
 
-
-    Map<String, String> map = new HashMap<String, String>() {{put("k1", "v1");}};
+    Map<String, String> map = new HashMap<String, String>() {{
+      put("k1", "v1");
+    }};
     record.setMapField("map", map);
     ZKUtil.createOrUpdate(_gZkClient, path, record, true, true);
     record = _gZkClient.readData(path);
     AssertJUnit.assertEquals(map, record.getMapField("map"));
 
     record = new ZNRecord("id9");
-    Map<String, String> map2 = new HashMap<String, String>() {{put("k2", "v2");}};
+    Map<String, String> map2 = new HashMap<String, String>() {{
+      put("k2", "v2");
+    }};
     record.setMapField("map", map2);
     ZKUtil.createOrUpdate(_gZkClient, path, record, true, true);
     record = _gZkClient.readData(path);
     AssertJUnit.assertEquals(new HashMap<String, String>() {{
       put("k2", "v2");
     }}, record.getMapField("map"));
+    _gZkClient.delete(path);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKUtil.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -62,6 +63,13 @@ public class TestZKUtil extends ZkUnitTestBase {
   @AfterClass()
   public void afterClass() {
     deleteCluster(clusterName);
+  }
+
+  @AfterMethod()
+  public void afterMethod() {
+    String path = PropertyPathBuilder.instanceConfig(clusterName);
+    _gZkClient.deleteRecursively(path);
+    _gZkClient.createPersistent(path);
   }
 
   @Test()
@@ -99,7 +107,6 @@ public class TestZKUtil extends ZkUnitTestBase {
     AssertJUnit.assertTrue(_gZkClient.exists(path));
     record = _gZkClient.readData(path);
     AssertJUnit.assertEquals("id4", record.getId());
-    _gZkClient.delete(path);
   }
 
   @Test()
@@ -111,14 +118,12 @@ public class TestZKUtil extends ZkUnitTestBase {
     ZKUtil.subtract(_gZkClient, path, record);
     record = _gZkClient.readData(path);
     AssertJUnit.assertNull(record.getSimpleField("key1"));
-    _gZkClient.delete(path);
   }
 
   @Test()
   public void testNullChildren() {
     String path = PropertyPathBuilder.instanceConfig(clusterName, "id6");
     ZKUtil.createChildren(_gZkClient, path, (List<ZNRecord>) null);
-    _gZkClient.delete(path);
   }
 
   @Test()
@@ -157,7 +162,6 @@ public class TestZKUtil extends ZkUnitTestBase {
       put("k1", "v1");
       put("k2", "v2");
     }}, record.getMapField("map"));
-    _gZkClient.delete(path);
   }
 
   @Test()
@@ -171,7 +175,6 @@ public class TestZKUtil extends ZkUnitTestBase {
     ZKUtil.createOrReplace(_gZkClient, path, record, true);
     record = _gZkClient.readData(path);
     AssertJUnit.assertEquals("id9", record.getId());
-    _gZkClient.delete(path);
   }
 
   @Test()
@@ -214,6 +217,5 @@ public class TestZKUtil extends ZkUnitTestBase {
     AssertJUnit.assertEquals(new HashMap<String, String>() {{
       put("k2", "v2");
     }}, record.getMapField("map"));
-    _gZkClient.delete(path);
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#689

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

There is sometimes test failing because some znodes created in a test method didn't get deleted and it makes another test method's result false because we use one Zk cluster for all test methods in the same test class.
I added code to delete the created znodes at the end of each test method so each test method is truly independent.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 897, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,521.447 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 897, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  58:54 min
[INFO] Finished at: 2020-01-22T17:53:32-08:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml