### PR TITLE
Upgrade ZkTestBase with multi-ZK support in helix-core

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
@@ -148,7 +148,8 @@ public class ZkTestBase {
     _numZk++; // Now we have 1 ZK
 
     // If multi-ZooKeeper is enabled, start more ZKs
-    if (System.getProperty(MULTI_ZK_PROPERTY_KEY) != null) {
+    String multiZkConfig = System.getProperty(MULTI_ZK_PROPERTY_KEY);
+    if (multiZkConfig != null && multiZkConfig.equalsIgnoreCase(Boolean.TRUE.toString())) {
       int numZkFromConfig;
       try {
         numZkFromConfig = Integer.parseInt(System.getProperty(NUM_ZK_PROPERTY_KEY));
@@ -222,8 +223,9 @@ public class ZkTestBase {
     TestHelper.stopZkServer(_zkServer);
 
     // If there are multiple ZooKeepers, close them all
-    if (System.getProperty(MULTI_ZK_PROPERTY_KEY) != null) {
-      for (int i = 0; i < _numZk; i++) {
+    String multiZkConfig = System.getProperty(MULTI_ZK_PROPERTY_KEY);
+    if (multiZkConfig != null && multiZkConfig.equalsIgnoreCase(Boolean.TRUE.toString())) {
+      for (int i = 1; i < _numZk; i++) {
         if (_baseDataAccessorMap != null && _baseDataAccessorMap.containsKey(i)) {
           _baseDataAccessorMap.get(i).close();
         }

--- a/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
@@ -168,7 +168,7 @@ public class ZkTestBase {
         }
       } catch (Exception e) {
         // Parsing error - skip creating ZKs
-        LOG.error("Failed to create multiple ZooKeepers!");
+        System.out.println("Failed to create multiple ZooKeepers!");
       }
     }
 

--- a/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
@@ -150,27 +150,30 @@ public class ZkTestBase {
     // If multi-ZooKeeper is enabled, start more ZKs
     String multiZkConfig = System.getProperty(MULTI_ZK_PROPERTY_KEY);
     if (multiZkConfig != null && multiZkConfig.equalsIgnoreCase(Boolean.TRUE.toString())) {
-      int numZkFromConfig;
-      try {
-        numZkFromConfig = Integer.parseInt(System.getProperty(NUM_ZK_PROPERTY_KEY));
-        // Initialize maps to track multiple ZK servers
-        _zkServerMap = new HashMap<>();
-        _helixZkClientMap = new HashMap<>();
-        _clusterSetupMap = new HashMap<>();
-        _baseDataAccessorMap = new HashMap<>();
-        _zkServerMap.put(0, _zkServer);
-        _helixZkClientMap.put(0, _gZkClient);
-        _clusterSetupMap.put(0, _gSetupTool);
-        _baseDataAccessorMap.put(0, _baseAccessor);
+      String numZkFromConfig = System.getProperty(NUM_ZK_PROPERTY_KEY);
+      if (numZkFromConfig != null) {
+        try {
+          int numZkFromConfigInt = Integer.parseInt(numZkFromConfig);
+          // Initialize maps to track multiple ZK servers
+          // Initialize maps to track multiple ZK servers
+          _zkServerMap = new HashMap<>();
+          _helixZkClientMap = new HashMap<>();
+          _clusterSetupMap = new HashMap<>();
+          _baseDataAccessorMap = new HashMap<>();
+          _zkServerMap.put(0, _zkServer);
+          _helixZkClientMap.put(0, _gZkClient);
+          _clusterSetupMap.put(0, _gSetupTool);
+          _baseDataAccessorMap.put(0, _baseAccessor);
 
-        // Start (numZkFromConfig - 1) ZooKeepers
-        for (int i = 1; i < numZkFromConfig; i++) {
-          startZooKeeper();
+          // Start (numZkFromConfigInt - 1) ZooKeepers
+          for (int i = 1; i < numZkFromConfigInt; i++) {
+            startZooKeeper();
+          }
+        } catch (Exception e) {
+          Assert.fail("Failed to create multiple ZKs!");
         }
-      } catch (Exception e) {
-        // Parsing error - skip creating ZKs
-        System.out.println("Failed to create multiple ZooKeepers!");
       }
+      Assert.fail("multiZk config is set but numZk config is missing!");
     }
 
     // Clean up all JMX objects

--- a/pom.xml
+++ b/pom.xml
@@ -633,11 +633,6 @@ under the License.
               </goals>
               <id>default-test</id>
               <phase>test</phase>
-              <configuration>
-                <systemPropertyVariables>
-                  <multiZk>false</multiZk>
-                </systemPropertyVariables>
-              </configuration>
             </execution>
             <execution>
               <goals>
@@ -648,6 +643,7 @@ under the License.
               <configuration>
                 <systemPropertyVariables>
                   <multiZk>true</multiZk>
+                  <numZk>3</numZk>
                 </systemPropertyVariables>
               </configuration>
             </execution>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #711 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Prior to instrumenting Helix APIs and components so that they would be aware of multiple ZKs for horizontal scalability, we need to have a way to run all integration tests involving ZooKeeper in different environments: one with a single ZK and another with multiple ZKs.
Changelist:
1. Implement the logic in ZkTestBase so that in conjunction with maven-surefire-plugin configs, there will be two executions of the test suite
2. Remove system property variable from default-test since it's unnecessary

### Tests

- [x] The following tests are written for this issue:

Manual testing by way of mvn test:

[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running TestSuite
Start zookeeper at localhost:2183 in thread main
Start zookeeper at localhost:2184 in thread main
Start zookeeper at localhost:2185 in thread main

Spins up 3 ZKs as expected.

- [ ] The following is the result of the "mvn test" command on the appropriate module:

helix-core:

1st run:

> Shut down zookeeper at port 2183 in thread main
> [INFO] Tests run: 900, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,378.408 s - in TestSuite
> [INFO]
> [INFO] Results:
> [INFO]
> [INFO] Tests run: 900, Failures: 0, Errors: 0, Skipped: 0
> [INFO]
> [INFO]

2nd run (multi-zk);

> Shut down zookeeper at port 2183 in thread main
> Shut down zookeeper at port 2183 in thread main
> Shut down zookeeper at port 2184 in thread main
> Shut down zookeeper at port 2185 in thread main
> [INFO] Tests run: 900, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,294.053 s - in TestSuite
> [INFO]
> [INFO] Results:
> [INFO]
> [INFO] Tests run: 900, Failures: 0, Errors: 0, Skipped: 0
> [INFO]
> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD SUCCESS
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time:  01:51 h
> [INFO] Finished at: 2020-01-31T19:23:32-08:00
> [INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml

