### PR TITLE
WIP: Add SharedZkClient and update SharedZkClientFactory

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/client/SharedZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/client/SharedZkClient.java
@@ -20,7 +20,6 @@ package org.apache.helix.manager.zk.client;
  */
 
 import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
-import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory.InnerSharedZkClient;
 import org.apache.helix.zookeeper.impl.factory.ZkConnectionManager;
 
 
@@ -28,7 +27,7 @@ import org.apache.helix.zookeeper.impl.factory.ZkConnectionManager;
  * Deprecated; use SharedZkClient in zookeeper-api instead.
  */
 @Deprecated
-class SharedZkClient extends InnerSharedZkClient {
+class SharedZkClient extends SharedZkClientFactory.InnerSharedZkClient {
   SharedZkClient(ZkConnectionManager connectionManager, ZkClientConfig clientConfig,
       SharedZkClientFactory.OnCloseCallback callback) {
     super(connectionManager, clientConfig, callback);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/client/SharedZkClient.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/client/SharedZkClient.java
@@ -19,19 +19,18 @@ package org.apache.helix.manager.zk.client;
  * under the License.
  */
 
+import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
+import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory.InnerSharedZkClient;
+import org.apache.helix.zookeeper.impl.factory.ZkConnectionManager;
+
+
 /**
  * Deprecated; use SharedZkClient in zookeeper-api instead.
  */
 @Deprecated
-class SharedZkClient extends org.apache.helix.zookeeper.impl.client.SharedZkClient {
-  /**
-   * Construct a shared RealmAwareZkClient that uses a shared ZkConnection.
-   *  @param connectionManager     The manager of the shared ZkConnection.
-   * @param clientConfig          ZkClientConfig details to create the shared RealmAwareZkClient.
-   * @param callback              Clean up logic when the shared RealmAwareZkClient is closed.
-   */
-  protected SharedZkClient(ZkConnectionManager connectionManager, ZkClientConfig clientConfig,
-      org.apache.helix.zookeeper.impl.client.SharedZkClient.OnCloseCallback callback) {
+class SharedZkClient extends InnerSharedZkClient {
+  SharedZkClient(ZkConnectionManager connectionManager, ZkClientConfig clientConfig,
+      SharedZkClientFactory.OnCloseCallback callback) {
     super(connectionManager, clientConfig, callback);
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
@@ -21,7 +21,6 @@ package org.apache.helix.zookeeper.api.client;
 
 import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
-import org.apache.helix.zookeeper.zkclient.serialize.SerializableSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 
 
@@ -42,7 +41,7 @@ public interface HelixZkClient extends RealmAwareZkClient {
   class ZkConnectionConfig {
     // Connection configs
     private final String _zkServers;
-    private int _sessionTimeout = HelixZkClient.DEFAULT_SESSION_TIMEOUT;
+    private int _sessionTimeout = DEFAULT_SESSION_TIMEOUT;
 
     public ZkConnectionConfig(String zkServers) {
       _zkServers = zkServers;
@@ -53,10 +52,10 @@ public interface HelixZkClient extends RealmAwareZkClient {
       if (obj == this) {
         return true;
       }
-      if (!(obj instanceof HelixZkClient.ZkConnectionConfig)) {
+      if (!(obj instanceof ZkConnectionConfig)) {
         return false;
       }
-      HelixZkClient.ZkConnectionConfig configObj = (HelixZkClient.ZkConnectionConfig) obj;
+      ZkConnectionConfig configObj = (ZkConnectionConfig) obj;
       return (_zkServers == null && configObj._zkServers == null || _zkServers != null && _zkServers
           .equals(configObj._zkServers)) && _sessionTimeout == configObj._sessionTimeout;
     }
@@ -71,7 +70,7 @@ public interface HelixZkClient extends RealmAwareZkClient {
       return (_zkServers + "_" + _sessionTimeout).replaceAll("[\\W]", "_");
     }
 
-    public HelixZkClient.ZkConnectionConfig setSessionTimeout(Integer sessionTimeout) {
+    public ZkConnectionConfig setSessionTimeout(Integer sessionTimeout) {
       this._sessionTimeout = sessionTimeout;
       return this;
     }
@@ -89,32 +88,17 @@ public interface HelixZkClient extends RealmAwareZkClient {
    * Deprecated - please use RealmAwareZkClient and RealmAwareZkClientConfig instead.
    *
    * Configuration for creating a new HelixZkClient with serializer and monitor.
-   *
-   * TODO: If possible, try to merge with RealmAwareZkClient's RealmAwareZkClientConfig to reduce duplicate logic/code (without breaking backward-compatibility).
-   * Simply making this a subclass of RealmAwareZkClientConfig will break backward-compatiblity.
    */
   @Deprecated
-  class ZkClientConfig {
-    // For client to init the connection
-    private long _connectInitTimeout = DEFAULT_CONNECTION_TIMEOUT;
+  class ZkClientConfig extends RealmAwareZkClientConfig {
 
-    // Data access configs
-    private long _operationRetryTimeout = DEFAULT_OPERATION_TIMEOUT;
-
-    // Others
-    private PathBasedZkSerializer _zkSerializer;
-
-    // Monitoring
-    private String _monitorType;
-    private String _monitorKey;
-    private String _monitorInstanceName = null;
-    private boolean _monitorRootPathOnly = true;
-
+    @Override
     public ZkClientConfig setZkSerializer(PathBasedZkSerializer zkSerializer) {
       this._zkSerializer = zkSerializer;
       return this;
     }
 
+    @Override
     public ZkClientConfig setZkSerializer(ZkSerializer zkSerializer) {
       this._zkSerializer = new BasicZkSerializer(zkSerializer);
       return this;
@@ -125,6 +109,7 @@ public interface HelixZkClient extends RealmAwareZkClient {
      *
      * @param monitorType
      */
+    @Override
     public ZkClientConfig setMonitorType(String monitorType) {
       this._monitorType = monitorType;
       return this;
@@ -135,6 +120,7 @@ public interface HelixZkClient extends RealmAwareZkClient {
      *
      * @param monitorKey
      */
+    @Override
     public ZkClientConfig setMonitorKey(String monitorKey) {
       this._monitorKey = monitorKey;
       return this;
@@ -145,55 +131,28 @@ public interface HelixZkClient extends RealmAwareZkClient {
      *
      * @param instanceName
      */
+    @Override
     public ZkClientConfig setMonitorInstanceName(String instanceName) {
       this._monitorInstanceName = instanceName;
       return this;
     }
 
+    @Override
     public ZkClientConfig setMonitorRootPathOnly(Boolean monitorRootPathOnly) {
       this._monitorRootPathOnly = monitorRootPathOnly;
       return this;
     }
 
+    @Override
     public ZkClientConfig setOperationRetryTimeout(Long operationRetryTimeout) {
       this._operationRetryTimeout = operationRetryTimeout;
       return this;
     }
 
+    @Override
     public ZkClientConfig setConnectInitTimeout(long _connectInitTimeout) {
       this._connectInitTimeout = _connectInitTimeout;
       return this;
-    }
-
-    public PathBasedZkSerializer getZkSerializer() {
-      if (_zkSerializer == null) {
-        _zkSerializer = new BasicZkSerializer(new SerializableSerializer());
-      }
-      return _zkSerializer;
-    }
-
-    public long getOperationRetryTimeout() {
-      return _operationRetryTimeout;
-    }
-
-    public String getMonitorType() {
-      return _monitorType;
-    }
-
-    public String getMonitorKey() {
-      return _monitorKey;
-    }
-
-    public String getMonitorInstanceName() {
-      return _monitorInstanceName;
-    }
-
-    public boolean isMonitorRootPathOnly() {
-      return _monitorRootPathOnly;
-    }
-
-    public long getConnectInitTimeout() {
-      return _connectInitTimeout;
     }
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -380,19 +380,19 @@ public interface RealmAwareZkClient {
    */
   class RealmAwareZkClientConfig {
     // For client to init the connection
-    private long _connectInitTimeout = DEFAULT_CONNECTION_TIMEOUT;
+    protected long _connectInitTimeout = DEFAULT_CONNECTION_TIMEOUT;
 
     // Data access configs
-    private long _operationRetryTimeout = DEFAULT_OPERATION_TIMEOUT;
+    protected long _operationRetryTimeout = DEFAULT_OPERATION_TIMEOUT;
 
     // Others
-    private PathBasedZkSerializer _zkSerializer;
+    protected PathBasedZkSerializer _zkSerializer;
 
     // Monitoring
-    private String _monitorType;
-    private String _monitorKey;
-    private String _monitorInstanceName = null;
-    private boolean _monitorRootPathOnly = true;
+    protected String _monitorType;
+    protected String _monitorKey;
+    protected String _monitorInstanceName = null;
+    protected boolean _monitorRootPathOnly = true;
 
     public RealmAwareZkClientConfig setZkSerializer(PathBasedZkSerializer zkSerializer) {
       this._zkSerializer = zkSerializer;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -20,13 +20,26 @@ package org.apache.helix.zookeeper.impl.client;
  */
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
-import org.apache.helix.zookeeper.impl.factory.ZkConnectionManager;
-import org.apache.helix.zookeeper.zkclient.IZkConnection;
-import org.apache.helix.zookeeper.zkclient.ZkConnection;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
+import org.apache.helix.zookeeper.zkclient.DataUpdater;
+import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+import org.apache.helix.zookeeper.zkclient.IZkDataListener;
+import org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks;
+import org.apache.helix.zookeeper.zkclient.deprecated.IZkStateListener;
+import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
+import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
+import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Op;
+import org.apache.zookeeper.OpResult;
+import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,79 +50,541 @@ import org.slf4j.LoggerFactory;
  * HelixZkClient that uses shared ZkConnection.
  * A SharedZkClient won't manipulate the shared ZkConnection directly.
  */
-public class SharedZkClient extends ZkClient implements HelixZkClient {
+public class SharedZkClient implements RealmAwareZkClient {
   private static Logger LOG = LoggerFactory.getLogger(SharedZkClient.class);
-  /*
-   * Since we cannot really disconnect the ZkConnection, we need a dummy ZkConnection placeholder.
-   * This is to ensure connection field is never null even the shared RealmAwareZkClient instance is closed so as to avoid NPE.
-   */
-  private final static ZkConnection IDLE_CONNECTION = new ZkConnection("Dummy_ZkServers");
-  private final OnCloseCallback _onCloseCallback;
-  private final ZkConnectionManager _connectionManager;
 
-  public interface OnCloseCallback {
-    /**
-     * Triggered after the RealmAwareZkClient is closed.
-     */
-    void onClose();
+  private final HelixZkClient _innerSharedZkClient;
+  private final Map<String, String> _routingDataCache; // TODO: replace with RoutingDataCache
+  private final String _zkRealmShardingKey;
+
+  public SharedZkClient(RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
+      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig,
+      Map<String, String> routingDataCache) {
+
+    if (connectionConfig == null) {
+      throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
+    }
+    _zkRealmShardingKey = connectionConfig.getZkRealmShardingKey();
+
+    // TODO: Replace this Map with a real RoutingDataCache
+    if (routingDataCache == null) {
+      throw new IllegalArgumentException("RoutingDataCache cannot be null!");
+    }
+    _routingDataCache = routingDataCache;
+
+    // Get the ZkRealm address based on the ZK path sharding key
+    String zkRealmAddress = _routingDataCache.get(_zkRealmShardingKey);
+
+    // Create an InnerSharedZkClient to actually serve ZK requests
+    // TODO: Rename HelixZkClient in the future or remove it entirely - this will be a backward-compatibility breaking change because HelixZkClient is being used by Helix users.
+    HelixZkClient.ZkConnectionConfig zkConnectionConfig =
+        new HelixZkClient.ZkConnectionConfig(zkRealmAddress)
+            .setSessionTimeout(connectionConfig.getSessionTimeout());
+    _innerSharedZkClient = SharedZkClientFactory.getInstance()
+        .buildZkClient(zkConnectionConfig, (HelixZkClient.ZkClientConfig) clientConfig);
   }
 
-  /**
-   * Construct a shared RealmAwareZkClient that uses a shared ZkConnection.
-   *
-   * @param connectionManager     The manager of the shared ZkConnection.
-   * @param clientConfig          ZkClientConfig details to create the shared RealmAwareZkClient.
-   * @param callback              Clean up logic when the shared RealmAwareZkClient is closed.
-   */
-  public SharedZkClient(ZkConnectionManager connectionManager, ZkClientConfig clientConfig,
-      OnCloseCallback callback) {
-    super(connectionManager.getConnection(), 0, clientConfig.getOperationRetryTimeout(),
-        clientConfig.getZkSerializer(), clientConfig.getMonitorType(), clientConfig.getMonitorKey(),
-        clientConfig.getMonitorInstanceName(), clientConfig.isMonitorRootPathOnly());
-    _connectionManager = connectionManager;
-    // Register to the base dedicated RealmAwareZkClient
-    _connectionManager.registerWatcher(this);
-    _onCloseCallback = callback;
+  @Override
+  public List<String> subscribeChildChanges(String path, IZkChildListener listener) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.subscribeChildChanges(path, listener);
+  }
+
+  @Override
+  public void unsubscribeChildChanges(String path, IZkChildListener listener) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    _innerSharedZkClient.unsubscribeChildChanges(path, listener);
+  }
+
+  @Override
+  public void subscribeDataChanges(String path, IZkDataListener listener) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    _innerSharedZkClient.subscribeDataChanges(path, listener);
+  }
+
+  @Override
+  public void unsubscribeDataChanges(String path, IZkDataListener listener) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    _innerSharedZkClient.unsubscribeDataChanges(path, listener);
+  }
+
+  @Override
+  public void subscribeStateChanges(IZkStateListener listener) {
+    _innerSharedZkClient.subscribeStateChanges(listener);
+  }
+
+  @Override
+  public void unsubscribeStateChanges(IZkStateListener listener) {
+    _innerSharedZkClient.unsubscribeStateChanges(listener);
+  }
+
+  @Override
+  public void unsubscribeAll() {
+    _innerSharedZkClient.unsubscribeAll();
+  }
+
+  @Override
+  public void createPersistent(String path) {
+    createPersistent(path, false);
+  }
+
+  @Override
+  public void createPersistent(String path, boolean createParents) {
+    createPersistent(path, createParents, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+  }
+
+  @Override
+  public void createPersistent(String path, boolean createParents, List<ACL> acl) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    _innerSharedZkClient.createPersistent(path, createParents, acl);
+  }
+
+  @Override
+  public void createPersistent(String path, Object data) {
+    create(path, data, CreateMode.PERSISTENT);
+  }
+
+  @Override
+  public void createPersistent(String path, Object data, List<ACL> acl) {
+    create(path, data, acl, CreateMode.PERSISTENT);
+  }
+
+  @Override
+  public String createPersistentSequential(String path, Object data) {
+    return create(path, data, CreateMode.PERSISTENT_SEQUENTIAL);
+  }
+
+  @Override
+  public String createPersistentSequential(String path, Object data, List<ACL> acl) {
+    return create(path, data, acl, CreateMode.PERSISTENT_SEQUENTIAL);
+  }
+
+  @Override
+  public void createEphemeral(String path) {
+    throw new UnsupportedOperationException(
+        "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+            + " is not supported.");
+  }
+
+  @Override
+  public void createEphemeral(String path, String sessionId) {
+    throw new UnsupportedOperationException(
+        "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+            + " is not supported.");
+  }
+
+  @Override
+  public void createEphemeral(String path, List<ACL> acl) {
+    throw new UnsupportedOperationException(
+        "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+            + " is not supported.");
+  }
+
+  @Override
+  public void createEphemeral(String path, List<ACL> acl, String sessionId) {
+    throw new UnsupportedOperationException(
+        "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+            + " is not supported.");
+  }
+
+  @Override
+  public String create(String path, Object data, CreateMode mode) {
+    return create(path, data, mode);
+  }
+
+  @Override
+  public String create(String path, Object datat, List<ACL> acl, CreateMode mode) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.create(path, datat, acl, mode);
+  }
+
+  @Override
+  public void createEphemeral(String path, Object data) {
+    throw new UnsupportedOperationException(
+        "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+            + " is not supported.");
+  }
+
+  @Override
+  public void createEphemeral(String path, Object data, String sessionId) {
+    throw new UnsupportedOperationException(
+        "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+            + " is not supported.");
+  }
+
+  @Override
+  public void createEphemeral(String path, Object data, List<ACL> acl) {
+    throw new UnsupportedOperationException(
+        "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+            + " is not supported.");
+  }
+
+  @Override
+  public void createEphemeral(String path, Object data, List<ACL> acl, String sessionId) {
+    throw new UnsupportedOperationException(
+        "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+            + " is not supported.");
+  }
+
+  @Override
+  public String createEphemeralSequential(String path, Object data) {
+    throw new UnsupportedOperationException(
+        "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+            + " is not supported.");
+  }
+
+  @Override
+  public String createEphemeralSequential(String path, Object data, List<ACL> acl) {
+    throw new UnsupportedOperationException(
+        "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+            + " is not supported.");
+  }
+
+  @Override
+  public String createEphemeralSequential(String path, Object data, String sessionId) {
+    throw new UnsupportedOperationException(
+        "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+            + " is not supported.");
+  }
+
+  @Override
+  public String createEphemeralSequential(String path, Object data, List<ACL> acl,
+      String sessionId) {
+    throw new UnsupportedOperationException(
+        "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+            + " is not supported.");
+  }
+
+  @Override
+  public List<String> getChildren(String path) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.getChildren(path);
+  }
+
+  @Override
+  public int countChildren(String path) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return countChildren(path);
+  }
+
+  @Override
+  public boolean exists(String path) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.exists(path);
+  }
+
+  @Override
+  public Stat getStat(String path) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.getStat(path);
+  }
+
+  @Override
+  public boolean waitUntilExists(String path, TimeUnit timeUnit, long time) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.waitUntilExists(path, timeUnit, time);
+  }
+
+  @Override
+  public void deleteRecursively(String path) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    _innerSharedZkClient.deleteRecursively(path);
+  }
+
+  @Override
+  public boolean delete(String path) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.delete(path);
+  }
+
+  @Override
+  public <T> T readData(String path) {
+    return readData(path, false);
+  }
+
+  @Override
+  public <T> T readData(String path, boolean returnNullIfPathNotExists) {
+    T data = null;
+    try {
+      return readData(path, null);
+    } catch (ZkNoNodeException e) {
+      if (!returnNullIfPathNotExists) {
+        throw e;
+      }
+    }
+    return data;
+  }
+
+  @Override
+  public <T> T readData(String path, Stat stat) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.readData(path, stat);
+  }
+
+  @Override
+  public <T> T readData(String path, Stat stat, boolean watch) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.readData(path, stat, watch);
+  }
+
+  @Override
+  public <T> T readDataAndStat(String path, Stat stat, boolean returnNullIfPathNotExists) {
+    T data = null;
+    try {
+      data = readData(path, stat);
+    } catch (ZkNoNodeException e) {
+      if (!returnNullIfPathNotExists) {
+        throw e;
+      }
+    }
+    return data;
+  }
+
+  @Override
+  public void writeData(String path, Object object) {
+    writeData(path, object, -1);
+  }
+
+  @Override
+  public <T> void updateDataSerialized(String path, DataUpdater<T> updater) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    _innerSharedZkClient.updateDataSerialized(path, updater);
+  }
+
+  @Override
+  public void writeData(String path, Object datat, int expectedVersion) {
+    writeDataReturnStat(path, datat, expectedVersion);
+  }
+
+  @Override
+  public Stat writeDataReturnStat(String path, Object datat, int expectedVersion) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.writeDataReturnStat(path, datat, expectedVersion);
+  }
+
+  @Override
+  public Stat writeDataGetStat(String path, Object datat, int expectedVersion) {
+    return writeDataReturnStat(path, datat, expectedVersion);
+  }
+
+  @Override
+  public void asyncCreate(String path, Object datat, CreateMode mode,
+      ZkAsyncCallbacks.CreateCallbackHandler cb) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    _innerSharedZkClient.asyncCreate(path, datat, mode, cb);
+  }
+
+  @Override
+  public void asyncSetData(String path, Object datat, int version,
+      ZkAsyncCallbacks.SetDataCallbackHandler cb) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    _innerSharedZkClient.asyncSetData(path, datat, version, cb);
+  }
+
+  @Override
+  public void asyncGetData(String path, ZkAsyncCallbacks.GetDataCallbackHandler cb) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    _innerSharedZkClient.asyncGetData(path, cb);
+  }
+
+  @Override
+  public void asyncExists(String path, ZkAsyncCallbacks.ExistsCallbackHandler cb) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    _innerSharedZkClient.asyncExists(path, cb);
+  }
+
+  @Override
+  public void asyncDelete(String path, ZkAsyncCallbacks.DeleteCallbackHandler cb) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    _innerSharedZkClient.asyncDelete(path, cb);
+  }
+
+  @Override
+  public void watchForData(String path) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    _innerSharedZkClient.watchForData(path);
+  }
+
+  @Override
+  public List<String> watchForChilds(String path) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.watchForChilds(path);
+  }
+
+  @Override
+  public long getCreationTime(String path) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.getCreationTime(path);
+  }
+
+  @Override
+  public List<OpResult> multi(Iterable<Op> ops) {
+    return _innerSharedZkClient.multi(ops);
+  }
+
+  @Override
+  public boolean waitUntilConnected(long time, TimeUnit timeUnit) {
+    return _innerSharedZkClient.waitUntilConnected(time, timeUnit);
+  }
+
+  @Override
+  public String getServers() {
+    return _innerSharedZkClient.getServers();
+  }
+
+  @Override
+  public long getSessionId() {
+    return _innerSharedZkClient.getSessionId();
   }
 
   @Override
   public void close() {
-    super.close();
-    if (isClosed()) {
-      // Note that if register is not done while constructing, these private fields may not be init yet.
-      if (_connectionManager != null) {
-        _connectionManager.unregisterWatcher(this);
-      }
-      if (_onCloseCallback != null) {
-        _onCloseCallback.onClose();
-      }
-    }
+    _innerSharedZkClient.close();
   }
 
   @Override
-  public IZkConnection getConnection() {
-    if (isClosed()) {
-      return IDLE_CONNECTION;
-    }
-    return super.getConnection();
-  }
-
-  /**
-   * Since ZkConnection session is shared in this RealmAwareZkClient, do not create ephemeral node using a SharedZKClient.
-   */
-  @Override
-  public String create(final String path, Object datat, final List<ACL> acl,
-      final CreateMode mode) {
-    if (mode.isEphemeral()) {
-      throw new UnsupportedOperationException(
-          "Create ephemeral nodes using a " + SharedZkClient.class.getSimpleName()
-              + " is not supported.");
-    }
-    return super.create(path, datat, acl, mode);
+  public boolean isClosed() {
+    return _innerSharedZkClient.isClosed();
   }
 
   @Override
-  protected boolean isManagingZkConnection() {
-    return false;
+  public byte[] serialize(Object data, String path) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.serialize(data, path);
+  }
+
+  @Override
+  public <T> T deserialize(byte[] data, String path) {
+    if (!checkIfPathBelongsToZkRealm(path)) {
+      throw new IllegalArgumentException(
+          "The given path does not map to the ZK realm for this DedicatedZkClient! Path: " + path
+              + " ZK realm sharding key: " + _zkRealmShardingKey);
+    }
+    return _innerSharedZkClient.deserialize(data, path);
+  }
+
+  @Override
+  public void setZkSerializer(ZkSerializer zkSerializer) {
+    _innerSharedZkClient.setZkSerializer(zkSerializer);
+  }
+
+  @Override
+  public void setZkSerializer(PathBasedZkSerializer zkSerializer) {
+    _innerSharedZkClient.setZkSerializer(zkSerializer);
+  }
+
+  @Override
+  public PathBasedZkSerializer getZkSerializer() {
+    return _innerSharedZkClient.getZkSerializer();
+  }
+
+  private boolean checkIfPathBelongsToZkRealm(String path) {
+    // TODO: Check if the path's sharding key equals the sharding key
+    // TODO: Implement this with TrieRoutingData
+    return true;
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
@@ -20,11 +20,17 @@ package org.apache.helix.zookeeper.impl.factory;
  */
 
 import java.util.HashMap;
+import java.util.List;
 
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.exception.ZkClientException;
 import org.apache.helix.zookeeper.impl.client.SharedZkClient;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.apache.helix.zookeeper.zkclient.IZkConnection;
+import org.apache.helix.zookeeper.zkclient.ZkConnection;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +43,12 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
   // The connection pool to track all created connections.
   private final HashMap<HelixZkClient.ZkConnectionConfig, ZkConnectionManager>
       _connectionManagerPool = new HashMap<>();
+
+  /*
+   * Since we cannot really disconnect the ZkConnection, we need a dummy ZkConnection placeholder.
+   * This is to ensure connection field is never null even the shared RealmAwareZkClient instance is closed so as to avoid NPE.
+   */
+  private final static ZkConnection IDLE_CONNECTION = new ZkConnection("Dummy_ZkServers");
 
   protected SharedZkClientFactory() {
   }
@@ -82,13 +94,8 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
         throw new ZkClientException("Failed to create a connection manager in the pool to share.");
       }
       LOG.info("Sharing ZkConnection {} to a new SharedZkClient.", connectionConfig.toString());
-      return new SharedZkClient(zkConnectionManager, clientConfig,
-          new SharedZkClient.OnCloseCallback() {
-            @Override
-            public void onClose() {
-              cleanupConnectionManager(zkConnectionManager);
-            }
-          });
+      return new InnerSharedZkClient(zkConnectionManager, clientConfig,
+          () -> cleanupConnectionManager(zkConnectionManager));
     }
   }
 
@@ -124,5 +131,75 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
       }
     }
     return count;
+  }
+
+  public interface OnCloseCallback {
+    /**
+     * Triggered after the SharedZkClient is closed.
+     */
+    void onClose();
+  }
+
+  /**
+   * NOTE: do NOT use this class directly. Please use SharedZkClientFactory to create an instance of SharedZkClient.
+   * InnerSharedZkClient is a ZkClient used by SharedZkClient to power ZK operations against a single ZK realm.
+   */
+  public static class InnerSharedZkClient extends ZkClient implements HelixZkClient {
+
+    private final OnCloseCallback _onCloseCallback;
+    private final ZkConnectionManager _connectionManager;
+
+    public InnerSharedZkClient(ZkConnectionManager connectionManager, ZkClientConfig clientConfig,
+        OnCloseCallback callback) {
+      super(connectionManager.getConnection(), 0, clientConfig.getOperationRetryTimeout(),
+          clientConfig.getZkSerializer(), clientConfig.getMonitorType(),
+          clientConfig.getMonitorKey(), clientConfig.getMonitorInstanceName(),
+          clientConfig.isMonitorRootPathOnly());
+      _connectionManager = connectionManager;
+      // Register to the base dedicated RealmAwareZkClient
+      _connectionManager.registerWatcher(this);
+      _onCloseCallback = callback;
+    }
+
+    @Override
+    public void close() {
+      super.close();
+      if (isClosed()) {
+        // Note that if register is not done while constructing, these private fields may not be init yet.
+        if (_connectionManager != null) {
+          _connectionManager.unregisterWatcher(this);
+        }
+        if (_onCloseCallback != null) {
+          _onCloseCallback.onClose();
+        }
+      }
+    }
+
+    @Override
+    public IZkConnection getConnection() {
+      if (isClosed()) {
+        return IDLE_CONNECTION;
+      }
+      return super.getConnection();
+    }
+
+    /**
+     * Since ZkConnection session is shared in this HelixZkClient, do not create ephemeral node using a SharedZKClient.
+     */
+    @Override
+    public String create(final String path, Object datat, final List<ACL> acl,
+        final CreateMode mode) {
+      if (mode.isEphemeral()) {
+        throw new UnsupportedOperationException(
+            "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
+                + " is not supported.");
+      }
+      return super.create(path, datat, acl, mode);
+    }
+
+    @Override
+    protected boolean isManagingZkConnection() {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
**Note: this will be continued at https://github.com/apache/helix/pull/796 **

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #762 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

As part of ZkClient API enhancement, we wish to add SharedZkClient, which is a wrapper of the raw ZkClient, that provides realm-aware access to ZooKeeper.

Realm-aware in that it only performs requests whose path's Zk path sharding key belongs to the ZK realm it's connected to.

Also, we need to modify SharedZkClientFactory so that users could use this factory to generate instances of SharedZkClient.

### Tests

- [ ] The following tests are written for this issue:



- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml