### PR TITLE
[helix-rest] Add endpoint to get namespace routing data

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreDirectory.java
@@ -58,7 +58,7 @@ public interface MetadataStoreDirectory extends AutoCloseable {
    * @param namespace namespace in metadata store directory.
    * @return Routing data map: realm -> List of sharding keys
    */
-  Map<String, List<String>> getRoutingData(String namespace);
+  Map<String, List<String>> getNamespaceRoutingData(String namespace);
 
   /**
    * Returns all path-based sharding keys in the given namespace and the realm.

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreDirectory.java
@@ -20,6 +20,7 @@ package org.apache.helix.rest.metadatastore;
  */
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
@@ -50,6 +51,14 @@ public interface MetadataStoreDirectory extends AutoCloseable {
    * @return
    */
   Collection<String> getAllShardingKeys(String namespace);
+
+  /**
+   * Returns all path-based sharding keys by realm in the given namespace.
+   *
+   * @param namespace namespace in metadata store directory.
+   * @return Map: realm -> List of sharding keys
+   */
+  Map<String, List<String>> getShardingKeysByRealm(String namespace);
 
   /**
    * Returns all path-based sharding keys in the given namespace and the realm.

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreDirectory.java
@@ -53,12 +53,12 @@ public interface MetadataStoreDirectory extends AutoCloseable {
   Collection<String> getAllShardingKeys(String namespace);
 
   /**
-   * Returns all path-based sharding keys by realm in the given namespace.
+   * Returns routing data in the given namespace.
    *
    * @param namespace namespace in metadata store directory.
-   * @return Map: realm -> List of sharding keys
+   * @return Routing data map: realm -> List of sharding keys
    */
-  Map<String, List<String>> getShardingKeysByRealm(String namespace);
+  Map<String, List<String>> getRoutingData(String namespace);
 
   /**
    * Returns all path-based sharding keys in the given namespace and the realm.

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -112,7 +112,7 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
   }
 
   @Override
-  public Map<String, List<String>> getRoutingData(String namespace) {
+  public Map<String, List<String>> getNamespaceRoutingData(String namespace) {
     Map<String, List<String>> routingData = _realmToShardingKeysMap.get(namespace);
     if (routingData == null) {
       throw new NoSuchElementException("Namespace " + namespace + " does not exist!");

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -112,13 +112,13 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
   }
 
   @Override
-  public Map<String, List<String>> getShardingKeysByRealm(String namespace) {
-    Map<String, List<String>> shardingKeysByRealmMap = _realmToShardingKeysMap.get(namespace);
-    if (shardingKeysByRealmMap == null) {
+  public Map<String, List<String>> getRoutingData(String namespace) {
+    Map<String, List<String>> routingData = _realmToShardingKeysMap.get(namespace);
+    if (routingData == null) {
       throw new NoSuchElementException("Namespace " + namespace + " does not exist!");
     }
 
-    return shardingKeysByRealmMap;
+    return routingData;
   }
 
   @Override

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -112,6 +112,16 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
   }
 
   @Override
+  public Map<String, List<String>> getShardingKeysByRealm(String namespace) {
+    Map<String, List<String>> shardingKeysByRealmMap = _realmToShardingKeysMap.get(namespace);
+    if (shardingKeysByRealmMap == null) {
+      throw new NoSuchElementException("Namespace " + namespace + " does not exist!");
+    }
+
+    return shardingKeysByRealmMap;
+  }
+
+  @Override
   public Collection<String> getAllShardingKeysInRealm(String namespace, String realm) {
     if (!_realmToShardingKeysMap.containsKey(namespace)) {
       throw new NoSuchElementException("Namespace " + namespace + " does not exist!");

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/datamodel/MetadataStoreShardingKeysByRealm.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/datamodel/MetadataStoreShardingKeysByRealm.java
@@ -1,0 +1,56 @@
+package org.apache.helix.rest.metadatastore.datamodel;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+@JsonPropertyOrder({"realm", "shardingKeys"})
+public class MetadataStoreShardingKeysByRealm {
+  private String realm;
+  private List<String> shardingKeys;
+
+  @JsonCreator
+  public MetadataStoreShardingKeysByRealm(@JsonProperty String realm,
+      @JsonProperty List<String> shardingKeys) {
+    this.realm = realm;
+    this.shardingKeys = shardingKeys;
+  }
+
+  @JsonProperty
+  public String getRealm() {
+    return realm;
+  }
+
+  @JsonProperty
+  public List<String> getShardingKeys() {
+    return shardingKeys;
+  }
+
+  @Override
+  public String toString() {
+    return "MetadataStoreShardingKeysByRealm{" + "realm='" + realm + '\'' + ", shardingKeys="
+        + shardingKeys + '}';
+  }
+}

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/datamodel/MetadataStoreShardingKeysByRealm.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/datamodel/MetadataStoreShardingKeysByRealm.java
@@ -19,7 +19,7 @@ package org.apache.helix.rest.metadatastore.datamodel;
  * under the License.
  */
 
-import java.util.List;
+import java.util.Collection;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -29,11 +29,11 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonPropertyOrder({"realm", "shardingKeys"})
 public class MetadataStoreShardingKeysByRealm {
   private String realm;
-  private List<String> shardingKeys;
+  private Collection<String> shardingKeys;
 
   @JsonCreator
   public MetadataStoreShardingKeysByRealm(@JsonProperty String realm,
-      @JsonProperty List<String> shardingKeys) {
+      @JsonProperty Collection<String> shardingKeys) {
     this.realm = realm;
     this.shardingKeys = shardingKeys;
   }
@@ -44,7 +44,7 @@ public class MetadataStoreShardingKeysByRealm {
   }
 
   @JsonProperty
-  public List<String> getShardingKeys() {
+  public Collection<String> getShardingKeys() {
     return shardingKeys;
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/metadatastore/MetadataStoreDirectoryAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/metadatastore/MetadataStoreDirectoryAccessor.java
@@ -202,7 +202,7 @@ public class MetadataStoreDirectoryAccessor extends AbstractResource {
   public Response getRoutingData() {
     Map<String, List<String>> rawRoutingData;
     try {
-      rawRoutingData = _metadataStoreDirectory.getRoutingData(_namespace);
+      rawRoutingData = _metadataStoreDirectory.getNamespaceRoutingData(_namespace);
     } catch (NoSuchElementException ex) {
       return notFound(ex.getMessage());
     }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestMetadataStoreDirectoryAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestMetadataStoreDirectoryAccessor.java
@@ -282,15 +282,15 @@ public class TestMetadataStoreDirectoryAccessor extends AbstractTestClass {
   }
 
   /*
-   * Tests REST endpoint: "GET /sharding-keys?groupByRealm=true"
+   * Tests REST endpoint: "GET /routing-data"
    */
   @Test(dependsOnMethods = "testGetShardingKeysInNamespace")
-  public void testGetShardingKeysGroupByRealm() throws IOException {
+  public void testGetRoutingData() throws IOException {
     /*
      * responseBody:
      * {
      *   "namespace" : "test-namespace",
-     *   "shardingKeysByRealm" : [ {
+     *   "routingData" : [ {
      *     "realm" : "testRealm2",
      *     "shardingKeys" : [ "/sharding/key/1/d", "/sharding/key/1/e", "/sharding/key/1/f" ]
      *   }, {
@@ -300,7 +300,7 @@ public class TestMetadataStoreDirectoryAccessor extends AbstractTestClass {
      * }
      */
     String responseBody =
-        new JerseyUriRequestBuilder(TEST_NAMESPACE_URI_PREFIX + "/sharding-keys?groupByRealm=true")
+        new JerseyUriRequestBuilder(TEST_NAMESPACE_URI_PREFIX + "/routing-data")
             .isBodyReturnExpected(true).get(this);
 
     // It is safe to cast the object and suppress warnings.
@@ -310,7 +310,7 @@ public class TestMetadataStoreDirectoryAccessor extends AbstractTestClass {
     // Check fields.
     Assert.assertEquals(queriedShardingKeysMap.keySet(), ImmutableSet
         .of(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_NAMESPACE,
-            MetadataStoreRoutingConstants.SHARDING_KEYS_BY_REALM));
+            MetadataStoreRoutingConstants.ROUTING_DATA));
 
     // Check namespace in json response.
     Assert.assertEquals(
@@ -320,7 +320,7 @@ public class TestMetadataStoreDirectoryAccessor extends AbstractTestClass {
     @SuppressWarnings("unchecked")
     List<Map<String, Object>> queriedShardingKeys =
         (List<Map<String, Object>>) queriedShardingKeysMap
-            .get(MetadataStoreRoutingConstants.SHARDING_KEYS_BY_REALM);
+            .get(MetadataStoreRoutingConstants.ROUTING_DATA);
 
     Set<Map<String, Object>> queriedShardingKeysSet = new HashSet<>(queriedShardingKeys);
     Set<Map<String, Object>> expectedShardingKeysSet = ImmutableSet.of(ImmutableMap
@@ -335,7 +335,7 @@ public class TestMetadataStoreDirectoryAccessor extends AbstractTestClass {
   /*
    * Tests REST endpoint: "GET /metadata-store-realms/{realm}/sharding-keys"
    */
-  @Test(dependsOnMethods = "testGetShardingKeysGroupByRealm")
+  @Test(dependsOnMethods = "testGetRoutingData")
   public void testGetShardingKeysInRealm() throws IOException {
     // Test NOT_FOUND response for a non existed realm.
     new JerseyUriRequestBuilder(

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
@@ -43,8 +43,8 @@ public class MetadataStoreRoutingConstants {
   /** Field name in JSON REST response of getting sharding keys. */
   public static final String SHARDING_KEYS = "shardingKeys";
 
-  /** Field name in JSON REST response of getting sharding keys. */
-  public static final String SHARDING_KEYS_BY_REALM = "shardingKeysByRealm";
+  /** Field name in JSON REST response of getting routing data. */
+  public static final String ROUTING_DATA = "routingData";
 
   /** Field name in JSON REST response related to one single sharding key. */
   public static final String SINGLE_SHARDING_KEY = "shardingKey";

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
@@ -43,6 +43,9 @@ public class MetadataStoreRoutingConstants {
   /** Field name in JSON REST response of getting sharding keys. */
   public static final String SHARDING_KEYS = "shardingKeys";
 
+  /** Field name in JSON REST response of getting sharding keys. */
+  public static final String SHARDING_KEYS_BY_REALM = "shardingKeysByRealm";
+
   /** Field name in JSON REST response related to one single sharding key. */
   public static final String SINGLE_SHARDING_KEY = "shardingKey";
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Implements #798 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add Java API to support get mapping of all sharding keys by realm: realm -> list of sharding keys.
This will help with reducing REST calls down to one single call to read all raw routing data in ZK.

### Tests

- [x] The following tests are written for this issue:

 - testGetShardingKeysGroupByRealm

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 128, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 28.216 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 128, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:01 min
[INFO] Finished at: 2020-02-22T20:29:35-08:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml