### PR TITLE
Add HttpRoutingDataReader

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -29,6 +29,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.helix.msdcommon.callback.RoutingDataListener;
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.datamodel.TrieRoutingData;

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -29,7 +29,6 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.helix.msdcommon.callback.RoutingDataListener;
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.datamodel.TrieRoutingData;

--- a/metadata-store-directory-common/pom.xml
+++ b/metadata-store-directory-common/pom.xml
@@ -44,6 +44,11 @@ under the License.
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.8</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.10.2</version>

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
@@ -68,4 +68,7 @@ public class MetadataStoreRoutingConstants {
 
   // MSDS resource getAllRealms endpoint string
   public static final String MSDS_GET_ALL_REALMS_ENDPOINT = "/metadata-store-realms";
+
+  // MSDS resource get all routing data endpoint string
+  public static final String MSDS_GET_ALL_ROUTING_DATA_ENDPOINT = "/routing-data";
 }

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
@@ -68,7 +68,4 @@ public class MetadataStoreRoutingConstants {
 
   // MSDS resource getAllRealms endpoint string
   public static final String MSDS_GET_ALL_REALMS_ENDPOINT = "/metadata-store-realms";
-
-  // MSDS resource getShardingKeys endpoint string
-  public static final String MSDS_GET_ALL_SHARDING_KEYS_ENDPOINT = "/sharding-keys";
 }

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
@@ -65,4 +65,10 @@ public class MetadataStoreRoutingConstants {
 
   // System Property Metadata Store Directory Server endpoint key
   public static final String MSDS_SERVER_ENDPOINT_KEY = "metadataStoreDirectoryServerEndpoint";
+
+  // MSDS resource getAllRealms endpoint string
+  public static final String MSDS_GET_ALL_REALMS_ENDPOINT = "/metadata-store-realms";
+
+  // MSDS resource getShardingKeys endpoint string
+  public static final String MSDS_GET_ALL_SHARDING_KEYS_ENDPOINT = "/sharding-keys";
 }

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
@@ -62,4 +62,7 @@ public class MetadataStoreRoutingConstants {
    * }
    */
   public static final String SHARDING_KEY_PATH_PREFIX = "prefix";
+
+  // System Property Metadata Store Directory Server endpoint key
+  public static final String MSDS_SERVER_ENDPOINT_KEY = "metadataStoreDirectoryServerEndpoint";
 }

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/mock/MockMetadataStoreDirectoryServer.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/mock/MockMetadataStoreDirectoryServer.java
@@ -121,11 +121,11 @@ public class MockMetadataStoreDirectoryServer {
         .of(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM, entry.getKey(),
             MetadataStoreRoutingConstants.SHARDING_KEYS, entry.getValue()))
         .collect(Collectors.toList());
-    _server
-        .createContext(REST_PREFIX + _namespace + "/" + MetadataStoreRoutingConstants.ROUTING_DATA,
-            createHttpHandler(ImmutableMap
-                .of(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_NAMESPACE, _namespace,
-                    MetadataStoreRoutingConstants.ROUTING_DATA, result)));
+    _server.createContext(
+        REST_PREFIX + _namespace + MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT,
+        createHttpHandler(ImmutableMap
+            .of(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_NAMESPACE, _namespace,
+                MetadataStoreRoutingConstants.ROUTING_DATA, result)));
 
     // Get all realms endpoint
     _server.createContext(REST_PREFIX + _namespace + ZK_REALM_ENDPOINT, createHttpHandler(

--- a/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/mock/TestMockMetadataStoreDirectoryServer.java
+++ b/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/mock/TestMockMetadataStoreDirectoryServer.java
@@ -59,74 +59,57 @@ public class TestMockMetadataStoreDirectoryServer {
 
     // Send a GET request for all routing data
     HttpGet getRequest = new HttpGet(
-        endpoint + MockMetadataStoreDirectoryServer.REST_PREFIX + namespace + "/"
-            + MetadataStoreRoutingConstants.ROUTING_DATA);
-    try {
-      CloseableHttpResponse getResponse = httpClient.execute(getRequest);
-      Map<String, Object> resultMap = MockMetadataStoreDirectoryServer.OBJECT_MAPPER
-          .readValue(getResponse.getEntity().getContent(), Map.class);
-      List<Map<String, Object>> routingDataList =
-          (List<Map<String, Object>>) resultMap.get(MetadataStoreRoutingConstants.ROUTING_DATA);
-      Collection<String> allRealms = routingDataList.stream().map(mapEntry -> (String) mapEntry
-          .get(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM))
-          .collect(Collectors.toSet());
-      Assert.assertEquals(allRealms, routingData.keySet());
-      Map<String, List<String>> retrievedRoutingData = routingDataList.stream().collect(Collectors
-          .toMap(mapEntry -> (String) mapEntry
-                  .get(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM),
-              mapEntry -> (List<String>) mapEntry
-                  .get(MetadataStoreRoutingConstants.SHARDING_KEYS)));
-      Assert.assertEquals(retrievedRoutingData, routingData);
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+        endpoint + MockMetadataStoreDirectoryServer.REST_PREFIX + namespace
+            + MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT);
+
+    CloseableHttpResponse getResponse = httpClient.execute(getRequest);
+    Map<String, Object> resultMap = MockMetadataStoreDirectoryServer.OBJECT_MAPPER
+        .readValue(getResponse.getEntity().getContent(), Map.class);
+    List<Map<String, Object>> routingDataList =
+        (List<Map<String, Object>>) resultMap.get(MetadataStoreRoutingConstants.ROUTING_DATA);
+    Collection<String> allRealms = routingDataList.stream().map(mapEntry -> (String) mapEntry
+        .get(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM))
+        .collect(Collectors.toSet());
+    Assert.assertEquals(allRealms, routingData.keySet());
+    Map<String, List<String>> retrievedRoutingData = routingDataList.stream().collect(Collectors
+        .toMap(mapEntry -> (String) mapEntry
+                .get(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM),
+            mapEntry -> (List<String>) mapEntry.get(MetadataStoreRoutingConstants.SHARDING_KEYS)));
+    Assert.assertEquals(retrievedRoutingData, routingData);
 
     // Send a GET request for all realms
     getRequest = new HttpGet(endpoint + MockMetadataStoreDirectoryServer.REST_PREFIX + namespace
         + MockMetadataStoreDirectoryServer.ZK_REALM_ENDPOINT);
-    try {
-      CloseableHttpResponse getResponse = httpClient.execute(getRequest);
-      Map<String, Collection<String>> allRealmsMap = MockMetadataStoreDirectoryServer.OBJECT_MAPPER
-          .readValue(getResponse.getEntity().getContent(), Map.class);
-      Assert.assertTrue(
-          allRealmsMap.containsKey(MetadataStoreRoutingConstants.METADATA_STORE_REALMS));
-      Collection<String> allRealms =
-          allRealmsMap.get(MetadataStoreRoutingConstants.METADATA_STORE_REALMS);
-      Assert.assertEquals(allRealms, routingData.keySet());
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    getResponse = httpClient.execute(getRequest);
+    Map<String, Collection<String>> allRealmsMap = MockMetadataStoreDirectoryServer.OBJECT_MAPPER
+        .readValue(getResponse.getEntity().getContent(), Map.class);
+    Assert
+        .assertTrue(allRealmsMap.containsKey(MetadataStoreRoutingConstants.METADATA_STORE_REALMS));
+    allRealms = allRealmsMap.get(MetadataStoreRoutingConstants.METADATA_STORE_REALMS);
+    Assert.assertEquals(allRealms, routingData.keySet());
 
     // Send a GET request for testZkRealm
     String testZkRealm = "zk-0";
     getRequest = new HttpGet(endpoint + MockMetadataStoreDirectoryServer.REST_PREFIX + namespace
         + MockMetadataStoreDirectoryServer.ZK_REALM_ENDPOINT + "/" + testZkRealm);
-    try {
-      CloseableHttpResponse getResponse = httpClient.execute(getRequest);
-      Map<String, Object> shardingKeysMap = MockMetadataStoreDirectoryServer.OBJECT_MAPPER
-          .readValue(getResponse.getEntity().getContent(), Map.class);
-      Assert.assertTrue(
-          shardingKeysMap.containsKey(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM));
-      Assert.assertTrue(shardingKeysMap.containsKey(MetadataStoreRoutingConstants.SHARDING_KEYS));
-      String zkRealm =
-          (String) shardingKeysMap.get(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM);
-      Collection<String> shardingKeyList =
-          (Collection) shardingKeysMap.get(MetadataStoreRoutingConstants.SHARDING_KEYS);
-      Assert.assertEquals(zkRealm, testZkRealm);
-      Assert.assertEquals(shardingKeyList, routingData.get(testZkRealm));
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    getResponse = httpClient.execute(getRequest);
+    Map<String, Object> shardingKeysMap = MockMetadataStoreDirectoryServer.OBJECT_MAPPER
+        .readValue(getResponse.getEntity().getContent(), Map.class);
+    Assert.assertTrue(
+        shardingKeysMap.containsKey(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM));
+    Assert.assertTrue(shardingKeysMap.containsKey(MetadataStoreRoutingConstants.SHARDING_KEYS));
+    String zkRealm =
+        (String) shardingKeysMap.get(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM);
+    Collection<String> shardingKeyList =
+        (Collection) shardingKeysMap.get(MetadataStoreRoutingConstants.SHARDING_KEYS);
+    Assert.assertEquals(zkRealm, testZkRealm);
+    Assert.assertEquals(shardingKeyList, routingData.get(testZkRealm));
 
     // Try sending a POST request (not supported)
     HttpPost postRequest = new HttpPost(
         endpoint + MockMetadataStoreDirectoryServer.REST_PREFIX + namespace
             + MockMetadataStoreDirectoryServer.ZK_REALM_ENDPOINT + "/" + testZkRealm);
-    try {
-      CloseableHttpResponse postResponse = httpClient.execute(postRequest);
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    CloseableHttpResponse postResponse = httpClient.execute(postRequest);
 
     // Shutdown
     server.stopServer();

--- a/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/mock/TestMockMetadataStoreDirectoryServer.java
+++ b/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/mock/TestMockMetadataStoreDirectoryServer.java
@@ -54,9 +54,8 @@ public class TestMockMetadataStoreDirectoryServer {
 
     MockMetadataStoreDirectoryServer server =
         new MockMetadataStoreDirectoryServer(host, port, namespace, routingData);
+    server.startServer();
     try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-      server.startServer();
-
       // Send a GET request for all routing data
       HttpGet getRequest = new HttpGet(
           endpoint + MockMetadataStoreDirectoryServer.REST_PREFIX + namespace

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -64,12 +64,6 @@ under the License.
       <artifactId>httpclient</artifactId>
       <version>4.5.11</version>
     </dependency>
-    <!-- jcabi-aspects is used for @RetryOnFailure -->
-    <dependency>
-      <groupId>com.jcabi</groupId>
-      <artifactId>jcabi-aspects</artifactId>
-      <version>0.22.6</version>
-    </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-mapper-asl</artifactId>
@@ -128,31 +122,6 @@ under the License.
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <!-- For @RetryOnFailure -->
-      <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-        <version>0.14.1</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>ajc</goal>
-            </goals>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>org.aspectj</groupId>
-            <artifactId>aspectjtools</artifactId>
-            <version>1.9.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.aspectj</groupId>
-            <artifactId>aspectjweaver</artifactId>
-            <version>1.9.1</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -60,6 +60,11 @@ under the License.
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.11</version>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-mapper-asl</artifactId>
       <version>1.9.13</version>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -64,6 +64,12 @@ under the License.
       <artifactId>httpclient</artifactId>
       <version>4.5.11</version>
     </dependency>
+    <!-- jcabi-aspects is used for @RetryOnFailure -->
+    <dependency>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-aspects</artifactId>
+      <version>0.22.6</version>
+    </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-mapper-asl</artifactId>
@@ -122,6 +128,31 @@ under the License.
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <!-- For @RetryOnFailure -->
+      <plugin>
+        <groupId>com.jcabi</groupId>
+        <artifactId>jcabi-maven-plugin</artifactId>
+        <version>0.14.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>ajc</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjtools</artifactId>
+            <version>1.9.1</version>
+          </dependency>
+          <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+            <version>1.9.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -62,7 +62,7 @@ under the License.
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.11</version>
+      <version>4.5.8</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
@@ -23,10 +23,9 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import com.jcabi.aspects.RetryOnFailure;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.datamodel.TrieRoutingData;
@@ -35,13 +34,17 @@ import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultBackoffStrategy;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
-import org.codehaus.jackson.map.ObjectMapper;
 
 
 public class HttpRoutingDataReader {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String MSDS_ENDPOINT =
+      System.getProperty(MetadataStoreRoutingConstants.MSDS_SERVER_ENDPOINT_KEY);
+
+  /** Double-checked locking requires that the following fields be volatile */
   private static volatile Map<String, List<String>> _rawRoutingData;
   private static volatile MetadataStoreRoutingData _metadataStoreRoutingData;
 
@@ -57,25 +60,18 @@ public class HttpRoutingDataReader {
    * "metadata store sharding keys", where the sharding keys in a value list all route to
    * the realm address in the key disallows a meaningful mapping to be returned
    */
-  @RetryOnFailure(attempts = 3, delay = 1, unit = TimeUnit.SECONDS)
   public static Map<String, List<String>> getRawRoutingData()
       throws IOException {
+    if (MSDS_ENDPOINT == null || MSDS_ENDPOINT.isEmpty()) {
+      throw new IllegalStateException(
+          "HttpRoutingDataReader was unable to find a valid MSDS endpoint String in System Properties!");
+    }
     if (_rawRoutingData == null) {
       synchronized (HttpRoutingDataReader.class) {
         if (_rawRoutingData == null) {
-          String msdsEndpoint =
-              System.getProperty(MetadataStoreRoutingConstants.MSDS_SERVER_ENDPOINT_KEY);
-          if (msdsEndpoint == null || msdsEndpoint.isEmpty()) {
-            throw new IllegalStateException(
-                "HttpRoutingDataReader was unable to find a valid MSDS endpoint String in System Properties!");
-          }
-
-          // Note: HttpClient's timeout settings are system timeout settings by default
-          CloseableHttpClient httpClient = HttpClients.createDefault();
-          // Update the reference
-          _rawRoutingData = getAllRoutingData(httpClient, msdsEndpoint);
-          // Close any open resources
-          httpClient.close();
+          CloseableHttpResponse routingDataResponse = getAllRoutingData();
+          // Update the reference if reading routingData over HTTP is successful
+          _rawRoutingData = parseRoutingData(routingDataResponse);
         }
       }
     }
@@ -85,8 +81,8 @@ public class HttpRoutingDataReader {
   /**
    * Returns the routing data read from MSDS in a MetadataStoreRoutingData format.
    * @return
-   * @throws IOException
-   * @throws InvalidRoutingDataException
+   * @throws IOException if there is an issue connecting to MSDS
+   * @throws InvalidRoutingDataException if the raw routing data is not valid
    */
   public static MetadataStoreRoutingData getMetadataStoreRoutingData()
       throws IOException, InvalidRoutingDataException {
@@ -102,28 +98,40 @@ public class HttpRoutingDataReader {
 
   /**
    * Makes an HTTP call to fetch all routing data.
-   * @param httpClient
-   * @param msdsEndpoint
    * @return
    * @throws IOException
    */
-  private static Map<String, List<String>> getAllRoutingData(CloseableHttpClient httpClient,
-      String msdsEndpoint)
+  private static CloseableHttpResponse getAllRoutingData()
       throws IOException {
+    // Retry count is 3 by default
     HttpGet requestAllData = new HttpGet(
-        msdsEndpoint + MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT);
-    CloseableHttpResponse response = httpClient.execute(requestAllData);
-    HttpEntity entity = response.getEntity();
+        MSDS_ENDPOINT + MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT);
+    try (CloseableHttpClient httpClient = HttpClients.custom()
+        .setConnectionBackoffStrategy(new DefaultBackoffStrategy())
+        .setRetryHandler(new DefaultHttpRequestRetryHandler()).build()) {
+      return httpClient.execute(requestAllData);
+    }
+  }
+
+  /**
+   * Returns the raw routing data in a Map< ZkRealm, List of shardingKeys > format.
+   * @param routingDataResponse
+   * @return
+   */
+  private static Map<String, List<String>> parseRoutingData(
+      CloseableHttpResponse routingDataResponse)
+      throws IOException {
+    HttpEntity entity = routingDataResponse.getEntity();
     if (entity != null) {
       String resultStr = EntityUtils.toString(entity);
       @SuppressWarnings("unchecked")
-      Map<String, Object> resultMap = OBJECT_MAPPER.readValue(resultStr, Map.class);
+      Map<String, Object> resultMap = new ObjectMapper().readValue(resultStr, Map.class);
       @SuppressWarnings("unchecked")
       List<Map<String, Object>> routingDataList =
           (List<Map<String, Object>>) resultMap.get(MetadataStoreRoutingConstants.ROUTING_DATA);
       @SuppressWarnings("unchecked")
       Map<String, List<String>> routingData = routingDataList.stream().collect(Collectors.toMap(
-          mapEntry -> (String) mapEntry
+          realmKeyPair -> (String) realmKeyPair
               .get(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM),
           mapEntry -> (List<String>) mapEntry.get(MetadataStoreRoutingConstants.SHARDING_KEYS)));
       return routingData;
@@ -131,4 +139,3 @@ public class HttpRoutingDataReader {
     return Collections.emptyMap();
   }
 }
-

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
@@ -20,12 +20,17 @@ package org.apache.helix.zookeeper.util;
  */
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
+import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
+import org.apache.helix.msdcommon.datamodel.TrieRoutingData;
+import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.http.HttpEntity;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -37,6 +42,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 public class HttpRoutingDataReader {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static volatile Map<String, List<String>> _rawRoutingData;
+  private static volatile MetadataStoreRoutingData _metadataStoreRoutingData;
 
   /**
    * This class is a Singleton.
@@ -48,48 +54,73 @@ public class HttpRoutingDataReader {
    * Fetches routing data from the data source via HTTP.
    * @return a mapping from "metadata store realm addresses" to lists of "metadata store sharding keys", where the sharding keys in a value list all route to the realm address in the key disallows a meaningful mapping to be returned
    */
-  public static Map<String, List<String>> getRoutingData() {
-    String msdsEndpoint = System.getProperty(MetadataStoreRoutingConstants)
-
+  public static Map<String, List<String>> getRawRoutingData()
+      throws IOException {
     if (_rawRoutingData == null) {
       synchronized (HttpRoutingDataReader.class) {
         if (_rawRoutingData == null) {
+          Map<String, List<String>> rawRoutingData = new HashMap<>();
+          String msdsEndpoint =
+              System.getProperty(MetadataStoreRoutingConstants.MSDS_SERVER_ENDPOINT_KEY);
+          if (msdsEndpoint == null || msdsEndpoint.isEmpty()) {
+            throw new IllegalStateException(
+                "HttpRoutingDataReader was unable to find a valid MSDS endpoint String in System Properties!");
+          }
 
+          CloseableHttpClient httpClient = HttpClients.createDefault();
+          // TODO: Currently we are making multiple HTTP calls. We should cut it down to one call to retrieve all raw routing data
+          // TODO: See https://github.com/apache/helix/issues/798
+          // Get all realms
+          // For each realm, get all sharding keys
+          // Put <realm, sharding keys> in rawRoutingData
+          HttpGet requestAllRealmNames = new HttpGet(
+              msdsEndpoint + MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT);
+          CloseableHttpResponse response = httpClient.execute(requestAllRealmNames);
+          HttpEntity entity = response.getEntity();
+          if (entity != null) {
+            String resultStr = EntityUtils.toString(entity);
+            Map<String, Collection<String>> resultMap =
+                OBJECT_MAPPER.readValue(resultStr, Map.class);
+            Collection<String> realmNames =
+                resultMap.get(MetadataStoreRoutingConstants.METADATA_STORE_REALMS);
+            if (realmNames != null && !realmNames.isEmpty()) {
+              for (String realmName : realmNames) {
+                HttpGet requestAllShardingKeysForRealm = new HttpGet(
+                    msdsEndpoint + MetadataStoreRoutingConstants.MSDS_GET_ALL_SHARDING_KEYS_ENDPOINT
+                        + "?realm=" + realmName);
+                CloseableHttpResponse shardingKeyResponse =
+                    httpClient.execute(requestAllShardingKeysForRealm);
+                HttpEntity shardingKeyEntity = shardingKeyResponse.getEntity();
+                if (shardingKeyEntity != null) {
+                  String shardingKeyResultStr = EntityUtils.toString(shardingKeyEntity);
+                  Map<String, Collection<String>> shardingKeyMap =
+                      OBJECT_MAPPER.readValue(shardingKeyResultStr, Map.class);
+                  Collection<String> shardingKeys =
+                      shardingKeyMap.get(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM);
+                  if (shardingKeys != null && !shardingKeys.isEmpty()) {
+                    rawRoutingData.put(realmName, new ArrayList<>(shardingKeys));
+                  }
+                }
+              }
+            }
+          }
+          // Update the reference
+          _rawRoutingData = rawRoutingData;
         }
       }
     }
-
-
-
-
-
-//    Map<String, List<String>> rawRoutingData = new HashMap<>();
-//
-//    HttpGet requestAllRealmNames =
-//        new HttpGet(msdsEndpoint); //TODO: construct an endpoint once REST endpoint is finalized
-//    try (CloseableHttpClient httpClient = HttpClients.createDefault();
-//        CloseableHttpResponse response = httpClient.execute(requestAllRealmNames)) {
-//
-//      HttpEntity entity = response.getEntity();
-//      // return it as a String
-//      if (entity != null) {
-//        String result = EntityUtils.toString(entity);
-//        List<String> realmNames = OBJECT_MAPPER.readValue(result, List.class);
-//        for (String realmName : realmNames) {
-//          HttpGet requestAllShardingKeys =
-//              new HttpGet(msdsEndpoint); // TODO: construct the right endpoint for sharding keys
-//          CloseableHttpResponse shardingKeyResponse = httpClient.execute(requestAllShardingKeys);
-//          String shardingKeyString = EntityUtils.toString(shardingKeyResponse.getEntity());
-//          List<String> shardingKeys = OBJECT_MAPPER.readValue(shardingKeyString, List.class);
-//          _rawRoutingData.put(realmName, shardingKeys);
-//        }
-//      }
-//    } catch (ClientProtocolException e) {
-//      e.printStackTrace();
-//    } catch (IOException e) {
-//      e.printStackTrace();
-//    }
-
     return _rawRoutingData;
+  }
+
+  public MetadataStoreRoutingData getMetadataStoreRoutingData()
+      throws IOException, InvalidRoutingDataException {
+    if (_metadataStoreRoutingData == null) {
+      synchronized (HttpRoutingDataReader.class) {
+        if (_metadataStoreRoutingData == null) {
+          _metadataStoreRoutingData = new TrieRoutingData(getRawRoutingData());
+        }
+      }
+    }
+    return _metadataStoreRoutingData;
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
@@ -1,0 +1,81 @@
+package org.apache.helix.zookeeper.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.codehaus.jackson.map.ObjectMapper;
+
+
+public class HttpRoutingDataReader {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  /**
+   * This class is a Singleton.
+   */
+  private HttpRoutingDataReader() {
+  }
+
+  /**
+   * Fetches routing data from the data source via HTTP.
+   * @return a mapping from "metadata store realm addresses" to lists of "metadata store sharding keys", where the sharding keys in a value list all route to the realm address in the key disallows a meaningful mapping to be returned
+   */
+  public static Map<String, List<String>> getRoutingData(String msdsEndpoint) {
+
+    Map<String, List<String>> rawRoutingData = new HashMap<>();
+
+    HttpGet requestAllRealmNames =
+        new HttpGet(msdsEndpoint); //TODO: construct an endpoint once REST endpoint is finalized
+    try (CloseableHttpClient httpClient = HttpClients.createDefault();
+        CloseableHttpResponse response = httpClient.execute(requestAllRealmNames)) {
+
+      HttpEntity entity = response.getEntity();
+      // return it as a String
+      if (entity != null) {
+        String result = EntityUtils.toString(entity);
+        List<String> realmNames = OBJECT_MAPPER.readValue(result, List.class);
+        for (String realmName : realmNames) {
+          HttpGet requestAllShardingKeys =
+              new HttpGet(msdsEndpoint); // TODO: construct the right endpoint for sharding keys
+          CloseableHttpResponse shardingKeyResponse = httpClient.execute(requestAllShardingKeys);
+          String shardingKeyString = EntityUtils.toString(shardingKeyResponse.getEntity());
+          List<String> shardingKeys = OBJECT_MAPPER.readValue(shardingKeyString, List.class);
+          rawRoutingData.put(realmName, shardingKeys);
+        }
+      }
+    } catch (ClientProtocolException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    return rawRoutingData;
+  }
+}

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
@@ -103,7 +103,8 @@ public class HttpRoutingDataReader {
    * @throws IOException
    */
   private static CloseableHttpResponse getAllRoutingData() throws IOException {
-    // Retry count is 3 by default
+    // Note that MSDS_ENDPOINT should provide high-availability - it risks becoming a single point of failure if it's backed by a single IP address/host
+    // Retry count is 3 by default.
     HttpGet requestAllData = new HttpGet(
         MSDS_ENDPOINT + MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT);
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
@@ -53,7 +53,9 @@ public class HttpRoutingDataReader {
 
   /**
    * Fetches routing data from the data source via HTTP.
-   * @return a mapping from "metadata store realm addresses" to lists of "metadata store sharding keys", where the sharding keys in a value list all route to the realm address in the key disallows a meaningful mapping to be returned
+   * @return a mapping from "metadata store realm addresses" to lists of
+   * "metadata store sharding keys", where the sharding keys in a value list all route to
+   * the realm address in the key disallows a meaningful mapping to be returned
    */
   public static Map<String, List<String>> getRawRoutingData()
       throws IOException {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
@@ -110,8 +110,8 @@ public class HttpRoutingDataReader {
   private static Map<String, List<String>> getAllRoutingData(CloseableHttpClient httpClient,
       String msdsEndpoint)
       throws IOException {
-    HttpGet requestAllData =
-        new HttpGet(msdsEndpoint + "/" + MetadataStoreRoutingConstants.ROUTING_DATA);
+    HttpGet requestAllData = new HttpGet(
+        msdsEndpoint + MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT);
     CloseableHttpResponse response = httpClient.execute(requestAllData);
     HttpEntity entity = response.getEntity();
     if (entity != null) {

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
@@ -19,16 +19,107 @@ package org.apache.helix.zookeeper.util;
  * under the License.
  */
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
+import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
+import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
+import org.apache.helix.msdcommon.mock.MockMetadataStoreDirectoryServer;
 import org.apache.helix.zookeeper.impl.ZkTestBase;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 
 public class TestHttpRoutingDataReader extends ZkTestBase {
+  private MockMetadataStoreDirectoryServer _msdsServer;
+  private Map<String, Collection<String>> _testRawRoutingData;
+  private String _host = "localhost";
+  private int _port = 1991;
+  private String _namespace = "TestHttpRoutingDataReader";
 
   @BeforeClass
-  public void beforeClass() {
-    for (int i = 0; i < _numZk; i++) {
+  public void beforeClass()
+      throws IOException {
+    // Create fake routing data
+    _testRawRoutingData = new HashMap<>();
+    _testRawRoutingData
+        .put("zk-0", ImmutableSet.of("/sharding-key-0", "/sharding-key-1", "/sharding-key-2"));
+    _testRawRoutingData
+        .put("zk-1", ImmutableSet.of("/sharding-key-3", "/sharding-key-4", "/sharding-key-5"));
+    _testRawRoutingData
+        .put("zk-2", ImmutableSet.of("/sharding-key-6", "/sharding-key-7", "/sharding-key-8"));
 
-    }
+    // Start MockMSDS
+    _msdsServer =
+        new MockMetadataStoreDirectoryServer(_host, _port, _namespace, _testRawRoutingData);
+    _msdsServer.startServer();
+
+    // Register the endpoint as a System property
+    String msdsEndpoint = "http://" + _host + ":" + _port + "/admin/v2/namespaces/" + _namespace;
+    System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_ENDPOINT_KEY, msdsEndpoint);
+  }
+
+  @AfterClass
+  public void afterClass() {
+    _msdsServer.stopServer();
+  }
+
+  @Test
+  public void testGetRawRoutingData()
+      throws IOException {
+    Map<String, List<String>> rawRoutingData = HttpRoutingDataReader.getRawRoutingData();
+    _testRawRoutingData
+        .forEach((realm, keys) -> Assert.assertEquals(rawRoutingData.get(realm), keys));
+  }
+
+  @Test(dependsOnMethods = "testGetRawRoutingData")
+  public void testGetMetadataStoreRoutingData()
+      throws IOException, InvalidRoutingDataException {
+    MetadataStoreRoutingData data = HttpRoutingDataReader.getMetadataStoreRoutingData();
+    Map<String, String> allMappings = data.getAllMappingUnderPath("/");
+    Map<String, Set<String>> groupedMappings = allMappings.entrySet().stream().collect(Collectors
+        .groupingBy(Map.Entry::getValue,
+            Collectors.mapping(Map.Entry::getKey, Collectors.toSet())));
+    _testRawRoutingData.forEach((realm, keys) -> {
+      Assert.assertTrue(groupedMappings.get(realm).containsAll(keys));
+      Assert.assertTrue(keys.containsAll(groupedMappings.get(realm)));
+    });
+  }
+
+  /**
+   * Test that the static methods in HttpRoutingDataReader returns consistent results even though MSDS's data have been updated.
+   */
+  @Test(dependsOnMethods = "testGetMetadataStoreRoutingData")
+  public void testStaticMapping()
+      throws IOException, InvalidRoutingDataException {
+    // Modify routing data
+    String newRealm = "newRealm";
+    _testRawRoutingData.put(newRealm, ImmutableSet.of("/newKey"));
+
+    // Kill MSDS and restart with a new mapping
+    _msdsServer.stopServer();
+    _msdsServer =
+        new MockMetadataStoreDirectoryServer(_host, _port, _namespace, _testRawRoutingData);
+
+    // HttpRoutingDataReader should still return old data because it's static
+    // Make sure the results don't contain the new realm
+    Map<String, List<String>> rawRoutingData = HttpRoutingDataReader.getRawRoutingData();
+    Assert.assertFalse(rawRoutingData.containsKey(newRealm));
+
+    MetadataStoreRoutingData data = HttpRoutingDataReader.getMetadataStoreRoutingData();
+    Map<String, String> allMappings = data.getAllMappingUnderPath("/");
+    Map<String, Set<String>> groupedMappings = allMappings.entrySet().stream().collect(Collectors
+        .groupingBy(Map.Entry::getValue,
+            Collectors.mapping(Map.Entry::getKey, Collectors.toSet())));
+    Assert.assertFalse(groupedMappings.containsKey(newRealm));
   }
 }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
@@ -42,9 +42,9 @@ import org.testng.annotations.Test;
 public class TestHttpRoutingDataReader extends ZkTestBase {
   private MockMetadataStoreDirectoryServer _msdsServer;
   private Map<String, Collection<String>> _testRawRoutingData;
-  private String _host = "localhost";
-  private int _port = 1991;
-  private String _namespace = "TestHttpRoutingDataReader";
+  private final String _host = "localhost";
+  private final int _port = 1991;
+  private final String _namespace = "TestHttpRoutingDataReader";
 
   @BeforeClass
   public void beforeClass()
@@ -90,6 +90,8 @@ public class TestHttpRoutingDataReader extends ZkTestBase {
         .groupingBy(Map.Entry::getValue,
             Collectors.mapping(Map.Entry::getKey, Collectors.toSet())));
     _testRawRoutingData.forEach((realm, keys) -> {
+      // Two way containsAll because AssertEquals on two set collections is buggy in that
+      // it will fail if the ordering of elements is not equal (we just want to compare contents)
       Assert.assertTrue(groupedMappings.get(realm).containsAll(keys));
       Assert.assertTrue(keys.containsAll(groupedMappings.get(realm)));
     });

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
@@ -22,6 +22,7 @@ package org.apache.helix.zookeeper.util;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -75,8 +76,8 @@ public class TestHttpRoutingDataReader extends ZkTestBase {
   @Test
   public void testGetRawRoutingData() throws IOException {
     Map<String, List<String>> rawRoutingData = HttpRoutingDataReader.getRawRoutingData();
-    _testRawRoutingData
-        .forEach((realm, keys) -> Assert.assertEquals(rawRoutingData.get(realm), keys));
+    _testRawRoutingData.forEach((realm, keys) -> Assert
+        .assertEquals(new HashSet(rawRoutingData.get(realm)), new HashSet(keys)));
   }
 
   @Test(dependsOnMethods = "testGetRawRoutingData")
@@ -113,6 +114,12 @@ public class TestHttpRoutingDataReader extends ZkTestBase {
     // Make sure the results don't contain the new realm
     Map<String, List<String>> rawRoutingData = HttpRoutingDataReader.getRawRoutingData();
     Assert.assertFalse(rawRoutingData.containsKey(newRealm));
+
+    // Remove newRealm and check for equality
+    _testRawRoutingData.remove(newRealm);
+    Assert.assertEquals(rawRoutingData.keySet(), _testRawRoutingData.keySet());
+    _testRawRoutingData.forEach((realm, keys) -> Assert
+        .assertEquals(new HashSet(rawRoutingData.get(realm)), new HashSet(keys)));
 
     MetadataStoreRoutingData data = HttpRoutingDataReader.getMetadataStoreRoutingData();
     Map<String, String> allMappings = data.getAllMappingUnderPath("/");

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
@@ -109,6 +109,7 @@ public class TestHttpRoutingDataReader extends ZkTestBase {
     _msdsServer.stopServer();
     _msdsServer =
         new MockMetadataStoreDirectoryServer(_host, _port, _namespace, _testRawRoutingData);
+    _msdsServer.startServer();
 
     // HttpRoutingDataReader should still return old data because it's static
     // Make sure the results don't contain the new realm

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
@@ -47,8 +47,7 @@ public class TestHttpRoutingDataReader extends ZkTestBase {
   private final String _namespace = "TestHttpRoutingDataReader";
 
   @BeforeClass
-  public void beforeClass()
-      throws IOException {
+  public void beforeClass() throws IOException {
     // Create fake routing data
     _testRawRoutingData = new HashMap<>();
     _testRawRoutingData
@@ -74,16 +73,14 @@ public class TestHttpRoutingDataReader extends ZkTestBase {
   }
 
   @Test
-  public void testGetRawRoutingData()
-      throws IOException {
+  public void testGetRawRoutingData() throws IOException {
     Map<String, List<String>> rawRoutingData = HttpRoutingDataReader.getRawRoutingData();
     _testRawRoutingData
         .forEach((realm, keys) -> Assert.assertEquals(rawRoutingData.get(realm), keys));
   }
 
   @Test(dependsOnMethods = "testGetRawRoutingData")
-  public void testGetMetadataStoreRoutingData()
-      throws IOException, InvalidRoutingDataException {
+  public void testGetMetadataStoreRoutingData() throws IOException, InvalidRoutingDataException {
     MetadataStoreRoutingData data = HttpRoutingDataReader.getMetadataStoreRoutingData();
     Map<String, String> allMappings = data.getAllMappingUnderPath("/");
     Map<String, Set<String>> groupedMappings = allMappings.entrySet().stream().collect(Collectors
@@ -101,8 +98,7 @@ public class TestHttpRoutingDataReader extends ZkTestBase {
    * Test that the static methods in HttpRoutingDataReader returns consistent results even though MSDS's data have been updated.
    */
   @Test(dependsOnMethods = "testGetMetadataStoreRoutingData")
-  public void testStaticMapping()
-      throws IOException, InvalidRoutingDataException {
+  public void testStaticMapping() throws IOException, InvalidRoutingDataException {
     // Modify routing data
     String newRealm = "newRealm";
     _testRawRoutingData.put(newRealm, ImmutableSet.of("/newKey"));

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
@@ -88,10 +88,7 @@ public class TestHttpRoutingDataReader extends ZkTestBase {
         .groupingBy(Map.Entry::getValue,
             Collectors.mapping(Map.Entry::getKey, Collectors.toSet())));
     _testRawRoutingData.forEach((realm, keys) -> {
-      // Two way containsAll because AssertEquals on two set collections is buggy in that
-      // it will fail if the ordering of elements is not equal (we just want to compare contents)
-      Assert.assertTrue(groupedMappings.get(realm).containsAll(keys));
-      Assert.assertTrue(keys.containsAll(groupedMappings.get(realm)));
+      Assert.assertEquals(groupedMappings.get(realm), new HashSet(keys));
     });
   }
 

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestHttpRoutingDataReader.java
@@ -1,0 +1,34 @@
+package org.apache.helix.zookeeper.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.zookeeper.impl.ZkTestBase;
+import org.testng.annotations.BeforeClass;
+
+
+public class TestHttpRoutingDataReader extends ZkTestBase {
+
+  @BeforeClass
+  public void beforeClass() {
+    for (int i = 0; i < _numZk; i++) {
+
+    }
+  }
+}

--- a/zookeeper-api/zookeeper-api-0.9.2-SNAPSHOT.ivy
+++ b/zookeeper-api/zookeeper-api-0.9.2-SNAPSHOT.ivy
@@ -46,6 +46,6 @@ under the License.
 		<dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.8.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.8.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
-		<dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.11" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.8" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 	</dependencies>
 </ivy-module>

--- a/zookeeper-api/zookeeper-api-0.9.2-SNAPSHOT.ivy
+++ b/zookeeper-api/zookeeper-api-0.9.2-SNAPSHOT.ivy
@@ -47,6 +47,5 @@ under the License.
 		<dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.8.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.11" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
-		<dependency org="com.jcabi" name="jcabi-aspects" rev="0.22.6" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 	</dependencies>
 </ivy-module>

--- a/zookeeper-api/zookeeper-api-0.9.2-SNAPSHOT.ivy
+++ b/zookeeper-api/zookeeper-api-0.9.2-SNAPSHOT.ivy
@@ -47,5 +47,6 @@ under the License.
 		<dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.8.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.11" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="com.jcabi" name="jcabi-aspects" rev="0.22.6" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 	</dependencies>
 </ivy-module>

--- a/zookeeper-api/zookeeper-api-0.9.2-SNAPSHOT.ivy
+++ b/zookeeper-api/zookeeper-api-0.9.2-SNAPSHOT.ivy
@@ -46,5 +46,6 @@ under the License.
 		<dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.8.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.8.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.11" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 	</dependencies>
 </ivy-module>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #774 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

HttpRoutingDataReader is a component used by new ZkClient APIs to make an HTTP read request to the metadata store directory service to retrieve routing data. ZkClient APIs will construct an internal MetadataStoreRoutingData instance based on the raw routing data retrieved from MSDS.

Note: this change contains modifications to MockMSDS because the actual endpoint names changed. The methods and http server contexts have been updated.

### Tests

- [x] The following tests are written for this issue:

TestHttpRoutingDataReader

- [x] The following is the result of the "mvn test" command on the appropriate module:

zookeeper-api

> [INFO]  T E S T S
> [INFO] -------------------------------------------------------
> [INFO] Running TestSuite
> [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.429 s - in TestSuite
> [INFO] 
> [INFO] Results:
> [INFO] 
> [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
> [INFO] 
> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD SUCCESS
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time:  7.497 s
> [INFO] Finished at: 2020-02-22T17:59:33-08:00
> [INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml