### PR TITLE
Fix zookeeper endpoint error when path has leading slash

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
@@ -62,14 +62,20 @@ public class ZooKeeperAccessor extends AbstractResource {
     if (cmd == null) {
       return badRequest("Invalid ZooKeeper command: " + commandStr);
     }
+    if (path == null) {
+      return badRequest("Path is missing in the request!");
+    }
 
     // Lazily initialize ZkBaseDataAccessor
     ServerContext _serverContext =
         (ServerContext) _application.getProperties().get(ContextPropertyKeys.SERVER_CONTEXT.name());
     _zkBaseDataAccessor = _serverContext.getByteArrayZkBaseDataAccessor();
 
-    // Need to prepend a "/" since JAX-RS regex removes it
-    path = "/" + path;
+    if (path.isEmpty() || path.charAt(0) != '/') {
+      // Need to prepend a "/" since JAX-RS regex removes it in the case:
+      // path "a/b/c" is extracted from request "/zookeeper/a/b/c"
+      path = "/" + path;
+    }
 
     // Check that the path supplied is valid
     if (!isPathValid(path)) {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
@@ -64,8 +64,7 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
   }
 
   @Test
-  public void testExists()
-      throws IOException {
+  public void testExists() throws IOException {
     String path = "/path";
     Assert.assertFalse(_testBaseDataAccessor.exists(path, AccessOption.PERSISTENT));
     Map<String, Boolean> result;
@@ -92,8 +91,7 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
   }
 
   @Test
-  public void testGetData()
-      throws IOException {
+  public void testGetData() throws IOException {
     String path = "/path";
     String content = "testGetData";
 
@@ -130,8 +128,7 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
   }
 
   @Test
-  public void testGetChildren()
-      throws IOException {
+  public void testGetChildren() throws IOException {
     String path = "/path";
     String childrenKey = "/children";
     int numChildren = 20;
@@ -153,6 +150,35 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
     result.get(getChildrenKey).forEach(child -> {
       Assert.assertTrue(child.contains("children"));
     });
+
+    // Clean up
+    _testBaseDataAccessor.remove(path, AccessOption.PERSISTENT);
+  }
+
+  /*
+   * Tests a path has leading slash in the URI: "/zookeeper//path".
+   */
+  @Test
+  public void testPathHasLeadingSlash() throws IOException {
+    String content = "testGetData";
+    String path = "/path";
+
+    Assert.assertFalse(_testBaseDataAccessor.exists(path, AccessOption.PERSISTENT));
+
+    // Now write data and test
+    _testBaseDataAccessor.create(path, content.getBytes(), AccessOption.PERSISTENT);
+
+    // Test getStringData
+    String getStringDataKey = "getStringData";
+
+    // Simulate URI concatenation in code: endpoint + "/" + path
+    // URI would have 2 slashes: "/zookeeper//path"
+    String uri = "/zookeeper" + "/" + path + "?command=" + getStringDataKey;
+    String data = new JerseyUriRequestBuilder(uri).isBodyReturnExpected(true).get(this);
+    @SuppressWarnings("unchecked")
+    Map<String, String> stringResult = OBJECT_MAPPER.readValue(data, Map.class);
+    Assert.assertTrue(stringResult.containsKey(getStringDataKey));
+    Assert.assertEquals(stringResult.get(getStringDataKey), content);
 
     // Clean up
     _testBaseDataAccessor.remove(path, AccessOption.PERSISTENT);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #810

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

If path has leading slash in Zookeeper REST endpoint: `/zookeeper//tmp/folder`, response is incorrect: response status code is 400.

This endpoint should be able to handle the case correctly.

### Tests

- [x] The following tests are written for this issue:

 - testPathHasLeadingSlash

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml