### PR TITLE
Call session aware createEphemeral to create live instance.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -201,6 +201,7 @@ public class ParticipantManager {
     do {
       retry = false;
       try {
+        // Zk session ID will be validated in createEphemeral.
         _zkclient.createEphemeral(liveInstancePath, liveInstance.getRecord(), _sessionId);
         LOG.info("LiveInstance created, path: {}, sessionId: {}", liveInstancePath,
             liveInstance.getEphemeralOwner());
@@ -243,6 +244,7 @@ public class ParticipantManager {
      */
     if (retry) {
       try {
+        // Zk session ID will be validated in createEphemeral.
         _zkclient.createEphemeral(liveInstancePath, liveInstance.getRecord(), _sessionId);
         LOG.info("LiveInstance created, path: {}, sessionId: {}", liveInstancePath,
             liveInstance.getEphemeralOwner());

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -201,7 +201,7 @@ public class ParticipantManager {
     do {
       retry = false;
       try {
-        _zkclient.createEphemeral(liveInstancePath, liveInstance.getRecord());
+        _zkclient.createEphemeral(liveInstancePath, liveInstance.getRecord(), _sessionId);
         LOG.info("LiveInstance created, path: {}, sessionId: {}", liveInstancePath,
             liveInstance.getEphemeralOwner());
       } catch (ZkSessionMismatchedException e) {
@@ -243,7 +243,7 @@ public class ParticipantManager {
      */
     if (retry) {
       try {
-        _zkclient.createEphemeral(liveInstancePath, liveInstance.getRecord());
+        _zkclient.createEphemeral(liveInstancePath, liveInstance.getRecord(), _sessionId);
         LOG.info("LiveInstance created, path: {}, sessionId: {}", liveInstancePath,
             liveInstance.getEphemeralOwner());
       } catch (ZkSessionMismatchedException e) {

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestParticipantManager.java
@@ -40,7 +40,8 @@ public class TestParticipantManager extends ZkTestBase {
 
   /*
    * Simulates zk session expiry before creating live instance in participant manager. This test
-   * makes sure the session aware create ephemeral API is called.
+   * makes sure the session aware create ephemeral API is called, which validates the expected zk
+   * session.
    * What this test does is:
    * 1. Sets up live instance with session S0
    * 2. Expires S0 and gets new session S1

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestParticipantManager.java
@@ -1,0 +1,182 @@
+package org.apache.helix.manager.zk;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+
+import org.apache.helix.PreConnectCallback;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.TestHelper;
+import org.apache.helix.ZkTestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.LiveInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestParticipantManager extends ZkTestBase {
+  private static Logger LOG = LoggerFactory.getLogger(TestParticipantManager.class);
+
+  /*
+   * Simulates zk session expiry before creating live instance in participant manager. This test
+   * makes sure the session aware create ephemeral API is called.
+   * What this test does is:
+   * 1. Sets up live instance with session S0
+   * 2. Expires S0 and gets new session S1
+   * 3. S1 is blocked before creating live instance in participant manager
+   * 4. Expires S1 and gets new session S2
+   * 5. Proceeds S1 to create live instance, which will fail because session S1 is expired
+   * 6. Proceeds S2 to create live instance, which will succeed
+   */
+  @Test
+  public void testSessionExpiryCreateLiveInstance() throws Exception {
+    final String className = TestHelper.getTestClassName();
+    final String methodName = TestHelper.getTestMethodName();
+    final String clusterName = className + "_" + methodName;
+
+    final ZKHelixDataAccessor accessor =
+        new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(ZK_ADDR));
+    final PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+
+    TestHelper.setupCluster(clusterName, ZK_ADDR,
+        12918, // participant port
+        "localhost", // participant name prefix
+        "TestDB", // resource name prefix
+        1, // resources
+        10, // partitions per resource
+        5, // number of nodes
+        3, // replicas
+        "MasterSlave",
+        true); // do rebalance
+
+    final String instanceName = "localhost_12918";
+    final MockParticipantManager manager =
+        new MockParticipantManager(ZK_ADDR, clusterName, instanceName);
+
+    manager.syncStart();
+
+    final LiveInstance liveInstance = accessor.getProperty(keyBuilder.liveInstance(instanceName));
+    final long originalCreationTime = liveInstance.getStat().getCreationTime();
+    final String originalSessionId = manager.getSessionId();
+
+    // Verify current live instance.
+    Assert.assertNotNull(liveInstance);
+    Assert.assertEquals(liveInstance.getEphemeralOwner(), originalSessionId);
+
+    final CountDownLatch startCountdown = new CountDownLatch(1);
+    final CountDownLatch endCountdown = new CountDownLatch(1);
+    final Semaphore semaphore = new Semaphore(0);
+    manager.addPreConnectCallback(
+        new BlockingPreConnectCallback(instanceName, startCountdown, endCountdown, semaphore));
+
+    // Expire S0 and new session S1 will be created.
+    ZkTestHelper.asyncExpireSession(manager.getZkClient());
+
+    // Wait for onPreConnect to start
+    semaphore.acquire();
+
+    // New session S1 should not be equal to S0.
+    Assert.assertFalse(originalSessionId.equals(manager.getSessionId()));
+
+    // Live instance should be gone as original session S0 is expired.
+    Assert.assertNull(accessor.getProperty(keyBuilder.liveInstance(instanceName)));
+
+    final String lastSessionId = manager.getSessionId();
+
+    // Expire S1 when S1 is blocked in onPreConnect().
+    // New session S2 will be created.
+    ZkTestHelper.asyncExpireSession(manager.getZkClient());
+
+    TestHelper.verify(
+        () -> !(ZKUtil.toHexSessionId(manager.getZkClient().getSessionId()).equals(lastSessionId)),
+        3000L);
+
+    // New session S2 should not be equal to S1.
+    final String latestSessionId = ZKUtil.toHexSessionId(manager.getZkClient().getSessionId());
+    Assert.assertFalse(lastSessionId.equals(latestSessionId));
+
+    // Proceed S1 to create live instance, which will fail.
+    startCountdown.countDown();
+
+    // Wait until S1's handling new session is completed.
+    semaphore.acquire();
+
+    // Live instance should not be created because zk session is expired.
+    Assert.assertNull(accessor.getProperty(keyBuilder.liveInstance(instanceName)),
+        "Live instance should not be created because zk session is expired!");
+
+    // Proceed S2 to create live instance.
+    endCountdown.countDown();
+
+    TestHelper.verify(() -> {
+      // Newly created live instance should be created by the latest session S2
+      // and have a new creation time.
+      LiveInstance newLiveInstance =
+          accessor.getProperty(keyBuilder.liveInstance(instanceName));
+      return newLiveInstance != null
+          && newLiveInstance.getStat().getCreationTime() != originalCreationTime
+          && newLiveInstance.getEphemeralOwner().equals(latestSessionId);
+    }, 2000L);
+
+    // Clean up.
+    manager.syncStop();
+    deleteCluster(clusterName);
+  }
+
+  /*
+   * Mocks PreConnectCallback to insert session expiry during ParticipantManager#handleNewSession()
+   */
+  static class BlockingPreConnectCallback implements PreConnectCallback {
+    private final String instanceName;
+    private final CountDownLatch startCountDown;
+    private final CountDownLatch endCountDown;
+    private final Semaphore semaphore;
+
+    private int count;
+
+    BlockingPreConnectCallback(String instanceName, CountDownLatch startCountdown,
+        CountDownLatch endCountdown, Semaphore semaphore) {
+      this.instanceName = instanceName;
+      this.startCountDown = startCountdown;
+      this.endCountDown = endCountdown;
+      this.semaphore = semaphore;
+    }
+
+    @Override
+    public void onPreConnect() {
+      LOG.info("Handling new session for instance: {}", instanceName);
+      semaphore.release();
+      try {
+        LOG.info("Waiting session expiry to happen.");
+        startCountDown.await();
+        if (count++ == 1) {
+          LOG.info("Waiting to continue creating live instance.");
+          endCountDown.await();
+        }
+      } catch (InterruptedException ex) {
+        LOG.error("Interrupted in waiting", ex);
+      }
+    }
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestParticipantManager.java
@@ -102,19 +102,19 @@ public class TestParticipantManager extends ZkTestBase {
     // Live instance should be gone as original session S0 is expired.
     Assert.assertNull(accessor.getProperty(keyBuilder.liveInstance(instanceName)));
 
-    final String lastSessionId = manager.getSessionId();
+    final String sessionOne = manager.getSessionId();
 
     // Expire S1 when S1 is blocked in onPreConnect().
     // New session S2 will be created.
     ZkTestHelper.asyncExpireSession(manager.getZkClient());
 
     TestHelper.verify(
-        () -> !(ZKUtil.toHexSessionId(manager.getZkClient().getSessionId()).equals(lastSessionId)),
+        () -> !(ZKUtil.toHexSessionId(manager.getZkClient().getSessionId()).equals(sessionOne)),
         TestHelper.WAIT_DURATION);
 
     // New session S2 should not be equal to S1.
-    final String latestSessionId = ZKUtil.toHexSessionId(manager.getZkClient().getSessionId());
-    Assert.assertFalse(lastSessionId.equals(latestSessionId));
+    final String sessionTwo = ZKUtil.toHexSessionId(manager.getZkClient().getSessionId());
+    Assert.assertFalse(sessionOne.equals(sessionTwo));
 
     // Proceed S1 to create live instance, which will fail.
     startCountdown.countDown();
@@ -136,7 +136,7 @@ public class TestParticipantManager extends ZkTestBase {
           accessor.getProperty(keyBuilder.liveInstance(instanceName));
       return newLiveInstance != null
           && newLiveInstance.getStat().getCreationTime() != originalCreationTime
-          && newLiveInstance.getEphemeralOwner().equals(latestSessionId);
+          && newLiveInstance.getEphemeralOwner().equals(sessionTwo);
     }, TestHelper.WAIT_DURATION);
 
     // Clean up.


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #699 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We implemented a new API `ZkClient.createEphemeral(path, data, sessionId)` to validate the zk session and create a live instance. Currently, live instance creation is still using the old API `createEphemeral(path, data)` without the session ID. So zk session race condition is not completely fixed.

This PR changes the api to use `createEphemeral(path, data, sessionId)` for live instance creation. A new test is added to cover the case of using the old API. If the old API is used, the test will fail like below:
```
java.lang.AssertionError: Live instance should not be created because zk session is expired!
Expected :true
Actual   :false
```

### Tests

- [x] The following tests are written for this issue:

- TestParticipantManager.testSessionExpiryCreateLiveInstance

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 898, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,370.606 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 898, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  56:15 min
[INFO] Finished at: 2020-01-22T21:35:30-08:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml