### PR TITLE
Fix bugs in ZkRoutingDataReader and ZkRoutingDataWriter

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/common/HttpConstants.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/common/HttpConstants.java
@@ -27,5 +27,5 @@ public class HttpConstants {
     DELETE
   }
 
-  public static final String HTTP_PROTOCOL = "http://";
+  public static final String HTTP_PROTOCOL_PREFIX = "http://";
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/common/HttpConstants.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/common/HttpConstants.java
@@ -26,4 +26,6 @@ public class HttpConstants {
     PUT,
     DELETE
   }
+
+  public static final String HTTP_PROTOCOL = "http://";
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -188,7 +188,9 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
   @Override
   public boolean addMetadataStoreRealm(String namespace, String realm) {
     if (!_routingDataWriterMap.containsKey(namespace)) {
-      throw new IllegalArgumentException(
+      // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
+      // status code in the Accessor level
+      throw new NoSuchElementException(
           "Failed to add metadata store realm: Namespace " + namespace + " is not found!");
     }
     return _routingDataWriterMap.get(namespace).addMetadataStoreRealm(realm);
@@ -197,7 +199,9 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
   @Override
   public boolean deleteMetadataStoreRealm(String namespace, String realm) {
     if (!_routingDataWriterMap.containsKey(namespace)) {
-      throw new IllegalArgumentException(
+      // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
+      // status code in the Accessor level
+      throw new NoSuchElementException(
           "Failed to delete metadata store realm: Namespace " + namespace + " is not found!");
     }
     return _routingDataWriterMap.get(namespace).deleteMetadataStoreRealm(realm);
@@ -206,7 +210,9 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
   @Override
   public boolean addShardingKey(String namespace, String realm, String shardingKey) {
     if (!_routingDataWriterMap.containsKey(namespace) || !_routingDataMap.containsKey(namespace)) {
-      throw new IllegalArgumentException(
+      // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
+      // status code in the Accessor level
+      throw new NoSuchElementException(
           "Failed to add sharding key: Namespace " + namespace + " is not found!");
     }
     if (_routingDataMap.get(namespace).containsKeyRealmPair(shardingKey, realm)) {
@@ -223,7 +229,9 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
   @Override
   public boolean deleteShardingKey(String namespace, String realm, String shardingKey) {
     if (!_routingDataWriterMap.containsKey(namespace)) {
-      throw new IllegalArgumentException(
+      // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
+      // status code in the Accessor level
+      throw new NoSuchElementException(
           "Failed to delete sharding key: Namespace " + namespace + " is not found!");
     }
     return _routingDataWriterMap.get(namespace).deleteShardingKey(realm, shardingKey);

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
@@ -96,11 +96,10 @@ public class ZkRoutingDataReader implements MetadataStoreRoutingDataReader, IZkD
           "Routing data directory ZNode " + MetadataStoreRoutingConstants.ROUTING_DATA_PATH
               + " does not exist. Routing ZooKeeper address: " + _zkAddress);
     }
-    if (allRealmAddresses != null)
-    {
+    if (allRealmAddresses != null) {
       for (String realmAddress : allRealmAddresses) {
-        ZNRecord record =
-            _zkClient.readData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + realmAddress);
+        ZNRecord record = _zkClient
+            .readData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + realmAddress);
         if (record != null) {
           List<String> shardingKeys =
               record.getListField(MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY);

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
@@ -86,8 +86,7 @@ public class ZkRoutingDataReader implements MetadataStoreRoutingDataReader, IZkD
    * @throws InvalidRoutingDataException - when the node on
    *           MetadataStoreRoutingConstants.ROUTING_DATA_PATH is missing
    */
-  public Map<String, List<String>> getRoutingData()
-      throws InvalidRoutingDataException {
+  public Map<String, List<String>> getRoutingData() throws InvalidRoutingDataException {
     Map<String, List<String>> routingData = new HashMap<>();
     List<String> allRealmAddresses;
     try {
@@ -125,11 +124,13 @@ public class ZkRoutingDataReader implements MetadataStoreRoutingDataReader, IZkD
 
   @Override
   public synchronized void handleDataDeleted(String s) {
+    // Duplicating handleChildChange because sometimes callbacks go missing
     if (_zkClient.isClosed()) {
       return;
     }
 
     // Renew subscription
+    _zkClient.unsubscribeAll();
     _zkClient.subscribeChildChanges(MetadataStoreRoutingConstants.ROUTING_DATA_PATH, this);
     for (String child : _zkClient.getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH)) {
       _zkClient.subscribeDataChanges(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + child,
@@ -146,6 +147,7 @@ public class ZkRoutingDataReader implements MetadataStoreRoutingDataReader, IZkD
 
     // Subscribe data changes again because some children might have been deleted or added
     _zkClient.unsubscribeAll();
+    _zkClient.subscribeChildChanges(MetadataStoreRoutingConstants.ROUTING_DATA_PATH, this);
     for (String child : _zkClient.getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH)) {
       _zkClient.subscribeDataChanges(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + child,
           this);

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
@@ -90,7 +90,7 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
     if (hostName.charAt(hostName.length() - 1) == '/') {
       hostName = hostName.substring(0, hostName.length() - 1);
     }
-    _myHostName = hostName;
+    _myHostName = HttpConstants.HTTP_PROTOCOL + hostName;
     ZNRecord myServerInfo = new ZNRecord(_myHostName);
 
     _leaderElection = new ZkDistributedLeaderElection(_zkClient,

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
@@ -90,7 +90,7 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
     if (hostName.charAt(hostName.length() - 1) == '/') {
       hostName = hostName.substring(0, hostName.length() - 1);
     }
-    _myHostName = HttpConstants.HTTP_PROTOCOL + hostName;
+    _myHostName = HttpConstants.HTTP_PROTOCOL_PREFIX + hostName;
     ZNRecord myServerInfo = new ZNRecord(_myHostName);
 
     _leaderElection = new ZkDistributedLeaderElection(_zkClient,

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
@@ -247,6 +247,12 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
   }
 
   protected boolean deleteZkRealm(String realm) {
+    if (!_zkClient.exists(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + realm)) {
+      LOG.warn(
+          "deleteZkRealm() called for realm: {}, but this realm already doesn't exist! Namespace: {}",
+          realm, _namespace);
+      return true;
+    }
     return _zkClient.delete(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + realm);
   }
 
@@ -339,7 +345,8 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
         request = new HttpDelete(url);
         break;
       default:
-        throw new IllegalArgumentException("Unsupported request_method: " + request_method);
+        LOG.error("Unsupported request_method: " + request_method.name());
+        return false;
     }
 
     return sendRequestToLeader(request, expectedResponseCode, leaderHostName);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/metadatastore/MetadataStoreDirectoryAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/metadatastore/MetadataStoreDirectoryAccessor.java
@@ -108,6 +108,8 @@ public class MetadataStoreDirectoryAccessor extends AbstractResource {
       return JSONRepresentation(new MetadataStoreShardingKey(shardingKey, realm));
     } catch (NoSuchElementException ex) {
       return notFound(ex.getMessage());
+    } catch (IllegalArgumentException e) {
+      return badRequest(e.getMessage());
     }
   }
 
@@ -176,6 +178,8 @@ public class MetadataStoreDirectoryAccessor extends AbstractResource {
       return getAllShardingKeysUnderPath(prefix);
     } catch (NoSuchElementException ex) {
       return notFound(ex.getMessage());
+    } catch (IllegalArgumentException e) {
+      return badRequest(e.getMessage());
     }
   }
 
@@ -240,6 +244,8 @@ public class MetadataStoreDirectoryAccessor extends AbstractResource {
       return getRealmShardingKeysUnderPath(realm, prefix);
     } catch (NoSuchElementException ex) {
       return notFound(ex.getMessage());
+    } catch (IllegalArgumentException e) {
+      return badRequest(e.getMessage());
     }
   }
 
@@ -252,8 +258,10 @@ public class MetadataStoreDirectoryAccessor extends AbstractResource {
       if (!_metadataStoreDirectory.addShardingKey(_namespace, realm, shardingKey)) {
         return serverError();
       }
-    } catch (IllegalArgumentException ex) {
+    } catch (NoSuchElementException ex) {
       return notFound(ex.getMessage());
+    } catch (IllegalArgumentException e) {
+      return badRequest(e.getMessage());
     }
 
     return created();

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java
@@ -101,7 +101,7 @@ public class TestZkMetadataStoreDirectory extends AbstractTestClass {
     });
 
     System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY,
-        getBaseUri().toString());
+        getBaseUri().getHost() + ":" + getBaseUri().getPort());
 
     // Create metadataStoreDirectory
     for (Map.Entry<String, String> entry : _routingZkAddrMap.entrySet()) {

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
@@ -63,7 +63,7 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
   public void beforeClass() {
     _baseAccessor.remove(MetadataStoreRoutingConstants.ROUTING_DATA_PATH, AccessOption.PERSISTENT);
     System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY,
-        getBaseUri().toString());
+        getBaseUri().getHost() + ":" + getBaseUri().getPort());
     _zkRoutingDataWriter = new ZkRoutingDataWriter(DUMMY_NAMESPACE, ZK_ADDR);
   }
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/MetadataStoreDirectoryAccessorTestBase.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/MetadataStoreDirectoryAccessorTestBase.java
@@ -52,6 +52,7 @@ public class MetadataStoreDirectoryAccessorTestBase extends AbstractTestClass {
       Arrays.asList("/sharding/key/1/d", "/sharding/key/1/e", "/sharding/key/1/f");
   protected static final String TEST_REALM_3 = "testRealm3";
   protected static final String TEST_SHARDING_KEY = "/sharding/key/1/x";
+  protected static final String INVALID_TEST_SHARDING_KEY = "sharding/key/1/x";
 
   // List of all ZK addresses, each of which corresponds to a namespace/routing ZK
   protected List<String> _zkList;

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/MetadataStoreDirectoryAccessorTestBase.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/MetadataStoreDirectoryAccessorTestBase.java
@@ -93,7 +93,7 @@ public class MetadataStoreDirectoryAccessorTestBase extends AbstractTestClass {
     _routingDataReader = new ZkRoutingDataReader(TEST_NAMESPACE, _zkAddrTestNS, null);
 
     System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY,
-        getBaseUri().toString());
+        getBaseUri().getHost() + ":" + getBaseUri().getPort());
   }
 
   @AfterClass

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestMSDAccessorLeaderElection.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestMSDAccessorLeaderElection.java
@@ -74,7 +74,7 @@ public class TestMSDAccessorLeaderElection extends MetadataStoreDirectoryAccesso
     int newPort = getBaseUri().getPort() + 1;
 
     // Start a second server for testing Distributed Leader Election for writes
-    _mockBaseUri = HttpConstants.HTTP_PROTOCOL + getBaseUri().getHost() + ":" + newPort;
+    _mockBaseUri = HttpConstants.HTTP_PROTOCOL_PREFIX + getBaseUri().getHost() + ":" + newPort;
     try {
       List<HelixRestNamespace> namespaces = new ArrayList<>();
       // Add test namespace

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestMSDAccessorLeaderElection.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestMSDAccessorLeaderElection.java
@@ -74,7 +74,7 @@ public class TestMSDAccessorLeaderElection extends MetadataStoreDirectoryAccesso
     int newPort = getBaseUri().getPort() + 1;
 
     // Start a second server for testing Distributed Leader Election for writes
-    _mockBaseUri = getBaseUri().getScheme() + "://" + getBaseUri().getHost() + ":" + newPort;
+    _mockBaseUri = HttpConstants.HTTP_PROTOCOL + getBaseUri().getHost() + ":" + newPort;
     try {
       List<HelixRestNamespace> namespaces = new ArrayList<>();
       // Add test namespace
@@ -93,7 +93,8 @@ public class TestMSDAccessorLeaderElection extends MetadataStoreDirectoryAccesso
         Response.Status.OK.getStatusCode(), true);
 
     // Set the new uri to be used in leader election
-    System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY, _mockBaseUri);
+    System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY,
+        getBaseUri().getHost() + ":" + newPort);
 
     // Start http client for testing
     _httpClient = HttpClients.createDefault();

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestMetadataStoreDirectoryAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestMetadataStoreDirectoryAccessor.java
@@ -168,7 +168,6 @@ public class TestMetadataStoreDirectoryAccessor extends MetadataStoreDirectoryAc
     delete(TEST_NAMESPACE_URI_PREFIX + "/metadata-store-realms/" + TEST_REALM_3,
         Response.Status.OK.getStatusCode());
 
-
     Set<String> updateRealmsSet = getAllRealms();
     expectedRealmsSet.remove(TEST_REALM_3);
     Assert.assertEquals(updateRealmsSet, expectedRealmsSet);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #828, #832 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR fixes the following bugs:
1. When the routing data is not initialized for a namespace, creating a `ZkRoutingDataReader` for that namespace causes a NoNodeException due to a `getChildren` call. Fix: initialize the base node for routing data across all zookeeper-related actors (`ZkMetadataStoreDirectory`, `ZkRoutingDataReader`, `ZkRoutingDataWriter`)
2. In the `getRoutingData()` method of `ZkRoutingDataReader`, a null check is necessary before getting sharding keys from a realm node, because the realm node may be an invalid ZNRecord. Fix: add null check. 
3. The hostname provided from system properties does not have the protocol. `ZkRoutingDataWriter` was using the hostname directly for request forwarding. Fix: add protocol to the hostname before request forwarding. 
4. `ZkRoutingDataReader`'s `handleDataDeleted` is missing an unsubscribe operation which may lead to watcher leak; `handleChildChange` is missing the resubscription operation. Fix: add both.

This PR also introduced an improvement to `MetadataStoreDirectoryAccessor` endpoints. Previously, the endpoints in `MetadataStoreDirectoryAccessor` are missing proper status codes for some cases: for example for `IllegalArgumentException`, it's most fitting to return 400 Bad Request to users, but currently the exception will not be handled and cause a 500 to be returned. 
A change that can fix this issue while improving the status code behavior is to bind exception types with status codes. `NoSuchElementException` should be paired with 404, `IllegalArgumentException` should be paired with 400, while `IllegalStateException` (currently used when underlying ZkClients are closed) should be paired with 500. This has two major benefits:
1. Code maintenance is made easier. The exception types clearly and meaningfully translate to status codes. Developers no longer need to traverse layer by layer to figure out what happened to each exception; all of them are handled at the accessor layer.
2. The status codes are verbose and helpful, because they now contain the underlying exception messages that explain the exact reason behind the exceptions. 

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 136, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.201 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 136, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  52.954 s
[INFO] Finished at: 2020-02-27T12:06:15-08:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml