### PR TITLE
Implement getAllMappingUnderPath and getMetadataStoreRealm

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
@@ -162,15 +162,11 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
    * @throws InvalidRoutingDataException - when there is an empty sharding key (edge case that
    *           always renders the routing data invalid); when there is a sharding key which already
    *           contains a sharding key (invalid); when there is a sharding key that is a part of
-   *           another sharding key (invalid)
+   *           another sharding key (invalid); when a sharding key doesn't have a leading delimiter
    */
   private void constructTrie(Map<String, List<String>> routingData)
       throws InvalidRoutingDataException {
     for (Map.Entry<String, List<String>> entry : routingData.entrySet()) {
-      if (entry.getValue().isEmpty()) {
-        throw new InvalidRoutingDataException(
-            "Realm address does not have associating sharding keys: " + entry.getKey());
-      }
       for (String shardingKey : entry.getValue()) {
         // Missing leading delimiter is invalid
         if (shardingKey.isEmpty() || !shardingKey.substring(0, 1).equals(DELIMITER)) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -119,14 +119,20 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
 
   @Override
   public Map<String, String> getAllMappingUnderPath(String namespace, String path) {
-    // TODO: get it from routingData
-    throw new UnsupportedOperationException();
+    if (!_routingDataMap.containsKey(namespace)) {
+      throw new IllegalArgumentException(
+          "Failed to get all mapping under path: Namespace " + namespace + " is not found!");
+    }
+    return _routingDataMap.get(namespace).getAllMappingUnderPath(path);
   }
 
   @Override
   public String getMetadataStoreRealm(String namespace, String shardingKey) {
-    // TODO: get it from routingData
-    throw new UnsupportedOperationException();
+    if (!_routingDataMap.containsKey(namespace)) {
+      throw new IllegalArgumentException(
+          "Failed to get all mapping under path: Namespace " + namespace + " is not found!");
+    }
+    return _routingDataMap.get(namespace).getMetadataStoreRealm(shardingKey);
   }
 
   @Override

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -120,7 +120,7 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
   @Override
   public Map<String, String> getAllMappingUnderPath(String namespace, String path) {
     if (!_routingDataMap.containsKey(namespace)) {
-      throw new IllegalArgumentException(
+      throw new NoSuchElementException(
           "Failed to get all mapping under path: Namespace " + namespace + " is not found!");
     }
     return _routingDataMap.get(namespace).getAllMappingUnderPath(path);
@@ -129,8 +129,8 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
   @Override
   public String getMetadataStoreRealm(String namespace, String shardingKey) {
     if (!_routingDataMap.containsKey(namespace)) {
-      throw new IllegalArgumentException(
-          "Failed to get all mapping under path: Namespace " + namespace + " is not found!");
+      throw new NoSuchElementException(
+          "Failed to get metadata store realm: Namespace " + namespace + " is not found!");
     }
     return _routingDataMap.get(namespace).getMetadataStoreRealm(shardingKey);
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -79,6 +79,8 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
       // Populate realmToShardingKeys with ZkRoutingDataReader
       _realmToShardingKeysMap.put(routingEntry.getKey(),
           _routingDataReaderMap.get(routingEntry.getKey()).getRoutingData());
+      _routingDataMap.put(routingEntry.getKey(),
+          new TrieRoutingData(_realmToShardingKeysMap.get(routingEntry.getKey())));
     }
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/MetadataStoreRoutingDataReader.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/MetadataStoreRoutingDataReader.java
@@ -35,7 +35,8 @@ public interface MetadataStoreRoutingDataReader {
    * @return a mapping from "metadata store realm addresses" to lists of "metadata store sharding
    *         keys", where the sharding keys in a value list all route to the realm address in the
    *         key
-   * @throws InvalidRoutingDataException - when the routing data is missing
+   * @throws InvalidRoutingDataException - when the routing data is malformed in any way that
+   *           disallows a meaningful mapping to be returned
    */
   Map<String, List<String>> getRoutingData() throws InvalidRoutingDataException;
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/MetadataStoreRoutingDataReader.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/MetadataStoreRoutingDataReader.java
@@ -35,8 +35,7 @@ public interface MetadataStoreRoutingDataReader {
    * @return a mapping from "metadata store realm addresses" to lists of "metadata store sharding
    *         keys", where the sharding keys in a value list all route to the realm address in the
    *         key
-   * @throws InvalidRoutingDataException - when the routing data is malformed in any way that
-   *           disallows a meaningful mapping to be returned
+   * @throws InvalidRoutingDataException - when the routing data is missing
    */
   Map<String, List<String>> getRoutingData() throws InvalidRoutingDataException;
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
@@ -36,8 +36,8 @@ import org.apache.helix.zookeeper.zkclient.IZkStateListener;
 import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
 import org.apache.zookeeper.Watcher;
 
-
-public class ZkRoutingDataReader implements MetadataStoreRoutingDataReader, IZkDataListener, IZkChildListener, IZkStateListener {
+public class ZkRoutingDataReader
+    implements MetadataStoreRoutingDataReader, IZkDataListener, IZkChildListener, IZkStateListener {
   private final String _namespace;
   private final String _zkAddress;
   private final HelixZkClient _zkClient;
@@ -53,18 +53,17 @@ public class ZkRoutingDataReader implements MetadataStoreRoutingDataReader, IZkD
       throw new IllegalArgumentException("Zk address cannot be null or empty!");
     }
     _zkAddress = zkAddress;
-    _zkClient = DedicatedZkClientFactory.getInstance()
-        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
-            new HelixZkClient.ZkClientConfig().setZkSerializer(new ZNRecordSerializer()));
+    _zkClient = DedicatedZkClientFactory.getInstance().buildZkClient(
+        new HelixZkClient.ZkConnectionConfig(zkAddress),
+        new HelixZkClient.ZkClientConfig().setZkSerializer(new ZNRecordSerializer()));
     _routingDataListener = routingDataListener;
     if (_routingDataListener != null) {
       // Subscribe child changes
       _zkClient.subscribeChildChanges(MetadataStoreRoutingConstants.ROUTING_DATA_PATH, this);
       // Subscribe data changes
       for (String child : _zkClient.getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH)) {
-        _zkClient
-            .subscribeDataChanges(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + child,
-                this);
+        _zkClient.subscribeDataChanges(
+            MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + child, this);
       }
     }
   }
@@ -72,10 +71,10 @@ public class ZkRoutingDataReader implements MetadataStoreRoutingDataReader, IZkD
   /**
    * Returns (realm, list of ZK path sharding keys) mappings.
    * @return Map <realm, list of ZK path sharding keys>
-   * @throws InvalidRoutingDataException
+   * @throws InvalidRoutingDataException - when the node on
+   *           MetadataStoreRoutingConstants.ROUTING_DATA_PATH is missing
    */
-  public Map<String, List<String>> getRoutingData()
-      throws InvalidRoutingDataException {
+  public Map<String, List<String>> getRoutingData() throws InvalidRoutingDataException {
     Map<String, List<String>> routingData = new HashMap<>();
     List<String> allRealmAddresses;
     try {

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
@@ -36,8 +36,8 @@ import org.apache.helix.zookeeper.zkclient.IZkStateListener;
 import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
 import org.apache.zookeeper.Watcher;
 
-public class ZkRoutingDataReader
-    implements MetadataStoreRoutingDataReader, IZkDataListener, IZkChildListener, IZkStateListener {
+
+public class ZkRoutingDataReader implements MetadataStoreRoutingDataReader, IZkDataListener, IZkChildListener, IZkStateListener {
   private final String _namespace;
   private final String _zkAddress;
   private final HelixZkClient _zkClient;
@@ -53,17 +53,18 @@ public class ZkRoutingDataReader
       throw new IllegalArgumentException("Zk address cannot be null or empty!");
     }
     _zkAddress = zkAddress;
-    _zkClient = DedicatedZkClientFactory.getInstance().buildZkClient(
-        new HelixZkClient.ZkConnectionConfig(zkAddress),
-        new HelixZkClient.ZkClientConfig().setZkSerializer(new ZNRecordSerializer()));
+    _zkClient = DedicatedZkClientFactory.getInstance()
+        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
+            new HelixZkClient.ZkClientConfig().setZkSerializer(new ZNRecordSerializer()));
     _routingDataListener = routingDataListener;
     if (_routingDataListener != null) {
       // Subscribe child changes
       _zkClient.subscribeChildChanges(MetadataStoreRoutingConstants.ROUTING_DATA_PATH, this);
       // Subscribe data changes
       for (String child : _zkClient.getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH)) {
-        _zkClient.subscribeDataChanges(
-            MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + child, this);
+        _zkClient
+            .subscribeDataChanges(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + child,
+                this);
       }
     }
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
@@ -77,21 +77,21 @@ public class ZkRoutingDataReader implements MetadataStoreRoutingDataReader, IZkD
   public Map<String, List<String>> getRoutingData()
       throws InvalidRoutingDataException {
     Map<String, List<String>> routingData = new HashMap<>();
-    List<String> children;
+    List<String> allRealmAddresses;
     try {
-      children = _zkClient.getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH);
+      allRealmAddresses = _zkClient.getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH);
     } catch (ZkNoNodeException e) {
       throw new InvalidRoutingDataException(
           "Routing data directory ZNode " + MetadataStoreRoutingConstants.ROUTING_DATA_PATH
               + " does not exist. Routing ZooKeeper address: " + _zkAddress);
     }
-    for (String child : children) {
+    for (String realmAddress : allRealmAddresses) {
       ZNRecord record =
-          _zkClient.readData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + child);
+          _zkClient.readData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + realmAddress);
       List<String> shardingKeys =
           record.getListField(MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY);
-      if (shardingKeys != null && !shardingKeys.isEmpty()) {
-        routingData.put(child, shardingKeys);
+      if (shardingKeys != null) {
+        routingData.put(realmAddress, shardingKeys);
       }
     }
     return routingData;

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
@@ -85,23 +85,14 @@ public class ZkRoutingDataReader implements MetadataStoreRoutingDataReader, IZkD
           "Routing data directory ZNode " + MetadataStoreRoutingConstants.ROUTING_DATA_PATH
               + " does not exist. Routing ZooKeeper address: " + _zkAddress);
     }
-    if (children == null || children.isEmpty()) {
-      throw new InvalidRoutingDataException(
-          "There are no metadata store realms defined. Routing ZooKeeper address: " + _zkAddress);
-    }
     for (String child : children) {
       ZNRecord record =
           _zkClient.readData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + child);
       List<String> shardingKeys =
           record.getListField(MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY);
-      if (shardingKeys == null || shardingKeys.isEmpty()) {
-        throw new InvalidRoutingDataException(
-            "Realm address ZNode " + MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + child
-                + " does not have a value for key "
-                + MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY
-                + ". Routing ZooKeeper address: " + _zkAddress);
+      if (shardingKeys != null && !shardingKeys.isEmpty()) {
+        routingData.put(child, shardingKeys);
       }
-      routingData.put(child, shardingKeys);
     }
     return routingData;
   }

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestTrieRoutingData.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestTrieRoutingData.java
@@ -67,19 +67,6 @@ public class TestTrieRoutingData {
   }
 
   @Test
-  public void testConstructionEmptyShardingKeys() {
-    Map<String, List<String>> routingData = new HashMap<>();
-    routingData.put("realmAddress1", Collections.emptyList());
-    try {
-      new TrieRoutingData(routingData);
-      Assert.fail("Expecting InvalidRoutingDataException");
-    } catch (InvalidRoutingDataException e) {
-      Assert.assertTrue(e.getMessage()
-          .contains("Realm address does not have associating sharding keys: realmAddress1"));
-    }
-  }
-
-  @Test
   public void testConstructionShardingKeyNoLeadingSlash() {
     Map<String, List<String>> routingData = new HashMap<>();
     routingData.put("realmAddress1", Arrays.asList("/g", "/h/i", "/h/j"));

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataReader.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataReader.java
@@ -104,11 +104,10 @@ public class TestZkRoutingDataReader extends AbstractTestClass {
     _baseAccessor.create(MetadataStoreRoutingConstants.ROUTING_DATA_PATH, new ZNRecord("test"),
         AccessOption.PERSISTENT);
     try {
-      _zkRoutingDataReader.getRoutingData();
-      Assert.fail("Expecting InvalidRoutingDataException");
+      Map<String, List<String>> routingData = _zkRoutingDataReader.getRoutingData();
+      Assert.assertEquals(routingData.size(), 0);
     } catch (InvalidRoutingDataException e) {
-      Assert.assertTrue(e.getMessage().contains(
-          "There are no metadata store realms defined. Routing ZooKeeper address: " + ZK_ADDR));
+      Assert.fail("Not expecting InvalidRoutingDataException");
     }
   }
 
@@ -120,14 +119,10 @@ public class TestZkRoutingDataReader extends AbstractTestClass {
     _baseAccessor.create(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1",
         testZnRecord1, AccessOption.PERSISTENT);
     try {
-      _zkRoutingDataReader.getRoutingData();
-      Assert.fail("Expecting InvalidRoutingDataException");
+      Map<String, List<String>> routingData = _zkRoutingDataReader.getRoutingData();
+      Assert.assertEquals(routingData.size(), 0);
     } catch (InvalidRoutingDataException e) {
-      Assert.assertTrue(e.getMessage().contains(
-          "Realm address ZNode " + MetadataStoreRoutingConstants.ROUTING_DATA_PATH
-              + "/testRealmAddress1 does not have a value for key "
-              + MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY
-              + ". Routing ZooKeeper address: " + ZK_ADDR));
+      Assert.fail("Not expecting InvalidRoutingDataException");
     }
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataReader.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataReader.java
@@ -120,7 +120,8 @@ public class TestZkRoutingDataReader extends AbstractTestClass {
         testZnRecord1, AccessOption.PERSISTENT);
     try {
       Map<String, List<String>> routingData = _zkRoutingDataReader.getRoutingData();
-      Assert.assertEquals(routingData.size(), 0);
+      Assert.assertEquals(routingData.size(), 1);
+      Assert.assertTrue(routingData.get("testRealmAddress1").isEmpty());
     } catch (InvalidRoutingDataException e) {
       Assert.fail("Not expecting InvalidRoutingDataException");
     }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #750 0   

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR implements `getAllMappingUnderPath` and `getMetadataStoreRealm` in `ZkMetadataStoreDirectory`. Also, `ZkRoutingDataReader` is updated specifically in `getRoutingData`: not having realm addresses and not having sharding keys for some realm addresses no longer raise exceptions. 

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 127, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.928 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 127, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  44.894 s
[INFO] Finished at: 2020-02-11T11:09:09-08:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml