### PR TITLE
Add validation logic to MSD write operations

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreRoutingData.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreRoutingData.java
@@ -56,4 +56,12 @@ public interface MetadataStoreRoutingData {
    * @return true if the sharding key could be inserted, false otherwise
    */
   boolean isShardingKeyInsertionValid(String shardingKey);
+
+  /**
+   * Check if the provided sharding key and realm address pair exists in the routing data.
+   * @param shardingKey - the sharding key checked
+   * @param realmAddress - the realm address corresponding to the key
+   * @return true if the sharding key and realm address pair exist in the routing data
+   */
+  boolean containsKeyRealmPair(String shardingKey, String realmAddress);
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreRoutingData.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreRoutingData.java
@@ -45,4 +45,15 @@ public interface MetadataStoreRoutingData {
    * @throws NoSuchElementException - when the path doesn't contain a sharding key
    */
   String getMetadataStoreRealm(String path) throws IllegalArgumentException, NoSuchElementException;
+
+  /**
+   * Check if the provided sharding key can be inserted to the routing data. The insertion is
+   * invalid if: 1. the sharding key is a parent key to an existing sharding key; 2. the sharding
+   * key has a parent key that is an existing sharding key; 3. the sharding key already exists. In
+   * any of these cases, inserting the sharding key will cause ambiguity among 2 sharding keys,
+   * rendering the routing data invalid.
+   * @param shardingKey - the sharding key to be inserted
+   * @return true if the sharding key could be inserted, false otherwise
+   */
+  boolean isShardingKeyInsertionValid(String shardingKey);
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+
 import org.apache.helix.rest.metadatastore.exceptions.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.util.ZkValidationUtil;
 
@@ -183,8 +184,8 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
       for (String shardingKey : entry.getValue()) {
         // Missing leading delimiter is invalid
         if (!ZkValidationUtil.isPathValid(shardingKey)) {
-          throw new InvalidRoutingDataException("Sharding key is not a valid Zookeeper path: " +
-              shardingKey);
+          throw new InvalidRoutingDataException(
+              "Sharding key is not a valid Zookeeper path: " + shardingKey);
         }
 
         // Root can only be a sharding key if it's the only sharding key. Since this method is
@@ -208,12 +209,14 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
           // If the node is already a leaf node, the current sharding key is invalid; if the node
           // doesn't exist, construct a node and continue
           if (nextNode != null && nextNode.isShardingKey()) {
-            throw new InvalidRoutingDataException(shardingKey + " cannot be a sharding key because "
-                + shardingKey.substring(0, nextDelimiterIndex)
-                + " is its parent key and is also a sharding key.");
+            throw new InvalidRoutingDataException(
+                shardingKey + " cannot be a sharding key because " + shardingKey
+                    .substring(0, nextDelimiterIndex)
+                    + " is its parent key and is also a sharding key.");
           } else if (nextNode == null) {
-            nextNode = new TrieNode(new HashMap<>(), shardingKey.substring(0, nextDelimiterIndex),
-                false, "");
+            nextNode =
+                new TrieNode(new HashMap<>(), shardingKey.substring(0, nextDelimiterIndex), false,
+                    "");
             curNode.addChild(keySection, nextNode);
           }
           prevDelimiterIndex = nextDelimiterIndex;

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/TrieRoutingData.java
@@ -110,7 +110,7 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
    * Given a path, find a trie node that represents the longest prefix of the path. For example,
    * given "/a/b/c", the method starts at "/", and attempts to reach "/a", then attempts to reach
    * "/a/b", then ends on "/a/b/c"; if any of the node doesn't exist, the traversal terminates and
-   * the last existing node is returned.
+   * the last seen existing node is returned.
    * Note:
    * 1. When the returned TrieNode is a sharding key, it is the only sharding key along the
    * provided path (the path points to this sharding key);

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -157,9 +157,14 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
 
   @Override
   public boolean addShardingKey(String namespace, String realm, String shardingKey) {
-    if (!_routingDataWriterMap.containsKey(namespace)) {
+    if (!_routingDataWriterMap.containsKey(namespace) || !_routingDataMap.containsKey(namespace)) {
       throw new IllegalArgumentException(
           "Failed to add sharding key: Namespace " + namespace + " is not found!");
+    }
+    if (!_routingDataMap.get(namespace).isShardingKeyInsertionValid(shardingKey)) {
+      throw new IllegalArgumentException(
+          "Failed to add sharding key: Adding sharding key " + shardingKey
+              + " makes routing data invalid!");
     }
     return _routingDataWriterMap.get(namespace).addShardingKey(realm, shardingKey);
   }
@@ -210,7 +215,6 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
     } catch (InvalidRoutingDataException e) {
       LOG.error("Failed to refresh cached routing data for namespace {}", namespace, e);
     }
-
   }
 
   @Override

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -161,6 +161,9 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
       throw new IllegalArgumentException(
           "Failed to add sharding key: Namespace " + namespace + " is not found!");
     }
+    if (_routingDataMap.get(namespace).containsKeyRealmPair(shardingKey, realm)) {
+      return true;
+    }
     if (!_routingDataMap.get(namespace).isShardingKeyInsertionValid(shardingKey)) {
       throw new IllegalArgumentException(
           "Failed to add sharding key: Adding sharding key " + shardingKey

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -37,6 +37,7 @@ import org.apache.helix.rest.metadatastore.exceptions.InvalidRoutingDataExceptio
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * ZK-based MetadataStoreDirectory that listens on the routing data in routing ZKs with a update
  * callback.

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
@@ -31,6 +31,7 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.rest.server.resources.zookeeper.ZooKeeperAccessor;
+import org.apache.helix.zookeeper.util.ZkValidationUtil;
 import org.codehaus.jackson.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +57,7 @@ public class PropertyStoreAccessor extends AbstractHelixResource {
   public Response getPropertyByPath(@PathParam("clusterId") String clusterId,
       @PathParam("path") String path) {
     path = "/" + path;
-    if (!ZooKeeperAccessor.isPathValid(path)) {
+    if (!ZkValidationUtil.isPathValid(path)) {
       LOG.info("The propertyStore path {} is invalid for cluster {}", path, clusterId);
       return badRequest(
           "Invalid path string. Valid path strings use slash as the directory separator and names the location of ZNode");

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
@@ -35,6 +35,7 @@ import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.rest.common.ContextPropertyKeys;
 import org.apache.helix.rest.server.ServerContext;
 import org.apache.helix.rest.server.resources.AbstractResource;
+import org.apache.helix.zookeeper.util.ZkValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +73,7 @@ public class ZooKeeperAccessor extends AbstractResource {
     path = "/" + path;
 
     // Check that the path supplied is valid
-    if (!isPathValid(path)) {
+    if (!ZkValidationUtil.isPathValid(path)) {
       String errMsg = "The given path is not a valid ZooKeeper path: " + path;
       LOG.info(errMsg);
       return badRequest(errMsg);
@@ -169,21 +170,5 @@ public class ZooKeeperAccessor extends AbstractResource {
 
   private ZooKeeperCommand getZooKeeperCommandIfPresent(String command) {
     return Enums.getIfPresent(ZooKeeperCommand.class, command).orNull();
-  }
-
-  /**
-   * Validates whether a given path string is a valid ZK path.
-   *
-   * Valid matches:
-   * /
-   * /abc
-   * /abc/abc/abc/abc
-   * Invalid matches:
-   * null or empty string
-   * /abc/
-   * /abc/abc/abc/abc/
-   **/
-  public static boolean isPathValid(String path) {
-    return path.matches("^/|(/[\\w-]+)+$");
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestTrieRoutingData.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestTrieRoutingData.java
@@ -78,8 +78,8 @@ public class TestTrieRoutingData {
       new TrieRoutingData(routingData);
       Assert.fail("Expecting InvalidRoutingDataException");
     } catch (InvalidRoutingDataException e) {
-      Assert.assertTrue(
-          e.getMessage().contains("Sharding key does not have a leading \"/\" character: b/c/d"));
+      Assert
+          .assertTrue(e.getMessage().contains("Sharding key is not a valid Zookeeper path: b/c/d"));
     }
   }
 
@@ -153,8 +153,7 @@ public class TestTrieRoutingData {
       _trie.getAllMappingUnderPath("");
       Assert.fail("Expecting IllegalArgumentException");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
-          .contains("Provided path is empty or does not have a leading \"/\" character: "));
+      Assert.assertTrue(e.getMessage().contains("Provided path is not a valid Zookeeper path: "));
     }
   }
 
@@ -164,8 +163,8 @@ public class TestTrieRoutingData {
       _trie.getAllMappingUnderPath("test");
       Assert.fail("Expecting IllegalArgumentException");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
-          .contains("Provided path is empty or does not have a leading \"/\" character: test"));
+      Assert
+          .assertTrue(e.getMessage().contains("Provided path is not a valid Zookeeper path: test"));
     }
   }
 
@@ -209,8 +208,7 @@ public class TestTrieRoutingData {
       Assert.assertEquals(_trie.getMetadataStoreRealm(""), "realmAddress2");
       Assert.fail("Expecting IllegalArgumentException");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
-          .contains("Provided path is empty or does not have a leading \"/\" character: "));
+      Assert.assertTrue(e.getMessage().contains("Provided path is not a valid Zookeeper path: "));
     }
   }
 
@@ -220,8 +218,8 @@ public class TestTrieRoutingData {
       Assert.assertEquals(_trie.getMetadataStoreRealm("b/c/d/x/y/z"), "realmAddress2");
       Assert.fail("Expecting IllegalArgumentException");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
-          "Provided path is empty or does not have a leading \"/\" character: b/c/d/x/y/z"));
+      Assert.assertTrue(
+          e.getMessage().contains("Provided path is not a valid Zookeeper path: b/c/d/x/y/z"));
     }
   }
 
@@ -262,8 +260,8 @@ public class TestTrieRoutingData {
       _trie.isShardingKeyInsertionValid("x/y/z");
       Assert.fail("Expecting IllegalArgumentException");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
-          "Provided shardingKey is empty or does not have a leading \"/\" character: x/y/z"));
+      Assert.assertTrue(
+          e.getMessage().contains("Provided shardingKey is not a valid Zookeeper path: x/y/z"));
     }
   }
 
