### PR TITLE
Add RealmAwareZkClient and RealmAwareZkClientFactory interfaces

### DIFF
--- a/helix-core/TESTRES
+++ b/helix-core/TESTRES
@@ -1,0 +1,107 @@
+[INFO] Scanning for projects...
+[INFO] 
+[INFO] --------------------< org.apache.helix:helix-core >---------------------
+[INFO] Building Apache Helix :: Core 0.9.2-SNAPSHOT
+[INFO] -------------------------------[ bundle ]-------------------------------
+[INFO] 
+[INFO] --- maven-remote-resources-plugin:1.4:process (default) @ helix-core ---
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ helix-core ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] Copying 2 resources
+[INFO] Copying 0 resource
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:2.5.1:compile (default-compile) @ helix-core ---
+[INFO] Compiling 18 source files to /home/hulee/mp/helix2/helix-core/target/classes
+[INFO] 
+[INFO] --- maven-bundle-plugin:3.5.0:manifest (bundle-manifest) @ helix-core ---
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ helix-core ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] Copying 14 resources
+[INFO] Copying 3 resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:2.5.1:testCompile (default-testCompile) @ helix-core ---
+[INFO] Nothing to compile - all classes are up to date
+[INFO] 
+[INFO] --- maven-surefire-plugin:3.0.0-M3:test (default-test) @ helix-core ---
+Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng/3.0.0-M3/surefire-testng-3.0.0-M3.jar
+Progress (1): 2.2/44 kBProgress (1): 5.0/44 kBProgress (1): 7.8/44 kBProgress (1): 11/44 kB Progress (1): 13/44 kBProgress (1): 16/44 kBProgress (1): 19/44 kBProgress (1): 21/44 kBProgress (1): 24/44 kBProgress (1): 27/44 kBProgress (1): 30/44 kBProgress (1): 32/44 kBProgress (1): 36/44 kBProgress (1): 40/44 kBProgress (1): 44 kB                      Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng/3.0.0-M3/surefire-testng-3.0.0-M3.jar (44 kB at 172 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng/3.0.0-M3/surefire-testng-3.0.0-M3.pom
+Progress (1): 2.6 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng/3.0.0-M3/surefire-testng-3.0.0-M3.pom (2.6 kB at 262 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-providers/3.0.0-M3/surefire-providers-3.0.0-M3.pom
+Progress (1): 2.5 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-providers/3.0.0-M3/surefire-providers-3.0.0-M3.pom (2.5 kB at 282 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.0.0-M3/common-java5-3.0.0-M3.pom
+Progress (1): 2.2/3.1 kBProgress (1): 3.1 kB                        Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.0.0-M3/common-java5-3.0.0-M3.pom (3.1 kB at 341 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng-utils/3.0.0-M3/surefire-testng-utils-3.0.0-M3.pom
+Progress (1): 2.2/2.5 kBProgress (1): 2.5 kB                        Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng-utils/3.0.0-M3/surefire-testng-utils-3.0.0-M3.pom (2.5 kB at 307 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-grouper/3.0.0-M3/surefire-grouper-3.0.0-M3.pom
+Progress (1): 2.2/2.6 kBProgress (1): 2.6 kB                        Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-grouper/3.0.0-M3/surefire-grouper-3.0.0-M3.pom (2.6 kB at 330 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.0.0-M3/common-java5-3.0.0-M3.jar
+Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-grouper/3.0.0-M3/surefire-grouper-3.0.0-M3.jar
+Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng-utils/3.0.0-M3/surefire-testng-utils-3.0.0-M3.jar
+Progress (1): 2.2/32 kBProgress (1): 5.0/32 kBProgress (1): 7.7/32 kBProgress (1): 10/32 kB Progress (1): 13/32 kBProgress (1): 16/32 kBProgress (1): 19/32 kBProgress (1): 21/32 kBProgress (1): 24/32 kBProgress (1): 27/32 kBProgress (1): 30/32 kBProgress (1): 32 kB                      Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.0.0-M3/common-java5-3.0.0-M3.jar (32 kB at 2.0 MB/s)
+Progress (1): 2.8/14 kBProgress (1): 5.5/14 kBProgress (2): 5.5/14 kB | 2.8/40 kBProgress (2): 8.3/14 kB | 2.8/40 kBProgress (2): 8.3/14 kB | 5.5/40 kBProgress (2): 11/14 kB | 5.5/40 kB Progress (2): 11/14 kB | 8.3/40 kBProgress (2): 14 kB | 8.3/40 kB   Progress (2): 14 kB | 11/40 kB Progress (2): 14 kB | 14/40 kBProgress (2): 14 kB | 16/40 kBProgress (2): 14 kB | 19/40 kB                              Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng-utils/3.0.0-M3/surefire-testng-utils-3.0.0-M3.jar (14 kB at 569 kB/s)
+Progress (1): 22/40 kBProgress (1): 25/40 kBProgress (1): 27/40 kBProgress (1): 30/40 kBProgress (1): 33/40 kBProgress (1): 36/40 kBProgress (1): 38/40 kBProgress (1): 40 kB                      Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-grouper/3.0.0-M3/surefire-grouper-3.0.0-M3.jar (40 kB at 1.2 MB/s)
+[INFO] 
+[INFO] -------------------------------------------------------
+[INFO]  T E S T S
+[INFO] -------------------------------------------------------
+[INFO] Running TestSuite
+Start zookeeper at localhost:2183 in thread main
+START TestRoutingDataCache at Thu Feb 13 14:49:33 PST 2020
+START testUpdateOnNotification at Thu Feb 13 14:49:35 PST 2020
+END testUpdateOnNotification at Thu Feb 13 14:49:35 PST 2020, took: 34ms.
+START testSelectiveUpdates at Thu Feb 13 14:49:35 PST 2020
+END testSelectiveUpdates at Thu Feb 13 14:49:36 PST 2020, took: 1091ms.
+START testHandleNewSession at Thu Feb 13 14:49:40 PST 2020
+START TestHandleNewSession_testHandleNewSession at Thu Feb 13 14:49:40 PST 2020
+Disconnecting ...
+END TestHandleNewSession_testHandleNewSession at Thu Feb 13 14:49:46 PST 2020
+END testHandleNewSession at Thu Feb 13 14:49:46 PST 2020, took: 6105ms.
+START testAcquireLeadershipOnNewSession at Thu Feb 13 14:49:46 PST 2020
+0    [HelixController-pipeline-default-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(50681950_DEFAULT)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
+3    [HelixController-pipeline-task-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(50681950_TASK)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
+5    [HelixController-pipeline-default-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(f365a02a_DEFAULT)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
+6    [HelixController-pipeline-task-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(f365a02a_TASK)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
+6    [HelixController-pipeline-default-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(3935c3d2_DEFAULT)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
+7    [HelixController-pipeline-default-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(2bfffa49_DEFAULT)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
+7    [HelixController-pipeline-task-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(3935c3d2_TASK)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
+8    [HelixController-pipeline-task-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(2bfffa49_TASK)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
+78   [HelixController-pipeline-default-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(d832147b_DEFAULT)] ERROR org.apache.helix.controller.GenericHelixController  - Exception while executing DEFAULT pipeline: CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession for cluster [org.apache.helix.zookeeper.zkclient.ZkClient.retryUntilConnected(ZkClient.java:1481), org.apache.helix.zookeeper.zkclient.ZkClient.getChildren(ZkClient.java:977), org.apache.helix.zookeeper.zkclient.ZkClient.getChildren(ZkClient.java:971), org.apache.helix.manager.zk.ZkBaseDataAccessor.getChildNames(ZkBaseDataAccessor.java:633), org.apache.helix.manager.zk.ZkBaseDataAccessor.getChildren(ZkBaseDataAccessor.java:589), org.apache.helix.manager.zk.ZkBaseDataAccessor.getChildren(ZkBaseDataAccessor.java:565), org.apache.helix.manager.zk.ZKHelixDataAccessor.getChildValues(ZKHelixDataAccessor.java:415), org.apache.helix.manager.zk.ZKHelixDataAccessor.getChildValuesMap(ZKHelixDataAccessor.java:476), org.apache.helix.common.caches.PropertyCache.doSimpleCacheRefresh(PropertyCache.java:168), org.apache.helix.common.caches.PropertyCache.refresh(PropertyCache.java:160), org.apache.helix.controller.dataproviders.BaseControllerDataProvider.doRefresh(BaseControllerDataProvider.java:327), org.apache.helix.controller.dataproviders.ResourceControllerDataProvider.refresh(ResourceControllerDataProvider.java:120), org.apache.helix.controller.stages.ReadClusterDataStage.process(ReadClusterDataStage.java:60), org.apache.helix.controller.pipeline.Pipeline.handle(Pipeline.java:68), org.apache.helix.controller.GenericHelixController.handleEvent(GenericHelixController.java:728), org.apache.helix.controller.GenericHelixController.access$500(GenericHelixController.java:120), org.apache.helix.controller.GenericHelixController$ClusterEventProcessor.run(GenericHelixController.java:1266)]. Will not continue to next pipeline
+END testAcquireLeadershipOnNewSession at Thu Feb 13 14:49:48 PST 2020, took: 1454ms.
+START testZkClientMonitor at Thu Feb 13 14:49:48 PST 2020
+END testZkClientMonitor at Thu Feb 13 14:49:48 PST 2020, took: 39ms.
+START testPendingRequestGauge at Thu Feb 13 14:49:48 PST 2020
+Start zookeeper at localhost:36683 in thread TestNGInvoker-testPendingRequestGauge()
+END testPendingRequestGauge at Thu Feb 13 14:49:50 PST 2020, took: 2058ms.
+START testZkConnectionManager at Thu Feb 13 14:49:54 PST 2020
+END testZkConnectionManager at Thu Feb 13 14:49:54 PST 2020, took: 234ms.
+START testSharingZkClient at Thu Feb 13 14:49:54 PST 2020
+END testSharingZkClient at Thu Feb 13 14:49:56 PST 2020, took: 1412ms.
+START testSubscribeDataChange at Thu Feb 13 14:49:56 PST 2020
+END testSubscribeDataChange at Thu Feb 13 14:49:56 PST 2020, took: 7ms.
+START testSubscribeChildChange at Thu Feb 13 14:49:56 PST 2020
+END testSubscribeChildChange at Thu Feb 13 14:49:56 PST 2020, took: 10ms.
+START testSubscribeDataChangeOnNonExistPath at Thu Feb 13 14:49:56 PST 2020
+END testSubscribeDataChangeOnNonExistPath at Thu Feb 13 14:49:56 PST 2020, took: 2ms.
+START testCompressedBucketWrite at Thu Feb 13 14:49:56 PST 2020
+END testCompressedBucketWrite at Thu Feb 13 14:49:56 PST 2020, took: 28ms.
+START testMultipleWrites at Thu Feb 13 14:49:56 PST 2020
+END testMultipleWrites at Thu Feb 13 14:49:56 PST 2020, took: 687ms.
+START testCompressedBucketRead at Thu Feb 13 14:49:56 PST 2020
+END testCompressedBucketRead at Thu Feb 13 14:49:56 PST 2020, took: 16ms.
+START testLargeWriteAndRead at Thu Feb 13 14:49:56 PST 2020
+Write took 1455 ms
+Read took 2272 ms
+END testLargeWriteAndRead at Thu Feb 13 14:50:01 PST 2020, took: 4071ms.
+START testAddCluster at Thu Feb 13 14:50:05 PST 2020
+END testAddCluster at Thu Feb 13 14:50:05 PST 2020, took: 327ms.
+START testAddResource at Thu Feb 13 14:50:05 PST 2020
+END testAddResource at Thu Feb 13 14:50:05 PST 2020, took: 119ms.
+START testAddInstance at Thu Feb 13 14:50:05 PST 2020
+END testAddInstance at Thu Feb 13 14:50:05 PST 2020, took: 315ms.
+START testRebalanceResource at Thu Feb 13 14:50:05 PST 2020
+END testRebalanceResource at Thu Feb 13 14:50:06 PST 2020, took: 271ms.
+START testStartCluster at Thu Feb 13 14:50:06 PST 2020

--- a/helix-core/TESTRES
+++ b/helix-core/TESTRES
@@ -1,107 +1,0 @@
-[INFO] Scanning for projects...
-[INFO] 
-[INFO] --------------------< org.apache.helix:helix-core >---------------------
-[INFO] Building Apache Helix :: Core 0.9.2-SNAPSHOT
-[INFO] -------------------------------[ bundle ]-------------------------------
-[INFO] 
-[INFO] --- maven-remote-resources-plugin:1.4:process (default) @ helix-core ---
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ helix-core ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] Copying 2 resources
-[INFO] Copying 0 resource
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:2.5.1:compile (default-compile) @ helix-core ---
-[INFO] Compiling 18 source files to /home/hulee/mp/helix2/helix-core/target/classes
-[INFO] 
-[INFO] --- maven-bundle-plugin:3.5.0:manifest (bundle-manifest) @ helix-core ---
-[INFO] 
-[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ helix-core ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] Copying 14 resources
-[INFO] Copying 3 resources
-[INFO] 
-[INFO] --- maven-compiler-plugin:2.5.1:testCompile (default-testCompile) @ helix-core ---
-[INFO] Nothing to compile - all classes are up to date
-[INFO] 
-[INFO] --- maven-surefire-plugin:3.0.0-M3:test (default-test) @ helix-core ---
-Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng/3.0.0-M3/surefire-testng-3.0.0-M3.jar
-Progress (1): 2.2/44 kBProgress (1): 5.0/44 kBProgress (1): 7.8/44 kBProgress (1): 11/44 kB Progress (1): 13/44 kBProgress (1): 16/44 kBProgress (1): 19/44 kBProgress (1): 21/44 kBProgress (1): 24/44 kBProgress (1): 27/44 kBProgress (1): 30/44 kBProgress (1): 32/44 kBProgress (1): 36/44 kBProgress (1): 40/44 kBProgress (1): 44 kB                      Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng/3.0.0-M3/surefire-testng-3.0.0-M3.jar (44 kB at 172 kB/s)
-Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng/3.0.0-M3/surefire-testng-3.0.0-M3.pom
-Progress (1): 2.6 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng/3.0.0-M3/surefire-testng-3.0.0-M3.pom (2.6 kB at 262 kB/s)
-Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-providers/3.0.0-M3/surefire-providers-3.0.0-M3.pom
-Progress (1): 2.5 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-providers/3.0.0-M3/surefire-providers-3.0.0-M3.pom (2.5 kB at 282 kB/s)
-Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.0.0-M3/common-java5-3.0.0-M3.pom
-Progress (1): 2.2/3.1 kBProgress (1): 3.1 kB                        Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.0.0-M3/common-java5-3.0.0-M3.pom (3.1 kB at 341 kB/s)
-Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng-utils/3.0.0-M3/surefire-testng-utils-3.0.0-M3.pom
-Progress (1): 2.2/2.5 kBProgress (1): 2.5 kB                        Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng-utils/3.0.0-M3/surefire-testng-utils-3.0.0-M3.pom (2.5 kB at 307 kB/s)
-Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-grouper/3.0.0-M3/surefire-grouper-3.0.0-M3.pom
-Progress (1): 2.2/2.6 kBProgress (1): 2.6 kB                        Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-grouper/3.0.0-M3/surefire-grouper-3.0.0-M3.pom (2.6 kB at 330 kB/s)
-Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.0.0-M3/common-java5-3.0.0-M3.jar
-Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-grouper/3.0.0-M3/surefire-grouper-3.0.0-M3.jar
-Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng-utils/3.0.0-M3/surefire-testng-utils-3.0.0-M3.jar
-Progress (1): 2.2/32 kBProgress (1): 5.0/32 kBProgress (1): 7.7/32 kBProgress (1): 10/32 kB Progress (1): 13/32 kBProgress (1): 16/32 kBProgress (1): 19/32 kBProgress (1): 21/32 kBProgress (1): 24/32 kBProgress (1): 27/32 kBProgress (1): 30/32 kBProgress (1): 32 kB                      Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.0.0-M3/common-java5-3.0.0-M3.jar (32 kB at 2.0 MB/s)
-Progress (1): 2.8/14 kBProgress (1): 5.5/14 kBProgress (2): 5.5/14 kB | 2.8/40 kBProgress (2): 8.3/14 kB | 2.8/40 kBProgress (2): 8.3/14 kB | 5.5/40 kBProgress (2): 11/14 kB | 5.5/40 kB Progress (2): 11/14 kB | 8.3/40 kBProgress (2): 14 kB | 8.3/40 kB   Progress (2): 14 kB | 11/40 kB Progress (2): 14 kB | 14/40 kBProgress (2): 14 kB | 16/40 kBProgress (2): 14 kB | 19/40 kB                              Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-testng-utils/3.0.0-M3/surefire-testng-utils-3.0.0-M3.jar (14 kB at 569 kB/s)
-Progress (1): 22/40 kBProgress (1): 25/40 kBProgress (1): 27/40 kBProgress (1): 30/40 kBProgress (1): 33/40 kBProgress (1): 36/40 kBProgress (1): 38/40 kBProgress (1): 40 kB                      Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-grouper/3.0.0-M3/surefire-grouper-3.0.0-M3.jar (40 kB at 1.2 MB/s)
-[INFO] 
-[INFO] -------------------------------------------------------
-[INFO]  T E S T S
-[INFO] -------------------------------------------------------
-[INFO] Running TestSuite
-Start zookeeper at localhost:2183 in thread main
-START TestRoutingDataCache at Thu Feb 13 14:49:33 PST 2020
-START testUpdateOnNotification at Thu Feb 13 14:49:35 PST 2020
-END testUpdateOnNotification at Thu Feb 13 14:49:35 PST 2020, took: 34ms.
-START testSelectiveUpdates at Thu Feb 13 14:49:35 PST 2020
-END testSelectiveUpdates at Thu Feb 13 14:49:36 PST 2020, took: 1091ms.
-START testHandleNewSession at Thu Feb 13 14:49:40 PST 2020
-START TestHandleNewSession_testHandleNewSession at Thu Feb 13 14:49:40 PST 2020
-Disconnecting ...
-END TestHandleNewSession_testHandleNewSession at Thu Feb 13 14:49:46 PST 2020
-END testHandleNewSession at Thu Feb 13 14:49:46 PST 2020, took: 6105ms.
-START testAcquireLeadershipOnNewSession at Thu Feb 13 14:49:46 PST 2020
-0    [HelixController-pipeline-default-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(50681950_DEFAULT)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
-3    [HelixController-pipeline-task-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(50681950_TASK)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
-5    [HelixController-pipeline-default-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(f365a02a_DEFAULT)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
-6    [HelixController-pipeline-task-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(f365a02a_TASK)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
-6    [HelixController-pipeline-default-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(3935c3d2_DEFAULT)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
-7    [HelixController-pipeline-default-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(2bfffa49_DEFAULT)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
-7    [HelixController-pipeline-task-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(3935c3d2_TASK)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
-8    [HelixController-pipeline-task-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(2bfffa49_TASK)] ERROR org.apache.helix.controller.GenericHelixController  - Cluster manager: controller_0 is not leader for CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession. Pipeline will not be invoked
-78   [HelixController-pipeline-default-CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession-(d832147b_DEFAULT)] ERROR org.apache.helix.controller.GenericHelixController  - Exception while executing DEFAULT pipeline: CLUSTER_TestHandleNewSession_testAcquireLeadershipOnNewSession for cluster [org.apache.helix.zookeeper.zkclient.ZkClient.retryUntilConnected(ZkClient.java:1481), org.apache.helix.zookeeper.zkclient.ZkClient.getChildren(ZkClient.java:977), org.apache.helix.zookeeper.zkclient.ZkClient.getChildren(ZkClient.java:971), org.apache.helix.manager.zk.ZkBaseDataAccessor.getChildNames(ZkBaseDataAccessor.java:633), org.apache.helix.manager.zk.ZkBaseDataAccessor.getChildren(ZkBaseDataAccessor.java:589), org.apache.helix.manager.zk.ZkBaseDataAccessor.getChildren(ZkBaseDataAccessor.java:565), org.apache.helix.manager.zk.ZKHelixDataAccessor.getChildValues(ZKHelixDataAccessor.java:415), org.apache.helix.manager.zk.ZKHelixDataAccessor.getChildValuesMap(ZKHelixDataAccessor.java:476), org.apache.helix.common.caches.PropertyCache.doSimpleCacheRefresh(PropertyCache.java:168), org.apache.helix.common.caches.PropertyCache.refresh(PropertyCache.java:160), org.apache.helix.controller.dataproviders.BaseControllerDataProvider.doRefresh(BaseControllerDataProvider.java:327), org.apache.helix.controller.dataproviders.ResourceControllerDataProvider.refresh(ResourceControllerDataProvider.java:120), org.apache.helix.controller.stages.ReadClusterDataStage.process(ReadClusterDataStage.java:60), org.apache.helix.controller.pipeline.Pipeline.handle(Pipeline.java:68), org.apache.helix.controller.GenericHelixController.handleEvent(GenericHelixController.java:728), org.apache.helix.controller.GenericHelixController.access$500(GenericHelixController.java:120), org.apache.helix.controller.GenericHelixController$ClusterEventProcessor.run(GenericHelixController.java:1266)]. Will not continue to next pipeline
-END testAcquireLeadershipOnNewSession at Thu Feb 13 14:49:48 PST 2020, took: 1454ms.
-START testZkClientMonitor at Thu Feb 13 14:49:48 PST 2020
-END testZkClientMonitor at Thu Feb 13 14:49:48 PST 2020, took: 39ms.
-START testPendingRequestGauge at Thu Feb 13 14:49:48 PST 2020
-Start zookeeper at localhost:36683 in thread TestNGInvoker-testPendingRequestGauge()
-END testPendingRequestGauge at Thu Feb 13 14:49:50 PST 2020, took: 2058ms.
-START testZkConnectionManager at Thu Feb 13 14:49:54 PST 2020
-END testZkConnectionManager at Thu Feb 13 14:49:54 PST 2020, took: 234ms.
-START testSharingZkClient at Thu Feb 13 14:49:54 PST 2020
-END testSharingZkClient at Thu Feb 13 14:49:56 PST 2020, took: 1412ms.
-START testSubscribeDataChange at Thu Feb 13 14:49:56 PST 2020
-END testSubscribeDataChange at Thu Feb 13 14:49:56 PST 2020, took: 7ms.
-START testSubscribeChildChange at Thu Feb 13 14:49:56 PST 2020
-END testSubscribeChildChange at Thu Feb 13 14:49:56 PST 2020, took: 10ms.
-START testSubscribeDataChangeOnNonExistPath at Thu Feb 13 14:49:56 PST 2020
-END testSubscribeDataChangeOnNonExistPath at Thu Feb 13 14:49:56 PST 2020, took: 2ms.
-START testCompressedBucketWrite at Thu Feb 13 14:49:56 PST 2020
-END testCompressedBucketWrite at Thu Feb 13 14:49:56 PST 2020, took: 28ms.
-START testMultipleWrites at Thu Feb 13 14:49:56 PST 2020
-END testMultipleWrites at Thu Feb 13 14:49:56 PST 2020, took: 687ms.
-START testCompressedBucketRead at Thu Feb 13 14:49:56 PST 2020
-END testCompressedBucketRead at Thu Feb 13 14:49:56 PST 2020, took: 16ms.
-START testLargeWriteAndRead at Thu Feb 13 14:49:56 PST 2020
-Write took 1455 ms
-Read took 2272 ms
-END testLargeWriteAndRead at Thu Feb 13 14:50:01 PST 2020, took: 4071ms.
-START testAddCluster at Thu Feb 13 14:50:05 PST 2020
-END testAddCluster at Thu Feb 13 14:50:05 PST 2020, took: 327ms.
-START testAddResource at Thu Feb 13 14:50:05 PST 2020
-END testAddResource at Thu Feb 13 14:50:05 PST 2020, took: 119ms.
-START testAddInstance at Thu Feb 13 14:50:05 PST 2020
-END testAddInstance at Thu Feb 13 14:50:05 PST 2020, took: 315ms.
-START testRebalanceResource at Thu Feb 13 14:50:05 PST 2020
-END testRebalanceResource at Thu Feb 13 14:50:06 PST 2020, took: 271ms.
-START testStartCluster at Thu Feb 13 14:50:06 PST 2020

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -1144,11 +1144,11 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
   @Override
   public void handleNewSession(String sessionId) throws Exception {
     /*
-     * TODO: after removing I0ItecIZkStateListenerHelixImpl, null session should be checked and
+     * TODO: after removing I0ItecIZkStateListenerImpl, null session should be checked and
      *  discarded.
      * Null session is still a special case here, which is treated as non-session aware operation.
      * This special case could still potentially cause race condition, so null session should NOT
-     * be acceptable, once I0ItecIZkStateListenerHelixImpl is removed. Currently this special case
+     * be acceptable, once I0ItecIZkStateListenerImpl is removed. Currently this special case
      * is kept for backward compatibility.
      */
 

--- a/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
@@ -149,8 +149,9 @@ public class ZkTestBase {
         } catch (Exception e) {
           Assert.fail("Failed to parse the number of ZKs from config!");
         }
+      } else {
+        Assert.fail("multiZk config is set but numZk config is missing!");
       }
-      Assert.fail("multiZk config is set but numZk config is missing!");
     }
 
     // Start "numZkFromConfigInt" ZooKeepers

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
@@ -89,6 +89,9 @@ public interface HelixZkClient extends RealmAwareZkClient {
    * Deprecated - please use RealmAwareZkClient and RealmAwareZkClientConfig instead.
    *
    * Configuration for creating a new HelixZkClient with serializer and monitor.
+   *
+   * TODO: If possible, try to merge with RealmAwareZkClient's RealmAwareZkClientConfig to reduce duplicate logic/code (without breaking backward-compatibility).
+   * Simply making this a subclass of RealmAwareZkClientConfig will break backward-compatiblity.
    */
   @Deprecated
   class ZkClientConfig {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
@@ -19,8 +19,178 @@ package org.apache.helix.zookeeper.api.client;
  * under the License.
  */
 
+import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
+import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
+import org.apache.helix.zookeeper.zkclient.serialize.SerializableSerializer;
+import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
+
+
 /**
+ * Deprecated - please use RealmAwareZkClient instead.
+ *
  * HelixZkClient interface that follows the supported API structure of RealmAwareZkClient.
  */
+@Deprecated
 public interface HelixZkClient extends RealmAwareZkClient {
+
+  /**
+   * Deprecated - please use RealmAwareZkClient and RealmAwareZkConnectionConfig instead.
+   *
+   * Configuration for creating a new ZkConnection.
+   */
+  @Deprecated
+  class ZkConnectionConfig {
+    // Connection configs
+    private final String _zkServers;
+    private int _sessionTimeout = HelixZkClient.DEFAULT_SESSION_TIMEOUT;
+
+    public ZkConnectionConfig(String zkServers) {
+      _zkServers = zkServers;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof HelixZkClient.ZkConnectionConfig)) {
+        return false;
+      }
+      HelixZkClient.ZkConnectionConfig configObj = (HelixZkClient.ZkConnectionConfig) obj;
+      return (_zkServers == null && configObj._zkServers == null || _zkServers != null && _zkServers
+          .equals(configObj._zkServers)) && _sessionTimeout == configObj._sessionTimeout;
+    }
+
+    @Override
+    public int hashCode() {
+      return _sessionTimeout * 31 + _zkServers.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return (_zkServers + "_" + _sessionTimeout).replaceAll("[\\W]", "_");
+    }
+
+    public HelixZkClient.ZkConnectionConfig setSessionTimeout(Integer sessionTimeout) {
+      this._sessionTimeout = sessionTimeout;
+      return this;
+    }
+
+    public String getZkServers() {
+      return _zkServers;
+    }
+
+    public int getSessionTimeout() {
+      return _sessionTimeout;
+    }
+  }
+
+  /**
+   * Deprecated - please use RealmAwareZkClient and RealmAwareZkClientConfig instead.
+   *
+   * Configuration for creating a new HelixZkClient with serializer and monitor.
+   */
+  @Deprecated
+  class ZkClientConfig extends RealmAwareZkClientConfig {
+    // For client to init the connection
+    private long _connectInitTimeout = DEFAULT_CONNECTION_TIMEOUT;
+
+    // Data access configs
+    private long _operationRetryTimeout = DEFAULT_OPERATION_TIMEOUT;
+
+    // Others
+    private PathBasedZkSerializer _zkSerializer;
+
+    // Monitoring
+    private String _monitorType;
+    private String _monitorKey;
+    private String _monitorInstanceName = null;
+    private boolean _monitorRootPathOnly = true;
+
+    public ZkClientConfig setZkSerializer(PathBasedZkSerializer zkSerializer) {
+      this._zkSerializer = zkSerializer;
+      return this;
+    }
+
+    public ZkClientConfig setZkSerializer(ZkSerializer zkSerializer) {
+      this._zkSerializer = new BasicZkSerializer(zkSerializer);
+      return this;
+    }
+
+    /**
+     * Used as part of the MBean ObjectName. This item is required for enabling monitoring.
+     *
+     * @param monitorType
+     */
+    public ZkClientConfig setMonitorType(String monitorType) {
+      this._monitorType = monitorType;
+      return this;
+    }
+
+    /**
+     * Used as part of the MBean ObjectName. This item is required for enabling monitoring.
+     *
+     * @param monitorKey
+     */
+    public ZkClientConfig setMonitorKey(String monitorKey) {
+      this._monitorKey = monitorKey;
+      return this;
+    }
+
+    /**
+     * Used as part of the MBean ObjectName. This item is optional.
+     *
+     * @param instanceName
+     */
+    public ZkClientConfig setMonitorInstanceName(String instanceName) {
+      this._monitorInstanceName = instanceName;
+      return this;
+    }
+
+    public ZkClientConfig setMonitorRootPathOnly(Boolean monitorRootPathOnly) {
+      this._monitorRootPathOnly = monitorRootPathOnly;
+      return this;
+    }
+
+    public ZkClientConfig setOperationRetryTimeout(Long operationRetryTimeout) {
+      this._operationRetryTimeout = operationRetryTimeout;
+      return this;
+    }
+
+    public ZkClientConfig setConnectInitTimeout(long _connectInitTimeout) {
+      this._connectInitTimeout = _connectInitTimeout;
+      return this;
+    }
+
+    public PathBasedZkSerializer getZkSerializer() {
+      if (_zkSerializer == null) {
+        _zkSerializer = new BasicZkSerializer(new SerializableSerializer());
+      }
+      return _zkSerializer;
+    }
+
+    public long getOperationRetryTimeout() {
+      return _operationRetryTimeout;
+    }
+
+    public String getMonitorType() {
+      return _monitorType;
+    }
+
+    public String getMonitorKey() {
+      return _monitorKey;
+    }
+
+    public String getMonitorInstanceName() {
+      return _monitorInstanceName;
+    }
+
+    public boolean isMonitorRootPathOnly() {
+      return _monitorRootPathOnly;
+    }
+
+    public long getConnectInitTimeout() {
+      return _connectInitTimeout;
+    }
+  }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
@@ -91,7 +91,7 @@ public interface HelixZkClient extends RealmAwareZkClient {
    * Configuration for creating a new HelixZkClient with serializer and monitor.
    */
   @Deprecated
-  class ZkClientConfig extends RealmAwareZkClientConfig {
+  class ZkClientConfig {
     // For client to init the connection
     private long _connectInitTimeout = DEFAULT_CONNECTION_TIMEOUT;
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -54,7 +54,10 @@ public interface RealmAwareZkClient {
    * SINGLE_REALM: CRUD, change subscription, and EPHEMERAL CreateMode are supported.
    * MULTI_REALM: CRUD and change subscription are supported. Operations involving EPHEMERAL CreateMode will throw an UnsupportedOperationException.
    */
-  enum MODE {SINGLE_REALM, MULTI_REALM}
+  enum MODE {
+    SINGLE_REALM,
+    MULTI_REALM
+  }
 
   int DEFAULT_OPERATION_TIMEOUT = Integer.MAX_VALUE;
   int DEFAULT_CONNECTION_TIMEOUT = 60 * 1000;
@@ -75,7 +78,7 @@ public interface RealmAwareZkClient {
    * TODO: remove below default implementation when getting rid of I0Itec in the new zk client.
    */
   default void subscribeStateChanges(final IZkStateListener listener) {
-    subscribeStateChanges(new HelixZkClient.I0ItecIZkStateListenerHelixImpl(listener));
+    subscribeStateChanges(new I0ItecIZkStateListenerImpl(listener));
   }
 
   /*
@@ -84,7 +87,7 @@ public interface RealmAwareZkClient {
    * TODO: remove below default implementation when getting rid of I0Itec in the new zk client.
    */
   default void unsubscribeStateChanges(IZkStateListener listener) {
-    unsubscribeStateChanges(new HelixZkClient.I0ItecIZkStateListenerHelixImpl(listener));
+    unsubscribeStateChanges(new I0ItecIZkStateListenerImpl(listener));
   }
 
   /**
@@ -265,10 +268,10 @@ public interface RealmAwareZkClient {
    * This is for backward compatibility and to avoid breaking the original implementation of
    * {@link org.apache.helix.zookeeper.zkclient.deprecated.IZkStateListener}.
    */
-  class I0ItecIZkStateListenerHelixImpl implements org.apache.helix.zookeeper.zkclient.deprecated.IZkStateListener {
+  class I0ItecIZkStateListenerImpl implements org.apache.helix.zookeeper.zkclient.deprecated.IZkStateListener {
     private IZkStateListener _listener;
 
-    I0ItecIZkStateListenerHelixImpl(IZkStateListener listener) {
+    I0ItecIZkStateListenerImpl(IZkStateListener listener) {
       _listener = listener;
     }
 
@@ -296,15 +299,14 @@ public interface RealmAwareZkClient {
       if (obj == this) {
         return true;
       }
-      if (!(obj instanceof HelixZkClient.I0ItecIZkStateListenerHelixImpl)) {
+      if (!(obj instanceof I0ItecIZkStateListenerImpl)) {
         return false;
       }
       if (_listener == null) {
         return false;
       }
 
-      HelixZkClient.I0ItecIZkStateListenerHelixImpl defaultListener =
-          (HelixZkClient.I0ItecIZkStateListenerHelixImpl) obj;
+      I0ItecIZkStateListenerImpl defaultListener = (I0ItecIZkStateListenerImpl) obj;
 
       return _listener.equals(defaultListener._listener);
     }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -22,6 +22,7 @@ package org.apache.helix.zookeeper.api.client;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.helix.zookeeper.exception.ZkClientException;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
@@ -334,13 +335,58 @@ public interface RealmAwareZkClient {
     private final MODE _mode;
     /**
      * zkRealmShardingKey: used to deduce which ZK realm this RealmAwareZkClientConfig should connect to.
-     * NOTE: this field is not used if MODE is MULTI_REALM!
+     * NOTE: this field will be ignored if MODE is MULTI_REALM!
      */
     private final String _zkRealmShardingKey;
+    private int _sessionTimeout = DEFAULT_SESSION_TIMEOUT;
 
     public RealmAwareZkConnectionConfig(MODE mode, String zkRealmShardingKey) {
+      if (mode == null) {
+        throw new ZkClientException("Mode cannot be null!");
+      }
       _mode = mode;
       _zkRealmShardingKey = zkRealmShardingKey;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof RealmAwareZkConnectionConfig)) {
+        return false;
+      }
+      RealmAwareZkConnectionConfig configObj = (RealmAwareZkConnectionConfig) obj;
+      return (_zkRealmShardingKey == null && configObj._zkRealmShardingKey == null
+          || _zkRealmShardingKey != null && _zkRealmShardingKey
+          .equals(configObj._zkRealmShardingKey)) && _sessionTimeout == configObj._sessionTimeout;
+    }
+
+    @Override
+    public int hashCode() {
+      return _sessionTimeout * 31 + _zkRealmShardingKey.hashCode() + _mode.name().hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return (_mode + "_" + _zkRealmShardingKey + "_" + _sessionTimeout).replaceAll("[\\W]", "_");
+    }
+
+    public RealmAwareZkConnectionConfig setSessionTimeout(int sessionTimeout) {
+      this._sessionTimeout = sessionTimeout;
+      return this;
+    }
+
+    public RealmAwareZkClient.MODE getMode() {
+      return _mode;
+    }
+
+    public String getZkRealmShardingKey() {
+      return _zkRealmShardingKey;
+    }
+
+    public int getSessionTimeout() {
+      return _sessionTimeout;
     }
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -41,8 +41,10 @@ import org.apache.zookeeper.data.Stat;
 
 
 /**
- * Realm-aware ZkClient interface.
- * NOTE: "Realm-aware" does not necessarily mean that the RealmAwareZkClient instance will
+ * The Realm-aware ZkClient interface.
+ * NOTE: "Realm-aware" does not necessarily mean that the RealmAwareZkClient instance will be connecting to multiple ZK realms.
+ * On single-realm mode, RealmAwareZkClient will reject requests going out to other ZK realms than the one set at initialization.
+ * On multi-realm mode, RealmAwareZkClient will connect to multiple ZK realms but will reject EPHEMERAL AccessMode operations.
  */
 public interface RealmAwareZkClient {
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -22,7 +22,6 @@ package org.apache.helix.zookeeper.api.client;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.helix.zookeeper.exception.ZkClientException;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
@@ -55,9 +54,7 @@ public interface RealmAwareZkClient {
    * SINGLE_REALM: CRUD, change subscription, and EPHEMERAL CreateMode are supported.
    * MULTI_REALM: CRUD and change subscription are supported. Operations involving EPHEMERAL CreateMode will throw an UnsupportedOperationException.
    */
-  enum MODE {
-    SINGLE_REALM, MULTI_REALM
-  }
+  enum MODE {SINGLE_REALM, MULTI_REALM}
 
   int DEFAULT_OPERATION_TIMEOUT = Integer.MAX_VALUE;
   int DEFAULT_CONNECTION_TIMEOUT = 60 * 1000;
@@ -276,14 +273,12 @@ public interface RealmAwareZkClient {
     }
 
     @Override
-    public void handleStateChanged(Watcher.Event.KeeperState keeperState)
-        throws Exception {
+    public void handleStateChanged(Watcher.Event.KeeperState keeperState) throws Exception {
       _listener.handleStateChanged(keeperState);
     }
 
     @Override
-    public void handleNewSession()
-        throws Exception {
+    public void handleNewSession() throws Exception {
       /*
        * org.apache.helix.manager.zk.zookeeper.IZkStateListener does not have handleNewSession(),
        * so null is passed into handleNewSession(sessionId).
@@ -292,8 +287,7 @@ public interface RealmAwareZkClient {
     }
 
     @Override
-    public void handleSessionEstablishmentError(Throwable error)
-        throws Exception {
+    public void handleSessionEstablishmentError(Throwable error) throws Exception {
       _listener.handleSessionEstablishmentError(error);
     }
 
@@ -329,10 +323,7 @@ public interface RealmAwareZkClient {
    * ZkConnection-related configs for creating an instance of RealmAwareZkClient.
    */
   class RealmAwareZkConnectionConfig {
-    /**
-     * mode: Which mode the RealmAwareZkClientConfig should be created in
-     */
-    private final MODE _mode;
+
     /**
      * zkRealmShardingKey: used to deduce which ZK realm this RealmAwareZkClientConfig should connect to.
      * NOTE: this field will be ignored if MODE is MULTI_REALM!
@@ -340,11 +331,7 @@ public interface RealmAwareZkClient {
     private final String _zkRealmShardingKey;
     private int _sessionTimeout = DEFAULT_SESSION_TIMEOUT;
 
-    public RealmAwareZkConnectionConfig(MODE mode, String zkRealmShardingKey) {
-      if (mode == null) {
-        throw new ZkClientException("Mode cannot be null!");
-      }
-      _mode = mode;
+    public RealmAwareZkConnectionConfig(String zkRealmShardingKey) {
       _zkRealmShardingKey = zkRealmShardingKey;
     }
 
@@ -364,21 +351,17 @@ public interface RealmAwareZkClient {
 
     @Override
     public int hashCode() {
-      return _sessionTimeout * 31 + _zkRealmShardingKey.hashCode() + _mode.name().hashCode();
+      return _sessionTimeout * 31 + _zkRealmShardingKey.hashCode();
     }
 
     @Override
     public String toString() {
-      return (_mode + "_" + _zkRealmShardingKey + "_" + _sessionTimeout).replaceAll("[\\W]", "_");
+      return (_zkRealmShardingKey + "_" + _sessionTimeout).replaceAll("[\\W]", "_");
     }
 
     public RealmAwareZkConnectionConfig setSessionTimeout(int sessionTimeout) {
       this._sessionTimeout = sessionTimeout;
       return this;
-    }
-
-    public RealmAwareZkClient.MODE getMode() {
-      return _mode;
     }
 
     public String getZkRealmShardingKey() {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/factory/RealmAwareZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/factory/RealmAwareZkClientFactory.java
@@ -19,5 +19,13 @@ package org.apache.helix.zookeeper.api.factory;
  * under the License.
  */
 
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+
+
+/**
+ * Creates an instance of RealmAwareZkClient.
+ */
 public interface RealmAwareZkClientFactory {
+  RealmAwareZkClient buildZkClient(RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
+      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig);
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/factory/RealmAwareZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/factory/RealmAwareZkClientFactory.java
@@ -26,6 +26,20 @@ import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
  * Creates an instance of RealmAwareZkClient.
  */
 public interface RealmAwareZkClientFactory {
+  /**
+   * Build a RealmAwareZkClient using specified connection config and client config.
+   * @param connectionConfig
+   * @param clientConfig
+   * @return HelixZkClient
+   */
   RealmAwareZkClient buildZkClient(RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
       RealmAwareZkClient.RealmAwareZkClientConfig clientConfig);
+
+  /**
+   * Builds a RealmAwareZkClient using specified connection config and default client config.
+   * @param connectionConfig
+   * @return RealmAwareZkClient
+   */
+  RealmAwareZkClient buildZkClient(
+      RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig);
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/DedicatedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/DedicatedZkClientFactory.java
@@ -41,6 +41,13 @@ public class DedicatedZkClientFactory extends HelixZkClientFactory {
     return null;
   }
 
+  @Override
+  public RealmAwareZkClient buildZkClient(
+      RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig) {
+    // TODO: Implement the logic
+    return null;
+  }
+
   private static class SingletonHelper {
     private static final DedicatedZkClientFactory INSTANCE = new DedicatedZkClientFactory();
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/DedicatedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/DedicatedZkClientFactory.java
@@ -20,6 +20,7 @@ package org.apache.helix.zookeeper.impl.factory;
  */
 
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 
 
@@ -29,6 +30,15 @@ import org.apache.helix.zookeeper.impl.client.ZkClient;
 public class DedicatedZkClientFactory extends HelixZkClientFactory {
 
   protected DedicatedZkClientFactory() {
+  }
+
+  @Override
+  public RealmAwareZkClient buildZkClient(
+      RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
+      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig) {
+    // TODO: Implement the logic
+    // Return an instance of DedicatedZkClient
+    return null;
   }
 
   private static class SingletonHelper {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/HelixZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/HelixZkClientFactory.java
@@ -20,6 +20,7 @@ package org.apache.helix.zookeeper.impl.factory;
  */
 
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
+import org.apache.helix.zookeeper.api.factory.RealmAwareZkClientFactory;
 import org.apache.helix.zookeeper.exception.ZkClientException;
 import org.apache.helix.zookeeper.zkclient.IZkConnection;
 import org.apache.helix.zookeeper.zkclient.ZkConnection;
@@ -28,7 +29,7 @@ import org.apache.helix.zookeeper.zkclient.ZkConnection;
 /**
  * Abstract class of the ZkClient factory.
  */
-abstract class HelixZkClientFactory {
+abstract class HelixZkClientFactory implements RealmAwareZkClientFactory {
 
   /**
    * Build a ZkClient using specified connection config and client config

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
@@ -50,6 +50,13 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
     return null;
   }
 
+  @Override
+  public RealmAwareZkClient buildZkClient(
+      RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig) {
+    // TODO: Implement the logic
+    return null;
+  }
+
   private static class SingletonHelper {
     private static final SharedZkClientFactory INSTANCE = new SharedZkClientFactory();
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
@@ -22,6 +22,7 @@ package org.apache.helix.zookeeper.impl.factory;
 import java.util.HashMap;
 
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.exception.ZkClientException;
 import org.apache.helix.zookeeper.impl.client.SharedZkClient;
 import org.slf4j.Logger;
@@ -38,6 +39,15 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
       _connectionManagerPool = new HashMap<>();
 
   protected SharedZkClientFactory() {
+  }
+
+  @Override
+  public RealmAwareZkClient buildZkClient(
+      RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
+      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig) {
+    // TODO: Implement the logic
+    // Return an instance of SharedZkClient
+    return null;
   }
 
   private static class SingletonHelper {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #760 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

RealmAwareZkClient and RealmAwareZkClientFactory are going to be the top-level interfaces for other realm-aware ZkClient APIs (think FederatedZkClient, DedicatedZkClient, etc.).

RealmAwareZkClient will support all the existing interface methods that HelixZkClient supports.
RealmAwareZkClientFactory will be the interface implemented by SharedZkClientFactory and DedicatedZkClientFactory.

### Tests

- [x] The following tests are written for this issue:

Interface methods without logic - no tests added.

- [x] The following is the result of the "mvn test" command on the appropriate module:

build passed.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml