### PR TITLE
Fix the unstable test TestWagedRebalance.testRebalancerReset.

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
@@ -33,6 +33,7 @@ import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.strategy.CrushRebalanceStrategy;
+import org.apache.helix.controller.rebalancer.util.RebalanceScheduler;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
@@ -514,8 +515,10 @@ public class TestWagedRebalance extends ZkTestBase {
     ExternalView oldEV =
         _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, moreDB);
 
-    // Expire the controller session so it will reset the internal rebalancer's status.
-    simulateSessionExpiry(_controller.getZkClient());
+    _controller.handleNewSession();
+    // Trigger a rebalance to test if the rebalancer calculate with empty cache states.
+    RebalanceScheduler.invokeRebalance(_controller.getHelixDataAccessor(), moreDB);
+
     // After reset done, the rebalancer will try to rebalance all the partitions since it has
     // forgotten the previous state.
     // TODO remove this sleep after fix https://github.com/apache/helix/issues/526


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#734 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Manually trigger the new session handling so there is no possible race condition in the test case.

### Tests

- [x] The following tests are written for this issue:

NA

- [x] The following is the result of the "mvn test" command on the appropriate module:

Run the test case for 50 times, all passed.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

NA

### Code Quality

- [x] My diff has been formatted using helix-style.xml