@@ -290,5 +288,20 @@ public class TestTrieRoutingData {
   @Test(dependsOnMethods = "testConstructionNormal")
   public void testIsShardingKeyInsertionValidChildKey() {
     Assert.assertFalse(_trie.isShardingKeyInsertionValid("/h/i/k"));
+  }
+
+  @Test(dependsOnMethods = "testConstructionNormal")
+  public void testContainsKeyRealmPair() {
+    Assert.assertTrue(_trie.containsKeyRealmPair("/h/i", "realmAddress1"));
+  }
+
+  @Test(dependsOnMethods = "testConstructionNormal")
+  public void testContainsKeyRealmPairNoKey() {
+    Assert.assertFalse(_trie.containsKeyRealmPair("/h/i/k", "realmAddress1"));
+  }
+
+  @Test(dependsOnMethods = "testConstructionNormal")
+  public void testContainsKeyRealmPairNoRealm() {
+    Assert.assertFalse(_trie.containsKeyRealmPair("/h/i", "realmAddress0"));
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/ZkValidationUtil.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/ZkValidationUtil.java
@@ -1,0 +1,38 @@
+package org.apache.helix.zookeeper.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class ZkValidationUtil {
+  /**
+   * Validates whether a given path string is a valid ZK path.
+   *
+   * Valid matches:
+   * /
+   * /abc
+   * /abc/abc/abc/abc
+   * Invalid matches:
+   * null or empty string
+   * /abc/
+   * /abc/abc/abc/abc/
+   **/
+  public static boolean isPathValid(String path) {
+    return path.matches("^/|(/[\\w-]+)+$");
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #758   

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR add routing data validation logic. When a user attempts to add a sharding key to some existing routing data, validation logic is used to confirm that the addition will leave the resulting routing data in a valid state. We make use of the existing trie structure to efficiently check if a sharding key results in an ambiguity case. Some old code in `TrieRoutingData` is modified to minimize duplicate code and make everything a lot cleaner. 

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 143, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.642 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 143, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  47.466 s
[INFO] Finished at: 2020-02-13T11:13:56-08:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml