### PR TITLE
Implement Helix API for updating customized state

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/PropertyKey.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyKey.java
@@ -27,6 +27,7 @@ import org.apache.helix.model.ClusterConstraints;
 import org.apache.helix.model.ControllerHistory;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.CustomizedStateAggregationConfig;
+import org.apache.helix.model.CustomizedState;
 import org.apache.helix.model.Error;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HealthStat;
@@ -52,6 +53,7 @@ import org.slf4j.LoggerFactory;
 import static org.apache.helix.PropertyType.CONFIGS;
 import static org.apache.helix.PropertyType.CONTROLLER;
 import static org.apache.helix.PropertyType.CURRENTSTATES;
+import static org.apache.helix.PropertyType.CUSTOMIZEDSTATES;
 import static org.apache.helix.PropertyType.ERRORS;
 import static org.apache.helix.PropertyType.ERRORS_CONTROLLER;
 import static org.apache.helix.PropertyType.EXTERNALVIEW;
@@ -467,6 +469,30 @@ public class PropertyKey {
         return new PropertyKey(CURRENTSTATES, CurrentState.class, _clusterName, instanceName,
             sessionId, resourceName, bucketName);
       }
+    }
+
+    /**
+     * Get a property key associated with {@link CustomizedState} of an instance and customized state
+     * @param instanceName
+     * @param customizedStateName
+     * @return {@link PropertyKey}
+     */
+    public PropertyKey customizedStates(String instanceName, String customizedStateName) {
+      return new PropertyKey(CUSTOMIZEDSTATES, CustomizedState.class, _clusterName, instanceName,
+          customizedStateName);
+    }
+
+    /**
+     * Get a property key associated with {@link CustomizedState} of an instance, customized state, and resource
+     * @param instanceName
+     * @param customizedStateName
+     * @param resourceName
+     * @return {@link PropertyKey}
+     */
+    public PropertyKey customizedState(String instanceName, String customizedStateName,
+        String resourceName) {
+      return new PropertyKey(CUSTOMIZEDSTATES, CustomizedState.class, _clusterName, instanceName,
+          customizedStateName, resourceName);
     }
 
     /**

--- a/helix-core/src/main/java/org/apache/helix/PropertyPathBuilder.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyPathBuilder.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 
 import org.apache.helix.model.ControllerHistory;
 import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.CustomizedState;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.helix.PropertyType.CONFIGS;
 import static org.apache.helix.PropertyType.CURRENTSTATES;
+import static org.apache.helix.PropertyType.CUSTOMIZEDSTATES;
 import static org.apache.helix.PropertyType.EXTERNALVIEW;
 import static org.apache.helix.PropertyType.HISTORY;
 import static org.apache.helix.PropertyType.IDEALSTATES;
@@ -52,6 +54,7 @@ import static org.apache.helix.PropertyType.PAUSE;
 import static org.apache.helix.PropertyType.STATEMODELDEFS;
 import static org.apache.helix.PropertyType.STATUSUPDATES;
 import static org.apache.helix.PropertyType.WORKFLOWCONTEXT;
+
 
 /**
  * Utility mapping properties to their Zookeeper locations
@@ -112,6 +115,12 @@ public class PropertyPathBuilder {
         "/{clusterName}/INSTANCES/{instanceName}/CURRENTSTATES/{sessionId}/{resourceName}");
     addEntry(PropertyType.CURRENTSTATES, 5,
         "/{clusterName}/INSTANCES/{instanceName}/CURRENTSTATES/{sessionId}/{resourceName}/{bucketName}");
+    addEntry(PropertyType.CUSTOMIZEDSTATES, 2,
+        "/{clusterName}/INSTANCES/{instanceName}/CUSTOMIZEDSTATES");
+    addEntry(PropertyType.CUSTOMIZEDSTATES, 3,
+        "/{clusterName}/INSTANCES/{instanceName}/CUSTOMIZEDSTATES/{customizedStateName}");
+    addEntry(PropertyType.CUSTOMIZEDSTATES, 4,
+        "/{clusterName}/INSTANCES/{instanceName}/CUSTOMIZEDSTATES/{customizedStateName}/{resourceName}");
     addEntry(PropertyType.STATUSUPDATES, 2,
         "/{clusterName}/INSTANCES/{instanceName}/STATUSUPDATES");
     addEntry(PropertyType.STATUSUPDATES, 3,
@@ -312,6 +321,20 @@ public class PropertyPathBuilder {
         sessionId, resourceName);
   }
 
+  public static String instanceCustomizedState(String clusterName, String instanceName) {
+    return String.format("/%s/INSTANCES/%s/CUSTOMIZEDSTATES", clusterName, instanceName);
+  }
+
+  public static String instanceCustomizedState(String clusterName, String instanceName,
+      String customizedStateName) {
+    return String.format("/%s/INSTANCES/%s/CUSTOMIZEDSTATES/%s", clusterName, instanceName, customizedStateName);
+  }
+
+  public static String instanceCustomizedState(String clusterName, String instanceName,
+      String customizedStateName, String resourceName) {
+    return String.format("/%s/INSTANCES/%s/CUSTOMIZEDSTATES/%s/%s", clusterName, instanceName,
+        customizedStateName, resourceName);
+  }
   public static String instanceError(String clusterName, String instanceName) {
     return String.format("/%s/INSTANCES/%s/ERRORS", clusterName, instanceName);
   }

--- a/helix-core/src/main/java/org/apache/helix/PropertyPathBuilder.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyPathBuilder.java
@@ -115,12 +115,6 @@ public class PropertyPathBuilder {
         "/{clusterName}/INSTANCES/{instanceName}/CURRENTSTATES/{sessionId}/{resourceName}");
     addEntry(PropertyType.CURRENTSTATES, 5,
         "/{clusterName}/INSTANCES/{instanceName}/CURRENTSTATES/{sessionId}/{resourceName}/{bucketName}");
-    addEntry(PropertyType.CUSTOMIZEDSTATES, 2,
-        "/{clusterName}/INSTANCES/{instanceName}/CUSTOMIZEDSTATES");
-    addEntry(PropertyType.CUSTOMIZEDSTATES, 3,
-        "/{clusterName}/INSTANCES/{instanceName}/CUSTOMIZEDSTATES/{customizedStateName}");
-    addEntry(PropertyType.CUSTOMIZEDSTATES, 4,
-        "/{clusterName}/INSTANCES/{instanceName}/CUSTOMIZEDSTATES/{customizedStateName}/{resourceName}");
     addEntry(PropertyType.STATUSUPDATES, 2,
         "/{clusterName}/INSTANCES/{instanceName}/STATUSUPDATES");
     addEntry(PropertyType.STATUSUPDATES, 3,

--- a/helix-core/src/main/java/org/apache/helix/PropertyPathBuilder.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyPathBuilder.java
@@ -115,6 +115,12 @@ public class PropertyPathBuilder {
         "/{clusterName}/INSTANCES/{instanceName}/CURRENTSTATES/{sessionId}/{resourceName}");
     addEntry(PropertyType.CURRENTSTATES, 5,
         "/{clusterName}/INSTANCES/{instanceName}/CURRENTSTATES/{sessionId}/{resourceName}/{bucketName}");
+    addEntry(PropertyType.CUSTOMIZEDSTATES, 2,
+        "/{clusterName}/INSTANCES/{instanceName}/CUSTOMIZEDSTATES");
+    addEntry(PropertyType.CUSTOMIZEDSTATES, 3,
+        "/{clusterName}/INSTANCES/{instanceName}/CUSTOMIZEDSTATES/{customizedStateName}");
+    addEntry(PropertyType.CUSTOMIZEDSTATES, 4,
+        "/{clusterName}/INSTANCES/{instanceName}/CUSTOMIZEDSTATES/{customizedStateName}/{resourceName}");
     addEntry(PropertyType.STATUSUPDATES, 2,
         "/{clusterName}/INSTANCES/{instanceName}/STATUSUPDATES");
     addEntry(PropertyType.STATUSUPDATES, 3,

--- a/helix-core/src/main/java/org/apache/helix/PropertyType.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyType.java
@@ -55,6 +55,8 @@ public enum PropertyType {
   ERRORS(Type.INSTANCE, true, true),
   INSTANCE_HISTORY(Type.INSTANCE, true, true, true),
   HEALTHREPORT(Type.INSTANCE, true, false, false, false, false, true),
+  CUSTOMIZEDSTATES(Type.INSTANCE, true, false, false, true, true),
+
 
   // CONTROLLER PROPERTY
   LEADER(Type.CONTROLLER, false, false, true, true),

--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
@@ -1,0 +1,61 @@
+package org.apache.helix.customizedstate;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Map;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixException;
+import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.CustomizedState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class for Helix customers to input customized state
+ */
+public class CustomizedStateProvider {
+  private static final Logger LOG = LoggerFactory.getLogger(CustomizedStateProvider.class);
+  private final HelixManager _helixManager;
+  String _instanceName;
+
+  public CustomizedStateProvider(HelixManager helixManager, String instanceName) {
+    _helixManager = helixManager;
+    _instanceName = instanceName;
+  }
+
+  public synchronized void updateCustomizedState(String customizedStateName,
+      Map<String, Map<String, Map<String, String>>> customizedState) {
+    for (String resourceName : customizedState.keySet()) {
+      ZNRecord record = new ZNRecord(resourceName);
+      record.setMapFields(customizedState.get(resourceName));
+      HelixDataAccessor accessor = _helixManager.getHelixDataAccessor();
+      PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+      if (!accessor.setProperty(
+          keyBuilder.customizedState(_instanceName, customizedStateName, record.getId()),
+          new CustomizedState(record))) {
+        throw new HelixException(String.format(
+            "Failed to persist customized state %s to zk for instance %s, resource %s",
+            customizedStateName, _instanceName, record.getId()));
+      }
+    }
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
@@ -58,7 +58,7 @@ public class CustomizedStateProvider {
   }
 
   /**
-   * Update a specific customized state based on the resource name and partition name. . The
+   * Update a specific customized state based on the resource name and partition name. The
    * customized state is input as a map
    */
   public synchronized void updateCustomizedState(String customizedStateName, String resourceName,

--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProviderFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProviderFactory.java
@@ -49,9 +49,8 @@ public class CustomizedStateProviderFactory {
   public CustomizedStateProvider buildCustomizedStateProvider(String instanceName) {
     if (_helixManager == null) {
       throw new HelixException("Helix Manager has not been set yet.");
-    } else {
-      return buildCustomizedStateProvider(_helixManager, instanceName);
     }
+    return buildCustomizedStateProvider(_helixManager, instanceName);
   }
 
   /**
@@ -66,12 +65,11 @@ public class CustomizedStateProviderFactory {
     synchronized (_customizedStateProviderMap) {
       if (_customizedStateProviderMap.get(instanceName) != null) {
         return _customizedStateProviderMap.get(instanceName);
-      } else {
-        CustomizedStateProvider customizedStateProvider =
-            new CustomizedStateProvider(helixManager, instanceName);
-        _customizedStateProviderMap.put(instanceName, customizedStateProvider);
-        return customizedStateProvider;
       }
+      CustomizedStateProvider customizedStateProvider =
+          new CustomizedStateProvider(helixManager, instanceName);
+      _customizedStateProviderMap.put(instanceName, customizedStateProvider);
+      return customizedStateProvider;
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProviderFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProviderFactory.java
@@ -1,0 +1,67 @@
+package org.apache.helix.customizedstate;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import org.apache.helix.HelixManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Singleton factory that build customized state provider.
+ */
+public class CustomizedStateProviderFactory {
+  private static Logger LOG = LoggerFactory.getLogger(CustomizedStateProvider.class);
+  private final HashMap<String, CustomizedStateProvider> _customizedStateProviderMap =
+      new HashMap<>();
+
+  protected CustomizedStateProviderFactory() {
+  }
+
+  private static class SingletonHelper {
+    private static final CustomizedStateProviderFactory INSTANCE =
+        new CustomizedStateProviderFactory();
+  }
+
+  public static CustomizedStateProviderFactory getInstance() {
+    return SingletonHelper.INSTANCE;
+  }
+
+  /**
+   * Build a customized state provider based on the specified input. If the instance already has a
+   * provider, return it. Otherwise, build a new one and put it in the map.
+   * @param helixManager The helix manager that belongs to the instance
+   * @param instanceName The name of the instance
+   * @return CustomizedStateProvider
+   */
+  public CustomizedStateProvider buildCustomizedStateProvider(HelixManager helixManager,
+      String instanceName) {
+    synchronized (_customizedStateProviderMap) {
+      if (_customizedStateProviderMap.get(instanceName) != null) {
+        return _customizedStateProviderMap.get(instanceName);
+      } else {
+        CustomizedStateProvider customizedStateProvider =
+            new CustomizedStateProvider(helixManager, instanceName);
+        _customizedStateProviderMap.put(instanceName, customizedStateProvider);
+        return customizedStateProvider;
+      }
+    }
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProviderFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProviderFactory.java
@@ -20,6 +20,7 @@ package org.apache.helix.customizedstate;
  */
 
 import java.util.HashMap;
+import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,7 @@ public class CustomizedStateProviderFactory {
   private static Logger LOG = LoggerFactory.getLogger(CustomizedStateProvider.class);
   private final HashMap<String, CustomizedStateProvider> _customizedStateProviderMap =
       new HashMap<>();
+  private HelixManager _helixManager;
 
   protected CustomizedStateProviderFactory() {
   }
@@ -42,6 +44,14 @@ public class CustomizedStateProviderFactory {
 
   public static CustomizedStateProviderFactory getInstance() {
     return SingletonHelper.INSTANCE;
+  }
+
+  public CustomizedStateProvider buildCustomizedStateProvider(String instanceName) {
+    if (_helixManager == null) {
+      throw new HelixException("Helix Manager has not been set yet.");
+    } else {
+      return buildCustomizedStateProvider(_helixManager, instanceName);
+    }
   }
 
   /**
@@ -63,5 +73,9 @@ public class CustomizedStateProviderFactory {
         return customizedStateProvider;
       }
     }
+  }
+
+  public void setHelixManager(HelixManager helixManager) {
+    _helixManager = helixManager;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -135,6 +135,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     _zkClient.createPersistent(PropertyPathBuilder.instanceMessage(clusterName, nodeId), true);
     _zkClient.createPersistent(PropertyPathBuilder.instanceCurrentState(clusterName, nodeId), true);
+    _zkClient.createPersistent(PropertyPathBuilder.instanceCustomizedState(clusterName, nodeId), true);
     _zkClient.createPersistent(PropertyPathBuilder.instanceError(clusterName, nodeId), true);
     _zkClient.createPersistent(PropertyPathBuilder.instanceStatusUpdate(clusterName, nodeId), true);
     _zkClient.createPersistent(PropertyPathBuilder.instanceHistory(clusterName, nodeId), true);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -139,7 +139,6 @@ public final class ZKUtil {
       requiredPaths.add(PropertyPathBuilder.instanceConfig(clusterName, instanceName));
       requiredPaths.add(PropertyPathBuilder.instanceMessage(clusterName, instanceName));
       requiredPaths.add(PropertyPathBuilder.instanceCurrentState(clusterName, instanceName));
-      requiredPaths.add(PropertyPathBuilder.instanceCustomizedState(clusterName, instanceName));
       requiredPaths.add(PropertyPathBuilder.instanceStatusUpdate(clusterName, instanceName));
       requiredPaths.add(PropertyPathBuilder.instanceError(clusterName, instanceName));
       boolean isValid = true;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -139,6 +139,7 @@ public final class ZKUtil {
       requiredPaths.add(PropertyPathBuilder.instanceConfig(clusterName, instanceName));
       requiredPaths.add(PropertyPathBuilder.instanceMessage(clusterName, instanceName));
       requiredPaths.add(PropertyPathBuilder.instanceCurrentState(clusterName, instanceName));
+      requiredPaths.add(PropertyPathBuilder.instanceCustomizedState(clusterName, instanceName));
       requiredPaths.add(PropertyPathBuilder.instanceStatusUpdate(clusterName, instanceName));
       requiredPaths.add(PropertyPathBuilder.instanceError(clusterName, instanceName));
       boolean isValid = true;

--- a/helix-core/src/main/java/org/apache/helix/model/CustomizedState.java
+++ b/helix-core/src/main/java/org/apache/helix/model/CustomizedState.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
  */
 public class CustomizedState extends HelixProperty {
   private static Logger LOG = LoggerFactory.getLogger(CustomizedState.class);
-  private static long NON_EXIST = -1L;
 
   /**
    * Lookup keys for the customized state
@@ -96,12 +95,15 @@ public class CustomizedState extends HelixProperty {
   }
 
   public long getStartTime(String partitionName) {
-    return _record.getLongField(CustomizedStateProperty.START_TIME.name(), NON_EXIST);
+    String startTime = getProperty(partitionName, CustomizedStateProperty.START_TIME);
+    return startTime == null ? -1L : Long.parseLong(startTime);
   }
 
   public long getEndTime(String partitionName) {
-    return _record.getLongField(CustomizedStateProperty.END_TIME.name(), NON_EXIST);
+    String endTime = getProperty(partitionName, CustomizedStateProperty.END_TIME);
+    return endTime == null ? -1L : Long.parseLong(endTime);
   }
+
 
   public String getPreviousState(String partitionName) {
     return getProperty(partitionName, CustomizedStateProperty.PREVIOUS_STATE);

--- a/helix-core/src/main/java/org/apache/helix/model/CustomizedState.java
+++ b/helix-core/src/main/java/org/apache/helix/model/CustomizedState.java
@@ -1,0 +1,156 @@
+package org.apache.helix.model;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.helix.HelixProperty;
+import org.apache.helix.ZNRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Customized states of partitions in a resource for an instance.
+ */
+public class CustomizedState extends HelixProperty {
+  private static Logger LOG = LoggerFactory.getLogger(CustomizedState.class);
+
+  /**
+   * Lookup keys for the customized state
+   */
+  public enum CustomizedStateProperty {
+    PREVIOUS_STATE,
+    CURRENT_STATE,
+    START_TIME,
+    END_TIME
+  }
+
+  /**
+   * Instantiate a customized state with a resource
+   * @param resourceName name identifying the resource
+   */
+  public CustomizedState(String resourceName) {
+    super(resourceName);
+  }
+
+  /**
+   * Instantiate a customized state with a pre-populated ZNRecord
+   * @param record a ZNRecord corresponding to the customized state
+   */
+  public CustomizedState(ZNRecord record) {
+    super(record);
+  }
+
+  /**
+   * Get the name of the resource
+   * @return String resource identifier
+   */
+  public String getResourceName() {
+    return _record.getId();
+  }
+
+  /**
+   * Get the partitions on this instance and the state that each partition is currently in.
+   * @return (partition, state) pairs
+   */
+  public Map<String, String> getPartitionStateMap() {
+    Map<String, String> map = new HashMap<String, String>();
+    Map<String, Map<String, String>> mapFields = _record.getMapFields();
+    for (String partitionName : mapFields.keySet()) {
+      Map<String, String> tempMap = mapFields.get(partitionName);
+      if (tempMap != null) {
+        map.put(partitionName, tempMap.get(CustomizedStateProperty.CURRENT_STATE.name()));
+      }
+    }
+    return map;
+  }
+
+  /**
+   * Get the state of a partition on this instance
+   * @param partitionName the name of the partition
+   * @return the state, or null if the partition is not present
+   */
+  public String getState(String partitionName) {
+    return getProperty(partitionName, CustomizedStateProperty.CURRENT_STATE);
+  }
+
+  public long getStartTime(String partitionName) {
+    String startTime = getProperty(partitionName, CustomizedStateProperty.START_TIME);
+    return startTime == null ? -1L : Long.parseLong(startTime);
+  }
+
+  public long getEndTime(String partitionName) {
+    String endTime = getProperty(partitionName, CustomizedStateProperty.END_TIME);
+    return endTime == null ? -1L : Long.parseLong(endTime);
+  }
+
+  public String getPreviousState(String partitionName) {
+    return getProperty(partitionName, CustomizedStateProperty.PREVIOUS_STATE);
+  }
+
+  private String getProperty(String partitionName, CustomizedStateProperty property) {
+    Map<String, String> mapField = _record.getMapField(partitionName);
+    if (mapField != null) {
+      return mapField.get(property.name());
+    }
+    return null;
+  }
+
+  /**
+   * Set the state that a partition is currently in on this instance
+   * @param partitionName the name of the partition
+   * @param state the state of the partition
+   */
+  public void setState(String partitionName, String state) {
+    setProperty(partitionName, CustomizedStateProperty.CURRENT_STATE, state);
+  }
+
+  public void setStartTime(String partitionName, long startTime) {
+    setProperty(partitionName, CustomizedStateProperty.START_TIME, String.valueOf(startTime));
+  }
+
+  public void setEndTime(String partitionName, long endTime) {
+    setProperty(partitionName, CustomizedStateProperty.END_TIME, String.valueOf(endTime));
+  }
+
+  public void setPreviousState(String partitionName, String state) {
+    setProperty(partitionName, CustomizedStateProperty.PREVIOUS_STATE, state);
+  }
+
+  private void setProperty(String partitionName, CustomizedStateProperty property, String value) {
+    Map<String, Map<String, String>> mapFields = _record.getMapFields();
+    if (mapFields.get(partitionName) == null) {
+      mapFields.put(partitionName, new TreeMap<String, String>());
+    }
+    mapFields.get(partitionName).put(property.name(), value);
+  }
+
+  @Override
+  public boolean isValid() {
+    if (getPartitionStateMap() == null) {
+      LOG.error("Customized state does not contain state map. id:" + getResourceName());
+      return false;
+    }
+    return true;
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/model/CustomizedState.java
+++ b/helix-core/src/main/java/org/apache/helix/model/CustomizedState.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CustomizedState extends HelixProperty {
   private static Logger LOG = LoggerFactory.getLogger(CustomizedState.class);
+  private static long NON_EXIST = -1L;
 
   /**
    * Lookup keys for the customized state
@@ -70,16 +71,16 @@ public class CustomizedState extends HelixProperty {
   }
 
   /**
-   * Get the partitions on this instance and the state that each partition is currently in.
-   * @return (partition, state) pairs
+   * Get the partitions on this instance and the specified property that each partition is currently having.
+   * @return (partition, property) pairs
    */
-  public Map<String, String> getPartitionStateMap() {
+  public Map<String, String> getPartitionStateMap(CustomizedStateProperty property) {
     Map<String, String> map = new HashMap<String, String>();
     Map<String, Map<String, String>> mapFields = _record.getMapFields();
     for (String partitionName : mapFields.keySet()) {
       Map<String, String> tempMap = mapFields.get(partitionName);
       if (tempMap != null) {
-        map.put(partitionName, tempMap.get(CustomizedStateProperty.CURRENT_STATE.name()));
+        map.put(partitionName, tempMap.get(property.name()));
       }
     }
     return map;
@@ -95,13 +96,11 @@ public class CustomizedState extends HelixProperty {
   }
 
   public long getStartTime(String partitionName) {
-    String startTime = getProperty(partitionName, CustomizedStateProperty.START_TIME);
-    return startTime == null ? -1L : Long.parseLong(startTime);
+    return _record.getLongField(CustomizedStateProperty.START_TIME.name(), NON_EXIST);
   }
 
   public long getEndTime(String partitionName) {
-    String endTime = getProperty(partitionName, CustomizedStateProperty.END_TIME);
-    return endTime == null ? -1L : Long.parseLong(endTime);
+    return _record.getLongField(CustomizedStateProperty.END_TIME.name(), NON_EXIST);
   }
 
   public String getPreviousState(String partitionName) {
@@ -147,7 +146,7 @@ public class CustomizedState extends HelixProperty {
 
   @Override
   public boolean isValid() {
-    if (getPartitionStateMap() == null) {
+    if (getPartitionStateMap(CustomizedStateProperty.CURRENT_STATE) == null) {
       LOG.error("Customized state does not contain state map. id:" + getResourceName());
       return false;
     }

--- a/helix-core/src/main/java/org/apache/helix/model/CustomizedState.java
+++ b/helix-core/src/main/java/org/apache/helix/model/CustomizedState.java
@@ -138,9 +138,7 @@ public class CustomizedState extends HelixProperty {
 
   private void setProperty(String partitionName, CustomizedStateProperty property, String value) {
     Map<String, Map<String, String>> mapFields = _record.getMapFields();
-    if (mapFields.get(partitionName) == null) {
-      mapFields.put(partitionName, new TreeMap<String, String>());
-    }
+    mapFields.putIfAbsent(partitionName, new TreeMap<String, String>());
     mapFields.get(partitionName).put(property.name(), value);
   }
 

--- a/helix-core/src/test/java/org/apache/helix/TestPropertyPathBuilder.java
+++ b/helix-core/src/test/java/org/apache/helix/TestPropertyPathBuilder.java
@@ -40,6 +40,11 @@ public class TestPropertyPathBuilder {
     actual = PropertyPathBuilder.instanceCurrentState("test_cluster", "instanceName1", "sessionId");
     AssertJUnit.assertEquals(actual, "/test_cluster/INSTANCES/instanceName1/CURRENTSTATES/sessionId");
 
+    actual = PropertyPathBuilder.instanceCustomizedState("test_cluster", "instanceName1");
+    AssertJUnit.assertEquals(actual, "/test_cluster/INSTANCES/instanceName1/CUSTOMIZEDSTATES");
+    actual = PropertyPathBuilder.instanceCustomizedState("test_cluster", "instanceName1", "customizedState1");
+    AssertJUnit.assertEquals(actual, "/test_cluster/INSTANCES/instanceName1/CUSTOMIZEDSTATES/customizedState1");
+
     actual = PropertyPathBuilder.controller("test_cluster");
     AssertJUnit.assertEquals(actual, "/test_cluster/CONTROLLER");
     actual = PropertyPathBuilder.controllerMessage("test_cluster");

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestCustomizedStateUpdate.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestCustomizedStateUpdate.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-
 public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
   private static Logger LOG = LoggerFactory.getLogger(TestCustomizedStateUpdate.class);
   private final String CUSTOMIZE_STATE_NAME = "testState1";
@@ -121,6 +120,15 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     Assert.assertEquals(partitionMap2.keySet().size(), 2);
     Assert.assertEquals(partitionMap2.get("PREVIOUS_STATE"), "STARTED");
     Assert.assertEquals(partitionMap2.get("CURRENT_STATE"), "END_OF_PUSH_RECEIVED");
+
+    // test delete
+    mockProvider.deletePerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME1);
+    customizedState = mockProvider.getCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME);
+    Assert.assertNotNull(customizedState);
+    Assert.assertEquals(customizedState.getId(), RESOURCE_NAME);
+    mapView = customizedState.getRecord().getMapFields();
+    Assert.assertEquals(mapView.keySet().size(), 1);
+    Assert.assertEquals(mapView.keySet().iterator().next(), PARTITION_NAME2);
 
     manager.disconnect();
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestCustomizedStateUpdate.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestCustomizedStateUpdate.java
@@ -20,23 +20,20 @@ package org.apache.helix.integration.paticipant;
  */
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.customizedstate.CustomizedStateProvider;
+import org.apache.helix.customizedstate.CustomizedStateProviderFactory;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
 import org.apache.helix.model.CustomizedState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import static java.lang.Thread.*;
 
 
 public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
@@ -48,32 +45,29 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
 
   @Test
   public void testUpdateCustomizedState() throws Exception {
-    HelixManager manager =
-        HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "admin", InstanceType.ADMINISTRATOR, ZK_ADDR);
+    HelixManager manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "admin",
+        InstanceType.ADMINISTRATOR, ZK_ADDR);
     manager.connect();
     _participants[0].connect();
 
     HelixDataAccessor dataAccessor = manager.getHelixDataAccessor();
-    PropertyKey propertyKey =
-        dataAccessor.keyBuilder().customizedStates(_participants[0].getInstanceName(), CUSTOMIZE_STATE_NAME);
+    PropertyKey propertyKey = dataAccessor.keyBuilder()
+        .customizedStates(_participants[0].getInstanceName(), CUSTOMIZE_STATE_NAME);
     CustomizedState customizedStates = manager.getHelixDataAccessor().getProperty(propertyKey);
     Assert.assertNull(customizedStates);
 
-    CustomizedStateProvider mockProvider = new CustomizedStateProvider(manager, _participants[0].getInstanceName());
+    CustomizedStateProvider mockProvider = CustomizedStateProviderFactory.getInstance()
+        .buildCustomizedStateProvider(manager, _participants[0].getInstanceName());
 
-    // test single update
-    Map<String, String> stateMap = new HashMap<>();
-    stateMap.put("PREVIOUS_STATE", "STARTED");
-    stateMap.put("CURRENT_STATE", "END_OF_PUSH_RECEIVED");
-    Map<String, Map<String, String>> partitionMap = new HashMap<>();
-    partitionMap.put(PARTITION_NAME1, stateMap);
-    Map<String, Map<String, Map<String, String>>> resourceMap = new HashMap<>();
-    resourceMap.put(RESOURCE_NAME, partitionMap);
-    mockProvider.updateCustomizedState(CUSTOMIZE_STATE_NAME, resourceMap);
+    // test adding customized state for a partition
+    Map<String, String> customizedStateMap = new HashMap<>();
+    customizedStateMap.put("PREVIOUS_STATE", "STARTED");
+    customizedStateMap.put("CURRENT_STATE", "END_OF_PUSH_RECEIVED");
+    mockProvider.updateCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME1,
+        customizedStateMap);
 
-    PropertyKey newPropertyKey = dataAccessor.keyBuilder()
-        .customizedState(_participants[0].getInstanceName(), CUSTOMIZE_STATE_NAME, RESOURCE_NAME);
-    CustomizedState customizedState = manager.getHelixDataAccessor().getProperty(newPropertyKey);
+    CustomizedState customizedState =
+        mockProvider.getCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME);
     Assert.assertNotNull(customizedState);
     Assert.assertEquals(customizedState.getId(), RESOURCE_NAME);
     Map<String, Map<String, String>> mapView = customizedState.getRecord().getMapFields();
@@ -83,33 +77,50 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     Assert.assertEquals(mapView.get(PARTITION_NAME1).get("PREVIOUS_STATE"), "STARTED");
     Assert.assertEquals(mapView.get(PARTITION_NAME1).get("CURRENT_STATE"), "END_OF_PUSH_RECEIVED");
 
-    //test batch update
+    // test update customized state for previous partition
     Map<String, String> stateMap1 = new HashMap<>();
     stateMap1.put("PREVIOUS_STATE", "END_OF_PUSH_RECEIVED");
     stateMap1.put("CURRENT_STATE", "COMPLETED");
-    Map<String, Map<String, String>> partitionMap1 = new HashMap<>();
-    partitionMap1.put(PARTITION_NAME1, stateMap1);
+    mockProvider.updateCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME1,
+        stateMap1);
 
-    Map<String, String> stateMap2 = new HashMap<>();
-    stateMap2.put("PREVIOUS_STATE", "STARTED");
-    stateMap2.put("CURRENT_STATE", "END_OF_PUSH_RECEIVED");
-    partitionMap1.put(PARTITION_NAME2, stateMap2);
-
-    Map<String, Map<String, Map<String, String>>> resourceMap1 = new HashMap<>();
-    resourceMap1.put(RESOURCE_NAME, partitionMap1);
-    mockProvider.updateCustomizedState(CUSTOMIZE_STATE_NAME, resourceMap1);
-
-
-    customizedState = manager.getHelixDataAccessor().getProperty(newPropertyKey);
+    customizedState = mockProvider.getCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME);
+    Assert.assertNotNull(customizedState);
+    Assert.assertEquals(customizedState.getId(), RESOURCE_NAME);
     mapView = customizedState.getRecord().getMapFields();
-    Assert.assertEquals(mapView.keySet().size(), 2);
-    Set<String> keys = new HashSet<>();
-    keys.add(PARTITION_NAME1);
-    keys.add(PARTITION_NAME2);
-    Assert.assertEquals(mapView.keySet(), keys);
+    Assert.assertEquals(mapView.keySet().size(), 1);
+    Assert.assertEquals(mapView.keySet().iterator().next(), PARTITION_NAME1);
     Assert.assertEquals(mapView.get(PARTITION_NAME1).keySet().size(), 2);
     Assert.assertEquals(mapView.get(PARTITION_NAME1).get("PREVIOUS_STATE"), "END_OF_PUSH_RECEIVED");
     Assert.assertEquals(mapView.get(PARTITION_NAME1).get("CURRENT_STATE"), "COMPLETED");
+
+    // test adding adding customized state for a new partition in the same resource
+    Map<String, String> stateMap2 = new HashMap<>();
+    stateMap2.put("PREVIOUS_STATE", "STARTED");
+    stateMap2.put("CURRENT_STATE", "END_OF_PUSH_RECEIVED");
+    mockProvider.updateCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME2,
+        stateMap2);
+
+    customizedState = mockProvider.getCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME);
+    Assert.assertNotNull(customizedState);
+    Assert.assertEquals(customizedState.getId(), RESOURCE_NAME);
+    mapView = customizedState.getRecord().getMapFields();
+    Assert.assertEquals(mapView.keySet().size(), 2);
+    Assert.assertEqualsNoOrder(mapView.keySet().toArray(), new String[] {
+        PARTITION_NAME1, PARTITION_NAME2
+    });
+
+    Map<String, String> partitionMap1 = mockProvider
+        .getPerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME1);
+    Assert.assertEquals(partitionMap1.keySet().size(), 2);
+    Assert.assertEquals(partitionMap1.get("PREVIOUS_STATE"), "END_OF_PUSH_RECEIVED");
+    Assert.assertEquals(partitionMap1.get("CURRENT_STATE"), "COMPLETED");
+
+    Map<String, String> partitionMap2 = mockProvider
+        .getPerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME2);
+    Assert.assertEquals(partitionMap2.keySet().size(), 2);
+    Assert.assertEquals(partitionMap2.get("PREVIOUS_STATE"), "STARTED");
+    Assert.assertEquals(partitionMap2.get("CURRENT_STATE"), "END_OF_PUSH_RECEIVED");
 
     manager.disconnect();
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestCustomizedStateUpdate.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestCustomizedStateUpdate.java
@@ -76,8 +76,24 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     Assert.assertEquals(mapView.get(PARTITION_NAME1).get("PREVIOUS_STATE"), "STARTED");
     Assert.assertEquals(mapView.get(PARTITION_NAME1).get("CURRENT_STATE"), "END_OF_PUSH_RECEIVED");
 
-    // test update customized state for previous partition
+    // test partial update customized state for previous partition
     Map<String, String> stateMap1 = new HashMap<>();
+    stateMap1.put("PREVIOUS_STATE", "END_OF_PUSH_RECEIVED");
+    mockProvider.updateCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME1,
+        stateMap1);
+
+    customizedState = mockProvider.getCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME);
+    Assert.assertNotNull(customizedState);
+    Assert.assertEquals(customizedState.getId(), RESOURCE_NAME);
+    mapView = customizedState.getRecord().getMapFields();
+    Assert.assertEquals(mapView.keySet().size(), 1);
+    Assert.assertEquals(mapView.keySet().iterator().next(), PARTITION_NAME1);
+    Assert.assertEquals(mapView.get(PARTITION_NAME1).keySet().size(), 2);
+    Assert.assertEquals(mapView.get(PARTITION_NAME1).get("PREVIOUS_STATE"), "END_OF_PUSH_RECEIVED");
+    Assert.assertEquals(mapView.get(PARTITION_NAME1).get("CURRENT_STATE"), "END_OF_PUSH_RECEIVED");
+
+    // test full update customized state for previous partition
+    stateMap1 = new HashMap<>();
     stateMap1.put("PREVIOUS_STATE", "END_OF_PUSH_RECEIVED");
     stateMap1.put("CURRENT_STATE", "COMPLETED");
     mockProvider.updateCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME1,
@@ -121,8 +137,9 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     Assert.assertEquals(partitionMap2.get("PREVIOUS_STATE"), "STARTED");
     Assert.assertEquals(partitionMap2.get("CURRENT_STATE"), "END_OF_PUSH_RECEIVED");
 
-    // test delete
-    mockProvider.deletePerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME1);
+    // test delete customized state for a partition
+    mockProvider.deletePerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME,
+        PARTITION_NAME1);
     customizedState = mockProvider.getCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME);
     Assert.assertNotNull(customizedState);
     Assert.assertEquals(customizedState.getId(), RESOURCE_NAME);

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestCustomizedStateUpdate.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestCustomizedStateUpdate.java
@@ -1,0 +1,116 @@
+package org.apache.helix.integration.paticipant;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.customizedstate.CustomizedStateProvider;
+import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
+import org.apache.helix.model.CustomizedState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static java.lang.Thread.*;
+
+
+public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
+  private static Logger LOG = LoggerFactory.getLogger(TestCustomizedStateUpdate.class);
+  private final String CUSTOMIZE_STATE_NAME = "testState1";
+  private final String PARTITION_NAME1 = "testPartition1";
+  private final String PARTITION_NAME2 = "testPartition2";
+  private final String RESOURCE_NAME = "testResource1";
+
+  @Test
+  public void testUpdateCustomizedState() throws Exception {
+    HelixManager manager =
+        HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "admin", InstanceType.ADMINISTRATOR, ZK_ADDR);
+    manager.connect();
+    _participants[0].connect();
+
+    HelixDataAccessor dataAccessor = manager.getHelixDataAccessor();
+    PropertyKey propertyKey =
+        dataAccessor.keyBuilder().customizedStates(_participants[0].getInstanceName(), CUSTOMIZE_STATE_NAME);
+    CustomizedState customizedStates = manager.getHelixDataAccessor().getProperty(propertyKey);
+    Assert.assertNull(customizedStates);
+
+    CustomizedStateProvider mockProvider = new CustomizedStateProvider(manager, _participants[0].getInstanceName());
+
+    // test single update
+    Map<String, String> stateMap = new HashMap<>();
+    stateMap.put("PREVIOUS_STATE", "STARTED");
+    stateMap.put("CURRENT_STATE", "END_OF_PUSH_RECEIVED");
+    Map<String, Map<String, String>> partitionMap = new HashMap<>();
+    partitionMap.put(PARTITION_NAME1, stateMap);
+    Map<String, Map<String, Map<String, String>>> resourceMap = new HashMap<>();
+    resourceMap.put(RESOURCE_NAME, partitionMap);
+    mockProvider.updateCustomizedState(CUSTOMIZE_STATE_NAME, resourceMap);
+
+    PropertyKey newPropertyKey = dataAccessor.keyBuilder()
+        .customizedState(_participants[0].getInstanceName(), CUSTOMIZE_STATE_NAME, RESOURCE_NAME);
+    CustomizedState customizedState = manager.getHelixDataAccessor().getProperty(newPropertyKey);
+    Assert.assertNotNull(customizedState);
+    Assert.assertEquals(customizedState.getId(), RESOURCE_NAME);
+    Map<String, Map<String, String>> mapView = customizedState.getRecord().getMapFields();
+    Assert.assertEquals(mapView.keySet().size(), 1);
+    Assert.assertEquals(mapView.keySet().iterator().next(), PARTITION_NAME1);
+    Assert.assertEquals(mapView.get(PARTITION_NAME1).keySet().size(), 2);
+    Assert.assertEquals(mapView.get(PARTITION_NAME1).get("PREVIOUS_STATE"), "STARTED");
+    Assert.assertEquals(mapView.get(PARTITION_NAME1).get("CURRENT_STATE"), "END_OF_PUSH_RECEIVED");
+
+    //test batch update
+    Map<String, String> stateMap1 = new HashMap<>();
+    stateMap1.put("PREVIOUS_STATE", "END_OF_PUSH_RECEIVED");
+    stateMap1.put("CURRENT_STATE", "COMPLETED");
+    Map<String, Map<String, String>> partitionMap1 = new HashMap<>();
+    partitionMap1.put(PARTITION_NAME1, stateMap1);
+
+    Map<String, String> stateMap2 = new HashMap<>();
+    stateMap2.put("PREVIOUS_STATE", "STARTED");
+    stateMap2.put("CURRENT_STATE", "END_OF_PUSH_RECEIVED");
+    partitionMap1.put(PARTITION_NAME2, stateMap2);
+
+    Map<String, Map<String, Map<String, String>>> resourceMap1 = new HashMap<>();
+    resourceMap1.put(RESOURCE_NAME, partitionMap1);
+    mockProvider.updateCustomizedState(CUSTOMIZE_STATE_NAME, resourceMap1);
+
+
+    customizedState = manager.getHelixDataAccessor().getProperty(newPropertyKey);
+    mapView = customizedState.getRecord().getMapFields();
+    Assert.assertEquals(mapView.keySet().size(), 2);
+    Set<String> keys = new HashSet<>();
+    keys.add(PARTITION_NAME1);
+    keys.add(PARTITION_NAME2);
+    Assert.assertEquals(mapView.keySet(), keys);
+    Assert.assertEquals(mapView.get(PARTITION_NAME1).keySet().size(), 2);
+    Assert.assertEquals(mapView.get(PARTITION_NAME1).get("PREVIOUS_STATE"), "END_OF_PUSH_RECEIVED");
+    Assert.assertEquals(mapView.get(PARTITION_NAME1).get("CURRENT_STATE"), "COMPLETED");
+
+    manager.disconnect();
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -215,6 +215,9 @@ public class MockHelixAdmin implements HelixAdmin {
         .set(PropertyPathBuilder.instanceCurrentState(clusterName, nodeId), new ZNRecord(nodeId),
             0);
     _baseDataAccessor
+        .set(PropertyPathBuilder.instanceCustomizedState(clusterName, nodeId), new ZNRecord(nodeId),
+            0);
+    _baseDataAccessor
         .set(PropertyPathBuilder.instanceError(clusterName, nodeId), new ZNRecord(nodeId), 0);
     _baseDataAccessor
         .set(PropertyPathBuilder.instanceStatusUpdate(clusterName, nodeId), new ZNRecord(nodeId),


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

(#728 )

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Currently, Helix only supports a single state for every partition. There're increasing requests from customers to have more than one state, which is defined in Helix state model, for their practical use. For example, they may want to have read/write state, quota state, version state, etc. Helix will introduce the concept of customized state, which allows customer to define the states they are interested. 
This PR is to implement Helix API for customers to import their customized state. The customized state is adjacent to CURRENT_STATE as a separate znode. Under this znode, there are children znodes representing each individual customized state. And each customized state is categorized by resources.

### Tests

- [X] The following tests are written for this issue:

TestCustomizedStateUpdate.java

- [X] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Tests run: 902, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3,610.949 s <<< FAILURE! - in TestSuite
[ERROR] testWorkflowFailureJobThreshold(org.apache.helix.integration.task.TestJobFailureDependence)  Time elapsed: 300.01 s  <<< FAILURE!
org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testWorkflowFailureJobThreshold() didn't finish within the time-out 300000

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestJobFailureDependence.testWorkflowFailureJobThreshold » ThreadTimeout Metho...
[INFO] 
[ERROR] Tests run: 902, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:00 h
[INFO] Finished at: 2020-02-06T09:58:26-08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/mnzhang/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X] My diff has been formatted using helix-style.xml