### PR TITLE
Fix the ConcurrentModificationException in ClusterEvent.java

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEvent.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEvent.java
@@ -19,9 +19,9 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +37,7 @@ public class ClusterEvent {
   @Deprecated
   public ClusterEvent(ClusterEventType eventType) {
     _eventType = eventType;
-    _eventAttributeMap = new HashMap<>();
+    _eventAttributeMap = new ConcurrentHashMap<>();
     _creationTime = System.currentTimeMillis();
     _eventId = UUID.randomUUID().toString();
   }
@@ -50,21 +50,8 @@ public class ClusterEvent {
     _clusterName = clusterName;
     _eventType = eventType;
 
-    _eventAttributeMap = new HashMap<>();
+    _eventAttributeMap = new ConcurrentHashMap<>();
     _creationTime = System.currentTimeMillis();
-    _eventId = eventId;
-  }
-
-  /**
-   * A private copy constructor that allows the override of {@link #_eventId}
-   * @param clusterEvent The other cluster event object
-   * @param eventId The event id to be overridden
-   */
-  private ClusterEvent(ClusterEvent clusterEvent, String eventId) {
-    _clusterName = clusterEvent._clusterName;
-    _eventType = clusterEvent._eventType;
-    _eventAttributeMap = new HashMap<>(clusterEvent._eventAttributeMap);
-    _creationTime = clusterEvent._creationTime;
     _eventId = eventId;
   }
 
@@ -127,6 +114,11 @@ public class ClusterEvent {
   }
 
   public ClusterEvent clone(String eventId) {
-    return new ClusterEvent(this, eventId);
+    ClusterEvent newEvent = new ClusterEvent(_clusterName, _eventType, eventId);
+    newEvent.setCreationTime(_creationTime);
+    for (String attributeName : _eventAttributeMap.keySet()) {
+      newEvent.addAttribute(attributeName, _eventAttributeMap.get(attributeName));
+    }
+    return newEvent;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEvent.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEvent.java
@@ -58,7 +58,7 @@ public class ClusterEvent {
   /**
    * A private copy constructor that allows the override of {@link #_eventId}
    * @param clusterEvent The other cluster event object
-   * @param eventId The event Id to be overriden
+   * @param eventId The event id to be overridden
    */
   private ClusterEvent(ClusterEvent clusterEvent, String eventId) {
     _clusterName = clusterEvent._clusterName;

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEvent.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEvent.java
@@ -55,6 +55,19 @@ public class ClusterEvent {
     _eventId = eventId;
   }
 
+  /**
+   * A private copy constructor that allows the override of {@link #_eventId}
+   * @param clusterEvent The other cluster event object
+   * @param eventId The event Id to be overriden
+   */
+  private ClusterEvent(ClusterEvent clusterEvent, String eventId) {
+    _clusterName = clusterEvent._clusterName;
+    _eventType = clusterEvent._eventType;
+    _eventAttributeMap = new HashMap<>(clusterEvent._eventAttributeMap);
+    _creationTime = clusterEvent._creationTime;
+    _eventId = eventId;
+  }
+
   public void addAttribute(String attrName, Object attrValue) {
     if (logger.isTraceEnabled()) {
       logger.trace("Adding attribute:" + attrName);
@@ -114,11 +127,6 @@ public class ClusterEvent {
   }
 
   public ClusterEvent clone(String eventId) {
-    ClusterEvent newEvent = new ClusterEvent(_clusterName, _eventType, eventId);
-    newEvent.setCreationTime(_creationTime);
-    for (String attributeName : _eventAttributeMap.keySet()) {
-      newEvent.addAttribute(attributeName, _eventAttributeMap.get(attributeName));
-    }
-    return newEvent;
+    return new ClusterEvent(this, eventId);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestClusterEvent.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestClusterEvent.java
@@ -19,16 +19,30 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
+import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
-@Test
+
 public class TestClusterEvent {
+
   @Test
-  public void testSimplePutandGet() {
+  public void testSimplePutAndGet() {
     ClusterEvent event = new ClusterEvent(ClusterEventType.Unknown);
     AssertJUnit.assertEquals(event.getEventType(), ClusterEventType.Unknown);
     event.addAttribute("attr1", "value");
     AssertJUnit.assertEquals(event.getAttribute("attr1"), "value");
+  }
+
+  @Test
+  public void testClone() {
+    String clusterName = "TestCluster";
+    ClusterEvent event = new ClusterEvent(clusterName, ClusterEventType.Unknown, "testId");
+    event.addAttribute("key", "value");
+
+    ClusterEvent clonedEvent = event.clone("cloneId");
+    Assert.assertEquals(clonedEvent.getClusterName(), clusterName);
+    Assert.assertEquals(clonedEvent.getEventId(), "cloneId");
+    Assert.assertEquals(clonedEvent.getAttribute("key"), "value");
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

(Fixes #784 )
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The `clone` method is not quite clean in its implementation, readers can hardly tell which `_eventAttributeMap` is the old event versus the new one.

Also, the stack trace in #784 proves the possibility of ConcurrentModificationException. A right and straightforward way is to make the current attribute map concurrent and thread-safe

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)
- TestClusterEvent#testClone

- [x] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")
END testSessionExpiredWhenResetHandlers at Wed Feb 19 19:03:44 PST 2020, took: 7722ms.
Shut down zookeeper at port 2183 in thread main
Tests run: 1083, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4,470.368 sec <<< FAILURE! - in TestSuite
testMissingTopStateDurationMonitoring(org.apache.helix.integration.controller.TestControllerLeadershipChange)  Time elapsed: 4.353 sec  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.testng.Assert.fail(Assert.java:89)
	at org.testng.Assert.failNotEquals(Assert.java:480)
	at org.testng.Assert.assertTrue(Assert.java:37)
	at org.testng.Assert.assertTrue(Assert.java:47)
	at org.apache.helix.integration.controller.TestControllerLeadershipChange.testMissingTopStateDurationMonitoring(TestControllerLeadershipChange.java:262)


Results :

Failed tests: 
  TestControllerLeadershipChange.testMissingTopStateDurationMonitoring:262 expected:<true> but was:<false>

Tests run: 1083, Failures: 1, Errors: 0, Skipped: 0

The failed test passed in IDE

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml