### PR TITLE
Add intermediate storage for customized state

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateCache.java
@@ -19,33 +19,21 @@ package org.apache.helix.common.caches;
  * under the License.
  */
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.collect.Maps;
-import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.common.controllers.ControlContextProvider;
-import org.apache.helix.controller.LogUtil;
 import org.apache.helix.model.CurrentState;
-import org.apache.helix.model.LiveInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Cache to hold all CurrentStates of a cluster.
  */
-public class CurrentStateCache extends AbstractDataCache<CurrentState> {
+public class CurrentStateCache extends ParticipantStateCache<CurrentState> {
   private static final Logger LOG = LoggerFactory.getLogger(CurrentStateCache.class.getName());
-
-  private Map<String, Map<String, Map<String, CurrentState>>> _currentStateMap;
-  private Map<PropertyKey, CurrentState> _currentStateCache = Maps.newHashMap();
-  // If the cache is already refreshed with current state data.
+  // If the snapshot is already refreshed with current state data.
   private boolean _initialized = false;
   private CurrentStateSnapshot _snapshot;
 
@@ -55,149 +43,17 @@ public class CurrentStateCache extends AbstractDataCache<CurrentState> {
 
   public CurrentStateCache(ControlContextProvider contextProvider) {
     super(contextProvider);
-    _currentStateMap = Collections.emptyMap();
-    _snapshot = new CurrentStateSnapshot(_currentStateCache);
+    _snapshot = new CurrentStateSnapshot(_participantStateCache);
   }
 
-  /**
-   * This refreshes the CurrentStates data by re-fetching the data from zookeeper in an efficient
-   * way
-   *
-   * @param accessor
-   * @param liveInstanceMap map of all liveInstances in cluster
-   *
-   * @return
-   */
-  public boolean refresh(HelixDataAccessor accessor,
-      Map<String, LiveInstance> liveInstanceMap) {
-    long startTime = System.currentTimeMillis();
-
-    refreshCurrentStatesCache(accessor, liveInstanceMap);
-    Map<String, Map<String, Map<String, CurrentState>>> allCurStateMap = new HashMap<>();
-    for (PropertyKey key : _currentStateCache.keySet()) {
-      CurrentState currentState = _currentStateCache.get(key);
-      String[] params = key.getParams();
-      if (currentState != null && params.length >= 4) {
-        String instanceName = params[1];
-        String sessionId = params[2];
-        String stateName = params[3];
-        Map<String, Map<String, CurrentState>> instanceCurStateMap =
-            allCurStateMap.get(instanceName);
-        if (instanceCurStateMap == null) {
-          instanceCurStateMap = Maps.newHashMap();
-          allCurStateMap.put(instanceName, instanceCurStateMap);
-        }
-        Map<String, CurrentState> sessionCurStateMap = instanceCurStateMap.get(sessionId);
-        if (sessionCurStateMap == null) {
-          sessionCurStateMap = Maps.newHashMap();
-          instanceCurStateMap.put(sessionId, sessionCurStateMap);
-        }
-        sessionCurStateMap.put(stateName, currentState);
-      }
-    }
-
-    for (String instance : allCurStateMap.keySet()) {
-      allCurStateMap.put(instance, Collections.unmodifiableMap(allCurStateMap.get(instance)));
-    }
-    _currentStateMap = Collections.unmodifiableMap(allCurStateMap);
-
-    long endTime = System.currentTimeMillis();
-    LogUtil.logInfo(LOG, genEventInfo(),
-        "END: CurrentStateCache.refresh() for cluster " + _controlContextProvider.getClusterName()
-            + ", started at : " + startTime + ", took " + (endTime - startTime) + " ms");
-    if (LOG.isDebugEnabled()) {
-      LogUtil.logDebug(LOG, genEventInfo(),
-          String.format("Current State refreshed : %s", _currentStateMap.toString()));
-    }
-    return true;
-  }
-
-  // reload current states that has been changed from zk to local cache.
-  private void refreshCurrentStatesCache(HelixDataAccessor accessor,
-      Map<String, LiveInstance> liveInstanceMap) {
-
-    long start = System.currentTimeMillis();
-    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
-
-    Set<PropertyKey> currentStateKeys = new HashSet<>();
-    for (String instanceName : liveInstanceMap.keySet()) {
-      LiveInstance liveInstance = liveInstanceMap.get(instanceName);
-      String sessionId = liveInstance.getEphemeralOwner();
-      List<String> currentStateNames =
-          accessor.getChildNames(keyBuilder.currentStates(instanceName, sessionId));
-      for (String currentStateName : currentStateNames) {
-        currentStateKeys.add(keyBuilder.currentState(instanceName, sessionId, currentStateName));
-      }
-    }
-    // All new entries from zk not cached locally yet should be read from ZK.
-    Set<PropertyKey> reloadKeys = new HashSet<>(currentStateKeys);
-    reloadKeys.removeAll(_currentStateCache.keySet());
-
-    Set<PropertyKey> cachedKeys = new HashSet<>(_currentStateCache.keySet());
-    cachedKeys.retainAll(currentStateKeys);
-
-    Set<PropertyKey> reloadedKeys = new HashSet<>();
-    Map<PropertyKey, CurrentState> newStateCache = Collections.unmodifiableMap(
-        refreshProperties(accessor, reloadKeys, new ArrayList<>(cachedKeys),
-            _currentStateCache, reloadedKeys));
-
-    // if the cache was not initialized, the previous state should not be included in the snapshot
+  protected void refreshSnapshot(Map<PropertyKey, CurrentState> newStateCache,
+      Map<PropertyKey, CurrentState> participantStateCache, Set<PropertyKey> reloadedKeys) {
     if (_initialized) {
-      _snapshot = new CurrentStateSnapshot(newStateCache, _currentStateCache, reloadedKeys);
+      _snapshot = new CurrentStateSnapshot(newStateCache, participantStateCache, reloadedKeys);
     } else {
       _snapshot = new CurrentStateSnapshot(newStateCache);
       _initialized = true;
     }
-
-    _currentStateCache = newStateCache;
-
-    if (LOG.isDebugEnabled()) {
-      LogUtil.logDebug(LOG, genEventInfo(),
-          "# of CurrentStates reload: " + reloadKeys.size() + ", skipped:" + (
-              currentStateKeys.size() - reloadKeys.size()) + ". took " + (System.currentTimeMillis()
-              - start) + " ms to reload new current states for cluster: " + _controlContextProvider
-              .getClusterName());
-    }
-  }
-
-  /**
-   * Return CurrentStates map for all instances.
-   *
-   * @return
-   */
-  public Map<String, Map<String, Map<String, CurrentState>>> getCurrentStatesMap() {
-    return Collections.unmodifiableMap(_currentStateMap);
-  }
-
-  /**
-   * Return all CurrentState on the given instance.
-   *
-   * @param instance
-   *
-   * @return
-   */
-  public Map<String, Map<String, CurrentState>> getCurrentStates(String instance) {
-    if (!_currentStateMap.containsKey(instance)) {
-      return Collections.emptyMap();
-    }
-    return Collections.unmodifiableMap(_currentStateMap.get(instance));
-  }
-
-  /**
-   * Provides the current state of the node for a given session id, the sessionid can be got from
-   * LiveInstance
-   *
-   * @param instance
-   * @param clientSessionId
-   *
-   * @return
-   */
-  public Map<String, CurrentState> getCurrentState(String instance, String clientSessionId) {
-    if (!_currentStateMap.containsKey(instance) || !_currentStateMap.get(instance)
-        .containsKey(clientSessionId)) {
-      return Collections.emptyMap();
-    }
-    return Collections.unmodifiableMap(_currentStateMap.get(instance).get(clientSessionId));
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CurrentStateCache.java
@@ -59,9 +59,11 @@ public class CurrentStateCache extends ParticipantStateCache<CurrentState> {
     for (String instanceName : liveInstanceMap.keySet()) {
       LiveInstance liveInstance = liveInstanceMap.get(instanceName);
       String sessionId = liveInstance.getEphemeralOwner();
-      List<String> currentStateNames = accessor.getChildNames(keyBuilder.currentStates(instanceName, sessionId));
+      List<String> currentStateNames =
+          accessor.getChildNames(keyBuilder.currentStates(instanceName, sessionId));
       for (String currentStateName : currentStateNames) {
-        participantStateKeys.add(keyBuilder.currentState(instanceName, sessionId, currentStateName));
+        participantStateKeys
+            .add(keyBuilder.currentState(instanceName, sessionId, currentStateName));
       }
     }
     return participantStateKeys;

--- a/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedStateCache.java
@@ -22,6 +22,7 @@ package org.apache.helix.common.caches;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.common.controllers.ControlContextProvider;
@@ -49,23 +50,17 @@ public class CustomizedStateCache extends ParticipantStateCache<CustomizedState>
     Set<PropertyKey> participantStateKeys = new HashSet<>();
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
     Set<String> restrictedKeys = new HashSet<>(
-        accessor.getProperty(accessor.keyBuilder().customizedStateAggregationConfig())
-            .getRecord()
-            .getListFields()
-            .get(CustomizedStateAggregationConfig.CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES.name()));
+        accessor.getProperty(accessor.keyBuilder().customizedStateAggregationConfig()).getRecord()
+            .getListFields().get(
+            CustomizedStateAggregationConfig.CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES
+                .name()));
     for (String instanceName : liveInstanceMap.keySet()) {
       for (String customizedStateType : restrictedKeys) {
         accessor.getChildNames(keyBuilder.customizedStates(instanceName, customizedStateType))
-            .stream()
-            .forEach(resourceName -> participantStateKeys.add(
-                keyBuilder.customizedState(instanceName, customizedStateType, resourceName)));
+            .stream().forEach(resourceName -> participantStateKeys
+            .add(keyBuilder.customizedState(instanceName, customizedStateType, resourceName)));
       }
     }
     return participantStateKeys;
-  }
-
-  @Override
-  protected void refreshSnapshot(Map<PropertyKey, CustomizedState> newStateCache,
-      Map<PropertyKey, CustomizedState> participantStateCache, Set<PropertyKey> reloadedKeys) {
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedStateCache.java
@@ -19,8 +19,13 @@ package org.apache.helix.common.caches;
  * under the License.
  */
 
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.PropertyKey;
 import org.apache.helix.common.controllers.ControlContextProvider;
 import org.apache.helix.model.CustomizedState;
+import org.apache.helix.model.LiveInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,5 +38,18 @@ public class CustomizedStateCache extends ParticipantStateCache<CustomizedState>
 
   public CustomizedStateCache(ControlContextProvider contextProvider) {
     super(contextProvider);
+  }
+
+  public void PopulateParticipantKeys(HelixDataAccessor accessor,
+      Set<PropertyKey> participantStateKeys, Map<String, LiveInstance> liveInstanceMap,
+      Set<String> restrictedKeys) {
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    for (String instanceName : liveInstanceMap.keySet()) {
+      for (String customizedStateType : restrictedKeys) {
+        accessor.getChildNames(keyBuilder.customizedStates(instanceName, customizedStateType))
+            .stream().forEach(resourceName -> participantStateKeys
+                .add(keyBuilder.customizedState(instanceName, customizedStateType, resourceName)));
+      }
+    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedStateCache.java
@@ -19,29 +19,13 @@ package org.apache.helix.common.caches;
  * under the License.
  */
 
-import com.google.common.collect.Maps;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.apache.helix.HelixDataAccessor;
-import org.apache.helix.PropertyKey;
 import org.apache.helix.common.controllers.ControlContextProvider;
-import org.apache.helix.controller.LogUtil;
 import org.apache.helix.model.CustomizedState;
-import org.apache.helix.model.LiveInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CustomizedStateCache extends AbstractDataCache<CustomizedState> {
+public class CustomizedStateCache extends ParticipantStateCache<CustomizedState> {
   private static final Logger LOG = LoggerFactory.getLogger(CurrentStateCache.class.getName());
-
-  // instance -> customizedStateType -> resource -> CustomizedState
-  private Map<String, Map<String, Map<String, CustomizedState>>> _customizedStateMap;
-  private Map<PropertyKey, CustomizedState> _customizedStateCache = Maps.newHashMap();
 
   public CustomizedStateCache(String clusterName) {
     this(createDefaultControlContextProvider(clusterName));
@@ -49,138 +33,5 @@ public class CustomizedStateCache extends AbstractDataCache<CustomizedState> {
 
   public CustomizedStateCache(ControlContextProvider contextProvider) {
     super(contextProvider);
-    _customizedStateMap = Collections.emptyMap();
-  }
-
-  /**
-   * This refreshes the CustomizedStates data by re-fetching the data from zookeeper in an efficient
-   * way
-   * @param accessor
-   * @param liveInstanceMap map of all liveInstances in cluster
-   * @return
-   */
-  public boolean refresh(HelixDataAccessor accessor, Map<String, LiveInstance> liveInstanceMap,
-      Set<String> aggregationEnabledTypes) {
-    long startTime = System.currentTimeMillis();
-
-    refreshCustomizedStatesCache(accessor, liveInstanceMap, aggregationEnabledTypes);
-
-    Map<String, Map<String, Map<String, CustomizedState>>> allCustomizedStateMap = new HashMap<>();
-    for (PropertyKey key : _customizedStateCache.keySet()) {
-      CustomizedState customizedState = _customizedStateCache.get(key);
-      String[] params = key.getParams();
-      if (customizedState != null && params.length >= 4) {
-        String instanceName = params[1];
-        String customizedStateType = params[2];
-        String resourceName = params[3];
-        Map<String, Map<String, CustomizedState>> instanceCustomizedStateMap =
-            allCustomizedStateMap.get(instanceName);
-        if (instanceCustomizedStateMap == null) {
-          instanceCustomizedStateMap = Maps.newHashMap();
-          allCustomizedStateMap.put(instanceName, instanceCustomizedStateMap);
-        }
-        Map<String, CustomizedState> customizedStateNameCustomizedStateMap =
-            instanceCustomizedStateMap.get(customizedStateType);
-        if (customizedStateNameCustomizedStateMap == null) {
-          customizedStateNameCustomizedStateMap = Maps.newHashMap();
-          instanceCustomizedStateMap.put(customizedStateType,
-              customizedStateNameCustomizedStateMap);
-        }
-        customizedStateNameCustomizedStateMap.put(resourceName, customizedState);
-      }
-    }
-
-    for (String instance : allCustomizedStateMap.keySet()) {
-      allCustomizedStateMap.put(instance,
-          Collections.unmodifiableMap(allCustomizedStateMap.get(instance)));
-    }
-    _customizedStateMap = Collections.unmodifiableMap(allCustomizedStateMap);
-
-    long endTime = System.currentTimeMillis();
-    LogUtil.logInfo(LOG, genEventInfo(),
-        "END: CustomizedStateCache.refresh() for cluster "
-            + _controlContextProvider.getClusterName() + ", started at : " + startTime + ", took "
-            + (endTime - startTime) + " ms");
-    if (LOG.isDebugEnabled()) {
-      LogUtil.logDebug(LOG, genEventInfo(),
-          String.format("Customized State refreshed : %s", _customizedStateMap.toString()));
-    }
-    return true;
-  }
-
-  // reload customized states that has been changed from zk to local cache.
-  private void refreshCustomizedStatesCache(HelixDataAccessor accessor,
-      Map<String, LiveInstance> liveInstanceMap, Set<String> aggregationEnabledTypes) {
-    long start = System.currentTimeMillis();
-    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
-    Set<PropertyKey> customizedStateKeys = new HashSet<>();
-    List<String> resourceNames = new ArrayList<>();
-    for (String instanceName : liveInstanceMap.keySet()) {
-      for (String customizedStateName : aggregationEnabledTypes) {
-        resourceNames =
-            accessor.getChildNames(keyBuilder.customizedStates(instanceName, customizedStateName));
-        for (String resourceName : resourceNames) {
-          customizedStateKeys
-              .add(keyBuilder.customizedState(instanceName, customizedStateName, resourceName));
-        }
-      }
-      // All new entries from zk not cached locally yet should be read from ZK.
-      Set<PropertyKey> reloadKeys = new HashSet<>(customizedStateKeys);
-      reloadKeys.removeAll(_customizedStateCache.keySet());
-
-      Set<PropertyKey> cachedKeys = new HashSet<>(_customizedStateCache.keySet());
-      cachedKeys.retainAll(customizedStateKeys);
-
-      Set<PropertyKey> reloadedKeys = new HashSet<>();
-      Map<PropertyKey, CustomizedState> newStateCache =
-          Collections.unmodifiableMap(refreshProperties(accessor, reloadKeys,
-              new ArrayList<>(cachedKeys), _customizedStateCache, reloadedKeys));
-
-      _customizedStateCache = newStateCache;
-
-      if (LOG.isDebugEnabled()) {
-        LogUtil.logDebug(LOG, genEventInfo(),
-            "# of CustomizedStates reload: " + reloadKeys.size() + ", skipped:"
-                + (customizedStateKeys.size() - reloadKeys.size()) + ". took "
-                + (System.currentTimeMillis() - start)
-                + " ms to reload new customized states for cluster: "
-                + _controlContextProvider.getClusterName());
-      }
-    }
-  }
-
-  /**
-   * Return CustomizedStates map for all instances.
-   * @return
-   */
-  public Map<String, Map<String, Map<String, CustomizedState>>> getCustomizedStatesMap() {
-    return Collections.unmodifiableMap(_customizedStateMap);
-  }
-
-  /**
-   * Return all CustomizedStates on the given instance.
-   * @param instance
-   * @return
-   */
-  public Map<String, Map<String, CustomizedState>> getCustomizedStates(String instance) {
-    if (!_customizedStateMap.containsKey(instance)) {
-      return Collections.emptyMap();
-    }
-    return Collections.unmodifiableMap(_customizedStateMap.get(instance));
-  }
-
-  /**
-   * Provides the customized state of the node for a given customized state type
-   * @param instance
-   * @param customizeStateType
-   * @return
-   */
-  public Map<String, CustomizedState> getCustomizedState(String instance,
-      String customizeStateType) {
-    if (!_customizedStateMap.containsKey(instance)
-        || !_customizedStateMap.get(instance).containsKey(customizeStateType)) {
-      return Collections.emptyMap();
-    }
-    return Collections.unmodifiableMap(_customizedStateMap.get(instance).get(customizeStateType));
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedStateCache.java
@@ -1,0 +1,186 @@
+package org.apache.helix.common.caches;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.collect.Maps;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.common.controllers.ControlContextProvider;
+import org.apache.helix.controller.LogUtil;
+import org.apache.helix.model.CustomizedState;
+import org.apache.helix.model.LiveInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CustomizedStateCache extends AbstractDataCache<CustomizedState> {
+  private static final Logger LOG = LoggerFactory.getLogger(CurrentStateCache.class.getName());
+
+  // instance -> customizedStateType -> resource -> CustomizedState
+  private Map<String, Map<String, Map<String, CustomizedState>>> _customizedStateMap;
+  private Map<PropertyKey, CustomizedState> _customizedStateCache = Maps.newHashMap();
+
+  public CustomizedStateCache(String clusterName) {
+    this(createDefaultControlContextProvider(clusterName));
+  }
+
+  public CustomizedStateCache(ControlContextProvider contextProvider) {
+    super(contextProvider);
+    _customizedStateMap = Collections.emptyMap();
+  }
+
+  /**
+   * This refreshes the CustomizedStates data by re-fetching the data from zookeeper in an efficient
+   * way
+   * @param accessor
+   * @param liveInstanceMap map of all liveInstances in cluster
+   * @return
+   */
+  public boolean refresh(HelixDataAccessor accessor, Map<String, LiveInstance> liveInstanceMap,
+      Set<String> aggregationEnabledTypes) {
+    long startTime = System.currentTimeMillis();
+
+    refreshCustomizedStatesCache(accessor, liveInstanceMap, aggregationEnabledTypes);
+
+    Map<String, Map<String, Map<String, CustomizedState>>> allCustomizedStateMap = new HashMap<>();
+    for (PropertyKey key : _customizedStateCache.keySet()) {
+      CustomizedState customizedState = _customizedStateCache.get(key);
+      String[] params = key.getParams();
+      if (customizedState != null && params.length >= 4) {
+        String instanceName = params[1];
+        String customizedStateType = params[2];
+        String resourceName = params[3];
+        Map<String, Map<String, CustomizedState>> instanceCustomizedStateMap =
+            allCustomizedStateMap.get(instanceName);
+        if (instanceCustomizedStateMap == null) {
+          instanceCustomizedStateMap = Maps.newHashMap();
+          allCustomizedStateMap.put(instanceName, instanceCustomizedStateMap);
+        }
+        Map<String, CustomizedState> customizedStateNameCustomizedStateMap =
+            instanceCustomizedStateMap.get(customizedStateType);
+        if (customizedStateNameCustomizedStateMap == null) {
+          customizedStateNameCustomizedStateMap = Maps.newHashMap();
+          instanceCustomizedStateMap.put(customizedStateType,
+              customizedStateNameCustomizedStateMap);
+        }
+        customizedStateNameCustomizedStateMap.put(resourceName, customizedState);
+      }
+    }
+
+    for (String instance : allCustomizedStateMap.keySet()) {
+      allCustomizedStateMap.put(instance,
+          Collections.unmodifiableMap(allCustomizedStateMap.get(instance)));
+    }
+    _customizedStateMap = Collections.unmodifiableMap(allCustomizedStateMap);
+
+    long endTime = System.currentTimeMillis();
+    LogUtil.logInfo(LOG, genEventInfo(),
+        "END: CustomizedStateCache.refresh() for cluster "
+            + _controlContextProvider.getClusterName() + ", started at : " + startTime + ", took "
+            + (endTime - startTime) + " ms");
+    if (LOG.isDebugEnabled()) {
+      LogUtil.logDebug(LOG, genEventInfo(),
+          String.format("Customized State refreshed : %s", _customizedStateMap.toString()));
+    }
+    return true;
+  }
+
+  // reload customized states that has been changed from zk to local cache.
+  private void refreshCustomizedStatesCache(HelixDataAccessor accessor,
+      Map<String, LiveInstance> liveInstanceMap, Set<String> aggregationEnabledTypes) {
+    long start = System.currentTimeMillis();
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    Set<PropertyKey> customizedStateKeys = new HashSet<>();
+    List<String> resourceNames = new ArrayList<>();
+    for (String instanceName : liveInstanceMap.keySet()) {
+      for (String customizedStateName : aggregationEnabledTypes) {
+        resourceNames =
+            accessor.getChildNames(keyBuilder.customizedStates(instanceName, customizedStateName));
+        for (String resourceName : resourceNames) {
+          customizedStateKeys
+              .add(keyBuilder.customizedState(instanceName, customizedStateName, resourceName));
+        }
+      }
+      // All new entries from zk not cached locally yet should be read from ZK.
+      Set<PropertyKey> reloadKeys = new HashSet<>(customizedStateKeys);
+      reloadKeys.removeAll(_customizedStateCache.keySet());
+
+      Set<PropertyKey> cachedKeys = new HashSet<>(_customizedStateCache.keySet());
+      cachedKeys.retainAll(customizedStateKeys);
+
+      Set<PropertyKey> reloadedKeys = new HashSet<>();
+      Map<PropertyKey, CustomizedState> newStateCache =
+          Collections.unmodifiableMap(refreshProperties(accessor, reloadKeys,
+              new ArrayList<>(cachedKeys), _customizedStateCache, reloadedKeys));
+
+      _customizedStateCache = newStateCache;
+
+      if (LOG.isDebugEnabled()) {
+        LogUtil.logDebug(LOG, genEventInfo(),
+            "# of CustomizedStates reload: " + reloadKeys.size() + ", skipped:"
+                + (customizedStateKeys.size() - reloadKeys.size()) + ". took "
+                + (System.currentTimeMillis() - start)
+                + " ms to reload new customized states for cluster: "
+                + _controlContextProvider.getClusterName());
+      }
+    }
+  }
+
+  /**
+   * Return CustomizedStates map for all instances.
+   * @return
+   */
+  public Map<String, Map<String, Map<String, CustomizedState>>> getCustomizedStatesMap() {
+    return Collections.unmodifiableMap(_customizedStateMap);
+  }
+
+  /**
+   * Return all CustomizedStates on the given instance.
+   * @param instance
+   * @return
+   */
+  public Map<String, Map<String, CustomizedState>> getCustomizedStates(String instance) {
+    if (!_customizedStateMap.containsKey(instance)) {
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(_customizedStateMap.get(instance));
+  }
+
+  /**
+   * Provides the customized state of the node for a given customized state type
+   * @param instance
+   * @param customizeStateType
+   * @return
+   */
+  public Map<String, CustomizedState> getCustomizedState(String instance,
+      String customizeStateType) {
+    if (!_customizedStateMap.containsKey(instance)
+        || !_customizedStateMap.get(instance).containsKey(customizeStateType)) {
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(_customizedStateMap.get(instance).get(customizeStateType));
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/common/caches/ParticipantStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/ParticipantStateCache.java
@@ -127,7 +127,7 @@ public abstract class ParticipantStateCache<T> extends AbstractDataCache {
       } else {
         for (String customizedStateType : restrictedKeys) {
           accessor.getChildNames(keyBuilder.customizedStates(instanceName, customizedStateType))
-              .stream().map(resourceName -> participantStateKeys.add(
+              .stream().forEach(resourceName -> participantStateKeys.add(
                   keyBuilder.customizedState(instanceName, customizedStateType, resourceName)));
         }
       }

--- a/helix-core/src/main/java/org/apache/helix/common/caches/ParticipantStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/ParticipantStateCache.java
@@ -1,0 +1,203 @@
+package org.apache.helix.common.caches;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.collect.Maps;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.common.controllers.ControlContextProvider;
+import org.apache.helix.controller.LogUtil;
+import org.apache.helix.model.LiveInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public abstract class ParticipantStateCache<T> extends AbstractDataCache {
+  private static Logger LOG = LoggerFactory.getLogger(ParticipantStateCache.class.getName());
+  protected Map<String, Map<String, Map<String, T>>> _participantStateMap;
+
+  protected Map<PropertyKey, T> _participantStateCache = Maps.newHashMap();
+  public ParticipantStateCache(ControlContextProvider controlContextProvider) {
+    super(controlContextProvider);
+    _participantStateMap = Collections.emptyMap();
+  }
+
+  public ParticipantStateCache(String clusterName) {
+    this(createDefaultControlContextProvider(clusterName));
+  }
+
+
+  /**
+   * This refreshes the participant state cache data by re-fetching the data from zookeeper in an efficient way
+   *
+   * @param accessor
+   * @param liveInstanceMap map of all liveInstances in cluster
+   *
+   * @return
+   */
+  public boolean refresh(HelixDataAccessor accessor,
+      Map<String, LiveInstance> liveInstanceMap, Boolean snapshotEnabled, Set<String> restrictedKeys) {
+    long startTime = System.currentTimeMillis();
+
+    refreshParticipantStatesCacheFromZk(accessor, liveInstanceMap, snapshotEnabled, restrictedKeys);
+    Map<String, Map<String, Map<String, T>>> allParticipantStateMap = new HashMap<>();
+    for (PropertyKey key : _participantStateCache.keySet()) {
+      T participantState = _participantStateCache.get(key);
+      String[] params = key.getParams();
+      if (participantState != null && params.length >= 4) {
+        String keyLevel1 = params[1];
+        String keyLevel2 = params[2];
+        String keyLevel3 = params[3];
+        Map<String, Map<String, T>> stateMapLevel1 =
+            allParticipantStateMap.get(keyLevel1);
+        if (stateMapLevel1 == null) {
+          stateMapLevel1 = Maps.newHashMap();
+          allParticipantStateMap.put(keyLevel1, stateMapLevel1);
+        }
+        Map<String, T> stateMapLevel2 = stateMapLevel1.get(keyLevel2);
+        if (stateMapLevel2 == null) {
+          stateMapLevel2 = Maps.newHashMap();
+          stateMapLevel1.put(keyLevel2, stateMapLevel2);
+        }
+        stateMapLevel2.put(keyLevel3, participantState);
+      }
+    }
+
+    for (String instance : allParticipantStateMap.keySet()) {
+      allParticipantStateMap.put(instance, Collections.unmodifiableMap(allParticipantStateMap.get(instance)));
+    }
+    _participantStateMap = Collections.unmodifiableMap(allParticipantStateMap);
+
+    long endTime = System.currentTimeMillis();
+    LogUtil.logInfo(LOG, genEventInfo(),
+        "END: participantStateCache.refresh() for cluster " + _controlContextProvider.getClusterName()
+            + ", started at : " + startTime + ", took " + (endTime - startTime) + " ms");
+    if (LOG.isDebugEnabled()) {
+      LogUtil.logDebug(LOG, genEventInfo(),
+          String.format("Participant State refreshed : %s", _participantStateMap.toString()));
+    }
+    return true;
+  }
+
+  // reload participant states that has been changed from zk to local cache.
+
+  private void refreshParticipantStatesCacheFromZk(HelixDataAccessor accessor,
+      Map<String, LiveInstance> liveInstanceMap, Boolean snapshotEnabled,
+      Set<String> restrictedKeys) {
+
+    long start = System.currentTimeMillis();
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+
+    Set<PropertyKey> participantStateKeys = new HashSet<>();
+    for (String instanceName : liveInstanceMap.keySet()) {
+      LiveInstance liveInstance = liveInstanceMap.get(instanceName);
+
+      if (restrictedKeys.isEmpty()) {
+        String sessionId = liveInstance.getEphemeralOwner();
+        List<String> currentStateNames =
+            accessor.getChildNames(keyBuilder.currentStates(instanceName, sessionId));
+
+        for (String currentStateName : currentStateNames) {
+          participantStateKeys
+              .add(keyBuilder.currentState(instanceName, sessionId, currentStateName));
+        }
+      } else {
+        List<String> resourceNames = new ArrayList<>();
+        for (String customizedStateType : restrictedKeys) {
+          resourceNames = accessor
+              .getChildNames(keyBuilder.customizedStates(instanceName, customizedStateType));
+          for (String resourceName : resourceNames) {
+            participantStateKeys
+                .add(keyBuilder.customizedState(instanceName, customizedStateType, resourceName));
+          }
+        }
+      }
+    }
+    // All new entries from zk not cached locally yet should be read from ZK.
+    Set<PropertyKey> reloadKeys = new HashSet<>(participantStateKeys);
+    reloadKeys.removeAll(_participantStateCache.keySet());
+
+    Set<PropertyKey> cachedKeys = new HashSet<>(_participantStateCache.keySet());
+    cachedKeys.retainAll(participantStateKeys);
+
+    Set<PropertyKey> reloadedKeys = new HashSet<>();
+    Map<PropertyKey, T> newStateCache = Collections.unmodifiableMap(refreshProperties(accessor,
+        reloadKeys, new ArrayList<>(cachedKeys), _participantStateCache, reloadedKeys));
+
+    if (snapshotEnabled) {
+      refreshSnapshot(newStateCache, _participantStateCache, reloadedKeys);
+    }
+
+    _participantStateCache = newStateCache;
+
+    if (LOG.isDebugEnabled()) {
+      LogUtil.logDebug(LOG, genEventInfo(), "# of participant state reload: " + reloadKeys.size()
+          + ", skipped:" + (participantStateKeys.size() - reloadKeys.size()) + ". took "
+          + (System.currentTimeMillis() - start) + " ms to reload new participant states for cluster: "
+          + _controlContextProvider.getClusterName() + "and state: " + this.getClass().getName());
+    }
+  }
+
+  protected void refreshSnapshot(Map<PropertyKey, T> newStateCache,
+      Map<PropertyKey, T> participantStateCache, Set<PropertyKey> reloadedKeys) {
+  }
+
+  /**
+   * Return the whole participant state map.
+   * @return
+   */
+  public Map<String, Map<String, Map<String, T>>> getParticipantStatesMap() {
+    return Collections.unmodifiableMap(_participantStateMap);
+  }
+
+  /**
+   * Return all participant states for a certain level1 key.
+   * @param keyLevel1
+   * @return
+   */
+  public Map<String, Map<String, T>> getParticipantStates(String keyLevel1) {
+    if (!_participantStateMap.containsKey(keyLevel1)) {
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(_participantStateMap.get(keyLevel1));
+  }
+
+  /**
+   * Provides the participant state map for a certain level1 key and level2 key
+   * @param keyLevel1
+   * @param keyLevel2
+   * @return
+   */
+  public Map<String, T> getParticipantState(String keyLevel1,
+      String keyLevel2) {
+    if (!_participantStateMap.containsKey(keyLevel1)
+        || !_participantStateMap.get(keyLevel1).containsKey(keyLevel2)) {
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(_participantStateMap.get(keyLevel1).get(keyLevel2));
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/common/caches/ParticipantStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/ParticipantStateCache.java
@@ -104,7 +104,6 @@ public abstract class ParticipantStateCache<T> extends AbstractDataCache {
   }
 
   // reload participant states that has been changed from zk to local cache.
-
   private void refreshParticipantStatesCacheFromZk(HelixDataAccessor accessor,
       Map<String, LiveInstance> liveInstanceMap, Boolean snapshotEnabled,
       Set<String> restrictedKeys) {
@@ -126,14 +125,10 @@ public abstract class ParticipantStateCache<T> extends AbstractDataCache {
               .add(keyBuilder.currentState(instanceName, sessionId, currentStateName));
         }
       } else {
-        List<String> resourceNames = new ArrayList<>();
         for (String customizedStateType : restrictedKeys) {
-          resourceNames = accessor
-              .getChildNames(keyBuilder.customizedStates(instanceName, customizedStateType));
-          for (String resourceName : resourceNames) {
-            participantStateKeys
-                .add(keyBuilder.customizedState(instanceName, customizedStateType, resourceName));
-          }
+          accessor.getChildNames(keyBuilder.customizedStates(instanceName, customizedStateType))
+              .stream().map(resourceName -> participantStateKeys.add(
+                  keyBuilder.customizedState(instanceName, customizedStateType, resourceName)));
         }
       }
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -332,7 +332,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
 
     // Refresh derived data
     _instanceMessagesCache.refresh(accessor, _liveInstanceCache.getPropertyMap());
-    _currentStateCache.refresh(accessor, _liveInstanceCache.getPropertyMap(), true);
+    _currentStateCache.refresh(accessor, _liveInstanceCache.getPropertyMap());
 
     // current state must be refreshed before refreshing relay messages
     // because we need to use current state to validate all relay messages.

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -332,12 +332,13 @@ public class BaseControllerDataProvider implements ControlContextProvider {
 
     // Refresh derived data
     _instanceMessagesCache.refresh(accessor, _liveInstanceCache.getPropertyMap());
-    _currentStateCache.refresh(accessor, _liveInstanceCache.getPropertyMap());
+    _currentStateCache.refresh(accessor, _liveInstanceCache.getPropertyMap(), true,
+        new HashSet<>());
 
     // current state must be refreshed before refreshing relay messages
     // because we need to use current state to validate all relay messages.
     _instanceMessagesCache.updateRelayMessages(_liveInstanceCache.getPropertyMap(),
-        _currentStateCache.getCurrentStatesMap());
+        _currentStateCache.getParticipantStatesMap());
 
     updateIdealRuleMap();
     updateDisabledInstances();
@@ -526,7 +527,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
    * @return
    */
   public Map<String, CurrentState> getCurrentState(String instanceName, String clientSessionId) {
-    return _currentStateCache.getCurrentState(instanceName, clientSessionId);
+    return _currentStateCache.getParticipantState(instanceName, clientSessionId);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -332,8 +332,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
 
     // Refresh derived data
     _instanceMessagesCache.refresh(accessor, _liveInstanceCache.getPropertyMap());
-    _currentStateCache.refresh(accessor, _liveInstanceCache.getPropertyMap(), true,
-        new HashSet<>());
+    _currentStateCache.refresh(accessor, _liveInstanceCache.getPropertyMap(), true);
 
     // current state must be refreshed before refreshing relay messages
     // because we need to use current state to validate all relay messages.

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateOutput.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateOutput.java
@@ -1,0 +1,135 @@
+package org.apache.helix.controller.stages;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.model.CustomizedState;
+import org.apache.helix.model.Partition;
+
+public class CustomizedStateOutput {
+  // stateType -> (resourceName -> (Partition -> (instanceName -> customizedState)))
+  private final Map<String, Map<String, Map<Partition, Map<String, String>>>> _customizedStateMap;
+
+  private final Map<String, CustomizedState> _customizedStateMetaMap;
+
+  public CustomizedStateOutput() {
+    _customizedStateMap = new HashMap<>();
+    _customizedStateMetaMap = new HashMap<>();
+  }
+
+  public void setCustomizedState(String stateType, String resourceName, Partition partition,
+      String instanceName, String state) {
+    if (!_customizedStateMap.containsKey(stateType)) {
+      _customizedStateMap.put(stateType,
+          new HashMap<String, Map<Partition, Map<String, String>>>());
+    }
+    if (!_customizedStateMap.get(stateType).containsKey(resourceName)) {
+      _customizedStateMap.get(stateType).put(resourceName,
+          new HashMap<Partition, Map<String, String>>());
+    }
+    if (!_customizedStateMap.get(stateType).get(resourceName).containsKey(partition)) {
+      _customizedStateMap.get(stateType).get(resourceName).put(partition,
+          new HashMap<String, String>());
+    }
+    _customizedStateMap.get(stateType).get(resourceName).get(partition).put(instanceName, state);
+  }
+
+  /**
+   * given (stateType, resource, partition, instance), returns customized state
+   * @param stateType
+   * @param resourceName
+   * @param partition
+   * @param instanceName
+   * @return
+   */
+  public String getCustomizedState(String stateType, String resourceName, Partition partition,
+      String instanceName) {
+    Map<String, Map<Partition, Map<String, String>>> map = _customizedStateMap.get(stateType);
+    if (map != null) {
+      Map<Partition, Map<String, String>> resourceMap = map.get(resourceName);
+      if (resourceMap != null) {
+        Map<String, String> instanceStateMap = resourceMap.get(partition);
+        if (instanceStateMap != null) {
+          return instanceStateMap.get(instanceName);
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Given stateType, returns resource customized state map (resource -> parition -> instance ->
+   * customizedState)
+   * @param stateType
+   * @return
+   */
+  public Map<String, Map<Partition, Map<String, String>>> getResourceCustomizedStateMap(
+      String stateType) {
+    if (_customizedStateMap.containsKey(stateType)) {
+      return _customizedStateMap.get(stateType);
+    }
+    return Collections.emptyMap();
+  }
+
+  /**
+   * given (stateType, resource), returns (partition -> instance-> customizedState) map
+   * @param stateType
+   * @param resourceName
+   * @return
+   */
+  public Map<Partition, Map<String, String>> getCustomizedStateMap(String stateType,
+      String resourceName) {
+    if (_customizedStateMap.containsKey(stateType)) {
+      Map<String, Map<Partition, Map<String, String>>> map = _customizedStateMap.get(stateType);
+      if (map.containsKey(resourceName)) {
+        return map.get(resourceName);
+      }
+    }
+    return Collections.emptyMap();
+  }
+
+  /**
+   * given (stateType, resource, partition), returns (instance-> customizedState) map
+   * @param stateType
+   * @param resourceName
+   * @param partition
+   * @return
+   */
+  public Map<String, String> getCustomizedStateMap(String stateType, String resourceName,
+      Partition partition) {
+    if (_customizedStateMap.containsKey(stateType)) {
+      Map<String, Map<Partition, Map<String, String>>> map = _customizedStateMap.get(stateType);
+      if (map.containsKey(resourceName)) {
+        Map<Partition, Map<String, String>> partitionMap = map.get(resourceName);
+        if (partitionMap != null) {
+          return partitionMap.get(partition);
+        }
+      }
+    }
+    return Collections.emptyMap();
+  }
+
+  public Set<String> getAllStateTypes() {
+    return _customizedStateMap.keySet();
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateOutput.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateOutput.java
@@ -23,33 +23,31 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.helix.model.CustomizedState;
+
 import org.apache.helix.model.Partition;
+
 
 public class CustomizedStateOutput {
   // stateType -> (resourceName -> (Partition -> (instanceName -> customizedState)))
   private final Map<String, Map<String, Map<Partition, Map<String, String>>>> _customizedStateMap;
 
-  private final Map<String, CustomizedState> _customizedStateMetaMap;
-
   public CustomizedStateOutput() {
     _customizedStateMap = new HashMap<>();
-    _customizedStateMetaMap = new HashMap<>();
   }
 
   public void setCustomizedState(String stateType, String resourceName, Partition partition,
       String instanceName, String state) {
     if (!_customizedStateMap.containsKey(stateType)) {
-      _customizedStateMap.put(stateType,
-          new HashMap<String, Map<Partition, Map<String, String>>>());
+      _customizedStateMap
+          .put(stateType, new HashMap<String, Map<Partition, Map<String, String>>>());
     }
     if (!_customizedStateMap.get(stateType).containsKey(resourceName)) {
-      _customizedStateMap.get(stateType).put(resourceName,
-          new HashMap<Partition, Map<String, String>>());
+      _customizedStateMap.get(stateType)
+          .put(resourceName, new HashMap<Partition, Map<String, String>>());
     }
     if (!_customizedStateMap.get(stateType).get(resourceName).containsKey(partition)) {
-      _customizedStateMap.get(stateType).get(resourceName).put(partition,
-          new HashMap<String, String>());
+      _customizedStateMap.get(stateType).get(resourceName)
+          .put(partition, new HashMap<String, String>());
     }
     _customizedStateMap.get(stateType).get(resourceName).get(partition).put(instanceName, state);
   }
@@ -60,8 +58,7 @@ public class CustomizedStateOutput {
    * @param stateType
    * @return
    */
-  public Map<String, Map<Partition, Map<String, String>>> getResourceCustomizedStateMap(
-      String stateType) {
+  public Map<String, Map<Partition, Map<String, String>>> getCustomizedStateMap(String stateType) {
     if (_customizedStateMap.containsKey(stateType)) {
       return Collections.unmodifiableMap(_customizedStateMap.get(stateType));
     }
@@ -74,11 +71,10 @@ public class CustomizedStateOutput {
    * @param resourceName
    * @return
    */
-  public Map<Partition, Map<String, String>> getPartitionCustomizedStateMap(String stateType,
+  public Map<Partition, Map<String, String>> getResourceCustomizedStateMap(String stateType,
       String resourceName) {
-    if (getResourceCustomizedStateMap(stateType).containsKey(resourceName)) {
-      return Collections
-          .unmodifiableMap(getResourceCustomizedStateMap(stateType).get(resourceName));
+    if (getCustomizedStateMap(stateType).containsKey(resourceName)) {
+      return Collections.unmodifiableMap(getCustomizedStateMap(stateType).get(resourceName));
     }
     return Collections.emptyMap();
   }
@@ -90,13 +86,12 @@ public class CustomizedStateOutput {
    * @param partition
    * @return
    */
-  public Map<String, String> getInstanceCustomizedStateMap(String stateType, String resourceName,
+  public Map<String, String> getPartitionCustomizedStateMap(String stateType, String resourceName,
       Partition partition) {
-    if (getResourceCustomizedStateMap(stateType).containsKey(resourceName)
-        && getPartitionCustomizedStateMap(stateType, resourceName).containsKey(partition)) {
+    if (getCustomizedStateMap(stateType).containsKey(resourceName) && getResourceCustomizedStateMap(
+        stateType, resourceName).containsKey(partition)) {
       return Collections
-          .unmodifiableMap(getPartitionCustomizedStateMap(stateType, resourceName).get(partition));
-
+          .unmodifiableMap(getResourceCustomizedStateMap(stateType, resourceName).get(partition));
     }
     return Collections.emptyMap();
   }
@@ -109,13 +104,12 @@ public class CustomizedStateOutput {
    * @param instanceName
    * @return
    */
-  public String getCustomizedState(String stateType, String resourceName, Partition partition,
-      String instanceName) {
-    if (getResourceCustomizedStateMap(stateType).containsKey(resourceName)
-        && getPartitionCustomizedStateMap(stateType, resourceName).containsKey(partition)
-        && getInstanceCustomizedStateMap(stateType, resourceName, partition)
-            .containsKey(instanceName)) {
-      return getInstanceCustomizedStateMap(stateType, resourceName, partition).get(instanceName);
+  public String getPartitionCustomizedState(String stateType, String resourceName,
+      Partition partition, String instanceName) {
+    if (getCustomizedStateMap(stateType).containsKey(resourceName) && getResourceCustomizedStateMap(
+        stateType, resourceName).containsKey(partition) && getPartitionCustomizedStateMap(stateType,
+        resourceName, partition).containsKey(instanceName)) {
+      return getPartitionCustomizedStateMap(stateType, resourceName, partition).get(instanceName);
     }
     return null;
   }

--- a/helix-core/src/main/java/org/apache/helix/model/CustomizedStateAggregationConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/CustomizedStateAggregationConfig.java
@@ -61,7 +61,7 @@ public class CustomizedStateAggregationConfig extends HelixProperty {
   }
 
   /**
-   * Set the AGGREGATION_ENABLED_STATES field.
+   * Set the AGGREGATION_ENABLED_TYPES field.
    * @param aggregationEnabledTypes
    */
   public void setAggregationEnabledTypes(List<String> aggregationEnabledTypes) {
@@ -70,8 +70,8 @@ public class CustomizedStateAggregationConfig extends HelixProperty {
   }
 
   /**
-   * Get the AGGREGATION_ENABLED_STATES field.
-   * @return AGGREGATION_ENABLED_STATES field.
+   * Get the AGGREGATION_ENABLED_TYPES field.
+   * @return AGGREGATION_ENABLED_TYPES field.
    */
   public List<String> getAggregationEnabledTypes() {
     return _record

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -81,7 +81,7 @@ class RoutingDataCache extends BasicClusterDataCache {
       long start = System.currentTimeMillis();
       _propertyDataChangedMap.put(HelixConstants.ChangeType.CURRENT_STATE, false);
       Map<String, LiveInstance> liveInstanceMap = getLiveInstances();
-      _currentStateCache.refresh(accessor, liveInstanceMap, true, new HashSet<>());
+      _currentStateCache.refresh(accessor, liveInstanceMap, true);
       LOG.info("Reload CurrentStates. Takes " + (System.currentTimeMillis() - start) + " ms");
     }
 

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -19,6 +19,7 @@ package org.apache.helix.spectator;
  * under the License.
  */
 
+import java.util.HashSet;
 import java.util.Map;
 
 import org.apache.helix.HelixConstants;
@@ -80,7 +81,7 @@ class RoutingDataCache extends BasicClusterDataCache {
       long start = System.currentTimeMillis();
       _propertyDataChangedMap.put(HelixConstants.ChangeType.CURRENT_STATE, false);
       Map<String, LiveInstance> liveInstanceMap = getLiveInstances();
-      _currentStateCache.refresh(accessor, liveInstanceMap);
+      _currentStateCache.refresh(accessor, liveInstanceMap, true, new HashSet<>());
       LOG.info("Reload CurrentStates. Takes " + (System.currentTimeMillis() - start) + " ms");
     }
 
@@ -110,7 +111,7 @@ class RoutingDataCache extends BasicClusterDataCache {
    * @return
    */
   public Map<String, Map<String, Map<String, CurrentState>>> getCurrentStatesMap() {
-    return _currentStateCache.getCurrentStatesMap();
+    return _currentStateCache.getParticipantStatesMap();
   }
 
   public CurrentStateSnapshot getCurrentStateSnapshot() {

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -19,7 +19,6 @@ package org.apache.helix.spectator;
  * under the License.
  */
 
-import java.util.HashSet;
 import java.util.Map;
 
 import org.apache.helix.HelixConstants;
@@ -81,7 +80,7 @@ class RoutingDataCache extends BasicClusterDataCache {
       long start = System.currentTimeMillis();
       _propertyDataChangedMap.put(HelixConstants.ChangeType.CURRENT_STATE, false);
       Map<String, LiveInstance> liveInstanceMap = getLiveInstances();
-      _currentStateCache.refresh(accessor, liveInstanceMap, true);
+      _currentStateCache.refresh(accessor, liveInstanceMap);
       LOG.info("Reload CurrentStates. Takes " + (System.currentTimeMillis() - start) + " ms");
     }
 

--- a/helix-core/src/test/java/org/apache/helix/common/caches/TestCurrentStateSnapshot.java
+++ b/helix-core/src/test/java/org/apache/helix/common/caches/TestCurrentStateSnapshot.java
@@ -91,14 +91,14 @@ public class TestCurrentStateSnapshot {
     Map<String, LiveInstance> liveInstanceMap = new HashMap<>();
     liveInstanceMap.put(instanceName, instance);
 
-    retVal = cache.refresh(accessor, liveInstanceMap, true, new HashSet<>());
+    retVal = cache.refresh(accessor, liveInstanceMap, true);
     Assert.assertTrue(retVal);
 
     retVal = accessor.setProperty(keyBuilder.currentState(instanceName, instance.getEphemeralOwner(), resourceName),
         currentState);
     Assert.assertTrue(retVal);
 
-    retVal = cache.refresh(accessor, liveInstanceMap, true, new HashSet<>());
+    retVal = cache.refresh(accessor, liveInstanceMap, true);
     Assert.assertTrue(retVal);
 
     CurrentStateSnapshot snapshot = cache.getSnapshot();

--- a/helix-core/src/test/java/org/apache/helix/common/caches/TestCurrentStateSnapshot.java
+++ b/helix-core/src/test/java/org/apache/helix/common/caches/TestCurrentStateSnapshot.java
@@ -91,14 +91,14 @@ public class TestCurrentStateSnapshot {
     Map<String, LiveInstance> liveInstanceMap = new HashMap<>();
     liveInstanceMap.put(instanceName, instance);
 
-    retVal = cache.refresh(accessor, liveInstanceMap, true);
+    retVal = cache.refresh(accessor, liveInstanceMap);
     Assert.assertTrue(retVal);
 
     retVal = accessor.setProperty(keyBuilder.currentState(instanceName, instance.getEphemeralOwner(), resourceName),
         currentState);
     Assert.assertTrue(retVal);
 
-    retVal = cache.refresh(accessor, liveInstanceMap, true);
+    retVal = cache.refresh(accessor, liveInstanceMap);
     Assert.assertTrue(retVal);
 
     CurrentStateSnapshot snapshot = cache.getSnapshot();

--- a/helix-core/src/test/java/org/apache/helix/common/caches/TestCurrentStateSnapshot.java
+++ b/helix-core/src/test/java/org/apache/helix/common/caches/TestCurrentStateSnapshot.java
@@ -91,14 +91,14 @@ public class TestCurrentStateSnapshot {
     Map<String, LiveInstance> liveInstanceMap = new HashMap<>();
     liveInstanceMap.put(instanceName, instance);
 
-    retVal = cache.refresh(accessor, liveInstanceMap);
+    retVal = cache.refresh(accessor, liveInstanceMap, true, new HashSet<>());
     Assert.assertTrue(retVal);
 
     retVal = accessor.setProperty(keyBuilder.currentState(instanceName, instance.getEphemeralOwner(), resourceName),
         currentState);
     Assert.assertTrue(retVal);
 
-    retVal = cache.refresh(accessor, liveInstanceMap);
+    retVal = cache.refresh(accessor, liveInstanceMap, true, new HashSet<>());
     Assert.assertTrue(retVal);
 
     CurrentStateSnapshot snapshot = cache.getSnapshot();


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

(#826  )

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
To support the storing and computation over customized state, Helix needs to implement some intermediate storage for better performance and easy operation. This PR adds a cache for store customized state and refresh it when necessary. It also adds a new customized state output data structure to store the data that will be used for computation. 

### Tests
[INFO] Tests run: 909, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,438.097 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 909, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

- [X] The following is the result of the "mvn test" command on the appropriate module:

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X] My diff has been formatted using helix-style.xml