### PR TITLE
add one more test for auto registration

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
@@ -1,15 +1,21 @@
 package org.apache.helix.integration.paticipant;
 
 import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.cloud.constants.CloudProvider;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.manager.zk.ZKHelixManager;
+import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.ConfigScope;
 import org.apache.helix.model.IdealState.RebalanceMode;
 import org.apache.helix.model.builder.ConfigScopeBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -32,14 +38,15 @@ import org.testng.annotations.Test;
 
 public class TestInstanceAutoJoin extends ZkStandAloneCMTestBase {
   String db2 = TEST_DB + "2";
+  String db3 = TEST_DB + "3";
 
   @Test
   public void testInstanceAutoJoin() throws Exception {
     HelixManager manager = _participants[0];
     HelixDataAccessor accessor = manager.getHelixDataAccessor();
 
-    _gSetupTool.addResourceToCluster(CLUSTER_NAME, db2, 60, "OnlineOffline", RebalanceMode.FULL_AUTO
-        + "");
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, db2, 60, "OnlineOffline",
+        RebalanceMode.FULL_AUTO + "");
 
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db2, 1);
     String instance2 = "localhost_279699";
@@ -50,8 +57,8 @@ public class TestInstanceAutoJoin extends ZkStandAloneCMTestBase {
 
     Thread.sleep(500);
     // Assert.assertFalse(result._thread.isAlive());
-    Assert.assertTrue(null == manager.getHelixDataAccessor().getProperty(
-        accessor.keyBuilder().liveInstance(instance2)));
+    Assert.assertTrue(null == manager.getHelixDataAccessor()
+        .getProperty(accessor.keyBuilder().liveInstance(instance2)));
 
     ConfigScope scope = new ConfigScopeBuilder().forCluster(CLUSTER_NAME).build();
 
@@ -63,15 +70,54 @@ public class TestInstanceAutoJoin extends ZkStandAloneCMTestBase {
     Thread.sleep(500);
     // Assert.assertTrue(result._thread.isAlive() || result2._thread.isAlive());
     for (int i = 0; i < 20; i++) {
-      if (null == manager.getHelixDataAccessor().getProperty(
-          accessor.keyBuilder().liveInstance(instance2))) {
+      if (null == manager.getHelixDataAccessor()
+          .getProperty(accessor.keyBuilder().liveInstance(instance2))) {
         Thread.sleep(100);
       } else
         break;
     }
-    Assert.assertTrue(null != manager.getHelixDataAccessor().getProperty(
-        accessor.keyBuilder().liveInstance(instance2)));
+    Assert.assertTrue(null != manager.getHelixDataAccessor()
+        .getProperty(accessor.keyBuilder().liveInstance(instance2)));
 
     newParticipant.syncStop();
+  }
+
+  @Test(dependsOnMethods = "testInstanceAutoJoin")
+  public void testAutoRegistrationShouldFailWhenWaitingResponse() throws Exception {
+    // Create CloudConfig object and add to config
+    CloudConfig.Builder cloudConfigBuilder = new CloudConfig.Builder();
+    cloudConfigBuilder.setCloudEnabled(true);
+    cloudConfigBuilder.setCloudProvider(CloudProvider.AZURE);
+    cloudConfigBuilder.setCloudID("TestID");
+    CloudConfig cloudConfig = cloudConfigBuilder.build();
+
+    HelixManager manager = _participants[0];
+    HelixDataAccessor accessor = manager.getHelixDataAccessor();
+
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, db3, 60, "OnlineOffline",
+        RebalanceMode.FULL_AUTO + "");
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db3, 1);
+    String instance3 = "localhost_279700";
+
+    ConfigScope scope = new ConfigScopeBuilder().forCluster(CLUSTER_NAME).build();
+
+    manager.getConfigAccessor().set(scope, ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, "true");
+    // Write the CloudConfig to Zookeeper
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    accessor.setProperty(keyBuilder.cloudConfig(), cloudConfig);
+
+    MockParticipantManager autoParticipant =
+        new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instance3);
+    autoParticipant.syncStart();
+
+    Assert.assertTrue(null == manager.getHelixDataAccessor()
+        .getProperty(accessor.keyBuilder().liveInstance(instance3)));
+    try {
+      manager.getConfigAccessor().getInstanceConfig(CLUSTER_NAME, instance3);
+      fail(
+          "Exception should be thrown because the instance cannot be added to the cluster due to the disconnection with Azure endpoint");
+    } catch (HelixException e) {
+
+    }
   }
 }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

(#694 )

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
This PR adds a test for testing auto registration. The basic logic of a participant auto registers to a cluster is tested, but when waiting for Azure cloud environment response, an exception will be thrown as there is no Azure environment available. The Azure specific logic will be tested in Azure real environment later. 

### Tests

- [X] The following tests are written for this issue:

testInstanceAutoJoin

- [X] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Tests run: 902, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3,610.949 s <<< FAILURE! - in TestSuite
[ERROR] testWorkflowFailureJobThreshold(org.apache.helix.integration.task.TestJobFailureDependence)  Time elapsed: 300.01 s  <<< FAILURE!
org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testWorkflowFailureJobThreshold() didn't finish within the time-out 300000

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestJobFailureDependence.testWorkflowFailureJobThreshold » ThreadTimeout Metho...
[INFO] 
[ERROR] Tests run: 902, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:00 h
[INFO] Finished at: 2020-02-06T09:58:26-08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/mnzhang/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X] My diff has been formatted using helix-style.xml