### PR TITLE
Add getShardingKeyInPath to MetadataStoreRoutingData

### DIFF
--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/datamodel/MetadataStoreRoutingData.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/datamodel/MetadataStoreRoutingData.java
@@ -22,6 +22,7 @@ package org.apache.helix.msdcommon.datamodel;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+
 public interface MetadataStoreRoutingData {
   /**
    * Given a path, return all the "metadata store sharding key-metadata store realm address" pairs
@@ -45,6 +46,16 @@ public interface MetadataStoreRoutingData {
    * @throws NoSuchElementException - when the path doesn't contain a sharding key
    */
   String getMetadataStoreRealm(String path) throws IllegalArgumentException, NoSuchElementException;
+
+  /**
+   * Given a path, return the sharding key contained in the path. If the path doesn't contain a
+   * sharding key, throw NoSuchElementException.
+   * @param path - the path that may contain a sharding key
+   * @return the sharding key contained in the path
+   * @throws IllegalArgumentException - when the path is invalid
+   * @throws NoSuchElementException - when the path doesn't contain a sharding key
+   */
+  String getShardingKeyInPath(String path) throws IllegalArgumentException, NoSuchElementException;
 
   /**
    * Check if the provided sharding key can be inserted to the routing data. The insertion is

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/datamodel/TrieRoutingData.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/datamodel/TrieRoutingData.java
@@ -98,6 +98,20 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
     return node.getRealmAddress();
   }
 
+  public String getShardingKeyInPath(String path)
+      throws IllegalArgumentException, NoSuchElementException {
+    if (!ZkValidationUtil.isPathValid(path)) {
+      throw new IllegalArgumentException("Provided path is not a valid Zookeeper path: " + path);
+    }
+
+    TrieNode node = getLongestPrefixNodeAlongPath(path);
+    if (!node.isShardingKey()) {
+      throw new NoSuchElementException(
+          "No sharding key found within the provided path. Path: " + path);
+    }
+    return node.getPath();
+  }
+
   public boolean isShardingKeyInsertionValid(String shardingKey) {
     if (!ZkValidationUtil.isPathValid(shardingKey)) {
       throw new IllegalArgumentException(

--- a/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/datamodel/TestTrieRoutingData.java
+++ b/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/datamodel/TestTrieRoutingData.java
@@ -257,7 +257,7 @@ public class TestTrieRoutingData {
   @Test(dependsOnMethods = "testConstructionNormal")
   public void testGetShardingKeyInPath() {
     try {
-      Assert.assertEquals(_trie.getMetadataStoreRealm("/b/c/d/x/y/z"), "realmAddress2");
+      Assert.assertEquals(_trie.getShardingKeyInPath("/b/c/d/x/y/z"), "/b/c/d");
     } catch (NoSuchElementException e) {
       Assert.fail("Not expecting NoSuchElementException");
     }
@@ -266,7 +266,7 @@ public class TestTrieRoutingData {
   @Test(dependsOnMethods = "testConstructionNormal")
   public void testGetShardingKeyInPathWrongPath() {
     try {
-      _trie.getMetadataStoreRealm("/x/y/z");
+      _trie.getShardingKeyInPath("/x/y/z");
       Assert.fail("Expecting NoSuchElementException");
     } catch (NoSuchElementException e) {
       Assert.assertTrue(
@@ -277,7 +277,7 @@ public class TestTrieRoutingData {
   @Test(dependsOnMethods = "testConstructionNormal")
   public void testGetShardingKeyInPathNoLeaf() {
     try {
-      _trie.getMetadataStoreRealm("/b/c");
+      _trie.getShardingKeyInPath("/b/c");
       Assert.fail("Expecting NoSuchElementException");
     } catch (NoSuchElementException e) {
       Assert.assertTrue(

--- a/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/datamodel/TestTrieRoutingData.java
+++ b/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/datamodel/TestTrieRoutingData.java
@@ -255,6 +255,37 @@ public class TestTrieRoutingData {
   }
 
   @Test(dependsOnMethods = "testConstructionNormal")
+  public void testGetShardingKeyInPath() {
+    try {
+      Assert.assertEquals(_trie.getMetadataStoreRealm("/b/c/d/x/y/z"), "realmAddress2");
+    } catch (NoSuchElementException e) {
+      Assert.fail("Not expecting NoSuchElementException");
+    }
+  }
+
+  @Test(dependsOnMethods = "testConstructionNormal")
+  public void testGetShardingKeyInPathWrongPath() {
+    try {
+      _trie.getMetadataStoreRealm("/x/y/z");
+      Assert.fail("Expecting NoSuchElementException");
+    } catch (NoSuchElementException e) {
+      Assert.assertTrue(
+          e.getMessage().contains("No sharding key found within the provided path. Path: /x/y/z"));
+    }
+  }
+
+  @Test(dependsOnMethods = "testConstructionNormal")
+  public void testGetShardingKeyInPathNoLeaf() {
+    try {
+      _trie.getMetadataStoreRealm("/b/c");
+      Assert.fail("Expecting NoSuchElementException");
+    } catch (NoSuchElementException e) {
+      Assert.assertTrue(
+          e.getMessage().contains("No sharding key found within the provided path. Path: /b/c"));
+    }
+  }
+
+  @Test(dependsOnMethods = "testConstructionNormal")
   public void testIsShardingKeyInsertionValidNoSlash() {
     try {
       _trie.isShardingKeyInsertionValid("x/y/z");


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #804 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds `getShardingKeyInPath(path)` to `MetadataStoreRoutingData`, which extracts the sharding key out of a path and return it.


### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:
[INFO] Tests run: 128, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.003 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 128, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  48.805 s
[INFO] Finished at: 2020-02-26T12:39:09-08:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml