### PR TITLE
Fix InvalidRoutingData error message in tests

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java
@@ -248,7 +248,7 @@ public class TestZkMetadataStoreDirectory extends AbstractTestClass {
     // Since there was a child change callback, make sure data change works on the new child (realm) as well by adding a key
     // This tests removing all subscriptions and subscribing with new children list
     // For all namespaces (Routing ZKs), add an extra sharding key to TEST_REALM_3
-    String newKey = "/a/b/c/d/e";
+    String newKey = "/x/y/z";
     _zkList.forEach(zk -> {
       ZNRecord znRecord = ZK_SERVER_MAP.get(zk).getZkClient()
           .readData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + TEST_REALM_3);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #820 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR aims to fix the `InvalidRoutingDataException` error message that shows up in tests. The source of this error was due to two test cases in `TestZkMetadataStoreDirectory`, in which both of the test cases inserted "/a/b/c/d/e" directly into the same set of routing data. This renders the routing data invalid because one sharding key is pointing to two realms. 
This was not caught at insertion because the insertion was done directly instead of through a dedicated API (because the code in question is a test case). The tests didn't fail because they relied on the raw routing data for correctness. The construction of `MetadataStoreRoutingData` failed "correctly" as can be seen from the error messages, however the construction failure was after raw routing data being fetched, therefore making the situation undetected. 

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 128, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.796 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 128, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  48.357 s
[INFO] Finished at: 2020-02-26T16:33:30-08:00
[INFO] ------------------------------------------------------------------------



### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml