### PR TITLE
Fix ConcurrentModification exception in Workflow Garbage Collection

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
@@ -1056,17 +1056,15 @@ public class TaskUtil {
         if (entry != null) {
           WorkflowConfig cfg = dataProvider.getWorkflowConfig(entry);
           WorkflowContext ctx = dataProvider.getWorkflowContext(entry);
-          if (ctx != null && ctx.getId().equals(TaskUtil.WORKFLOW_CONTEXT_KW)) {
-            if (cfg == null) {
-              toBeDeletedWorkflows.add(entry);
-            }
+          if (ctx != null && ctx.getId().equals(TaskUtil.WORKFLOW_CONTEXT_KW) && cfg == null) {
+            toBeDeletedWorkflows.add(entry);
           }
         }
       }
     } catch (Exception e) {
-      LOG.warn(String.format(
-          "Exception occurred while creating a list of all existing contexts with missing config!! Reason: %s"),
-          e.getMessage());
+      LOG.warn(
+          "Exception occurred while creating a list of all existing contexts with missing config!",
+          e);
     }
 
     HelixDataAccessor accessor = manager.getHelixDataAccessor();

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowContextWithoutConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowContextWithoutConfig.java
@@ -170,7 +170,7 @@ public class TestWorkflowContextWithoutConfig extends TaskTestBase {
     Assert.assertTrue(contextDeleted);
   }
 
-  Workflow.Builder createSimpleWorkflowBuilder(String workflowName) {
+  private Workflow.Builder createSimpleWorkflowBuilder(String workflowName) {
     final long expiryTime = 5000L;
     Workflow.Builder builder = new Workflow.Builder(workflowName);
 


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #738 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In workflow Garbage collection, there is possibility that we see ConcurrentMod exception
while looping through the contexts. The reason behind this exception is that the contexts can be modified using other thread (i.e. controller's main thread or other Garbage Collection threads). This commit fixes this issue by first making a copy of the contexts and then leveraging try catch to avoid such exceptions. 

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Tests run: 1083, Failures: 1, Errors: 0, Skipped: 2, Time elapsed: 4,194.441 s <<< FAILURE! - in TestSuite
[ERROR] testSubscribeDataChange(org.apache.helix.manager.zk.TestZKWatch)  Time elapsed: 0.023 s  <<< FAILURE!
java.lang.AssertionError: expected:<0> but was:<1>
	at org.apache.helix.manager.zk.TestZKWatch.testSubscribeDataChange(TestZKWatch.java:81)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestZKWatch.testSubscribeDataChange:81 expected:<0> but was:<1>
[INFO] 
[ERROR] Tests run: 1083, Failures: 1, Errors: 0, Skipped: 2
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:09 h
[INFO] Finished at: 2020-02-10T13:27:31-08:00
[INFO] ------------------------------------------------------------------------


mvn test -Dtest="TestZKWatch" result:
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.918 s - in org.apache.helix.manager.zk.TestZKWatch
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.069 s
[INFO] Finished at: 2020-02-10T13:27:54-08:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality
- [x] My diff has been formatted using helix-style.xml



