### PR TITLE
Fix the flaky test - TestZkWatch

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKWatch.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZKWatch.java
@@ -59,8 +59,8 @@ public class TestZKWatch extends ZkUnitTestBase {
 
       @Override
       public void handleDataDeleted(String path) throws Exception {
-        deleteCondition.countDown();
         _zkClient.unsubscribeDataChanges(path, this);
+        deleteCondition.countDown();
       }
     };
     _zkClient.subscribeDataChanges(existPath, dataListener);
@@ -91,8 +91,8 @@ public class TestZKWatch extends ZkUnitTestBase {
     IZkChildListener childListener = new IZkChildListener() {
       @Override
       public void handleChildChange(String parentPath, List<String> childrenPaths) throws Exception {
-        deleteCondition.countDown();
         _zkClient.unsubscribeChildChanges(parentPath, this);
+        deleteCondition.countDown();
       }
     };
     _zkClient.subscribeChildChanges(parentPath, childListener);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

(Fixes #746  )

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

The root cause of the instability is due to the incorrect condition notify time: it should notify other threads waiting for the condition after zkClient finishes the unsubscribing all listeners.

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")
Shut down zookeeper at port 2183 in thread main
[ERROR] Tests run: 1086, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4,587.356 s <<< FAILURE! - in TestSuite
[ERROR] testMissingTopStateDurationMonitoring(org.apache.helix.integration.controller.TestControllerLeadershipChange)  Time elapsed: 4.779 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.integration.controller.TestControllerLeadershipChange.testMissingTopStateDurationMonitoring(TestControllerLeadershipChange.java:262)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestControllerLeadershipChange.testMissingTopStateDurationMonitoring:262 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1086, Failures: 1, Errors: 0, Skipped: 0
[INFO] 


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml