### PR TITLE
Enable two test runs with multiZk system property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -620,6 +620,38 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M3</version>
+          <executions>
+            <!--
+            "executions" enables multiple runs of integration test suites. This is to enable two
+            runs: 1. run in a single-ZK environment, 2. run in a multi-ZK environment.
+            "multiZk" is the config accessible via Systems.Properties so that the two runs could be
+            differentiated.
+            -->
+            <execution>
+              <goals>
+                <goal>test</goal>
+              </goals>
+              <id>default-test</id>
+              <phase>test</phase>
+              <configuration>
+                <systemPropertyVariables>
+                  <multiZk>false</multiZk>
+                </systemPropertyVariables>
+              </configuration>
+            </execution>
+            <execution>
+              <goals>
+                <goal>test</goal>
+              </goals>
+              <id>multi-zk</id>
+              <phase>test</phase>
+              <configuration>
+                <systemPropertyVariables>
+                  <multiZk>true</multiZk>
+                </systemPropertyVariables>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #709 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We want to achieve horizontal scalability for ZK, meaning we want to allow users to add more ZK deployments and shard based on the ZK read/write path. To test this going forward, we want to be able to execute existing tests in two different environments: 1. single-ZK env, and 2. multi-ZK env.
Changelist:
1. Create two executions for maven-surefire-plugin with multiZk system property

### Tests

Manually tested

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml