### PR TITLE
SharedZKClient 

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/factory/RealmAwareZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/factory/RealmAwareZkClientFactory.java
@@ -40,6 +40,8 @@ public interface RealmAwareZkClientFactory {
    * @param connectionConfig
    * @return RealmAwareZkClient
    */
-  RealmAwareZkClient buildZkClient(
-      RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig);
+  default RealmAwareZkClient buildZkClient(
+      RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig) {
+    return buildZkClient(connectionConfig, new RealmAwareZkClient.RealmAwareZkClientConfig());
+  };
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -55,7 +55,7 @@ public class SharedZkClient extends ZkClient implements HelixZkClient {
   }
 
   /**
-   * Construct a shared RealmAwareZkClient that uses a shared ZkConnection.
+   * Construct a shared ZkClient that uses a shared ZkConnection.
    *
    * @param connectionManager     The manager of the shared ZkConnection.
    * @param clientConfig          ZkClientConfig details to create the shared RealmAwareZkClient.
@@ -64,6 +64,25 @@ public class SharedZkClient extends ZkClient implements HelixZkClient {
   public SharedZkClient(ZkConnectionManager connectionManager, ZkClientConfig clientConfig,
       OnCloseCallback callback) {
     super(connectionManager.getConnection(), 0, clientConfig.getOperationRetryTimeout(),
+        clientConfig.getZkSerializer(), clientConfig.getMonitorType(), clientConfig.getMonitorKey(),
+        clientConfig.getMonitorInstanceName(), clientConfig.isMonitorRootPathOnly());
+    _connectionManager = connectionManager;
+    // Register to the base dedicated RealmAwareZkClient
+    _connectionManager.registerWatcher(this);
+    _onCloseCallback = callback;
+  }
+
+  /**
+   * Construct a shared RealmAwareZkClient that uses a shared ZkConnection.
+   *
+   * @param connectionManager     The manager of the shared ZkConnection.
+   * @param clientConfig          ZkClientConfig details to create the shared RealmAwareZkClient.
+   * @param callback              Clean up logic when the shared RealmAwareZkClient is closed.
+   */
+  public SharedZkClient(String realmKey, ZkConnectionManager connectionManager, RealmAwareZkClientConfig clientConfig,
+      OnCloseCallback callback) {
+    // todo: assert realmKey != null?
+    super(realmKey,connectionManager.getConnection(), 0, clientConfig.getOperationRetryTimeout(),
         clientConfig.getZkSerializer(), clientConfig.getMonitorType(), clientConfig.getMonitorKey(),
         clientConfig.getMonitorInstanceName(), clientConfig.isMonitorRootPathOnly());
     _connectionManager = connectionManager;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/ZkClient.java
@@ -90,7 +90,15 @@ public class ZkClient extends org.apache.helix.zookeeper.zkclient.ZkClient imple
       PathBasedZkSerializer zkSerializer,
       String monitorType, String monitorKey, String monitorInstanceName,
       boolean monitorRootPathOnly) {
-    super(zkConnection, connectionTimeout, operationRetryTimeout, zkSerializer, monitorType,
+    super(null, zkConnection, connectionTimeout, operationRetryTimeout, zkSerializer, monitorType,
+        monitorKey, monitorInstanceName, monitorRootPathOnly);
+  }
+
+  public ZkClient(String realmKey, IZkConnection zkConnection, int connectionTimeout, long operationRetryTimeout,
+      PathBasedZkSerializer zkSerializer,
+      String monitorType, String monitorKey, String monitorInstanceName,
+      boolean monitorRootPathOnly) {
+    super(realmKey, zkConnection, connectionTimeout, operationRetryTimeout, zkSerializer, monitorType,
         monitorKey, monitorInstanceName, monitorRootPathOnly);
   }
 


### PR DESCRIPTION
### Issues

- [ x ] My PR addresses the following Helix issues and references them in the PR description:

Resolve #762 


### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

This diff added the implementation of building realm aware shared ZKClient implementation to ShareZkClientFactory.

The diff intends to achieve this with minimal change and easy to reason correctness in terms of keeping the zk client session management, sync and async semantic and auto-reconnection upon session expiration intact.

### Tests

- [ ] The following tests are written for this issue:

To be done.

- [x ] The following is the result of the "mvn test" command on the appropriate module:

"mvn -pl zookeeper-api test" pass though it does not seem to invoke any real test.

### Commits

- [ ] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [ ] My diff has been formatted using helix-style.xml