### PR TITLE
Make ConfigAccessor and ZkUtil realm-aware

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -899,16 +899,12 @@ public class ConfigAccessor {
      */
     private void validate() {
       // Resolve RealmMode based on other parameters
-      boolean isRealmModeSet = _realmMode != null;
       boolean isZkAddressSet = _zkAddress != null && !_zkAddress.isEmpty();
-      if (isRealmModeSet) {
-        if (_realmMode == RealmAwareZkClient.RealmMode.SINGLE_REALM && !isZkAddressSet) {
-          throw new HelixException(
-              "ConfigAccessor: RealmMode cannot be single-realm without a valid ZkAddress set!");
-        }
-        // If realm mode is set to multi-realm, we simply ignore the given ZK address
-      } else {
-        // If zkAddress is set, that implies single-realm mode. Otherwise, multi-realm mode.
+      if (_realmMode == RealmAwareZkClient.RealmMode.SINGLE_REALM && !isZkAddressSet) {
+        throw new HelixException(
+            "ConfigAccessor: RealmMode cannot be single-realm without a valid ZkAddress set!");
+      }
+      if (_realmMode == null) {
         _realmMode = isZkAddressSet ? RealmAwareZkClient.RealmMode.SINGLE_REALM
             : RealmAwareZkClient.RealmMode.MULTI_REALM;
       }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -66,10 +66,6 @@ public final class ZKUtil {
     return result;
   }
 
-  public static boolean isClusterSetup(String clusterName, HelixZkClient zkClient) {
-    return isClusterSetup(clusterName, (RealmAwareZkClient) zkClient);
-  }
-
   public static boolean isClusterSetup(String clusterName, RealmAwareZkClient zkClient) {
     if (clusterName == null) {
       logger.info("Fail to check cluster setup : cluster name is null!");
@@ -80,7 +76,7 @@ public final class ZKUtil {
       logger.info("Fail to check cluster setup : zookeeper client is null!");
       return false;
     }
-    ArrayList<String> requiredPaths = new ArrayList<>();
+    List<String> requiredPaths = new ArrayList<>();
     requiredPaths.add(PropertyPathBuilder.idealState(clusterName));
     requiredPaths.add(PropertyPathBuilder.clusterConfig(clusterName));
     requiredPaths.add(PropertyPathBuilder.instanceConfig(clusterName));
@@ -99,7 +95,11 @@ public final class ZKUtil {
 
     boolean[] ret = new boolean[requiredPaths.size()];
     for (int i = 0; i < requiredPaths.size(); i++) {
-      ret[i] = zkClient.exists(requiredPaths.get(i));
+      try {
+        ret[i] = zkClient.exists(requiredPaths.get(i));
+      } catch (Exception e) {
+        ret[i] = false;
+      }
     }
     StringBuilder errorMsg = new StringBuilder();
 
@@ -139,15 +139,10 @@ public final class ZKUtil {
     return result;
   }
 
-  public static boolean isInstanceSetup(HelixZkClient zkClient, String clusterName,
-      String instanceName, InstanceType type) {
-    return isInstanceSetup((RealmAwareZkClient) zkClient, clusterName, instanceName, type);
-  }
-
   public static boolean isInstanceSetup(RealmAwareZkClient zkclient, String clusterName,
       String instanceName, InstanceType type) {
     if (type == InstanceType.PARTICIPANT || type == InstanceType.CONTROLLER_PARTICIPANT) {
-      ArrayList<String> requiredPaths = new ArrayList<>();
+      List<String> requiredPaths = new ArrayList<>();
       requiredPaths.add(PropertyPathBuilder.instanceConfig(clusterName, instanceName));
       requiredPaths.add(PropertyPathBuilder.instanceMessage(clusterName, instanceName));
       requiredPaths.add(PropertyPathBuilder.instanceCurrentState(clusterName, instanceName));
@@ -192,10 +187,6 @@ public final class ZKUtil {
     }
   }
 
-  public static void createChildren(HelixZkClient client, String parentPath, List<ZNRecord> list) {
-    createChildren((RealmAwareZkClient) client, parentPath, list);
-  }
-
   public static void createChildren(RealmAwareZkClient client, String parentPath,
       List<ZNRecord> list) {
     client.createPersistent(parentPath, true);
@@ -222,10 +213,6 @@ public final class ZKUtil {
     }
   }
 
-  public static void createChildren(HelixZkClient client, String parentPath, ZNRecord nodeRecord) {
-    createChildren((RealmAwareZkClient) client, parentPath, nodeRecord);
-  }
-
   public static void createChildren(RealmAwareZkClient client, String parentPath,
       ZNRecord nodeRecord) {
     client.createPersistent(parentPath, true);
@@ -249,10 +236,6 @@ public final class ZKUtil {
     } finally {
       zkClient.close();
     }
-  }
-
-  public static void dropChildren(HelixZkClient client, String parentPath, List<ZNRecord> list) {
-    dropChildren((RealmAwareZkClient) client, parentPath, list);
   }
 
   public static void dropChildren(RealmAwareZkClient client, String parentPath,
@@ -281,10 +264,6 @@ public final class ZKUtil {
     }
   }
 
-  public static void dropChildren(HelixZkClient client, String parentPath, ZNRecord nodeRecord) {
-    dropChildren((RealmAwareZkClient) client, parentPath, nodeRecord);
-  }
-
   public static void dropChildren(RealmAwareZkClient client, String parentPath,
       ZNRecord nodeRecord) {
     // TODO: check if parentPath exists
@@ -309,10 +288,6 @@ public final class ZKUtil {
       zkClient.close();
     }
     return result;
-  }
-
-  public static List<ZNRecord> getChildren(HelixZkClient client, String path) {
-    return getChildren((RealmAwareZkClient) client, path);
   }
 
   public static List<ZNRecord> getChildren(RealmAwareZkClient client, String path) {
@@ -356,11 +331,6 @@ public final class ZKUtil {
     }
   }
 
-  public static void updateIfExists(HelixZkClient client, String path, final ZNRecord record,
-      boolean mergeOnUpdate) {
-    updateIfExists((RealmAwareZkClient) client, path, record, mergeOnUpdate);
-  }
-
   public static void updateIfExists(RealmAwareZkClient client, String path, final ZNRecord record,
       boolean mergeOnUpdate) {
     if (client.exists(path)) {
@@ -391,11 +361,6 @@ public final class ZKUtil {
     } finally {
       zkClient.close();
     }
-  }
-
-  public static void createOrMerge(HelixZkClient client, String path, final ZNRecord record,
-      final boolean persistent, final boolean mergeOnUpdate) {
-    createOrMerge((RealmAwareZkClient) client, path, record, persistent, mergeOnUpdate);
   }
 
   public static void createOrMerge(RealmAwareZkClient client, String path, final ZNRecord record,
@@ -453,11 +418,6 @@ public final class ZKUtil {
     }
   }
 
-  public static void createOrUpdate(HelixZkClient client, String path, final ZNRecord record,
-      final boolean persistent, final boolean mergeOnUpdate) {
-    createOrUpdate((RealmAwareZkClient) client, path, record, persistent, mergeOnUpdate);
-  }
-
   public static void createOrUpdate(RealmAwareZkClient client, String path, final ZNRecord record,
       final boolean persistent, final boolean mergeOnUpdate) {
     int retryCount = 0;
@@ -505,11 +465,6 @@ public final class ZKUtil {
     } finally {
       zkClient.close();
     }
-  }
-
-  public static void asyncCreateOrMerge(HelixZkClient client, String path, final ZNRecord record,
-      final boolean persistent, final boolean mergeOnUpdate) {
-    asyncCreateOrMerge((RealmAwareZkClient) client, path, record, persistent, mergeOnUpdate);
   }
 
   public static void asyncCreateOrMerge(RealmAwareZkClient client, String path,
@@ -565,11 +520,6 @@ public final class ZKUtil {
     }
   }
 
-  public static void createOrReplace(HelixZkClient client, String path, final ZNRecord record,
-      final boolean persistent) {
-    createOrReplace((RealmAwareZkClient) client, path, record, persistent);
-  }
-
   public static void createOrReplace(RealmAwareZkClient client, String path, final ZNRecord record,
       final boolean persistent) {
     int retryCount = 0;
@@ -611,11 +561,6 @@ public final class ZKUtil {
     } finally {
       zkClient.close();
     }
-  }
-
-  public static void subtract(HelixZkClient client, final String path,
-      final ZNRecord recordTosubtract) {
-    subtract((RealmAwareZkClient) client, path, recordTosubtract);
   }
 
   public static void subtract(RealmAwareZkClient client, final String path,

--- a/metadata-store-directory-common/pom.xml
+++ b/metadata-store-directory-common/pom.xml
@@ -33,8 +33,6 @@ under the License.
 
   <properties>
     <osgi.import>
-      org.apache.commons.cli*,
-      org.apache.commons.io*;version="[1.4,2)",
       org.slf4j*;version="[1.6,2)",
       *
     </osgi.import>
@@ -67,11 +65,6 @@ under the License.
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.8.1</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
-      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
@@ -19,7 +19,6 @@ package org.apache.helix.zookeeper.api.client;
  * under the License.
  */
 
-import org.apache.helix.zookeeper.zkclient.ZkClient;
 import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
@@ -150,8 +150,8 @@ public interface HelixZkClient extends RealmAwareZkClient {
     }
 
     @Override
-    public ZkClientConfig setConnectInitTimeout(long _connectInitTimeout) {
-      this._connectInitTimeout = _connectInitTimeout;
+    public ZkClientConfig setConnectInitTimeout(long connectInitTimeout) {
+      this._connectInitTimeout = connectInitTimeout;
       return this;
     }
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -58,7 +58,10 @@ public interface RealmAwareZkClient {
    * SINGLE_REALM: CRUD, change subscription, and EPHEMERAL CreateMode are supported.
    * MULTI_REALM: CRUD and change subscription are supported. Operations involving EPHEMERAL CreateMode will throw an UnsupportedOperationException.
    */
-  enum RealmMode {SINGLE_REALM, MULTI_REALM}
+  enum RealmMode {
+    SINGLE_REALM,
+    MULTI_REALM
+  }
 
   int DEFAULT_OPERATION_TIMEOUT = Integer.MAX_VALUE;
   int DEFAULT_CONNECTION_TIMEOUT = 60 * 1000;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -59,8 +59,7 @@ public interface RealmAwareZkClient {
    * MULTI_REALM: CRUD and change subscription are supported. Operations involving EPHEMERAL CreateMode will throw an UnsupportedOperationException.
    */
   enum RealmMode {
-    SINGLE_REALM,
-    MULTI_REALM
+    SINGLE_REALM, MULTI_REALM
   }
 
   int DEFAULT_OPERATION_TIMEOUT = Integer.MAX_VALUE;
@@ -443,24 +442,14 @@ public interface RealmAwareZkClient {
        * Validate the internal fields of the builder before creating an instance.
        */
       private void validate() {
-        boolean isRealmModeSet = _realmMode != null;
         boolean isShardingKeySet = _zkRealmShardingKey != null && !_zkRealmShardingKey.isEmpty();
-        switch (isRealmModeSet ? _realmMode : RealmMode.MULTI_REALM) {
-          case MULTI_REALM:
-            if (isShardingKeySet && isRealmModeSet) {
-              throw new IllegalArgumentException(
-                  "ZK sharding key cannot be set on multi-realm mode! Sharding key: "
-                      + _zkRealmShardingKey);
-            }
-            break;
-          case SINGLE_REALM:
-            if (!isShardingKeySet) {
-              throw new IllegalArgumentException(
-                  "ZK sharding key must be set on single-realm mode!");
-            }
-            break;
-          default:
-            throw new ZkClientException("RealmAwareZkConnectionConfig: Unknown mode!");
+        if (_realmMode == RealmMode.MULTI_REALM && isShardingKeySet) {
+          throw new IllegalArgumentException(
+              "ZK sharding key cannot be set on multi-realm mode! Sharding key: "
+                  + _zkRealmShardingKey);
+        }
+        if (_realmMode == RealmMode.SINGLE_REALM && !isShardingKeySet) {
+          throw new IllegalArgumentException("ZK sharding key must be set on single-realm mode!");
         }
       }
     }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -479,5 +479,7 @@ public interface RealmAwareZkClient {
     public long getConnectInitTimeout() {
       return _connectInitTimeout;
     }
+
+    public HelixZkClient.ZkClientConfig getZkClientConfig
   }
 }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientTestBase.java
@@ -85,8 +85,10 @@ public abstract class RealmAwareZkClientTestBase extends ZkTestBase {
         new RealmAwareZkClient.RealmAwareZkClientConfig();
 
     // Create a connection config with the invalid sharding key
+    RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder builder =
+        new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder();
     RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =
-        new RealmAwareZkClient.RealmAwareZkConnectionConfig(invalidShardingKey);
+        builder.setZkRealmShardingKey(invalidShardingKey).build();
 
     try {
       _realmAwareZkClient = _realmAwareZkClientFactory
@@ -98,7 +100,8 @@ public abstract class RealmAwareZkClientTestBase extends ZkTestBase {
 
     // Use a valid sharding key this time around
     String validShardingKey = ZK_SHARDING_KEY_PREFIX + "_" + 0; // Use TEST_SHARDING_KEY_0
-    connectionConfig = new RealmAwareZkClient.RealmAwareZkConnectionConfig(validShardingKey);
+    builder.setZkRealmShardingKey(validShardingKey);
+    connectionConfig = builder.build();
     _realmAwareZkClient = _realmAwareZkClientFactory
         .buildZkClient(connectionConfig, clientConfig, _metadataStoreRoutingData);
   }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #839 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

To make Helix Java APIs realm-aware, we first make ConfigAccessor and ZkUtil realm-aware by instrumenting these APIs with a Builder and RealmAwareZkClients.

The Builder pattern is chosen because it is a scalable option when there are a lot of configurable parameters. It makes it easy to validate the given parameters as well.

### Tests

- [x] The following tests are written for this issue:

ConfigAccessor is already covered by TestConfigAccessor.

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestEnableCompression.testEnableCompressionResource:108 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1083, Failures: 1, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:08 h
[INFO] Finished at: 2020-02-29T20:46:35-08:00


TestCompression passes when run individually

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)