### PR TITLE
Add FederatedZkClient

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -26,7 +26,6 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import com.sun.istack.internal.NotNull;
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
@@ -478,7 +477,6 @@ public class FederatedZkClient implements RealmAwareZkClient {
     return getZkClient(path).create(path, dataObject, acl, mode);
   }
 
-  @NotNull
   private ZkClient getZkClient(String path) {
     // If FederatedZkClient is closed, should not return ZkClient.
     checkClosedState();

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -20,344 +20,478 @@ package org.apache.helix.zookeeper.impl.client;
  */
 
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
+import org.apache.helix.zookeeper.zkclient.ZkConnection;
 import org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks;
-import org.apache.helix.zookeeper.zkclient.deprecated.IZkStateListener;
+import org.apache.helix.zookeeper.zkclient.IZkStateListener;
+import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Op;
 import org.apache.zookeeper.OpResult;
+import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
+/**
+ * Implements and supports all ZK operations defined in interface {@link RealmAwareZkClient},
+ * except for session-aware operations such as creating ephemeral nodes, for which
+ * an {@link UnsupportedOperationException} will be thrown.
+ * <p>
+ * It acts as a single ZK client but will automatically route read/write/change subscription
+ * requests to the corresponding ZkClient with the help of metadata store directory service.
+ * It could connect to multiple ZK addresses and maintain a {@link ZkClient} for each ZK address.
+ */
 public class FederatedZkClient implements RealmAwareZkClient {
+  private static final Logger LOG = LoggerFactory.getLogger(FederatedZkClient.class);
+
+  private static final String FEDERATED_ZK_CLIENT = FederatedZkClient.class.getSimpleName();
+  private static final String DEDICATED_ZK_CLIENT_FACTORY =
+      DedicatedZkClientFactory.class.getSimpleName();
+
+  private final MetadataStoreRoutingData _metadataStoreRoutingData;
+  private final RealmAwareZkClient.RealmAwareZkClientConfig _clientConfig;
+
+  // ZK realm -> ZkClient
+  private final Map<String, ZkClient> _zkRealmToZkClientMap;
+
+  private PathBasedZkSerializer _pathBasedZkSerializer;
+
+  // TODO: support capacity of ZkClient number in one FederatedZkClient and do garbage collection.
+  public FederatedZkClient(RealmAwareZkClient.RealmAwareZkClientConfig clientConfig,
+      MetadataStoreRoutingData metadataStoreRoutingData) {
+    if (metadataStoreRoutingData == null) {
+      throw new IllegalArgumentException("MetadataStoreRoutingData cannot be null!");
+    }
+    if (clientConfig == null) {
+      throw new IllegalArgumentException("Client config cannot be null!");
+    }
+
+    _clientConfig = clientConfig;
+    _pathBasedZkSerializer = clientConfig.getZkSerializer();
+    _metadataStoreRoutingData = metadataStoreRoutingData;
+    _zkRealmToZkClientMap = new ConcurrentHashMap<>();
+  }
+
   @Override
   public List<String> subscribeChildChanges(String path, IZkChildListener listener) {
-    return null;
+    return getZkClient(path).subscribeChildChanges(path, listener);
   }
 
   @Override
   public void unsubscribeChildChanges(String path, IZkChildListener listener) {
-
+    getZkClient(path).unsubscribeChildChanges(path, listener);
   }
 
   @Override
   public void subscribeDataChanges(String path, IZkDataListener listener) {
-
+    getZkClient(path).subscribeDataChanges(path, listener);
   }
 
   @Override
   public void unsubscribeDataChanges(String path, IZkDataListener listener) {
-
+    getZkClient(path).unsubscribeDataChanges(path, listener);
   }
 
   @Override
   public void subscribeStateChanges(IZkStateListener listener) {
-
+    throwUnsupportedOperationException();
   }
 
   @Override
   public void unsubscribeStateChanges(IZkStateListener listener) {
+    throwUnsupportedOperationException();
+  }
 
+  @Override
+  public void subscribeStateChanges(
+      org.apache.helix.zookeeper.zkclient.deprecated.IZkStateListener listener) {
+    throwUnsupportedOperationException();
+  }
+
+  @Override
+  public void unsubscribeStateChanges(
+      org.apache.helix.zookeeper.zkclient.deprecated.IZkStateListener listener) {
+    throwUnsupportedOperationException();
   }
 
   @Override
   public void unsubscribeAll() {
-
+    _zkRealmToZkClientMap.values().forEach(ZkClient::unsubscribeAll);
   }
 
   @Override
   public void createPersistent(String path) {
-
+    createPersistent(path, false);
   }
 
   @Override
   public void createPersistent(String path, boolean createParents) {
-
+    createPersistent(path, createParents, ZooDefs.Ids.OPEN_ACL_UNSAFE);
   }
 
   @Override
   public void createPersistent(String path, boolean createParents, List<ACL> acl) {
-
+    getZkClient(path).createPersistent(path, createParents, acl);
   }
 
   @Override
   public void createPersistent(String path, Object data) {
-
+    create(path, data, CreateMode.PERSISTENT);
   }
 
   @Override
   public void createPersistent(String path, Object data, List<ACL> acl) {
-
+    create(path, data, acl, CreateMode.PERSISTENT);
   }
 
   @Override
   public String createPersistentSequential(String path, Object data) {
-    return null;
+    return create(path, data, CreateMode.PERSISTENT_SEQUENTIAL);
   }
 
   @Override
   public String createPersistentSequential(String path, Object data, List<ACL> acl) {
-    return null;
+    return create(path, data, acl, CreateMode.PERSISTENT_SEQUENTIAL);
   }
 
   @Override
   public void createEphemeral(String path) {
-
+    create(path, null, CreateMode.EPHEMERAL);
   }
 
   @Override
   public void createEphemeral(String path, String sessionId) {
-
+    createEphemeral(path, null, sessionId);
   }
 
   @Override
   public void createEphemeral(String path, List<ACL> acl) {
-
+    create(path, null, acl, CreateMode.EPHEMERAL);
   }
 
   @Override
   public void createEphemeral(String path, List<ACL> acl, String sessionId) {
-
+    create(path, null, acl, CreateMode.EPHEMERAL, sessionId);
   }
 
   @Override
   public String create(String path, Object data, CreateMode mode) {
-    return null;
+    return create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, mode);
   }
 
   @Override
-  public String create(String path, Object datat, List<ACL> acl, CreateMode mode) {
-    return null;
+  public String create(String path, Object data, List<ACL> acl, CreateMode mode) {
+    return create(path, data, acl, mode, null);
   }
 
   @Override
   public void createEphemeral(String path, Object data) {
-
+    create(path, data, CreateMode.EPHEMERAL);
   }
 
   @Override
   public void createEphemeral(String path, Object data, String sessionId) {
-
+    create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL, sessionId);
   }
 
   @Override
   public void createEphemeral(String path, Object data, List<ACL> acl) {
-
+    create(path, data, acl, CreateMode.EPHEMERAL);
   }
 
   @Override
   public void createEphemeral(String path, Object data, List<ACL> acl, String sessionId) {
-
+    create(path, data, acl, CreateMode.EPHEMERAL, sessionId);
   }
 
   @Override
   public String createEphemeralSequential(String path, Object data) {
-    return null;
+    return create(path, data, CreateMode.EPHEMERAL_SEQUENTIAL);
   }
 
   @Override
   public String createEphemeralSequential(String path, Object data, List<ACL> acl) {
-    return null;
+    return create(path, data, acl, CreateMode.EPHEMERAL_SEQUENTIAL);
   }
 
   @Override
   public String createEphemeralSequential(String path, Object data, String sessionId) {
-    return null;
+    return create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL,
+        sessionId);
   }
 
   @Override
   public String createEphemeralSequential(String path, Object data, List<ACL> acl,
       String sessionId) {
-    return null;
+    return create(path, data, acl, CreateMode.EPHEMERAL_SEQUENTIAL, sessionId);
   }
 
   @Override
   public List<String> getChildren(String path) {
-    return null;
+    return getZkClient(path).getChildren(path);
   }
 
   @Override
   public int countChildren(String path) {
-    return 0;
+    return getZkClient(path).countChildren(path);
   }
 
   @Override
   public boolean exists(String path) {
-    return false;
+    return getZkClient(path).exists(path);
   }
 
   @Override
   public Stat getStat(String path) {
-    return null;
+    return getZkClient(path).getStat(path);
   }
 
   @Override
   public boolean waitUntilExists(String path, TimeUnit timeUnit, long time) {
-    return false;
+    return getZkClient(path).waitUntilExists(path, timeUnit, time);
   }
 
   @Override
   public void deleteRecursively(String path) {
-
+    getZkClient(path).deleteRecursively(path);
   }
 
   @Override
   public boolean delete(String path) {
-    return false;
+    return getZkClient(path).delete(path);
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public <T> T readData(String path) {
-    return null;
+    return (T) readData(path, false);
   }
 
   @Override
   public <T> T readData(String path, boolean returnNullIfPathNotExists) {
-    return null;
+    return getZkClient(path).readData(path, returnNullIfPathNotExists);
   }
 
   @Override
   public <T> T readData(String path, Stat stat) {
-    return null;
+    return getZkClient(path).readData(path, stat);
   }
 
   @Override
   public <T> T readData(String path, Stat stat, boolean watch) {
-    return null;
+    return getZkClient(path).readData(path, stat, watch);
   }
 
   @Override
   public <T> T readDataAndStat(String path, Stat stat, boolean returnNullIfPathNotExists) {
-    return null;
+    return getZkClient(path).readData(path, stat, returnNullIfPathNotExists);
   }
 
   @Override
   public void writeData(String path, Object object) {
-
+    writeData(path, object, -1);
   }
 
   @Override
   public <T> void updateDataSerialized(String path, DataUpdater<T> updater) {
-
+    getZkClient(path).updateDataSerialized(path, updater);
   }
 
   @Override
-  public void writeData(String path, Object datat, int expectedVersion) {
-
+  public void writeData(String path, Object data, int expectedVersion) {
+    writeDataReturnStat(path, data, expectedVersion);
   }
 
   @Override
-  public Stat writeDataReturnStat(String path, Object datat, int expectedVersion) {
-    return null;
+  public Stat writeDataReturnStat(String path, Object data, int expectedVersion) {
+    return getZkClient(path).writeDataReturnStat(path, data, expectedVersion);
   }
 
   @Override
-  public Stat writeDataGetStat(String path, Object datat, int expectedVersion) {
-    return null;
+  public Stat writeDataGetStat(String path, Object data, int expectedVersion) {
+    return writeDataReturnStat(path, data, expectedVersion);
   }
 
   @Override
-  public void asyncCreate(String path, Object datat, CreateMode mode,
+  public void asyncCreate(String path, Object data, CreateMode mode,
       ZkAsyncCallbacks.CreateCallbackHandler cb) {
-
+    getZkClient(path).asyncCreate(path, data, mode, cb);
   }
 
   @Override
-  public void asyncSetData(String path, Object datat, int version,
+  public void asyncSetData(String path, Object data, int version,
       ZkAsyncCallbacks.SetDataCallbackHandler cb) {
-
+    getZkClient(path).asyncSetData(path, data, version, cb);
   }
 
   @Override
   public void asyncGetData(String path, ZkAsyncCallbacks.GetDataCallbackHandler cb) {
-
+    getZkClient(path).asyncGetData(path, cb);
   }
 
   @Override
   public void asyncExists(String path, ZkAsyncCallbacks.ExistsCallbackHandler cb) {
-
+    getZkClient(path).asyncExists(path, cb);
   }
 
   @Override
   public void asyncDelete(String path, ZkAsyncCallbacks.DeleteCallbackHandler cb) {
-
+    getZkClient(path).asyncDelete(path, cb);
   }
 
   @Override
   public void watchForData(String path) {
-
+    getZkClient(path).watchForData(path);
   }
 
   @Override
   public List<String> watchForChilds(String path) {
-    return null;
+    return getZkClient(path).watchForChilds(path);
   }
 
   @Override
   public long getCreationTime(String path) {
-    return 0;
+    return getZkClient(path).getCreationTime(path);
   }
 
   @Override
   public List<OpResult> multi(Iterable<Op> ops) {
+    throwUnsupportedOperationException();
     return null;
   }
 
   @Override
   public boolean waitUntilConnected(long time, TimeUnit timeUnit) {
+    throwUnsupportedOperationException();
     return false;
   }
 
   @Override
   public String getServers() {
+    throwUnsupportedOperationException();
     return null;
   }
 
   @Override
   public long getSessionId() {
-    return 0;
+    // Session-aware is unsupported.
+    throwUnsupportedOperationException();
+    return 0L;
   }
 
   @Override
   public void close() {
+    if (isClosed()) {
+      return;
+    }
 
+    LOG.info("Closing {}.", FEDERATED_ZK_CLIENT);
+
+    synchronized (_zkRealmToZkClientMap) {
+      _zkRealmToZkClientMap.values().forEach(ZkClient::close);
+      _zkRealmToZkClientMap.clear();
+    }
   }
 
   @Override
   public boolean isClosed() {
-    return false;
+    return _zkRealmToZkClientMap.isEmpty();
   }
 
   @Override
   public byte[] serialize(Object data, String path) {
-    return new byte[0];
+    return getZkClient(path).serialize(data, path);
   }
 
   @Override
   public <T> T deserialize(byte[] data, String path) {
-    return null;
+    return getZkClient(path).deserialize(data, path);
   }
 
   @Override
   public void setZkSerializer(ZkSerializer zkSerializer) {
-
+    _pathBasedZkSerializer = new BasicZkSerializer(zkSerializer);
+    _zkRealmToZkClientMap.values()
+        .forEach(zkClient -> zkClient.setZkSerializer(_pathBasedZkSerializer));
   }
 
   @Override
   public void setZkSerializer(PathBasedZkSerializer zkSerializer) {
-
+    _pathBasedZkSerializer = zkSerializer;
+    _zkRealmToZkClientMap.values().forEach(zkClient -> zkClient.setZkSerializer(zkSerializer));
   }
 
   @Override
   public PathBasedZkSerializer getZkSerializer() {
-    return null;
+    return _pathBasedZkSerializer;
+  }
+
+  private String create(final String path, final Object dataObject, final List<ACL> acl,
+      final CreateMode mode, final String expectedSessionId) {
+    if (mode.isEphemeral()) {
+      throwUnsupportedOperationException();
+    }
+
+    // Create mode is not session-aware, so the node does not have to be created
+    // by the expectedSessionId.
+    return getZkClient(path).create(path, dataObject, acl, mode);
+  }
+
+  private ZkClient getZkClient(String path) {
+    String zkRealm = getZkRealm(path);
+    if (!_zkRealmToZkClientMap.containsKey(zkRealm)) {
+      // Synchronized to avoid creating duplicate ZkClient for the same ZkRealm.
+      synchronized (_zkRealmToZkClientMap) {
+        if (!_zkRealmToZkClientMap.containsKey(zkRealm)) {
+          _zkRealmToZkClientMap.put(zkRealm, createZkClient(zkRealm));
+        }
+      }
+    }
+
+    return _zkRealmToZkClientMap.get(zkRealm);
+  }
+
+  private String getZkRealm(String path) {
+    String zkRealm;
+    try {
+      zkRealm = _metadataStoreRoutingData.getMetadataStoreRealm(path);
+    } catch (NoSuchElementException ex) {
+      throw new NoSuchElementException("Cannot find ZK realm for the path: " + path);
+    }
+
+    if (zkRealm == null || zkRealm.isEmpty()) {
+      throw new NoSuchElementException("Cannot find ZK realm for the path: " + path);
+    }
+
+    return zkRealm;
+  }
+
+  private ZkClient createZkClient(String zkAddress) {
+    LOG.debug("Creating ZkClient for realm: {}.", zkAddress);
+    return new ZkClient(new ZkConnection(zkAddress), (int) _clientConfig.getConnectInitTimeout(),
+        _clientConfig.getOperationRetryTimeout(), _pathBasedZkSerializer,
+        _clientConfig.getMonitorType(), _clientConfig.getMonitorKey(),
+        _clientConfig.getMonitorInstanceName(), _clientConfig.isMonitorRootPathOnly());
+  }
+
+  private void throwUnsupportedOperationException() {
+    throw new UnsupportedOperationException(
+        "Session-aware operation is not supported by " + FEDERATED_ZK_CLIENT
+            + ". Instead, please use " + DEDICATED_ZK_CLIENT_FACTORY + " for this operation");
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -500,6 +500,7 @@ public class FederatedZkClient implements RealmAwareZkClient {
   private void throwUnsupportedOperationException() {
     throw new UnsupportedOperationException(
         "Session-aware operation is not supported by " + FEDERATED_ZK_CLIENT
-            + ". Instead, please use " + DEDICATED_ZK_CLIENT_FACTORY + " for this operation");
+            + ". Instead, please use " + DEDICATED_ZK_CLIENT_FACTORY
+            + " to create a dedicated RealmAwareZkClient for this operation");
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -480,6 +480,8 @@ public class FederatedZkClient implements RealmAwareZkClient {
         if (!_zkRealmToZkClientMap.containsKey(zkRealm)) {
           zkClient = createZkClient(zkRealm);
           _zkRealmToZkClientMap.put(zkRealm, zkClient);
+        } else {
+          zkClient = _zkRealmToZkClientMap.get(zkRealm);
         }
       }
     }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestBase.java
@@ -57,12 +57,11 @@ public class ZkTestBase {
    * Multiple ZK references
    */
   // The following maps hold ZK connect string as keys
-  protected Map<String, ZkServer> _zkServerMap = new HashMap<>();
+  protected final Map<String, ZkServer> _zkServerMap = new HashMap<>();
   protected int _numZk = 1; // Initial value
 
   @BeforeSuite
-  public void beforeSuite()
-      throws IOException {
+  public void beforeSuite() throws IOException {
     // Due to ZOOKEEPER-2693 fix, we need to specify whitelist for execute zk commends
     System.setProperty("zookeeper.4lw.commands.whitelist", "*");
 
@@ -80,8 +79,7 @@ public class ZkTestBase {
   }
 
   @AfterSuite
-  public void afterSuite()
-      throws IOException {
+  public void afterSuite() throws IOException {
     // Clean up all JMX objects
     for (ObjectName mbean : MBEAN_SERVER.queryNames(null, null)) {
       try {
@@ -124,7 +122,7 @@ public class ZkTestBase {
    * @param zkAddress
    * @return
    */
-  private ZkServer startZkServer(final String zkAddress) {
+  protected ZkServer startZkServer(final String zkAddress) {
     String zkDir = zkAddress.replace(':', '_');
     final String logDir = "/tmp/" + zkDir + "/logs";
     final String dataDir = "/tmp/" + zkDir + "/dataDir";
@@ -142,6 +140,7 @@ public class ZkTestBase {
 
     int port = Integer.parseInt(zkAddress.substring(zkAddress.lastIndexOf(':') + 1));
     ZkServer zkServer = new ZkServer(dataDir, logDir, defaultNameSpace, port);
+    System.out.println("Starting ZK server at " + zkAddress);
     zkServer.start();
     return zkServer;
   }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestBase.java
@@ -58,7 +58,7 @@ public class ZkTestBase {
    */
   // The following maps hold ZK connect string as keys
   protected final Map<String, ZkServer> _zkServerMap = new HashMap<>();
-  protected int _numZk = 1; // Initial value
+  protected static int _numZk = 1; // Initial value
 
   @BeforeSuite
   public void beforeSuite() throws IOException {

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
@@ -289,6 +289,8 @@ public class TestFederatedZkClient extends ZkTestBase {
 
   /*
    * Tests that close() works.
+   * TODO: test that all raw zkClients are closed after FederatedZkClient close() is called. This
+   *  could help avoid ZkClient leakage.
    */
   @Test(dependsOnMethods = "testMultiRealmCRUD")
   public void testClose() {

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
@@ -240,5 +240,13 @@ public class TestFederatedZkClient extends ZkTestBase {
     _realmAwareZkClient.close();
 
     Assert.assertTrue(_realmAwareZkClient.isClosed());
+
+    // Client is closed, so operation should not be executed.
+    try {
+      _realmAwareZkClient.createPersistent(TEST_VALID_PATH);
+      Assert.fail("createPersistent() should not be executed because RealmAwareZkClient is closed.");
+    } catch (IllegalStateException ex) {
+      Assert.assertEquals(ex.getMessage(), "FederatedZkClient is closed!");
+    }
   }
 }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
@@ -1,0 +1,244 @@
+package org.apache.helix.zookeeper.impl.client;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.helix.msdcommon.datamodel.TrieRoutingData;
+import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
+import org.apache.helix.zookeeper.impl.ZkTestBase;
+import org.apache.helix.zookeeper.zkclient.IZkStateListener;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Op;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestFederatedZkClient extends ZkTestBase {
+  private static final String TEST_SHARDING_KEY_PREFIX = "/test_sharding_key_";
+  private static final String TEST_VALID_PATH = TEST_SHARDING_KEY_PREFIX + "0/a/b/c";
+  private static final String TEST_INVALID_PATH = TEST_SHARDING_KEY_PREFIX + "invalid/a/b/c";
+  private static final String UNSUPPORTED_OPERATION_MESSAGE =
+      "Session-aware operation is not supported by FederatedZkClient.";
+
+  private RealmAwareZkClient _realmAwareZkClient;
+
+  @BeforeClass
+  public void beforeClass() throws InvalidRoutingDataException {
+    // Populate rawRoutingData
+    // <Realm, List of sharding keys> Mapping
+    Map<String, List<String>> rawRoutingData = new HashMap<>();
+    for (int i = 0; i < _numZk; i++) {
+      List<String> shardingKeyList = Collections.singletonList(TEST_SHARDING_KEY_PREFIX + i);
+      String realmName = ZK_PREFIX + (ZK_START_PORT + i);
+      rawRoutingData.put(realmName, shardingKeyList);
+    }
+
+    // Feed the raw routing data into TrieRoutingData to construct an in-memory representation
+    // of routing information.
+    _realmAwareZkClient = new FederatedZkClient(new RealmAwareZkClient.RealmAwareZkClientConfig(),
+        new TrieRoutingData(rawRoutingData));
+  }
+
+  @AfterClass
+  public void afterClass() {
+    // Close it as it is created in before class.
+    _realmAwareZkClient.close();
+  }
+
+  /*
+   * Tests that an unsupported operation should throw an UnsupportedOperationException.
+   */
+  @Test
+  public void testUnsupportedOperations() {
+    // Test creating ephemeral.
+    try {
+      _realmAwareZkClient.create(TEST_VALID_PATH, "Hello", CreateMode.EPHEMERAL);
+      Assert.fail("Ephemeral node should not be created.");
+    } catch (UnsupportedOperationException ex) {
+      Assert.assertTrue(ex.getMessage()
+          .startsWith(UNSUPPORTED_OPERATION_MESSAGE));
+    }
+
+    // Test creating ephemeral sequential.
+    try {
+      _realmAwareZkClient.create(TEST_VALID_PATH, "Hello", CreateMode.EPHEMERAL_SEQUENTIAL);
+      Assert.fail("Ephemeral node should not be created.");
+    } catch (UnsupportedOperationException ex) {
+      Assert.assertTrue(ex.getMessage()
+          .startsWith(UNSUPPORTED_OPERATION_MESSAGE));
+    }
+
+    List<Op> ops = Arrays.asList(
+        Op.create(TEST_VALID_PATH, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT),
+        Op.delete(TEST_VALID_PATH, -1));
+    try {
+      _realmAwareZkClient.multi(ops);
+      Assert.fail("multi() should not be supported.");
+    } catch (UnsupportedOperationException ex) {
+      Assert.assertTrue(ex.getMessage()
+          .startsWith(UNSUPPORTED_OPERATION_MESSAGE));
+    }
+
+    try {
+      _realmAwareZkClient.getSessionId();
+      Assert.fail("getSessionId() should not be supported.");
+    } catch (UnsupportedOperationException ex) {
+      Assert.assertTrue(ex.getMessage()
+          .startsWith(UNSUPPORTED_OPERATION_MESSAGE));
+    }
+
+    try {
+      _realmAwareZkClient.getServers();
+      Assert.fail("getServers() should not be supported.");
+    } catch (UnsupportedOperationException ex) {
+      Assert.assertTrue(ex.getMessage()
+          .startsWith(UNSUPPORTED_OPERATION_MESSAGE));
+    }
+
+    try {
+      _realmAwareZkClient.waitUntilConnected(5L, TimeUnit.SECONDS);
+      Assert.fail("getServers() should not be supported.");
+    } catch (UnsupportedOperationException ex) {
+      Assert.assertTrue(ex.getMessage()
+          .startsWith(UNSUPPORTED_OPERATION_MESSAGE));
+    }
+
+    // Test state change subscription.
+    IZkStateListener listener = new IZkStateListener() {
+      @Override
+      public void handleStateChanged(Watcher.Event.KeeperState state) {
+        System.out.println("Handle new state: " + state);
+      }
+
+      @Override
+      public void handleNewSession(String sessionId) {
+        System.out.println("Handle new session: " + sessionId);
+      }
+
+      @Override
+      public void handleSessionEstablishmentError(Throwable error) {
+        System.out.println("Handle session establishment error: " + error);
+      }
+    };
+
+    try {
+      _realmAwareZkClient.subscribeStateChanges(listener);
+      Assert.fail("getServers() should not be supported.");
+    } catch (UnsupportedOperationException ex) {
+      Assert.assertTrue(ex.getMessage()
+          .startsWith(UNSUPPORTED_OPERATION_MESSAGE));
+    }
+
+    try {
+      _realmAwareZkClient.unsubscribeStateChanges(listener);
+      Assert.fail("getServers() should not be supported.");
+    } catch (UnsupportedOperationException ex) {
+      Assert.assertTrue(ex.getMessage()
+          .startsWith(UNSUPPORTED_OPERATION_MESSAGE));
+    }
+  }
+
+  /*
+   * Tests the persistent create() call against a valid path and an invalid path.
+   * Valid path is one that belongs to the realm designated by the sharding key.
+   * Invalid path is one that does not belong to the realm designated by the sharding key.
+   */
+  @Test(dependsOnMethods = "testUnsupportedOperations")
+  public void testCreatePersistent() {
+    _realmAwareZkClient.setZkSerializer(new ZNRecordSerializer());
+
+    // Create a dummy ZNRecord
+    ZNRecord znRecord = new ZNRecord("DummyRecord");
+    znRecord.setSimpleField("Dummy", "Value");
+
+    // Test writing and reading against the validPath
+    _realmAwareZkClient.createPersistent(TEST_VALID_PATH, true);
+    _realmAwareZkClient.writeData(TEST_VALID_PATH, znRecord);
+    Assert.assertEquals(_realmAwareZkClient.readData(TEST_VALID_PATH), znRecord);
+
+    // Test writing and reading against the invalid path
+    try {
+      _realmAwareZkClient.createPersistent(TEST_INVALID_PATH, true);
+      Assert.fail("Create() should not succeed on an invalid path!");
+    } catch (NoSuchElementException ex) {
+      Assert
+          .assertEquals(ex.getMessage(), "Cannot find ZK realm for the path: " + TEST_INVALID_PATH);
+    }
+  }
+
+  /*
+   * Tests that exists() works on valid path and fails on invalid path.
+   */
+  @Test(dependsOnMethods = "testCreatePersistent")
+  public void testExists() {
+    Assert.assertTrue(_realmAwareZkClient.exists(TEST_VALID_PATH));
+
+    try {
+      _realmAwareZkClient.exists(TEST_INVALID_PATH);
+      Assert.fail("Exists() should not succeed on an invalid path!");
+    } catch (NoSuchElementException ex) {
+      Assert
+          .assertEquals(ex.getMessage(), "Cannot find ZK realm for the path: " + TEST_INVALID_PATH);
+    }
+  }
+
+  /*
+   * Tests that delete() works on valid path and fails on invalid path.
+   */
+  @Test(dependsOnMethods = "testExists")
+  public void testDelete() {
+    try {
+      _realmAwareZkClient.delete(TEST_INVALID_PATH);
+      Assert.fail("Exists() should not succeed on an invalid path!");
+    } catch (NoSuchElementException ex) {
+      Assert
+          .assertEquals(ex.getMessage(), "Cannot find ZK realm for the path: " + TEST_INVALID_PATH);
+    }
+
+    Assert.assertTrue(_realmAwareZkClient.delete(TEST_VALID_PATH));
+    Assert.assertFalse(_realmAwareZkClient.exists(TEST_VALID_PATH));
+  }
+
+  /*
+   * Tests that close() works.
+   */
+  @Test(dependsOnMethods = "testDelete")
+  public void testClose() {
+    Assert.assertFalse(_realmAwareZkClient.isClosed());
+
+    _realmAwareZkClient.close();
+
+    Assert.assertTrue(_realmAwareZkClient.isClosed());
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Implements #779 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

FederatedZkClient (One FederatedZkClient, multiple Zookeeper sessions inside)
- Some Helix Java APIs such as HelixAdmin can only perform CRUD operations.
- In order to enable such Java APIs to operate against multiple Zookeeper realms, we will create FederatedZkClient, which is a new version of ZkClient that could replace the existing HelixZkClient used by CRUD-only Java APIs.
- FederatedZkClient will internally maintain multiple ZooKeeper sessions connecting to different ZooKeeper realms on an as-needed basis.
- By creating and maintaining multiple ZooKeeper sessions, FederatedZkClient will route incoming ZooKeeper requests to the appropriate ZooKeeper sessions based on the ZK path sharding key.

FederatedZkClient (implements RealmAwareZkClient)
- An implementation of RealmAwareZkClient that connects to multiple ZK realms.
- Supports CRUD + change subscription.

### Tests

- [x] The following tests are written for this issue:

 - TestFederatedZkClient

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] --- maven-surefire-plugin:3.0.0-M3:test (default-test) @ zookeeper-api ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.024 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- maven-surefire-plugin:3.0.0-M3:test (multi-zk) @ zookeeper-api ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------

[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.032 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.370 s
[INFO] Finished at: 2020-02-22T18:01:25-08:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml