### PR TITLE
Make RealmAwareZkClient implementations use HttpRoutingDataReader for routing data

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -88,10 +88,8 @@ public class ConfigAccessor {
   private ConfigAccessor(Builder builder) throws IOException, InvalidRoutingDataException {
     switch (builder._realmMode) {
       case MULTI_REALM:
-        // TODO: make sure FederatedZkClient is created correctly
-        // TODO: pass in MSDS endpoint or pass in _realmAwareZkConnectionConfig
-        String msdsEndpoint = builder._realmAwareZkConnectionConfig.getMsdsEndpoint();
-        _zkClient = new FederatedZkClient();
+        _zkClient = new FederatedZkClient(builder._realmAwareZkConnectionConfig,
+            builder._realmAwareZkClientConfig);
         break;
       case SINGLE_REALM:
         // Create a HelixZkClient: Use a SharedZkClient because ConfigAccessor does not need to do

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/mock/MockMetadataStoreDirectoryServer.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/mock/MockMetadataStoreDirectoryServer.java
@@ -68,7 +68,7 @@ public class MockMetadataStoreDirectoryServer {
   /**
    * Constructs a Mock MSDS.
    * A sample GET might look like the following:
-   *     curl localhost:11000/admin/v2/namespaces/MY-HELIX-NAMESPACE/METADATA_STORE_ROUTING_DATA/zk-1
+   *     curl localhost:11000/admin/v2/namespaces/MY-HELIX-NAMESPACE/metadata-store-realms/zk-1
    * @param hostname hostname for the REST server. E.g.) "localhost"
    * @param port port to use. E.g.) 11000
    * @param namespace the Helix REST namespace to mock. E.g.) "MY-HELIX-NAMESPACE"
@@ -94,8 +94,7 @@ public class MockMetadataStoreDirectoryServer {
     _routingDataMap = routingData;
   }
 
-  public void startServer()
-      throws IOException {
+  public void startServer() throws IOException {
     _server = HttpServer.create(new InetSocketAddress(_hostname, _mockServerPort), 0);
     generateContexts();
     _server.setExecutor(_executor);

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/mock/MockMetadataStoreDirectoryServer.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/mock/MockMetadataStoreDirectoryServer.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;

--- a/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/constant/TestConstants.java
+++ b/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/constant/TestConstants.java
@@ -1,0 +1,37 @@
+package org.apache.helix.msdcommon.constant;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+
+/**
+ * Constants to be used for testing.
+ */
+public class TestConstants {
+  public static final Map<String, Collection<String>> FAKE_ROUTING_DATA = ImmutableMap.of(
+      "zk-0", ImmutableList.of("/sharding-key-0", "/sharding-key-1", "/sharding-key-2"),
+      "zk-1", ImmutableList.of("/sharding-key-3", "/sharding-key-4", "/sharding-key-5"),
+      "zk-2", ImmutableList.of("/sharding-key-6", "/sharding-key-7", "/sharding-key-8"));
+}

--- a/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/mock/TestMockMetadataStoreDirectoryServer.java
+++ b/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/mock/TestMockMetadataStoreDirectoryServer.java
@@ -22,6 +22,7 @@ package org.apache.helix.msdcommon.mock;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -65,7 +66,7 @@ public class TestMockMetadataStoreDirectoryServer {
       Collection<String> allRealms = routingDataList.stream().map(mapEntry -> (String) mapEntry
           .get(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM))
           .collect(Collectors.toSet());
-      Assert.assertEquals(allRealms, TestConstants.FAKE_ROUTING_DATA.keySet());
+      Assert.assertEquals(new HashSet(allRealms), TestConstants.FAKE_ROUTING_DATA.keySet());
       Map<String, List<String>> retrievedRoutingData = routingDataList.stream().collect(Collectors
           .toMap(mapEntry -> (String) mapEntry
                   .get(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM),

--- a/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/mock/TestMockMetadataStoreDirectoryServer.java
+++ b/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/mock/TestMockMetadataStoreDirectoryServer.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
+import org.apache.helix.msdcommon.constant.TestConstants;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -40,12 +41,6 @@ import org.testng.Assert;
 public class TestMockMetadataStoreDirectoryServer {
   @Test
   public void testMockMetadataStoreDirectoryServer() throws IOException {
-    // Create fake routing data
-    Map<String, Collection<String>> routingData = new HashMap<>();
-    routingData.put("zk-0", ImmutableList.of("sharding-key-0", "sharding-key-1", "sharding-key-2"));
-    routingData.put("zk-1", ImmutableList.of("sharding-key-3", "sharding-key-4", "sharding-key-5"));
-    routingData.put("zk-2", ImmutableList.of("sharding-key-6", "sharding-key-7", "sharding-key-8"));
-
     // Start MockMSDS
     String host = "localhost";
     int port = 11000;
@@ -53,7 +48,8 @@ public class TestMockMetadataStoreDirectoryServer {
     String namespace = "MY-HELIX-NAMESPACE";
 
     MockMetadataStoreDirectoryServer server =
-        new MockMetadataStoreDirectoryServer(host, port, namespace, routingData);
+        new MockMetadataStoreDirectoryServer(host, port, namespace,
+            TestConstants.FAKE_ROUTING_DATA);
     server.startServer();
     try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
       // Send a GET request for all routing data
@@ -69,13 +65,13 @@ public class TestMockMetadataStoreDirectoryServer {
       Collection<String> allRealms = routingDataList.stream().map(mapEntry -> (String) mapEntry
           .get(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM))
           .collect(Collectors.toSet());
-      Assert.assertEquals(allRealms, routingData.keySet());
+      Assert.assertEquals(allRealms, TestConstants.FAKE_ROUTING_DATA.keySet());
       Map<String, List<String>> retrievedRoutingData = routingDataList.stream().collect(Collectors
           .toMap(mapEntry -> (String) mapEntry
                   .get(MetadataStoreRoutingConstants.SINGLE_METADATA_STORE_REALM),
               mapEntry -> (List<String>) mapEntry
                   .get(MetadataStoreRoutingConstants.SHARDING_KEYS)));
-      Assert.assertEquals(retrievedRoutingData, routingData);
+      Assert.assertEquals(retrievedRoutingData, TestConstants.FAKE_ROUTING_DATA);
 
       // Send a GET request for all realms
       getRequest = new HttpGet(endpoint + MockMetadataStoreDirectoryServer.REST_PREFIX + namespace
@@ -86,7 +82,7 @@ public class TestMockMetadataStoreDirectoryServer {
       Assert.assertTrue(
           allRealmsMap.containsKey(MetadataStoreRoutingConstants.METADATA_STORE_REALMS));
       allRealms = allRealmsMap.get(MetadataStoreRoutingConstants.METADATA_STORE_REALMS);
-      Assert.assertEquals(allRealms, routingData.keySet());
+      Assert.assertEquals(allRealms, TestConstants.FAKE_ROUTING_DATA.keySet());
 
       // Send a GET request for testZkRealm
       String testZkRealm = "zk-0";
@@ -103,7 +99,7 @@ public class TestMockMetadataStoreDirectoryServer {
       Collection<String> shardingKeyList =
           (Collection) shardingKeysMap.get(MetadataStoreRoutingConstants.SHARDING_KEYS);
       Assert.assertEquals(zkRealm, testZkRealm);
-      Assert.assertEquals(shardingKeyList, routingData.get(testZkRealm));
+      Assert.assertEquals(shardingKeyList, TestConstants.FAKE_ROUTING_DATA.get(testZkRealm));
 
       // Try sending a POST request (not supported)
       HttpPost postRequest = new HttpPost(

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/factory/RealmAwareZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/factory/RealmAwareZkClientFactory.java
@@ -19,7 +19,9 @@ package org.apache.helix.zookeeper.api.factory;
  * under the License.
  */
 
-import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
+import java.io.IOException;
+
+import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 
 
@@ -31,26 +33,20 @@ public interface RealmAwareZkClientFactory {
    * Build a RealmAwareZkClient using specified connection config and client config.
    * @param connectionConfig
    * @param clientConfig
-   * @param metadataStoreRoutingData
    * @return HelixZkClient
    */
-  // TODO: remove MetadataStoreRoutingData
   RealmAwareZkClient buildZkClient(RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
-      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig,
-      MetadataStoreRoutingData metadataStoreRoutingData);
+      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig)
+      throws IOException, InvalidRoutingDataException;
 
   /**
    * Builds a RealmAwareZkClient using specified connection config and default client config.
    * @param connectionConfig
-   * @param metadataStoreRoutingData
    * @return RealmAwareZkClient
    */
-
-  // TODO: remove MetadataStoreRoutingData
   default RealmAwareZkClient buildZkClient(
-      RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
-      MetadataStoreRoutingData metadataStoreRoutingData) {
-    return buildZkClient(connectionConfig, new RealmAwareZkClient.RealmAwareZkClientConfig(),
-        metadataStoreRoutingData);
+      RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig)
+      throws IOException, InvalidRoutingDataException {
+    return buildZkClient(connectionConfig, new RealmAwareZkClient.RealmAwareZkClientConfig());
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/factory/RealmAwareZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/factory/RealmAwareZkClientFactory.java
@@ -33,7 +33,9 @@ public interface RealmAwareZkClientFactory {
    * Build a RealmAwareZkClient using specified connection config and client config.
    * @param connectionConfig
    * @param clientConfig
-   * @return HelixZkClient
+   * @return RealmAwareZkClient
+   * @throws IOException if Metadata Store Directory Service is unresponsive over HTTP
+   * @throws InvalidRoutingDataException if the routing data received is invalid or empty
    */
   RealmAwareZkClient buildZkClient(RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
       RealmAwareZkClient.RealmAwareZkClientConfig clientConfig)
@@ -43,6 +45,8 @@ public interface RealmAwareZkClientFactory {
    * Builds a RealmAwareZkClient using specified connection config and default client config.
    * @param connectionConfig
    * @return RealmAwareZkClient
+   * @throws IOException if Metadata Store Directory Service is unresponsive over HTTP
+   * @throws InvalidRoutingDataException if the routing data received is invalid or empty
    */
   default RealmAwareZkClient buildZkClient(
       RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig)

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -75,7 +75,7 @@ public class DedicatedZkClient implements RealmAwareZkClient {
       throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
     }
     if (clientConfig == null) {
-      throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
+      throw new IllegalArgumentException("RealmAwareZkClientConfig cannot be null!");
     }
 
     // Get the routing data from a static Singleton HttpRoutingDataReader
@@ -87,6 +87,10 @@ public class DedicatedZkClient implements RealmAwareZkClient {
     }
 
     _zkRealmShardingKey = connectionConfig.getZkRealmShardingKey();
+    if (_zkRealmShardingKey == null || _zkRealmShardingKey.isEmpty()) {
+      throw new IllegalArgumentException(
+          "RealmAwareZkConnectionConfig's ZK realm sharding key cannot be null or empty for DedicatedZkClient!");
+    }
 
     // Get the ZkRealm address based on the ZK path sharding key
     String zkRealmAddress = _metadataStoreRoutingData.getMetadataStoreRealm(_zkRealmShardingKey);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -72,12 +72,21 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   public DedicatedZkClient(RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
       RealmAwareZkClient.RealmAwareZkClientConfig clientConfig)
       throws IOException, InvalidRoutingDataException {
-    // Get the routing data from a static Singleton HttpRoutingDataReader
-    _metadataStoreRoutingData = HttpRoutingDataReader.getMetadataStoreRoutingData();
-
     if (connectionConfig == null) {
       throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
     }
+    if (clientConfig == null) {
+      throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
+    }
+
+    // Get the routing data from a static Singleton HttpRoutingDataReader
+    String msdsEndpoint = connectionConfig.getMsdsEndpoint();
+    if (msdsEndpoint == null || msdsEndpoint.isEmpty()) {
+      _metadataStoreRoutingData = HttpRoutingDataReader.getMetadataStoreRoutingData();
+    } else {
+      _metadataStoreRoutingData = HttpRoutingDataReader.getMetadataStoreRoutingData(msdsEndpoint);
+    }
+
     _zkRealmShardingKey = connectionConfig.getZkRealmShardingKey();
 
     // Get the ZkRealm address based on the ZK path sharding key

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -59,7 +59,6 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   private final ZkClient _rawZkClient;
   private final MetadataStoreRoutingData _metadataStoreRoutingData;
   private final String _zkRealmShardingKey;
-  private final String _zkRealmAddress;
 
   /**
    * DedicatedZkClient connects to a single ZK realm and supports full ZkClient functionalities
@@ -96,7 +95,6 @@ public class DedicatedZkClient implements RealmAwareZkClient {
           "ZK realm address for the given ZK realm sharding key is invalid! ZK realm address: "
               + zkRealmAddress + " ZK realm sharding key: " + _zkRealmShardingKey);
     }
-    _zkRealmAddress = zkRealmAddress;
 
     // Create a ZK connection
     IZkConnection zkConnection =

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -19,6 +19,7 @@ package org.apache.helix.zookeeper.impl.client;
  * under the License.
  */
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -27,8 +28,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
+import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
+import org.apache.helix.zookeeper.util.HttpRoutingDataReader;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
@@ -80,11 +83,10 @@ public class FederatedZkClient implements RealmAwareZkClient {
   private PathBasedZkSerializer _pathBasedZkSerializer;
 
   // TODO: support capacity of ZkClient number in one FederatedZkClient and do garbage collection.
-  public FederatedZkClient(RealmAwareZkClient.RealmAwareZkClientConfig clientConfig,
-      MetadataStoreRoutingData metadataStoreRoutingData) {
-    if (metadataStoreRoutingData == null) {
-      throw new IllegalArgumentException("MetadataStoreRoutingData cannot be null!");
-    }
+  public FederatedZkClient(RealmAwareZkClient.RealmAwareZkClientConfig clientConfig)
+      throws IOException, InvalidRoutingDataException {
+    _metadataStoreRoutingData = HttpRoutingDataReader.getMetadataStoreRoutingData();
+
     if (clientConfig == null) {
       throw new IllegalArgumentException("Client config cannot be null!");
     }
@@ -92,7 +94,6 @@ public class FederatedZkClient implements RealmAwareZkClient {
     _isClosed = false;
     _clientConfig = clientConfig;
     _pathBasedZkSerializer = clientConfig.getZkSerializer();
-    _metadataStoreRoutingData = metadataStoreRoutingData;
     _zkRealmToZkClientMap = new ConcurrentHashMap<>();
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -35,9 +35,9 @@ import org.apache.helix.zookeeper.util.HttpRoutingDataReader;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
+import org.apache.helix.zookeeper.zkclient.IZkStateListener;
 import org.apache.helix.zookeeper.zkclient.ZkConnection;
 import org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks;
-import org.apache.helix.zookeeper.zkclient.IZkStateListener;
 import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
@@ -90,7 +90,7 @@ public class FederatedZkClient implements RealmAwareZkClient {
       throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
     }
     if (clientConfig == null) {
-      throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
+      throw new IllegalArgumentException("RealmAwareZkClientConfig cannot be null!");
     }
 
     // Attempt to get MetadataStoreRoutingData

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -83,12 +83,22 @@ public class FederatedZkClient implements RealmAwareZkClient {
   private PathBasedZkSerializer _pathBasedZkSerializer;
 
   // TODO: support capacity of ZkClient number in one FederatedZkClient and do garbage collection.
-  public FederatedZkClient(RealmAwareZkClient.RealmAwareZkClientConfig clientConfig)
+  public FederatedZkClient(RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
+      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig)
       throws IOException, InvalidRoutingDataException {
-    _metadataStoreRoutingData = HttpRoutingDataReader.getMetadataStoreRoutingData();
-
+    if (connectionConfig == null) {
+      throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
+    }
     if (clientConfig == null) {
-      throw new IllegalArgumentException("Client config cannot be null!");
+      throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
+    }
+
+    // Attempt to get MetadataStoreRoutingData
+    String msdsEndpoint = connectionConfig.getMsdsEndpoint();
+    if (msdsEndpoint == null || msdsEndpoint.isEmpty()) {
+      _metadataStoreRoutingData = HttpRoutingDataReader.getMetadataStoreRoutingData();
+    } else {
+      _metadataStoreRoutingData = HttpRoutingDataReader.getMetadataStoreRoutingData(msdsEndpoint);
     }
 
     _isClosed = false;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -63,12 +63,21 @@ public class SharedZkClient implements RealmAwareZkClient {
   public SharedZkClient(RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
       RealmAwareZkClient.RealmAwareZkClientConfig clientConfig)
       throws IOException, InvalidRoutingDataException {
-    // Get the routing data from a static Singleton HttpRoutingDataReader
-    _metadataStoreRoutingData = HttpRoutingDataReader.getMetadataStoreRoutingData();
-
     if (connectionConfig == null) {
       throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
     }
+    if (clientConfig == null) {
+      throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
+    }
+
+    // Get the routing data from a static Singleton HttpRoutingDataReader
+    String msdsEndpoint = connectionConfig.getMsdsEndpoint();
+    if (msdsEndpoint == null || msdsEndpoint.isEmpty()) {
+      _metadataStoreRoutingData = HttpRoutingDataReader.getMetadataStoreRoutingData();
+    } else {
+      _metadataStoreRoutingData = HttpRoutingDataReader.getMetadataStoreRoutingData(msdsEndpoint);
+    }
+
     _zkRealmShardingKey = connectionConfig.getZkRealmShardingKey();
 
     // Get the ZkRealm address based on the ZK path sharding key

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -67,7 +67,7 @@ public class SharedZkClient implements RealmAwareZkClient {
       throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
     }
     if (clientConfig == null) {
-      throw new IllegalArgumentException("RealmAwareZkConnectionConfig cannot be null!");
+      throw new IllegalArgumentException("RealmAwareZkClientConfig cannot be null!");
     }
 
     // Get the routing data from a static Singleton HttpRoutingDataReader
@@ -79,6 +79,10 @@ public class SharedZkClient implements RealmAwareZkClient {
     }
 
     _zkRealmShardingKey = connectionConfig.getZkRealmShardingKey();
+    if (_zkRealmShardingKey == null || _zkRealmShardingKey.isEmpty()) {
+      throw new IllegalArgumentException(
+          "RealmAwareZkConnectionConfig's ZK realm sharding key cannot be null or empty for SharedZkClient!");
+    }
 
     // Get the ZkRealm address based on the ZK path sharding key
     String zkRealmAddress = _metadataStoreRoutingData.getMetadataStoreRealm(_zkRealmShardingKey);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/DedicatedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/DedicatedZkClientFactory.java
@@ -19,7 +19,9 @@ package org.apache.helix.zookeeper.impl.factory;
  * under the License.
  */
 
-import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
+import java.io.IOException;
+
+import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.impl.client.DedicatedZkClient;
@@ -37,9 +39,9 @@ public class DedicatedZkClientFactory extends HelixZkClientFactory {
   @Override
   public RealmAwareZkClient buildZkClient(
       RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
-      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig,
-      MetadataStoreRoutingData metadataStoreRoutingData) {
-    return new DedicatedZkClient(connectionConfig, clientConfig, metadataStoreRoutingData);
+      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig)
+      throws IOException, InvalidRoutingDataException {
+    return new DedicatedZkClient(connectionConfig, clientConfig);
   }
 
   private static class SingletonHelper {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
@@ -57,18 +57,9 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
   @Override
   public RealmAwareZkClient buildZkClient(
       RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
-      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig,
-      MetadataStoreRoutingData metadataStoreRoutingData) {
+      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig) {
     // Note, the logic sharing connectionManager logic is inside SharedZkClient, similar to innerSharedZkClient.
-    return new SharedZkClient(connectionConfig, clientConfig, metadataStoreRoutingData);
-  }
-
-  @Override
-  public RealmAwareZkClient buildZkClient(
-      RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
-      MetadataStoreRoutingData metadataStoreRoutingData) {
-    // TODO: Implement the logic
-    return null;
+    return new SharedZkClient(connectionConfig, clientConfig);
   }
 
   private static class SingletonHelper {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
@@ -19,10 +19,11 @@ package org.apache.helix.zookeeper.impl.factory;
  * under the License.
  */
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 
-import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
+import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.exception.ZkClientException;
@@ -57,7 +58,8 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
   @Override
   public RealmAwareZkClient buildZkClient(
       RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
-      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig) {
+      RealmAwareZkClient.RealmAwareZkClientConfig clientConfig)
+      throws IOException, InvalidRoutingDataException {
     // Note, the logic sharing connectionManager logic is inside SharedZkClient, similar to innerSharedZkClient.
     return new SharedZkClient(connectionConfig, clientConfig);
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/HttpRoutingDataReader.java
@@ -141,7 +141,8 @@ public class HttpRoutingDataReader {
    * @throws IOException
    */
   private static String getAllRoutingData() throws IOException {
-    // Note that MSDS_ENDPOINT should provide high-availability - it risks becoming a single point of failure if it's backed by a single IP address/host
+    // Note that MSDS_ENDPOINT should provide high-availability - it risks becoming a single point
+    // of failure if it's backed by a single IP address/host
     // Retry count is 3 by default.
     HttpGet requestAllData = new HttpGet(
         SYSTEM_MSDS_ENDPOINT + MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT);

--- a/zookeeper-api/src/test/conf/testng.xml
+++ b/zookeeper-api/src/test/conf/testng.xml
@@ -18,8 +18,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="Suite" parallel="false">
-  <test name="Test" preserve-order="true">
+<suite name="Suite" parallel="false" preserve-order="true">
+  <test name="Test">
     <packages>
       <package name="org.apache.helix.zookeeper.*"/>
     </packages>

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/constant/TestConstants.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/constant/TestConstants.java
@@ -35,7 +35,7 @@ public class TestConstants {
   public static final int ZK_START_PORT = 2127;
 
   // Based on the ZK hostname constants, construct a set of fake routing data mappings
-  public static Map<String, Collection<String>> FAKE_ROUTING_DATA = ImmutableMap
+  public static final Map<String, Collection<String>> FAKE_ROUTING_DATA = ImmutableMap
       .of(ZK_PREFIX + ZK_START_PORT,
           ImmutableList.of("/sharding-key-0", "/sharding-key-1", "/sharding-key-2"),
           ZK_PREFIX + (ZK_START_PORT + 1),

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/constant/TestConstants.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/constant/TestConstants.java
@@ -1,0 +1,45 @@
+package org.apache.helix.zookeeper.constant;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+
+/**
+ * Constants to be used for testing.
+ */
+public class TestConstants {
+  // ZK hostname prefix and port to be used throughout the zookeeper-api module
+  public static final String ZK_PREFIX = "localhost:";
+  public static final int ZK_START_PORT = 2127;
+
+  // Based on the ZK hostname constants, construct a set of fake routing data mappings
+  public static Map<String, Collection<String>> FAKE_ROUTING_DATA = ImmutableMap
+      .of(ZK_PREFIX + ZK_START_PORT,
+          ImmutableList.of("/sharding-key-0", "/sharding-key-1", "/sharding-key-2"),
+          ZK_PREFIX + (ZK_START_PORT + 1),
+          ImmutableList.of("/sharding-key-3", "/sharding-key-4", "/sharding-key-5"),
+          ZK_PREFIX + (ZK_START_PORT + 2),
+          ImmutableList.of("/sharding-key-6", "/sharding-key-7", "/sharding-key-8"));
+}

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestBase.java
@@ -29,6 +29,7 @@ import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.helix.zookeeper.constant.TestConstants;
 import org.apache.helix.zookeeper.zkclient.IDefaultNameSpace;
 import org.apache.helix.zookeeper.zkclient.ZkServer;
 import org.slf4j.Logger;
@@ -50,8 +51,8 @@ public class ZkTestBase {
   private static final String MULTI_ZK_PROPERTY_KEY = "multiZk";
   private static final String NUM_ZK_PROPERTY_KEY = "numZk";
 
-  protected static final String ZK_PREFIX = "localhost:";
-  protected static final int ZK_START_PORT = 2127;
+  public static final String ZK_PREFIX = TestConstants.ZK_PREFIX;
+  public static final int ZK_START_PORT = TestConstants.ZK_START_PORT;
 
   /*
    * Multiple ZK references

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientFactoryTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientFactoryTestBase.java
@@ -1,0 +1,177 @@
+package org.apache.helix.zookeeper.impl.client;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.apache.helix.zookeeper.api.factory.RealmAwareZkClientFactory;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Test Base for DedicatedZkClient and SharedZkClient, which are implementations of
+ * RealmAwareZkClient.
+ * This class allows TestDedicatedZkClient and TestSharedZkClient to share the common test logic by
+ * just swapping out the factory classes.
+ */
+public abstract class RealmAwareZkClientFactoryTestBase extends RealmAwareZkClientTestBase {
+  // The following RealmAwareZkClientFactory is to be defined in subclasses
+  protected RealmAwareZkClientFactory _realmAwareZkClientFactory;
+  protected RealmAwareZkClient _realmAwareZkClient;
+  private static final ZNRecord DUMMY_RECORD = new ZNRecord("DummyRecord");
+
+  @BeforeClass
+  public void beforeClass() throws IOException, InvalidRoutingDataException {
+    super.beforeClass();
+    DUMMY_RECORD.setSimpleField("Dummy", "Value");
+  }
+
+  @AfterClass
+  public void afterClass() {
+    super.afterClass();
+    if (_realmAwareZkClient != null && !_realmAwareZkClient.isClosed()) {
+      _realmAwareZkClient.close();
+      _realmAwareZkClient = null;
+    }
+  }
+
+  /**
+   * 1. Create a RealmAwareZkClient with a non-existing sharding key (for which there is no valid ZK realm)
+   * -> This should fail with an exception
+   * 2. Create a RealmAwareZkClient with a valid sharding key
+   * -> This should pass
+   */
+  @Test
+  public void testRealmAwareZkClientCreation() {
+    // Create a RealmAwareZkClient
+    String invalidShardingKey = "InvalidShardingKeyNoLeadingSlash";
+    RealmAwareZkClient.RealmAwareZkClientConfig clientConfig =
+        new RealmAwareZkClient.RealmAwareZkClientConfig();
+
+    // Create a connection config with the invalid sharding key
+    RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =
+        new RealmAwareZkClient.RealmAwareZkConnectionConfig(invalidShardingKey);
+    try {
+      _realmAwareZkClient =
+          _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);
+      Assert.fail("Should not succeed with an invalid sharding key!");
+    } catch (IllegalArgumentException e) {
+      // Expected because invalid sharding key would cause an IllegalArgumentException to be thrown
+    } catch (Exception e) {
+      Assert.fail("Should not see any other types of Exceptions: " + e);
+    }
+
+    // Create a connection config with a valid sharding key, but one that does not exist in
+    // the routing data
+    String nonExistentShardingKey = "/NonExistentShardingKey";
+    connectionConfig = new RealmAwareZkClient.RealmAwareZkConnectionConfig(nonExistentShardingKey);
+    try {
+      _realmAwareZkClient =
+          _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);
+      Assert.fail("Should not succeed with a non-existent sharding key!");
+    } catch (NoSuchElementException e) {
+      // Expected non-existent sharding key would cause a NoSuchElementException to be thrown
+    } catch (Exception e) {
+      Assert.fail("Should not see any other types of Exceptions: " + e);
+    }
+
+    // Use a valid sharding key this time around
+    connectionConfig = new RealmAwareZkClient.RealmAwareZkConnectionConfig(ZK_SHARDING_KEY_PREFIX);
+    try {
+      _realmAwareZkClient =
+          _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);
+    } catch (Exception e) {
+      Assert.fail("All other exceptions not allowed: " + e);
+    }
+  }
+
+  /**
+   * Test the persistent create() call against a valid path and an invalid path.
+   * Valid path is one that belongs to the realm designated by the sharding key.
+   * Invalid path is one that does not belong to the realm designated by the sharding key.
+   */
+  @Test(dependsOnMethods = "testRealmAwareZkClientCreation")
+  public void testRealmAwareZkClientCreatePersistent() {
+    _realmAwareZkClient.setZkSerializer(new ZNRecordSerializer());
+
+    // Test writing and reading against the validPath
+    _realmAwareZkClient.createPersistent(TEST_VALID_PATH, true);
+    _realmAwareZkClient.writeData(TEST_VALID_PATH, DUMMY_RECORD);
+    Assert.assertEquals(_realmAwareZkClient.readData(TEST_VALID_PATH), DUMMY_RECORD);
+
+    // Test writing and reading against the invalid path
+    try {
+      _realmAwareZkClient.createPersistent(TEST_INVALID_PATH, true);
+      Assert.fail("Create() should not succeed on an invalid path!");
+    } catch (IllegalArgumentException e) {
+      // Okay - expected
+    }
+  }
+
+  /**
+   * Test that exists() works on valid path and fails on invalid path.
+   */
+  @Test(dependsOnMethods = "testRealmAwareZkClientCreatePersistent")
+  public void testExists() {
+    // Create a ZNode for testing
+    _realmAwareZkClient.createPersistent(TEST_VALID_PATH, true);
+    _realmAwareZkClient.writeData(TEST_VALID_PATH, DUMMY_RECORD);
+    Assert.assertEquals(_realmAwareZkClient.readData(TEST_VALID_PATH), DUMMY_RECORD);
+
+    // Test exists()
+    Assert.assertTrue(_realmAwareZkClient.exists(TEST_VALID_PATH));
+
+    try {
+      _realmAwareZkClient.exists(TEST_INVALID_PATH);
+      Assert.fail("Exists() should not succeed on an invalid path!");
+    } catch (IllegalArgumentException e) {
+      // Okay - expected
+    }
+  }
+
+  /**
+   * Test that delete() works on valid path and fails on invalid path.
+   */
+  @Test(dependsOnMethods = "testExists")
+  public void testDelete() {
+    // Create a ZNode for testing
+    _realmAwareZkClient.createPersistent(TEST_VALID_PATH, true);
+    _realmAwareZkClient.writeData(TEST_VALID_PATH, DUMMY_RECORD);
+    Assert.assertEquals(_realmAwareZkClient.readData(TEST_VALID_PATH), DUMMY_RECORD);
+
+    try {
+      _realmAwareZkClient.delete(TEST_INVALID_PATH);
+      Assert.fail("delete() should not succeed on an invalid path!");
+    } catch (IllegalArgumentException e) {
+      // Okay - expected
+    }
+
+    Assert.assertTrue(_realmAwareZkClient.delete(TEST_VALID_PATH));
+    Assert.assertFalse(_realmAwareZkClient.exists(TEST_VALID_PATH));
+  }
+}

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientFactoryTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientFactoryTestBase.java
@@ -74,8 +74,11 @@ public abstract class RealmAwareZkClientFactoryTestBase extends RealmAwareZkClie
         new RealmAwareZkClient.RealmAwareZkClientConfig();
 
     // Create a connection config with the invalid sharding key
+    RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder builder =
+        new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder();
     RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =
-        new RealmAwareZkClient.RealmAwareZkConnectionConfig(invalidShardingKey);
+        builder.setZkRealmShardingKey(invalidShardingKey).build();
+
     try {
       _realmAwareZkClient =
           _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);
@@ -89,7 +92,7 @@ public abstract class RealmAwareZkClientFactoryTestBase extends RealmAwareZkClie
     // Create a connection config with a valid sharding key, but one that does not exist in
     // the routing data
     String nonExistentShardingKey = "/NonExistentShardingKey";
-    connectionConfig = new RealmAwareZkClient.RealmAwareZkConnectionConfig(nonExistentShardingKey);
+    connectionConfig = builder.setZkRealmShardingKey(nonExistentShardingKey).build();
     try {
       _realmAwareZkClient =
           _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);
@@ -101,7 +104,7 @@ public abstract class RealmAwareZkClientFactoryTestBase extends RealmAwareZkClie
     }
 
     // Use a valid sharding key this time around
-    connectionConfig = new RealmAwareZkClient.RealmAwareZkConnectionConfig(ZK_SHARDING_KEY_PREFIX);
+    connectionConfig = builder.setZkRealmShardingKey(ZK_SHARDING_KEY_PREFIX).build();
     try {
       _realmAwareZkClient =
           _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientTestBase.java
@@ -124,7 +124,7 @@ public abstract class RealmAwareZkClientTestBase extends ZkTestBase {
     try {
       _realmAwareZkClient =
           _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);
-      Assert.fail("Should not succeed with an invalid sharding key!");
+      Assert.fail("Should not succeed with a non-existent sharding key!");
     } catch (NoSuchElementException e) {
       // Expected
     } catch (Exception e) {

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientTestBase.java
@@ -19,17 +19,13 @@ package org.apache.helix.zookeeper.impl.client;
  * under the License.
  */
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
 import org.apache.helix.msdcommon.mock.MockMetadataStoreDirectoryServer;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.api.factory.RealmAwareZkClientFactory;
+import org.apache.helix.zookeeper.constant.TestConstants;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.apache.helix.zookeeper.impl.ZkTestBase;
@@ -40,12 +36,9 @@ import org.testng.annotations.Test;
 
 
 public abstract class RealmAwareZkClientTestBase extends ZkTestBase {
-  protected static final String ZK_SHARDING_KEY_PREFIX = "/TEST_SHARDING_KEY";
-  protected static final String TEST_VALID_PATH = ZK_SHARDING_KEY_PREFIX + "_" + 0 + "/a/b/c";
-  protected static final String TEST_INVALID_PATH = ZK_SHARDING_KEY_PREFIX + "_invalid" + "/a/b/c";
-
-  // <Realm, List of sharding keys> Mapping
-  private static final Map<String, Collection<String>> RAW_ROUTING_DATA = new HashMap<>();
+  private static final String ZK_SHARDING_KEY_PREFIX = "/sharding-key-0";
+  private static final String TEST_VALID_PATH = ZK_SHARDING_KEY_PREFIX + "/a/b/c";
+  private static final String TEST_INVALID_PATH = ZK_SHARDING_KEY_PREFIX + "_invalid" + "/a/b/c";
 
   // The following RealmAwareZkClientFactory is to be defined in subclasses
   protected RealmAwareZkClientFactory _realmAwareZkClientFactory;
@@ -59,17 +52,9 @@ public abstract class RealmAwareZkClientTestBase extends ZkTestBase {
 
   @BeforeClass
   public void beforeClass() throws Exception {
-    // Populate RAW_ROUTING_DATA
-    for (int i = 0; i < _numZk; i++) {
-      List<String> shardingKeyList = new ArrayList<>();
-      shardingKeyList.add(ZK_SHARDING_KEY_PREFIX + "_" + i);
-      String realmName = ZK_PREFIX + (ZK_START_PORT + i);
-      RAW_ROUTING_DATA.put(realmName, shardingKeyList);
-    }
-
     // Create a mock MSDS so that HttpRoudingDataReader could fetch the routing data
     _msdsServer = new MockMetadataStoreDirectoryServer(MSDS_HOSTNAME, MSDS_PORT, MSDS_NAMESPACE,
-        RAW_ROUTING_DATA);
+        TestConstants.FAKE_ROUTING_DATA);
     _msdsServer.startServer();
 
     // Register the MSDS endpoint as a System variable
@@ -135,6 +120,7 @@ public abstract class RealmAwareZkClientTestBase extends ZkTestBase {
     String validShardingKey = ZK_SHARDING_KEY_PREFIX + "_" + 0; // Use TEST_SHARDING_KEY_0
     builder.setZkRealmShardingKey(validShardingKey);
     connectionConfig = builder.build();
+
     try {
       _realmAwareZkClient =
           _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientTestBase.java
@@ -36,13 +36,13 @@ import org.testng.annotations.Test;
 
 
 public abstract class RealmAwareZkClientTestBase extends ZkTestBase {
-  private static final String ZK_SHARDING_KEY_PREFIX = "/sharding-key-0";
-  private static final String TEST_VALID_PATH = ZK_SHARDING_KEY_PREFIX + "/a/b/c";
-  private static final String TEST_INVALID_PATH = ZK_SHARDING_KEY_PREFIX + "_invalid" + "/a/b/c";
+  protected static final String ZK_SHARDING_KEY_PREFIX = "/sharding-key-0";
+  protected static final String TEST_VALID_PATH = ZK_SHARDING_KEY_PREFIX + "/a/b/c";
+  protected static final String TEST_INVALID_PATH = ZK_SHARDING_KEY_PREFIX + "_invalid" + "/a/b/c";
 
   // The following RealmAwareZkClientFactory is to be defined in subclasses
   protected RealmAwareZkClientFactory _realmAwareZkClientFactory;
-  private RealmAwareZkClient _realmAwareZkClient;
+  protected RealmAwareZkClient _realmAwareZkClient;
 
   // Create a MockMSDS for testing
   private MockMetadataStoreDirectoryServer _msdsServer;

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientTestBase.java
@@ -97,7 +97,7 @@ public abstract class RealmAwareZkClientTestBase extends ZkTestBase {
           _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);
       Assert.fail("Should not succeed with an invalid sharding key!");
     } catch (IllegalArgumentException e) {
-      // Expected
+      // Expected because invalid sharding key would cause an IllegalArgumentException to be thrown
     } catch (Exception e) {
       Assert.fail("Should not see any other types of Exceptions: " + e);
     }
@@ -111,7 +111,7 @@ public abstract class RealmAwareZkClientTestBase extends ZkTestBase {
           _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);
       Assert.fail("Should not succeed with a non-existent sharding key!");
     } catch (NoSuchElementException e) {
-      // Expected
+      // Expected non-existent sharding key would cause a NoSuchElementException to be thrown
     } catch (Exception e) {
       Assert.fail("Should not see any other types of Exceptions: " + e);
     }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientTestBase.java
@@ -19,20 +19,15 @@ package org.apache.helix.zookeeper.impl.client;
  * under the License.
  */
 
-import java.util.NoSuchElementException;
+import java.io.IOException;
 
 import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
+import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.msdcommon.mock.MockMetadataStoreDirectoryServer;
-import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
-import org.apache.helix.zookeeper.api.factory.RealmAwareZkClientFactory;
 import org.apache.helix.zookeeper.constant.TestConstants;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.apache.helix.zookeeper.impl.ZkTestBase;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 
 public abstract class RealmAwareZkClientTestBase extends ZkTestBase {
@@ -40,22 +35,21 @@ public abstract class RealmAwareZkClientTestBase extends ZkTestBase {
   protected static final String TEST_VALID_PATH = ZK_SHARDING_KEY_PREFIX + "/a/b/c";
   protected static final String TEST_INVALID_PATH = ZK_SHARDING_KEY_PREFIX + "_invalid" + "/a/b/c";
 
-  // The following RealmAwareZkClientFactory is to be defined in subclasses
-  protected RealmAwareZkClientFactory _realmAwareZkClientFactory;
-  protected RealmAwareZkClient _realmAwareZkClient;
-
   // Create a MockMSDS for testing
-  private MockMetadataStoreDirectoryServer _msdsServer;
+  private static MockMetadataStoreDirectoryServer _msdsServer;
   private static final String MSDS_HOSTNAME = "localhost";
   private static final int MSDS_PORT = 1111;
   private static final String MSDS_NAMESPACE = "test";
 
   @BeforeClass
-  public void beforeClass() throws Exception {
+  public void beforeClass() throws IOException, InvalidRoutingDataException {
     // Create a mock MSDS so that HttpRoudingDataReader could fetch the routing data
-    _msdsServer = new MockMetadataStoreDirectoryServer(MSDS_HOSTNAME, MSDS_PORT, MSDS_NAMESPACE,
-        TestConstants.FAKE_ROUTING_DATA);
-    _msdsServer.startServer();
+    if (_msdsServer == null) {
+      // Do not create again if Mock MSDS server has already been created by other tests
+      _msdsServer = new MockMetadataStoreDirectoryServer(MSDS_HOSTNAME, MSDS_PORT, MSDS_NAMESPACE,
+          TestConstants.FAKE_ROUTING_DATA);
+      _msdsServer.startServer();
+    }
 
     // Register the MSDS endpoint as a System variable
     String msdsEndpoint =
@@ -65,125 +59,8 @@ public abstract class RealmAwareZkClientTestBase extends ZkTestBase {
 
   @AfterClass
   public void afterClass() {
-    if (_realmAwareZkClient != null && !_realmAwareZkClient.isClosed()) {
-      _realmAwareZkClient.close();
-    }
     if (_msdsServer != null) {
       _msdsServer.stopServer();
     }
-  }
-
-  /**
-   * 1. Create a RealmAwareZkClient with a non-existing sharding key (for which there is no valid ZK realm)
-   * -> This should fail with an exception
-   * 2. Create a RealmAwareZkClient with a valid sharding key
-   * -> This should pass
-   */
-  @Test
-  public void testRealmAwareZkClientCreation() {
-    // Create a RealmAwareZkClient
-    String invalidShardingKey = "InvalidShardingKeyNoLeadingSlash";
-    RealmAwareZkClient.RealmAwareZkClientConfig clientConfig =
-        new RealmAwareZkClient.RealmAwareZkClientConfig();
-
-    // Create a connection config with the invalid sharding key
-    RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder builder =
-        new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder();
-    RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =
-        builder.setZkRealmShardingKey(invalidShardingKey).build();
-
-    try {
-      _realmAwareZkClient =
-          _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);
-      Assert.fail("Should not succeed with an invalid sharding key!");
-    } catch (IllegalArgumentException e) {
-      // Expected because invalid sharding key would cause an IllegalArgumentException to be thrown
-    } catch (Exception e) {
-      Assert.fail("Should not see any other types of Exceptions: " + e);
-    }
-
-    // Create a connection config with a valid sharding key, but one that does not exist in
-    // the routing data
-    String nonExistentShardingKey = "/NonExistentShardingKey";
-    connectionConfig = builder.setZkRealmShardingKey(nonExistentShardingKey).build();
-    try {
-      _realmAwareZkClient =
-          _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);
-      Assert.fail("Should not succeed with a non-existent sharding key!");
-    } catch (NoSuchElementException e) {
-      // Expected non-existent sharding key would cause a NoSuchElementException to be thrown
-    } catch (Exception e) {
-      Assert.fail("Should not see any other types of Exceptions: " + e);
-    }
-
-    // Use a valid sharding key this time around
-    String validShardingKey = ZK_SHARDING_KEY_PREFIX + "_" + 0; // Use TEST_SHARDING_KEY_0
-    builder.setZkRealmShardingKey(validShardingKey);
-    connectionConfig = builder.build();
-
-    try {
-      _realmAwareZkClient =
-          _realmAwareZkClientFactory.buildZkClient(connectionConfig, clientConfig);
-    } catch (Exception e) {
-      Assert.fail("All other exceptions not allowed: " + e);
-    }
-  }
-
-  /**
-   * Test the persistent create() call against a valid path and an invalid path.
-   * Valid path is one that belongs to the realm designated by the sharding key.
-   * Invalid path is one that does not belong to the realm designated by the sharding key.
-   */
-  @Test(dependsOnMethods = "testRealmAwareZkClientCreation")
-  public void testRealmAwareZkClientCreatePersistent() {
-    _realmAwareZkClient.setZkSerializer(new ZNRecordSerializer());
-
-    // Create a dummy ZNRecord
-    ZNRecord znRecord = new ZNRecord("DummyRecord");
-    znRecord.setSimpleField("Dummy", "Value");
-
-    // Test writing and reading against the validPath
-    _realmAwareZkClient.createPersistent(TEST_VALID_PATH, true);
-    _realmAwareZkClient.writeData(TEST_VALID_PATH, znRecord);
-    Assert.assertEquals(_realmAwareZkClient.readData(TEST_VALID_PATH), znRecord);
-
-    // Test writing and reading against the invalid path
-    try {
-      _realmAwareZkClient.createPersistent(TEST_INVALID_PATH, true);
-      Assert.fail("Create() should not succeed on an invalid path!");
-    } catch (IllegalArgumentException e) {
-      // Okay - expected
-    }
-  }
-
-  /**
-   * Test that exists() works on valid path and fails on invalid path.
-   */
-  @Test(dependsOnMethods = "testRealmAwareZkClientCreatePersistent")
-  public void testExists() {
-    Assert.assertTrue(_realmAwareZkClient.exists(TEST_VALID_PATH));
-
-    try {
-      _realmAwareZkClient.exists(TEST_INVALID_PATH);
-      Assert.fail("Exists() should not succeed on an invalid path!");
-    } catch (IllegalArgumentException e) {
-      // Okay - expected
-    }
-  }
-
-  /**
-   * Test that delete() works on valid path and fails on invalid path.
-   */
-  @Test(dependsOnMethods = "testExists")
-  public void testDelete() {
-    try {
-      _realmAwareZkClient.delete(TEST_INVALID_PATH);
-      Assert.fail("Exists() should not succeed on an invalid path!");
-    } catch (IllegalArgumentException e) {
-      // Okay - expected
-    }
-
-    Assert.assertTrue(_realmAwareZkClient.delete(TEST_VALID_PATH));
-    Assert.assertFalse(_realmAwareZkClient.exists(TEST_VALID_PATH));
   }
 }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestDedicatedZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestDedicatedZkClient.java
@@ -19,15 +19,17 @@ package org.apache.helix.zookeeper.impl.client;
  * under the License.
  */
 
+import java.io.IOException;
+
+import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
 import org.testng.annotations.BeforeClass;
 
 
-public class TestDedicatedZkClient extends RealmAwareZkClientTestBase {
+public class TestDedicatedZkClient extends RealmAwareZkClientFactoryTestBase {
 
   @BeforeClass
-  public void beforeClass()
-      throws Exception {
+  public void beforeClass() throws IOException, InvalidRoutingDataException {
     super.beforeClass();
     // Set the factory to DedicatedZkClientFactory
     _realmAwareZkClientFactory = DedicatedZkClientFactory.getInstance();

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
@@ -57,7 +57,9 @@ public class TestFederatedZkClient extends RealmAwareZkClientTestBase {
 
     // Feed the raw routing data into TrieRoutingData to construct an in-memory representation
     // of routing information.
-    _realmAwareZkClient = new FederatedZkClient(new RealmAwareZkClient.RealmAwareZkClientConfig());
+    _realmAwareZkClient =
+        new FederatedZkClient(new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder().build(),
+            new RealmAwareZkClient.RealmAwareZkClientConfig());
   }
 
   @AfterClass

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
@@ -19,6 +19,7 @@ package org.apache.helix.zookeeper.impl.client;
  * under the License.
  */
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,7 +28,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.helix.msdcommon.datamodel.TrieRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -59,7 +59,7 @@ public class TestFederatedZkClient extends ZkTestBase {
   private ZkServer _extraZkServer;
 
   @BeforeClass
-  public void beforeClass() throws InvalidRoutingDataException {
+  public void beforeClass() throws InvalidRoutingDataException, IOException {
     System.out.println("Starting " + TestFederatedZkClient.class.getSimpleName());
 
     // Populate rawRoutingData
@@ -82,8 +82,7 @@ public class TestFederatedZkClient extends ZkTestBase {
 
     // Feed the raw routing data into TrieRoutingData to construct an in-memory representation
     // of routing information.
-    _realmAwareZkClient = new FederatedZkClient(new RealmAwareZkClient.RealmAwareZkClientConfig(),
-        new TrieRoutingData(rawRoutingData));
+    _realmAwareZkClient = new FederatedZkClient(new RealmAwareZkClient.RealmAwareZkClientConfig());
   }
 
   @AfterClass

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestSharedZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestSharedZkClient.java
@@ -19,6 +19,9 @@ package org.apache.helix.zookeeper.impl.client;
  * under the License.
  */
 
+import java.io.IOException;
+
+import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
@@ -28,9 +31,10 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
-public class TestSharedZkClient extends RealmAwareZkClientTestBase {
+public class TestSharedZkClient extends RealmAwareZkClientFactoryTestBase {
+
   @BeforeClass
-  public void beforeClass() throws Exception {
+  public void beforeClass() throws IOException, InvalidRoutingDataException {
     super.beforeClass();
     // Set the factory to SharedZkClientFactory
     _realmAwareZkClientFactory = SharedZkClientFactory.getInstance();


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #818 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We want all implementations of RealmAwareZkClient to do a one-time query to Metadata Store Directory Service for routing data and cache it in memory. In order to accomplish that, we have introduced HttpRoutingDataReader, which is a Singleton class that makes a REST call to read routing data and caches it in memory. This diff updates the initialization logic in RealmAwareZkClients accordingly.
Changelist:
1. Update all RealmAwareZkClient initialization logic
2. Fix tests

### Tests

- [x] The following tests are written for this issue:

TestDedicatedZkClient
TestSharedZkClient
TestFederatedZkClient

- [x] The following is the result of the "mvn test" command on the appropriate module:

- metadata-store-directory-common

```
[INFO] Tests run: 30, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.322 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 30, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.531 s
[INFO] Finished at: 2020-03-03T18:02:00-08:00
[INFO] ------------------------------------------------------------------------
```
- zookeeper-api
```
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.57 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.604 s
[INFO] Finished at: 2020-03-03T18:02:21-08:00
[INFO] ------------------------------------------------------------------------
```
- helix-rest
```
[INFO] Tests run: 136, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 25.661 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 136, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 


```
### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml (helix-style-intellij.xml if IntelliJ IDE is used)
