### PR TITLE
Modify participant manager to add cluster auto registration logic

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformation.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformation.java
@@ -44,7 +44,7 @@ public class AzureCloudInstanceInformation implements CloudInstanceInformation {
 
   public static class Builder {
 
-    private Map<String, String> _cloudInstanceInfoMap = new HashMap<>();
+    private final Map<String, String> _cloudInstanceInfoMap = new HashMap<>();
 
     public AzureCloudInstanceInformation build() {
       return new AzureCloudInstanceInformation(_cloudInstanceInfoMap);

--- a/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformation.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformation.java
@@ -43,11 +43,6 @@ public class AzureCloudInstanceInformation implements CloudInstanceInformation {
   }
 
   public static class Builder {
-    /**
-     * Default constructor
-     */
-    public Builder() {
-    }
 
     private Map<String, String> _cloudInstanceInfoMap = new HashMap<>();
 

--- a/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformation.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformation.java
@@ -19,6 +19,7 @@ package org.apache.helix.cloud.azure;
  * under the License.
  */
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.helix.api.cloud.CloudInstanceInformation;
@@ -42,7 +43,13 @@ public class AzureCloudInstanceInformation implements CloudInstanceInformation {
   }
 
   public static class Builder {
-    private Map<String, String> _cloudInstanceInfoMap = null;
+    /**
+     * Default constructor
+     */
+    public Builder() {
+    }
+
+    private Map<String, String> _cloudInstanceInfoMap = new HashMap<>();
 
     public AzureCloudInstanceInformation build() {
       return new AzureCloudInstanceInformation(_cloudInstanceInfoMap);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -179,7 +179,9 @@ public class ParticipantManager {
           CloudInstanceInformation cloudInstanceInformation = getCloudInstanceInformation();
           String domain = cloudInstanceInformation
               .get(CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name());
-          String cloudIdInRemote = cloudInstanceInformation
+
+          // Disable the verification for now
+          /*String cloudIdInRemote = cloudInstanceInformation
               .get(CloudInstanceInformation.CloudInstanceField.INSTANCE_SET_NAME.name());
           String cloudIdInConfig = _configAccessor.getCloudConfig(_clusterName).getCloudID();
 
@@ -188,7 +190,8 @@ public class ParticipantManager {
             throw new IllegalArgumentException(String.format(
                 "cloudId in config: %s is not consistent with cloudId from remote: %s. The instance is auto registering to a wrong cluster.",
                 cloudIdInConfig, cloudIdInRemote));
-          }
+          }*/
+
           InstanceConfig instanceConfig = HelixUtil.composeInstanceConfig(_instanceName);
           instanceConfig.setDomain(domain);
           _helixAdmin.addInstance(_clusterName, instanceConfig);

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -290,4 +290,23 @@ public final class HelixUtil {
     return propertyDefaultValue;
   }
 
+  /**
+   * Compose the config for an instance
+   * @param instanceName
+   * @return InstanceConfig
+   */
+  public static InstanceConfig composeInstanceConfig(String instanceName) {
+    InstanceConfig instanceConfig = new InstanceConfig(instanceName);
+    String hostName = instanceName;
+    String port = "";
+    int lastPos = instanceName.lastIndexOf("_");
+    if (lastPos > 0) {
+      hostName = instanceName.substring(0, lastPos);
+      port = instanceName.substring(lastPos + 1);
+    }
+    instanceConfig.setHostName(hostName);
+    instanceConfig.setPort(port);
+    instanceConfig.setInstanceEnabled(true);
+    return instanceConfig;
+  }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/MockParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/MockParticipantManager.java
@@ -22,6 +22,7 @@ package org.apache.helix.integration.manager;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
+import org.apache.helix.HelixCloudProperty;
 import org.apache.helix.InstanceType;
 import org.apache.helix.manager.zk.CallbackHandler;
 import org.apache.helix.manager.zk.ZKHelixManager;
@@ -48,6 +49,7 @@ public class MockParticipantManager extends ZKHelixManager implements Runnable, 
   protected MockMSModelFactory _msModelFactory;
   protected DummyLeaderStandbyStateModelFactory _lsModelFactory;
   protected DummyOnlineOfflineStateModelFactory _ofModelFactory;
+  protected HelixCloudProperty _helixCloudProperty;
 
   public MockParticipantManager(String zkAddr, String clusterName, String instanceName) {
     this(zkAddr, clusterName, instanceName, 10);
@@ -55,11 +57,17 @@ public class MockParticipantManager extends ZKHelixManager implements Runnable, 
 
   public MockParticipantManager(String zkAddr, String clusterName, String instanceName,
       int transDelay) {
+    this(zkAddr, clusterName, instanceName, transDelay, null);
+  }
+
+  public MockParticipantManager(String zkAddr, String clusterName, String instanceName,
+      int transDelay, HelixCloudProperty helixCloudProperty) {
     super(clusterName, instanceName, InstanceType.PARTICIPANT, zkAddr);
     _transDelay = transDelay;
     _msModelFactory = new MockMSModelFactory(null);
     _lsModelFactory = new DummyLeaderStandbyStateModelFactory(_transDelay);
     _ofModelFactory = new DummyOnlineOfflineStateModelFactory(_transDelay);
+    _helixCloudProperty = helixCloudProperty;
   }
 
   public void setTransition(MockTransition transition) {


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

(#694 )

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Helix is adding a new feature in which a participant may auto register itself to the cluster after connects. Different from current auto join function, auto registration will not only set up all the config information for the instance, but also retrieve the fault domain information for the participant, and register all this information to the cluster. This PR changes the logic in ParticipantManager by adding the auto registration logic. Two flags are used to denote auto join and auto registration. AutoJoin flag must be true if we would like to allow autoRegstration. 

### Tests

- [X] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 904, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,221.481 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 904, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  53:45 min
[INFO] Finished at: 2020-01-22T09:57:03-08:00
[INFO] ------------------------------------------------------------------------

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X] My diff has been formatted using helix-style.xml