### PR TITLE
Add TrieRoutingData constructor

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreRoutingData.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreRoutingData.java
@@ -22,7 +22,6 @@ package org.apache.helix.rest.metadatastore;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-
 public interface MetadataStoreRoutingData {
   /**
    * Given a path, return all the "metadata store sharding key-metadata store realm address" pairs
@@ -33,15 +32,17 @@ public interface MetadataStoreRoutingData {
    * @param path - the path where the search is conducted
    * @return all "sharding key-realm address" pairs where the sharding keys contain the given
    *         path if the path is valid; empty mapping otherwise
+   * @throws IllegalArgumentException - when the path is invalid
    */
-  Map<String, String> getAllMappingUnderPath(String path);
+  Map<String, String> getAllMappingUnderPath(String path) throws IllegalArgumentException;
 
   /**
    * Given a path, return the realm address corresponding to the sharding key contained in the
    * path. If the path doesn't contain a sharding key, throw NoSuchElementException.
    * @param path - the path where the search is conducted
    * @return the realm address corresponding to the sharding key contained in the path
+   * @throws IllegalArgumentException - when the path is invalid
    * @throws NoSuchElementException - when the path doesn't contain a sharding key
    */
-  String getMetadataStoreRealm(String path) throws NoSuchElementException;
+  String getMetadataStoreRealm(String path) throws IllegalArgumentException, NoSuchElementException;
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
@@ -71,8 +71,8 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
     nodeStack.push(curNode);
     while (!nodeStack.isEmpty()) {
       curNode = nodeStack.pop();
-      if (curNode.isLeaf()) {
-        resultMap.put(curNode.getName(), curNode.getRealmAddress());
+      if (curNode.isShardingKey()) {
+        resultMap.put(curNode.getPath(), curNode.getRealmAddress());
       } else {
         for (TrieNode child : curNode.getChildren().values()) {
           nodeStack.push(child);
@@ -108,14 +108,14 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
   private TrieNode findTrieNode(String path, boolean findLeafAlongPath)
       throws NoSuchElementException {
     if (path.equals(DELIMITER)) {
-      if (findLeafAlongPath && !_rootNode.isLeaf()) {
+      if (findLeafAlongPath && !_rootNode.isShardingKey()) {
         throw new NoSuchElementException("No leaf node found along the path. Path: " + path);
       }
       return _rootNode;
     }
 
     TrieNode curNode = _rootNode;
-    if (findLeafAlongPath && curNode.isLeaf()) {
+    if (findLeafAlongPath && curNode.isShardingKey()) {
       return curNode;
     }
     Map<String, TrieNode> curChildren = curNode.getChildren();
@@ -125,7 +125,7 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
         throw new NoSuchElementException(
             "The provided path is missing from the trie. Path: " + path);
       }
-      if (findLeafAlongPath && curNode.isLeaf()) {
+      if (findLeafAlongPath && curNode.isShardingKey()) {
         return curNode;
       }
       curChildren = curNode.getChildren();
@@ -198,7 +198,7 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
         while (nextDelimiterIndex > 0) {
           // If the node is already a leaf node, the current sharding key is invalid; if the node
           // doesn't exist, construct a node and continue
-          if (nextNode != null && nextNode.isLeaf()) {
+          if (nextNode != null && nextNode.isShardingKey()) {
             throw new InvalidRoutingDataException(shardingKey + " cannot be a sharding key because "
                 + shardingKey.substring(0, nextDelimiterIndex)
                 + " is its parent key and is also a sharding key.");
@@ -234,27 +234,26 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
      */
     private Map<String, TrieNode> _children;
     /**
-     * This field means if the node is a terminal node in the tree sense, not the trie sense. Any
-     * node that has children cannot possibly be a leaf node because only the node without children
-     * can store information. If a node is leaf, then it shouldn't have any children.
+     * This field states whether the path represented by the node is a sharding key
      */
-    private final boolean _isLeaf;
+    private final boolean _isShardingKey;
     /**
-     * This field aligns the traditional trie design: it entails the complete path/prefix leading to
-     * the current node. For example, the name of root node is "/", then the name of its child node
+     * This field contains the complete path/prefix leading to the current node. For example, the
+     * name of root node is "/", then the name of its child node
      * is "/a", and the name of the child's child node is "/a/b".
      */
-    private final String _name;
+    private final String _path;
     /**
      * This field represents the data contained in a node(which represents a path), and is only
      * available to the terminal nodes.
      */
     private final String _realmAddress;
 
-    TrieNode(Map<String, TrieNode> children, String name, boolean isLeaf, String realmAddress) {
+    TrieNode(Map<String, TrieNode> children, String path, boolean isShardingKey,
+        String realmAddress) {
       _children = children;
-      _isLeaf = isLeaf;
-      _name = name;
+      _isShardingKey = isShardingKey;
+      _path = path;
       _realmAddress = realmAddress;
     }
 
@@ -262,12 +261,12 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
       return _children;
     }
 
-    public boolean isLeaf() {
-      return _isLeaf;
+    public boolean isShardingKey() {
+      return _isShardingKey;
     }
 
-    public String getName() {
-      return _name;
+    public String getPath() {
+      return _path;
     }
 
     public String getRealmAddress() {

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
@@ -55,8 +55,8 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
 
   public Map<String, String> getAllMappingUnderPath(String path) throws IllegalArgumentException {
     if (path.isEmpty() || !path.substring(0, 1).equals(DELIMITER)) {
-      throw new IllegalArgumentException(
-          "Provided path is empty or does not have a leading \"" + DELIMITER + "\" character: " + path);
+      throw new IllegalArgumentException("Provided path is empty or does not have a leading \""
+          + DELIMITER + "\" character: " + path);
     }
 
     TrieNode curNode;
@@ -85,8 +85,8 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
   public String getMetadataStoreRealm(String path)
       throws IllegalArgumentException, NoSuchElementException {
     if (path.isEmpty() || !path.substring(0, 1).equals(DELIMITER)) {
-      throw new IllegalArgumentException(
-          "Provided path is empty or does not have a leading \"" + DELIMITER + "\" character: " + path);
+      throw new IllegalArgumentException("Provided path is empty or does not have a leading \""
+          + DELIMITER + "\" character: " + path);
     }
 
     TrieNode leafNode = findTrieNode(path, true);
@@ -174,8 +174,8 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
       for (String shardingKey : entry.getValue()) {
         // Missing leading delimiter is invalid
         if (shardingKey.isEmpty() || !shardingKey.substring(0, 1).equals(DELIMITER)) {
-          throw new InvalidRoutingDataException(
-              "Sharding key does not have a leading \"" + DELIMITER + "\" character: " + shardingKey);
+          throw new InvalidRoutingDataException("Sharding key does not have a leading \""
+              + DELIMITER + "\" character: " + shardingKey);
         }
 
         // Root can only be a sharding key if it's the only sharding key. Since this method is
@@ -199,8 +199,9 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
           // If the node is already a leaf node, the current sharding key is invalid; if the node
           // doesn't exist, construct a node and continue
           if (nextNode != null && nextNode.isLeaf()) {
-            throw new InvalidRoutingDataException(shardingKey.substring(0, nextDelimiterIndex)
-                + " is already a sharding key. " + shardingKey + " cannot be a sharding key.");
+            throw new InvalidRoutingDataException(shardingKey + " cannot be a sharding key because "
+                + shardingKey.substring(0, nextDelimiterIndex)
+                + " is its parent key and is also a sharding key.");
           } else if (nextNode == null) {
             nextNode = new TrieNode(new HashMap<>(), shardingKey.substring(0, nextDelimiterIndex),
                 false, "");
@@ -218,7 +219,7 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
         // sharding key invalid
         if (nextNode != null) {
           throw new InvalidRoutingDataException(shardingKey
-              + " is a part of another sharding key, therefore it cannot be a sharding key.");
+              + " cannot be a sharding key because it is a parent key to another sharding key.");
         }
         nextNode = new TrieNode(new HashMap<>(), shardingKey, true, entry.getKey());
         curNode.addChild(keySection, nextNode);

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
@@ -41,7 +41,7 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
 
   public TrieRoutingData(Map<String, List<String>> routingData) throws InvalidRoutingDataException {
     if (routingData == null || routingData.isEmpty()) {
-      throw new InvalidRoutingDataException("Missing routing data");
+      throw new InvalidRoutingDataException("routingData cannot be null or empty");
     }
 
     if (isRootShardingKey(routingData)) {
@@ -56,7 +56,7 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
   public Map<String, String> getAllMappingUnderPath(String path) throws IllegalArgumentException {
     if (path.isEmpty() || !path.substring(0, 1).equals(DELIMITER)) {
       throw new IllegalArgumentException(
-          "Provided path is empty or does not have a leading delimiter: " + path);
+          "Provided path is empty or does not have a leading \"" + DELIMITER + "\" character: " + path);
     }
 
     TrieNode curNode;
@@ -86,7 +86,7 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
       throws IllegalArgumentException, NoSuchElementException {
     if (path.isEmpty() || !path.substring(0, 1).equals(DELIMITER)) {
       throw new IllegalArgumentException(
-          "Provided path is empty or does not have a leading delimiter: " + path);
+          "Provided path is empty or does not have a leading \"" + DELIMITER + "\" character: " + path);
     }
 
     TrieNode leafNode = findTrieNode(path, true);
@@ -175,7 +175,7 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
         // Missing leading delimiter is invalid
         if (shardingKey.isEmpty() || !shardingKey.substring(0, 1).equals(DELIMITER)) {
           throw new InvalidRoutingDataException(
-              "Sharding key does not have a leading delimiter: " + shardingKey);
+              "Sharding key does not have a leading \"" + DELIMITER + "\" character: " + shardingKey);
         }
 
         // Root can only be a sharding key if it's the only sharding key. Since this method is

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
@@ -145,7 +145,7 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
    * @return whether the edge case is true
    */
   private boolean isRootShardingKey(Map<String, List<String>> routingData) {
-    if (routingData.values().size() == 1) {
+    if (routingData.size() == 1) {
       for (List<String> shardingKeys : routingData.values()) {
         return shardingKeys.size() == 1 && shardingKeys.get(0).equals(DELIMITER);
       }

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -179,10 +179,10 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
     }
 
     if (_routingDataMap != null) {
-      MetadataStoreRoutingData newRoutingData =
-          new TrieRoutingData(new TrieRoutingData.TrieNode(null, null, false, null));
+//      MetadataStoreRoutingData newRoutingData =
+//          new TrieRoutingData(new TrieRoutingData.TrieNode(null, null, false, null));
       // TODO call constructRoutingData() here.
-      _routingDataMap.put(namespace, newRoutingData);
+//      _routingDataMap.put(namespace, newRoutingData);
     }
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -42,9 +42,9 @@ import org.apache.zookeeper.Watcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
- * ZK-based MetadataStoreDirectory that listens on the routing data in routing ZKs with a update callback.
+ * ZK-based MetadataStoreDirectory that listens on the routing data in routing ZKs with a update
+ * callback.
  */
 public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, RoutingDataListener {
   private static final Logger LOG = LoggerFactory.getLogger(ZkMetadataStoreDirectory.class);
@@ -170,20 +170,21 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
     // Check if namespace exists; otherwise, return as a NOP and log it
     if (!_routingZkAddressMap.containsKey(namespace)) {
       LOG.error("Failed to refresh internally-cached routing data! Namespace not found: " + namespace);
+      return;
     }
 
     try {
-      _realmToShardingKeysMap.put(namespace, _routingDataReaderMap.get(namespace).getRoutingData());
+      Map<String, List<String>> routingData = _routingDataReaderMap.get(namespace).getRoutingData();
+      _realmToShardingKeysMap.put(namespace, routingData);
+
+      if (_routingDataMap != null) {
+        MetadataStoreRoutingData newRoutingData = new TrieRoutingData(routingData);
+        _routingDataMap.put(namespace, newRoutingData);
+      }
     } catch (InvalidRoutingDataException e) {
-      LOG.error("Failed to get routing data for namespace: " + namespace + "!");
+      LOG.error("Routing data construction has failed for namespace: " + namespace + "!");
     }
 
-    if (_routingDataMap != null) {
-//      MetadataStoreRoutingData newRoutingData =
-//          new TrieRoutingData(new TrieRoutingData.TrieNode(null, null, false, null));
-      // TODO call constructRoutingData() here.
-//      _routingDataMap.put(namespace, newRoutingData);
-    }
   }
 
   @Override

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -168,7 +168,8 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
     // Safe to ignore the callback if any of the mapping is null.
     // If routingDataMap is null, then it will be populated by the constructor anyway
     // If routingDataMap is not null, then it's safe for the callback function to update it
-    if (_routingZkAddressMap == null || _routingDataMap == null || _realmToShardingKeysMap == null) {
+    if (_routingZkAddressMap == null || _routingDataMap == null
+        || _realmToShardingKeysMap == null) {
       LOG.error("Construction is not completed! ");
       return;
     }
@@ -188,8 +189,7 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
       MetadataStoreRoutingData routingData = new TrieRoutingData(rawRoutingData);
       _routingDataMap.put(namespace, routingData);
     } catch (InvalidRoutingDataException e) {
-      LOG.error("Failed to refresh cached routing data for namespace {}, exception: {}", namespace,
-          e.getMessage());
+      LOG.error("Failed to refresh cached routing data for namespace {}", namespace, e);
     }
 
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -165,9 +165,13 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
    */
   @Override
   public void refreshRoutingData(String namespace) {
-    // Safe to ignore the callback if routingDataMap is null.
+    // Safe to ignore the callback if any of the mapping is null.
     // If routingDataMap is null, then it will be populated by the constructor anyway
     // If routingDataMap is not null, then it's safe for the callback function to update it
+    if (_routingZkAddressMap == null || _routingDataMap == null || _realmToShardingKeysMap == null) {
+      LOG.error("Construction is not completed! ");
+      return;
+    }
 
     // Check if namespace exists; otherwise, return as a NOP and log it
     if (!_routingZkAddressMap.containsKey(namespace)) {
@@ -181,10 +185,8 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
           _routingDataReaderMap.get(namespace).getRoutingData();
       _realmToShardingKeysMap.put(namespace, rawRoutingData);
 
-      if (_routingDataMap != null) {
-        MetadataStoreRoutingData routingData = new TrieRoutingData(rawRoutingData);
-        _routingDataMap.put(namespace, routingData);
-      }
+      MetadataStoreRoutingData routingData = new TrieRoutingData(rawRoutingData);
+      _routingDataMap.put(namespace, routingData);
     } catch (InvalidRoutingDataException e) {
       LOG.error("Failed to refresh cached routing data for namespace {}, exception: {}", namespace,
           e.getMessage());

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -156,9 +156,11 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
 
   /**
    * Callback for updating the cached routing data.
-   * Note: this method should not synchronize on the class or the map. We do not want namespaces blocking each other.
+   * Note: this method should not synchronize on the class or the map. We do not want namespaces
+   * blocking each other.
    * Threadsafe map is used for _realmToShardingKeysMap.
-   * The global consistency of the in-memory routing data is not a requirement (eventual consistency is enough).
+   * The global consistency of the in-memory routing data is not a requirement (eventual consistency
+   * is enough).
    * @param namespace
    */
   @Override
@@ -169,20 +171,23 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
 
     // Check if namespace exists; otherwise, return as a NOP and log it
     if (!_routingZkAddressMap.containsKey(namespace)) {
-      LOG.error("Failed to refresh internally-cached routing data! Namespace not found: " + namespace);
+      LOG.error("Failed to refresh internally-cached routing data! Namespace not found: {}",
+          namespace);
       return;
     }
 
     try {
-      Map<String, List<String>> routingData = _routingDataReaderMap.get(namespace).getRoutingData();
-      _realmToShardingKeysMap.put(namespace, routingData);
+      Map<String, List<String>> rawRoutingData =
+          _routingDataReaderMap.get(namespace).getRoutingData();
+      _realmToShardingKeysMap.put(namespace, rawRoutingData);
 
       if (_routingDataMap != null) {
-        MetadataStoreRoutingData newRoutingData = new TrieRoutingData(routingData);
-        _routingDataMap.put(namespace, newRoutingData);
+        MetadataStoreRoutingData routingData = new TrieRoutingData(rawRoutingData);
+        _routingDataMap.put(namespace, routingData);
       }
     } catch (InvalidRoutingDataException e) {
-      LOG.error("Routing data construction has failed for namespace: " + namespace + "!");
+      LOG.error("Failed to refresh cached routing data for namespace {}, exception: {}", namespace,
+          e.getMessage());
     }
 
   }

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestTrieRoutingData.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestTrieRoutingData.java
@@ -19,146 +19,175 @@ package org.apache.helix.rest.metadatastore;
  * under the License.
  */
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import org.apache.helix.rest.metadatastore.exceptions.InvalidRoutingDataException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class TestTrieRoutingData {
-  // TODO: add constructor related tests after constructor is finished
+  private TrieRoutingData _trie;
 
   @Test
+  public void testConstructionSpecialCase() {
+    Map<String, List<String>> routingData = new HashMap<>();
+    routingData.put("realmAddress", Collections.singletonList(""));
+    TrieRoutingData trie;
+    try {
+      trie = new TrieRoutingData(routingData);
+      Map<String, String> result = trie.getAllMappingUnderPath("/");
+      Assert.assertEquals(result.size(), 1);
+      Assert.assertEquals(result.get("/"), "realmAddress");
+    } catch (InvalidRoutingDataException e) {
+      Assert.fail("Not expecting InvalidRoutingDataException");
+    }
+  }
+
+  @Test
+  public void testConstructionRootAsShardingKeyInvalid() {
+    Map<String, List<String>> routingData = new HashMap<>();
+    routingData.put("realmAddress1", Arrays.asList("/a/b", "/"));
+    try {
+      new TrieRoutingData(routingData);
+      Assert.fail("Expecting InvalidRoutingDataException");
+    } catch (InvalidRoutingDataException e) {
+      Assert.assertTrue(e.getMessage().contains("There exists other sharding keys. Root cannot be a sharding key."));
+    }
+  }
+
+  @Test
+  public void testConstructionShardingKeyContainsAnother() {
+    Map<String, List<String>> routingData = new HashMap<>();
+    routingData.put("realmAddress1", Arrays.asList("/a/b", "/a/b/c"));
+    try {
+      new TrieRoutingData(routingData);
+      Assert.fail("Expecting InvalidRoutingDataException");
+    } catch (InvalidRoutingDataException e) {
+      Assert.assertTrue(e.getMessage().contains("/a/b is already a sharding key. /a/b/c cannot be a sharding key."));
+    }
+  }
+
+  @Test
+  public void testConstructionShardingKeyIsAPartOfAnother() {
+    Map<String, List<String>> routingData = new HashMap<>();
+    routingData.put("realmAddress1", Arrays.asList("/a/b/c", "/a/b"));
+    try {
+      new TrieRoutingData(routingData);
+      Assert.fail("Expecting InvalidRoutingDataException");
+    } catch (InvalidRoutingDataException e) {
+      Assert.assertTrue(e.getMessage().contains("/a/b is a part of another sharding key, therefore it cannot be a sharding key."));
+    }
+  }
+
+  /**
+   * Constructing a trie that will also be reused for other tests
+   * -----<empty>
+   * ------/-|--\
+   * -----b--g--h
+   * ----/-\---/-\
+   * ---c--f--i--j
+   * --/-\
+   * -d--e
+   * Note: "g", "i", "j" lead to "realmAddress1"; "d", "f" lead to "realmAddress2"; "e" leads to "realmAddress3"
+   */
+  @Test
+  public void testConstructionNormal() {
+    Map<String, List<String>> routingData = new HashMap<>();
+    routingData.put("realmAddress1", Arrays.asList("/g", "h/i", "/h/j"));
+    routingData.put("realmAddress2", Arrays.asList("b/c/d", "/b/f"));
+    routingData.put("realmAddress3", Collections.singletonList("/b/c/e"));
+    try {
+      _trie = new TrieRoutingData(routingData);
+    } catch (InvalidRoutingDataException e) {
+      Assert.fail("Not expecting InvalidRoutingDataException");
+    }
+  }
+
+  @Test(dependsOnMethods = "testConstructionNormal")
   public void testGetAllMappingUnderPathFromRoot() {
-    TrieRoutingData trie = constructTestTrie();
-    Map<String, String> result = trie.getAllMappingUnderPath("/");
-    Assert.assertEquals(result.size(), 4);
-    Assert.assertEquals(result.get("/b/c/d"), "realmAddressD");
-    Assert.assertEquals(result.get("/b/c/e"), "realmAddressE");
-    Assert.assertEquals(result.get("/b/f"), "realmAddressF");
-    Assert.assertEquals(result.get("/g"), "realmAddressG");
+    Map<String, String> result = _trie.getAllMappingUnderPath("/");
+    Assert.assertEquals(result.size(), 6);
+    Assert.assertEquals(result.get("/b/c/d"), "realmAddress2");
+    Assert.assertEquals(result.get("/b/c/e"), "realmAddress3");
+    Assert.assertEquals(result.get("/b/f"), "realmAddress2");
+    Assert.assertEquals(result.get("/g"), "realmAddress1");
+    Assert.assertEquals(result.get("/h/i"), "realmAddress1");
+    Assert.assertEquals(result.get("/h/j"), "realmAddress1");
   }
 
-  @Test
+  @Test(dependsOnMethods = "testConstructionNormal")
   public void testGetAllMappingUnderPathFromRootEmptyPath() {
-    TrieRoutingData trie = constructTestTrie();
-    Map<String, String> result = trie.getAllMappingUnderPath("");
-    Assert.assertEquals(result.size(), 4);
-    Assert.assertEquals(result.get("/b/c/d"), "realmAddressD");
-    Assert.assertEquals(result.get("/b/c/e"), "realmAddressE");
-    Assert.assertEquals(result.get("/b/f"), "realmAddressF");
-    Assert.assertEquals(result.get("/g"), "realmAddressG");
+    Map<String, String> result = _trie.getAllMappingUnderPath("");
+    Assert.assertEquals(result.size(), 6);
+    Assert.assertEquals(result.get("/b/c/d"), "realmAddress2");
+    Assert.assertEquals(result.get("/b/c/e"), "realmAddress3");
+    Assert.assertEquals(result.get("/b/f"), "realmAddress2");
+    Assert.assertEquals(result.get("/g"), "realmAddress1");
+    Assert.assertEquals(result.get("/h/i"), "realmAddress1");
+    Assert.assertEquals(result.get("/h/j"), "realmAddress1");
   }
 
-  @Test
+  @Test(dependsOnMethods = "testConstructionNormal")
   public void testGetAllMappingUnderPathFromSecondLevel() {
-    TrieRoutingData trie = constructTestTrie();
-    Map<String, String> result = trie.getAllMappingUnderPath("/b");
+    Map<String, String> result = _trie.getAllMappingUnderPath("/b");
     Assert.assertEquals(result.size(), 3);
-    Assert.assertEquals(result.get("/b/c/d"), "realmAddressD");
-    Assert.assertEquals(result.get("/b/c/e"), "realmAddressE");
-    Assert.assertEquals(result.get("/b/f"), "realmAddressF");
+    Assert.assertEquals(result.get("/b/c/d"), "realmAddress2");
+    Assert.assertEquals(result.get("/b/c/e"), "realmAddress3");
+    Assert.assertEquals(result.get("/b/f"), "realmAddress2");
   }
 
-  @Test
+  @Test(dependsOnMethods = "testConstructionNormal")
   public void testGetAllMappingUnderPathFromLeaf() {
-    TrieRoutingData trie = constructTestTrie();
-    Map<String, String> result = trie.getAllMappingUnderPath("/b/c/d");
+    Map<String, String> result = _trie.getAllMappingUnderPath("/b/c/d");
     Assert.assertEquals(result.size(), 1);
-    Assert.assertEquals(result.get("/b/c/d"), "realmAddressD");
+    Assert.assertEquals(result.get("/b/c/d"), "realmAddress2");
   }
 
-  @Test
+  @Test(dependsOnMethods = "testConstructionNormal")
   public void testGetAllMappingUnderPathWrongPath() {
-    TrieRoutingData trie = constructTestTrie();
-    Map<String, String> result = trie.getAllMappingUnderPath("/b/c/d/g");
+    Map<String, String> result = _trie.getAllMappingUnderPath("/b/c/d/g");
     Assert.assertEquals(result.size(), 0);
   }
 
-  @Test
+  @Test(dependsOnMethods = "testConstructionNormal")
   public void testGetMetadataStoreRealm() {
-    TrieRoutingData trie = constructTestTrie();
     try {
-      Assert.assertEquals(trie.getMetadataStoreRealm("/b/c/d/x/y/z"), "realmAddressD");
+      Assert.assertEquals(_trie.getMetadataStoreRealm("/b/c/d/x/y/z"), "realmAddress2");
     } catch (NoSuchElementException e) {
       Assert.fail("Not expecting NoSuchElementException");
     }
   }
 
-  @Test
+  @Test(dependsOnMethods = "testConstructionNormal")
   public void testGetMetadataStoreRealmNoSlash() {
-    TrieRoutingData trie = constructTestTrie();
     try {
-      Assert.assertEquals(trie.getMetadataStoreRealm("b/c/d/x/y/z"), "realmAddressD");
+      Assert.assertEquals(_trie.getMetadataStoreRealm("b/c/d/x/y/z"), "realmAddress2");
     } catch (NoSuchElementException e) {
       Assert.fail("Not expecting NoSuchElementException");
     }
   }
 
-  @Test
+  @Test(dependsOnMethods = "testConstructionNormal")
   public void testGetMetadataStoreRealmWrongPath() {
-    TrieRoutingData trie = constructTestTrie();
     try {
-      trie.getMetadataStoreRealm("/x/y/z");
+      _trie.getMetadataStoreRealm("/x/y/z");
       Assert.fail("Expecting NoSuchElementException");
     } catch (NoSuchElementException e) {
       Assert.assertTrue(e.getMessage().contains("The provided path is missing from the trie. Path: /x/y/z"));
     }
   }
 
-  @Test
+  @Test(dependsOnMethods = "testConstructionNormal")
   public void testGetMetadataStoreRealmNoLeaf() {
-    TrieRoutingData trie = constructTestTrie();
     try {
-      trie.getMetadataStoreRealm("/b/c");
+      _trie.getMetadataStoreRealm("/b/c");
       Assert.fail("Expecting NoSuchElementException");
     } catch (NoSuchElementException e) {
       Assert.assertTrue(e.getMessage().contains("No leaf node found along the path. Path: /b/c"));
     }
-  }
-
-  /**
-   * Constructing a trie for testing purposes
-   * -----<empty>
-   * ------/--\
-   * -----b---g
-   * ----/-\
-   * ---c--f
-   * --/-\
-   * -d--e
-   */
-  private TrieRoutingData constructTestTrie() {
-    TrieRoutingData.TrieNode nodeD =
-        new TrieRoutingData.TrieNode(Collections.emptyMap(), "/b/c/d", true, "realmAddressD");
-    TrieRoutingData.TrieNode nodeE =
-        new TrieRoutingData.TrieNode(Collections.emptyMap(), "/b/c/e", true, "realmAddressE");
-    TrieRoutingData.TrieNode nodeF =
-        new TrieRoutingData.TrieNode(Collections.emptyMap(), "/b/f", true, "realmAddressF");
-    TrieRoutingData.TrieNode nodeG =
-        new TrieRoutingData.TrieNode(Collections.emptyMap(), "/g", true, "realmAddressG");
-    TrieRoutingData.TrieNode nodeC =
-        new TrieRoutingData.TrieNode(new HashMap<String, TrieRoutingData.TrieNode>() {
-          {
-            put("d", nodeD);
-            put("e", nodeE);
-          }
-        }, "c", false, "");
-    TrieRoutingData.TrieNode nodeB =
-        new TrieRoutingData.TrieNode(new HashMap<String, TrieRoutingData.TrieNode>() {
-          {
-            put("c", nodeC);
-            put("f", nodeF);
-          }
-        }, "b", false, "");
-    TrieRoutingData.TrieNode root =
-        new TrieRoutingData.TrieNode(new HashMap<String, TrieRoutingData.TrieNode>() {
-          {
-            put("b", nodeB);
-            put("g", nodeG);
-          }
-        }, "", false, "");
-
-    return new TrieRoutingData(root);
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestTrieRoutingData.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestTrieRoutingData.java
@@ -38,13 +38,13 @@ public class TestTrieRoutingData {
       new TrieRoutingData(null);
       Assert.fail("Expecting InvalidRoutingDataException");
     } catch (InvalidRoutingDataException e) {
-      Assert.assertTrue(e.getMessage().contains("Missing routing data"));
+      Assert.assertTrue(e.getMessage().contains("routingData cannot be null or empty"));
     }
     try {
       new TrieRoutingData(Collections.emptyMap());
       Assert.fail("Expecting InvalidRoutingDataException");
     } catch (InvalidRoutingDataException e) {
-      Assert.assertTrue(e.getMessage().contains("Missing routing data"));
+      Assert.assertTrue(e.getMessage().contains("routingData cannot be null or empty"));
     }
   }
 
@@ -90,7 +90,7 @@ public class TestTrieRoutingData {
       Assert.fail("Expecting InvalidRoutingDataException");
     } catch (InvalidRoutingDataException e) {
       Assert.assertTrue(
-          e.getMessage().contains("Sharding key does not have a leading delimiter: b/c/d"));
+          e.getMessage().contains("Sharding key does not have a leading \"/\" character: b/c/d"));
     }
   }
 
@@ -164,8 +164,8 @@ public class TestTrieRoutingData {
       _trie.getAllMappingUnderPath("");
       Assert.fail("Expecting IllegalArgumentException");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(
-          e.getMessage().contains("Provided path is empty or does not have a leading delimiter: "));
+      Assert.assertTrue(e.getMessage()
+          .contains("Provided path is empty or does not have a leading \"/\" character: "));
     }
   }
 
@@ -176,7 +176,7 @@ public class TestTrieRoutingData {
       Assert.fail("Expecting IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage()
-          .contains("Provided path is empty or does not have a leading delimiter: test"));
+          .contains("Provided path is empty or does not have a leading \"/\" character: test"));
     }
   }
 
@@ -220,8 +220,8 @@ public class TestTrieRoutingData {
       Assert.assertEquals(_trie.getMetadataStoreRealm(""), "realmAddress2");
       Assert.fail("Expecting IllegalArgumentException");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(
-          e.getMessage().contains("Provided path is empty or does not have a leading delimiter: "));
+      Assert.assertTrue(e.getMessage()
+          .contains("Provided path is empty or does not have a leading \"/\" character: "));
     }
   }
 
@@ -231,8 +231,8 @@ public class TestTrieRoutingData {
       Assert.assertEquals(_trie.getMetadataStoreRealm("b/c/d/x/y/z"), "realmAddress2");
       Assert.fail("Expecting IllegalArgumentException");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
-          .contains("Provided path is empty or does not have a leading delimiter: b/c/d/x/y/z"));
+      Assert.assertTrue(e.getMessage().contains(
+          "Provided path is empty or does not have a leading \"/\" character: b/c/d/x/y/z"));
     }
   }
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestTrieRoutingData.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestTrieRoutingData.java
@@ -115,8 +115,8 @@ public class TestTrieRoutingData {
       new TrieRoutingData(routingData);
       Assert.fail("Expecting InvalidRoutingDataException");
     } catch (InvalidRoutingDataException e) {
-      Assert.assertTrue(e.getMessage()
-          .contains("/a/b is already a sharding key. /a/b/c cannot be a sharding key."));
+      Assert.assertTrue(e.getMessage().contains(
+          "/a/b/c cannot be a sharding key because /a/b is its parent key and is also a sharding key."));
     }
   }
 
@@ -129,7 +129,7 @@ public class TestTrieRoutingData {
       Assert.fail("Expecting InvalidRoutingDataException");
     } catch (InvalidRoutingDataException e) {
       Assert.assertTrue(e.getMessage().contains(
-          "/a/b is a part of another sharding key, therefore it cannot be a sharding key."));
+          "/a/b cannot be a sharding key because it is a parent key to another sharding key."));
     }
   }
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestTrieRoutingData.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestTrieRoutingData.java
@@ -55,7 +55,8 @@ public class TestTrieRoutingData {
       new TrieRoutingData(routingData);
       Assert.fail("Expecting InvalidRoutingDataException");
     } catch (InvalidRoutingDataException e) {
-      Assert.assertTrue(e.getMessage().contains("There exists other sharding keys. Root cannot be a sharding key."));
+      Assert.assertTrue(e.getMessage()
+          .contains("There exists other sharding keys. Root cannot be a sharding key."));
     }
   }
 
@@ -67,7 +68,8 @@ public class TestTrieRoutingData {
       new TrieRoutingData(routingData);
       Assert.fail("Expecting InvalidRoutingDataException");
     } catch (InvalidRoutingDataException e) {
-      Assert.assertTrue(e.getMessage().contains("/a/b is already a sharding key. /a/b/c cannot be a sharding key."));
+      Assert.assertTrue(e.getMessage()
+          .contains("/a/b is already a sharding key. /a/b/c cannot be a sharding key."));
     }
   }
 
@@ -79,7 +81,8 @@ public class TestTrieRoutingData {
       new TrieRoutingData(routingData);
       Assert.fail("Expecting InvalidRoutingDataException");
     } catch (InvalidRoutingDataException e) {
-      Assert.assertTrue(e.getMessage().contains("/a/b is a part of another sharding key, therefore it cannot be a sharding key."));
+      Assert.assertTrue(e.getMessage().contains(
+          "/a/b is a part of another sharding key, therefore it cannot be a sharding key."));
     }
   }
 
@@ -92,7 +95,8 @@ public class TestTrieRoutingData {
    * ---c--f--i--j
    * --/-\
    * -d--e
-   * Note: "g", "i", "j" lead to "realmAddress1"; "d", "f" lead to "realmAddress2"; "e" leads to "realmAddress3"
+   * Note: "g", "i", "j" lead to "realmAddress1"; "d", "f" lead to "realmAddress2"; "e" leads to
+   * "realmAddress3"
    */
   @Test
   public void testConstructionNormal() {
@@ -177,7 +181,8 @@ public class TestTrieRoutingData {
       _trie.getMetadataStoreRealm("/x/y/z");
       Assert.fail("Expecting NoSuchElementException");
     } catch (NoSuchElementException e) {
-      Assert.assertTrue(e.getMessage().contains("The provided path is missing from the trie. Path: /x/y/z"));
+      Assert.assertTrue(
+          e.getMessage().contains("The provided path is missing from the trie. Path: /x/y/z"));
     }
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #730   

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds a constructor to TrieRoutingData. The constructor takes in a mapping of sharding keys to realm addresses and parses it into a trie.

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 117, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.509 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 117, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  46.303 s
[INFO] Finished at: 2020-02-06T11:56:22-08:00
[INFO] -----------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml