### PR TITLE
Stabilize TestZKWatch

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKWatch.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKWatch.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CountDownLatch;
 
 import org.I0Itec.zkclient.IZkChildListener;
 import org.I0Itec.zkclient.IZkDataListener;
+import org.apache.helix.TestHelper;
 import org.apache.helix.ZkTestHelper;
 import org.apache.helix.ZkUnitTestBase;
 import org.testng.Assert;
@@ -78,7 +79,9 @@ public class TestZKWatch extends ZkUnitTestBase {
     Assert.assertEquals(zkWatch.get("existWatches").size(), 0);
     Assert.assertEquals(zkWatch.get("childWatches").size(), 0);
 
-    Assert.assertEquals(_zkClient.numberOfListeners(), 0);
+    boolean noListenerExists =
+        TestHelper.verify(() -> _zkClient.numberOfListeners() == 0, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(noListenerExists);
   }
 
   @Test(dependsOnMethods = "testSubscribeDataChange")
@@ -114,7 +117,10 @@ public class TestZKWatch extends ZkUnitTestBase {
     Assert.assertEquals(zkWatch.get("existWatches").size(), 0);
     Assert.assertEquals(zkWatch.get("childWatches").size(), 1);
     Assert.assertEquals(zkWatch.get("childWatches").get(0), parentPath);
-    Assert.assertEquals(_zkClient.numberOfListeners(), 0);
+
+    boolean noListenerExists =
+        TestHelper.verify(() -> _zkClient.numberOfListeners() == 0, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(noListenerExists);
 
     // delete the parent path
     _zkClient.delete(parentPath);


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #746 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR contains the necessary changes to stabilize the TestZKWatch

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 1083, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4,139.109 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1083, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:09 h
[INFO] Finished at: 2020-02-10T23:03:30-08:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality
- [x] My diff has been formatted using helix-style.xml