### PR TITLE
Implement setRoutingData for MetadataStoreDirectoryService

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/MetadataStoreDirectory.java
@@ -61,6 +61,15 @@ public interface MetadataStoreDirectory extends AutoCloseable {
   Map<String, List<String>> getNamespaceRoutingData(String namespace);
 
   /**
+   * Sets and overwrites routing data in the given namespace.
+   *
+   * @param namespace namespace in metadata store directory.
+   * @param routingData Routing data map: realm -> List of sharding keys
+   * @return true if successful; false otherwise.
+   */
+  boolean setNamespaceRoutingData(String namespace, Map<String, List<String>> routingData);
+
+  /**
    * Returns all path-based sharding keys in the given namespace and the realm.
    * @param namespace
    * @param realm

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -161,11 +161,11 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
 
   @Override
   public boolean setNamespaceRoutingData(String namespace, Map<String, List<String>> routingData) {
+    if (!_routingDataWriterMap.containsKey(namespace)) {
+      throw new IllegalArgumentException(
+          "Failed to set routing data: Namespace " + namespace + " is not found!");
+    }
     synchronized (this) {
-      if (!_routingDataWriterMap.containsKey(namespace)) {
-        throw new IllegalArgumentException(
-            "Failed to set routing data: Namespace " + namespace + " is not found!");
-      }
       boolean result = _routingDataWriterMap.get(namespace).setRoutingData(routingData);
       refreshRoutingData(namespace);
       return result;
@@ -216,13 +216,13 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
 
   @Override
   public boolean addMetadataStoreRealm(String namespace, String realm) {
+    if (!_routingDataWriterMap.containsKey(namespace)) {
+      // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
+      // status code in the Accessor level
+      throw new NoSuchElementException(
+          "Failed to add metadata store realm: Namespace " + namespace + " is not found!");
+    }
     synchronized (this) {
-      if (!_routingDataWriterMap.containsKey(namespace)) {
-        // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
-        // status code in the Accessor level
-        throw new NoSuchElementException(
-            "Failed to add metadata store realm: Namespace " + namespace + " is not found!");
-      }
       boolean result = _routingDataWriterMap.get(namespace).addMetadataStoreRealm(realm);
       refreshRoutingData(namespace);
       return result;
@@ -231,13 +231,13 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
 
   @Override
   public boolean deleteMetadataStoreRealm(String namespace, String realm) {
+    if (!_routingDataWriterMap.containsKey(namespace)) {
+      // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
+      // status code in the Accessor level
+      throw new NoSuchElementException(
+          "Failed to delete metadata store realm: Namespace " + namespace + " is not found!");
+    }
     synchronized (this) {
-      if (!_routingDataWriterMap.containsKey(namespace)) {
-        // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
-        // status code in the Accessor level
-        throw new NoSuchElementException(
-            "Failed to delete metadata store realm: Namespace " + namespace + " is not found!");
-      }
       boolean result = _routingDataWriterMap.get(namespace).deleteMetadataStoreRealm(realm);
       refreshRoutingData(namespace);
       return result;
@@ -246,13 +246,13 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
 
   @Override
   public boolean addShardingKey(String namespace, String realm, String shardingKey) {
+    if (!_routingDataWriterMap.containsKey(namespace)) {
+      // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
+      // status code in the Accessor level
+      throw new NoSuchElementException(
+          "Failed to add sharding key: Namespace " + namespace + " is not found!");
+    }
     synchronized (this) {
-      if (!_routingDataWriterMap.containsKey(namespace)) {
-        // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
-        // status code in the Accessor level
-        throw new NoSuchElementException(
-            "Failed to add sharding key: Namespace " + namespace + " is not found!");
-      }
       if (_routingDataMap.containsKey(namespace) && _routingDataMap.get(namespace)
           .containsKeyRealmPair(shardingKey, realm)) {
         return true;
@@ -271,13 +271,13 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
 
   @Override
   public boolean deleteShardingKey(String namespace, String realm, String shardingKey) {
+    if (!_routingDataWriterMap.containsKey(namespace)) {
+      // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
+      // status code in the Accessor level
+      throw new NoSuchElementException(
+          "Failed to delete sharding key: Namespace " + namespace + " is not found!");
+    }
     synchronized (this) {
-      if (!_routingDataWriterMap.containsKey(namespace)) {
-        // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
-        // status code in the Accessor level
-        throw new NoSuchElementException(
-            "Failed to delete sharding key: Namespace " + namespace + " is not found!");
-      }
       boolean result = _routingDataWriterMap.get(namespace).deleteShardingKey(realm, shardingKey);
       refreshRoutingData(namespace);
       return result;

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -119,7 +119,7 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
           try {
             _routingDataMap.put(namespace, new TrieRoutingData(rawRoutingData));
           } catch (InvalidRoutingDataException e) {
-            // Do not create TrieRoutingData if the routing data is invalid
+            LOG.warn("TrieRoutingData is not created for namespace {}", namespace, e);
           }
         }
       }
@@ -194,7 +194,7 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
     // If namespace is included but not routing data, it means the routing data is invalid
     if (!_routingDataMap.containsKey(namespace)) {
       throw new IllegalStateException("Failed to get all mapping under path: Namespace " + namespace
-          + " contains invalid routing data!");
+          + " contains either empty or invalid routing data!");
     }
     return _routingDataMap.get(namespace).getAllMappingUnderPath(path);
   }
@@ -209,7 +209,7 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
     // If namespace is included but not routing data, it means the routing data is invalid
     if (!_routingDataMap.containsKey(namespace)) {
       throw new IllegalStateException("Failed to get metadata store realm: Namespace " + namespace
-          + " contains invalid routing data!");
+          + " contains either empty or invalid routing data!");
     }
     return _routingDataMap.get(namespace).getMetadataStoreRealm(shardingKey);
   }
@@ -324,7 +324,7 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
     try {
       _routingDataMap.put(namespace, new TrieRoutingData(rawRoutingData));
     } catch (InvalidRoutingDataException e) {
-      // Do not create TrieRoutingData if the routing data is invalid
+      LOG.warn("TrieRoutingData is not created for namespace {}", namespace, e);
     }
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -113,10 +113,14 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
           _routingDataWriterMap.put(namespace, new ZkRoutingDataWriter(namespace, zkAddress));
 
           // Populate realmToShardingKeys with ZkRoutingDataReader
-          _realmToShardingKeysMap
-              .put(namespace, _routingDataReaderMap.get(namespace).getRoutingData());
-          _routingDataMap
-              .put(namespace, new TrieRoutingData(_realmToShardingKeysMap.get(namespace)));
+          Map<String, List<String>> rawRoutingData =
+              _routingDataReaderMap.get(namespace).getRoutingData();
+          _realmToShardingKeysMap.put(namespace, rawRoutingData);
+          try {
+            _routingDataMap.put(namespace, new TrieRoutingData(rawRoutingData));
+          } catch (InvalidRoutingDataException e) {
+            // Do not create TrieRoutingData if the routing data is invalid
+          }
         }
       }
     }
@@ -156,6 +160,19 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
   }
 
   @Override
+  public boolean setNamespaceRoutingData(String namespace, Map<String, List<String>> routingData) {
+    synchronized (this) {
+      if (!_routingDataWriterMap.containsKey(namespace)) {
+        throw new IllegalArgumentException(
+            "Failed to set routing data: Namespace " + namespace + " is not found!");
+      }
+      boolean result = _routingDataWriterMap.get(namespace).setRoutingData(routingData);
+      refreshRoutingData(namespace);
+      return result;
+    }
+  }
+
+  @Override
   public Collection<String> getAllShardingKeysInRealm(String namespace, String realm) {
     if (!_realmToShardingKeysMap.containsKey(namespace)) {
       throw new NoSuchElementException("Namespace " + namespace + " does not exist!");
@@ -169,72 +186,102 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
 
   @Override
   public Map<String, String> getAllMappingUnderPath(String namespace, String path) {
-    if (!_routingDataMap.containsKey(namespace)) {
+    // Check _routingZkAddressMap first to see if namespace is included
+    if (!_routingZkAddressMap.containsKey(namespace)) {
       throw new NoSuchElementException(
           "Failed to get all mapping under path: Namespace " + namespace + " is not found!");
+    }
+    // If namespace is included but not routing data, it means the routing data is invalid
+    if (!_routingDataMap.containsKey(namespace)) {
+      throw new IllegalStateException("Failed to get all mapping under path: Namespace " + namespace
+          + " contains invalid routing data!");
     }
     return _routingDataMap.get(namespace).getAllMappingUnderPath(path);
   }
 
   @Override
   public String getMetadataStoreRealm(String namespace, String shardingKey) {
-    if (!_routingDataMap.containsKey(namespace)) {
+    // Check _routingZkAddressMap first to see if namespace is included
+    if (!_routingZkAddressMap.containsKey(namespace)) {
       throw new NoSuchElementException(
           "Failed to get metadata store realm: Namespace " + namespace + " is not found!");
+    }
+    // If namespace is included but not routing data, it means the routing data is invalid
+    if (!_routingDataMap.containsKey(namespace)) {
+      throw new IllegalStateException("Failed to get metadata store realm: Namespace " + namespace
+          + " contains invalid routing data!");
     }
     return _routingDataMap.get(namespace).getMetadataStoreRealm(shardingKey);
   }
 
   @Override
   public boolean addMetadataStoreRealm(String namespace, String realm) {
-    if (!_routingDataWriterMap.containsKey(namespace)) {
-      // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
-      // status code in the Accessor level
-      throw new NoSuchElementException(
-          "Failed to add metadata store realm: Namespace " + namespace + " is not found!");
+    synchronized (this) {
+      if (!_routingDataWriterMap.containsKey(namespace)) {
+        // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
+        // status code in the Accessor level
+        throw new NoSuchElementException(
+            "Failed to add metadata store realm: Namespace " + namespace + " is not found!");
+      }
+      boolean result = _routingDataWriterMap.get(namespace).addMetadataStoreRealm(realm);
+      refreshRoutingData(namespace);
+      return result;
     }
-    return _routingDataWriterMap.get(namespace).addMetadataStoreRealm(realm);
   }
 
   @Override
   public boolean deleteMetadataStoreRealm(String namespace, String realm) {
-    if (!_routingDataWriterMap.containsKey(namespace)) {
-      // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
-      // status code in the Accessor level
-      throw new NoSuchElementException(
-          "Failed to delete metadata store realm: Namespace " + namespace + " is not found!");
+    synchronized (this) {
+      if (!_routingDataWriterMap.containsKey(namespace)) {
+        // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
+        // status code in the Accessor level
+        throw new NoSuchElementException(
+            "Failed to delete metadata store realm: Namespace " + namespace + " is not found!");
+      }
+      boolean result = _routingDataWriterMap.get(namespace).deleteMetadataStoreRealm(realm);
+      refreshRoutingData(namespace);
+      return result;
     }
-    return _routingDataWriterMap.get(namespace).deleteMetadataStoreRealm(realm);
   }
 
   @Override
   public boolean addShardingKey(String namespace, String realm, String shardingKey) {
-    if (!_routingDataWriterMap.containsKey(namespace) || !_routingDataMap.containsKey(namespace)) {
-      // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
-      // status code in the Accessor level
-      throw new NoSuchElementException(
-          "Failed to add sharding key: Namespace " + namespace + " is not found!");
+    synchronized (this) {
+      if (!_routingDataWriterMap.containsKey(namespace)) {
+        // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
+        // status code in the Accessor level
+        throw new NoSuchElementException(
+            "Failed to add sharding key: Namespace " + namespace + " is not found!");
+      }
+      if (_routingDataMap.containsKey(namespace) && _routingDataMap.get(namespace)
+          .containsKeyRealmPair(shardingKey, realm)) {
+        return true;
+      }
+      if (_routingDataMap.containsKey(namespace) && !_routingDataMap.get(namespace)
+          .isShardingKeyInsertionValid(shardingKey)) {
+        throw new IllegalArgumentException(
+            "Failed to add sharding key: Adding sharding key " + shardingKey
+                + " makes routing data invalid!");
+      }
+      boolean result = _routingDataWriterMap.get(namespace).addShardingKey(realm, shardingKey);
+      refreshRoutingData(namespace);
+      return result;
     }
-    if (_routingDataMap.get(namespace).containsKeyRealmPair(shardingKey, realm)) {
-      return true;
-    }
-    if (!_routingDataMap.get(namespace).isShardingKeyInsertionValid(shardingKey)) {
-      throw new IllegalArgumentException(
-          "Failed to add sharding key: Adding sharding key " + shardingKey
-              + " makes routing data invalid!");
-    }
-    return _routingDataWriterMap.get(namespace).addShardingKey(realm, shardingKey);
   }
 
   @Override
   public boolean deleteShardingKey(String namespace, String realm, String shardingKey) {
-    if (!_routingDataWriterMap.containsKey(namespace)) {
-      // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
-      // status code in the Accessor level
-      throw new NoSuchElementException(
-          "Failed to delete sharding key: Namespace " + namespace + " is not found!");
+    synchronized (this) {
+      if (!_routingDataWriterMap.containsKey(namespace)) {
+        // throwing NoSuchElementException instead of IllegalArgumentException to differentiate the
+        // status code in the Accessor level
+        throw new NoSuchElementException(
+            "Failed to delete sharding key: Namespace " + namespace + " is not found!");
+      }
+      boolean result = _routingDataWriterMap.get(namespace).deleteShardingKey(realm, shardingKey);
+      refreshRoutingData(namespace);
+      return result;
     }
-    return _routingDataWriterMap.get(namespace).deleteShardingKey(realm, shardingKey);
   }
 
   /**
@@ -251,7 +298,7 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
     // Safe to ignore the callback if any of the maps are null.
     // If routingDataMap is null, then it will be populated by the constructor anyway
     // If routingDataMap is not null, then it's safe for the callback function to update it
-    if (_routingZkAddressMap == null || _routingDataMap == null || _realmToShardingKeysMap == null
+    if (_routingZkAddressMap == null || _realmToShardingKeysMap == null
         || _routingDataReaderMap == null || _routingDataWriterMap == null) {
       LOG.warn(
           "refreshRoutingData callback called before ZKMetadataStoreDirectory was fully initialized. Skipping refresh!");
@@ -262,17 +309,22 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
     if (!_routingZkAddressMap.containsKey(namespace)) {
       LOG.error(
           "Failed to refresh internally-cached routing data! Namespace not found: " + namespace);
+      return;
+    }
+
+    Map<String, List<String>> rawRoutingData;
+    try {
+      rawRoutingData = _routingDataReaderMap.get(namespace).getRoutingData();
+      _realmToShardingKeysMap.put(namespace, rawRoutingData);
+    } catch (InvalidRoutingDataException e) {
+      LOG.error("Failed to refresh cached routing data for namespace {}", namespace, e);
+      return;
     }
 
     try {
-      Map<String, List<String>> rawRoutingData =
-          _routingDataReaderMap.get(namespace).getRoutingData();
-      _realmToShardingKeysMap.put(namespace, rawRoutingData);
-
-      MetadataStoreRoutingData routingData = new TrieRoutingData(rawRoutingData);
-      _routingDataMap.put(namespace, routingData);
+      _routingDataMap.put(namespace, new TrieRoutingData(rawRoutingData));
     } catch (InvalidRoutingDataException e) {
-      LOG.error("Failed to refresh cached routing data for namespace {}", namespace, e);
+      // Do not create TrieRoutingData if the routing data is invalid
     }
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/MetadataStoreRoutingDataWriter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/MetadataStoreRoutingDataWriter.java
@@ -63,7 +63,7 @@ public interface MetadataStoreRoutingDataWriter {
    * Sets (overwrites) the routing data with the given <realm, list of sharding keys> mapping.
    * WARNING: This overwrites all existing routing data. Use with care!
    * @param routingData
-   * @return
+   * @return true if successful; false otherwise.
    */
   boolean setRoutingData(Map<String, List<String>> routingData);
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
@@ -99,7 +99,7 @@ public class ZkRoutingDataReader implements MetadataStoreRoutingDataReader, IZkD
     if (allRealmAddresses != null) {
       for (String realmAddress : allRealmAddresses) {
         ZNRecord record = _zkClient
-            .readData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + realmAddress);
+            .readData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + realmAddress, true);
         if (record != null) {
           List<String> shardingKeys =
               record.getListField(MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY);

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
@@ -57,6 +57,7 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
   // Time out for http requests that are forwarded to leader instances measured in milliseconds
   private static final int HTTP_REQUEST_FORWARDING_TIMEOUT = 60 * 1000;
   private static final Logger LOG = LoggerFactory.getLogger(ZkRoutingDataWriter.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final String _namespace;
   private final HelixZkClient _zkClient;
@@ -220,7 +221,7 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
     HttpPut httpPut = new HttpPut(url);
     String routingDataJsonString;
     try {
-      routingDataJsonString = new ObjectMapper().writeValueAsString(routingData);
+      routingDataJsonString = OBJECT_MAPPER.writeValueAsString(routingData);
     } catch (JsonGenerationException | JsonMappingException e) {
       throw new IllegalArgumentException(e.getMessage());
     } catch (IOException e) {
@@ -350,12 +351,12 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
   }
 
   private boolean buildAndSendRequestToLeader(String urlSuffix,
-      HttpConstants.RestVerbs request_method, int expectedResponseCode)
+      HttpConstants.RestVerbs requestMethod, int expectedResponseCode)
       throws IllegalArgumentException {
     String leaderHostName = _leaderElection.getCurrentLeaderInfo().getId();
     String url = leaderHostName + urlSuffix;
     HttpUriRequest request;
-    switch (request_method) {
+    switch (requestMethod) {
       case PUT:
         request = new HttpPut(url);
         break;
@@ -363,7 +364,7 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
         request = new HttpDelete(url);
         break;
       default:
-        LOG.error("Unsupported request_method: " + request_method.name());
+        LOG.error("Unsupported requestMethod: " + requestMethod.name());
         return false;
     }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
@@ -225,6 +225,9 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
     } catch (JsonGenerationException | JsonMappingException e) {
       throw new IllegalArgumentException(e.getMessage());
     } catch (IOException e) {
+      LOG.error(
+          "setRoutingData failed before forwarding the request to leader: an exception happened while routingData is converted to json. routingData: {}",
+          routingData, e);
       return false;
     }
     httpPut.setEntity(new StringEntity(routingDataJsonString, ContentType.APPLICATION_JSON));
@@ -364,8 +367,7 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
         request = new HttpDelete(url);
         break;
       default:
-        LOG.error("Unsupported requestMethod: " + requestMethod.name());
-        return false;
+        throw new IllegalArgumentException("Unsupported requestMethod: " + requestMethod.name());
     }
 
     return sendRequestToLeader(request, expectedResponseCode, leaderHostName);

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/concurrency/ZkDistributedLeaderElection.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/concurrency/ZkDistributedLeaderElection.java
@@ -59,6 +59,7 @@ public class ZkDistributedLeaderElection implements IZkDataListener, IZkStateLis
       }
       _basePath = basePath;
       _participantInfo = participantInfo;
+      _isLeader = false;
     }
     init();
   }
@@ -67,7 +68,6 @@ public class ZkDistributedLeaderElection implements IZkDataListener, IZkStateLis
    * Create the base path if it doesn't exist and create an ephemeral sequential ZNode.
    */
   private void init() {
-    _isLeader = false;
     try {
       _zkClient.createPersistent(_basePath, true);
     } catch (ZkNodeExistsException e) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/concurrency/ZkDistributedLeaderElection.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/concurrency/ZkDistributedLeaderElection.java
@@ -59,7 +59,6 @@ public class ZkDistributedLeaderElection implements IZkDataListener, IZkStateLis
       }
       _basePath = basePath;
       _participantInfo = participantInfo;
-      _isLeader = false;
     }
     init();
   }
@@ -68,6 +67,7 @@ public class ZkDistributedLeaderElection implements IZkDataListener, IZkStateLis
    * Create the base path if it doesn't exist and create an ephemeral sequential ZNode.
    */
   private void init() {
+    _isLeader = false;
     try {
       _zkClient.createPersistent(_basePath, true);
     } catch (ZkNodeExistsException e) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/metadatastore/MetadataStoreDirectoryAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/metadatastore/MetadataStoreDirectoryAccessor.java
@@ -50,7 +50,6 @@ import org.apache.helix.rest.metadatastore.datamodel.MetadataStoreShardingKeysBy
 import org.apache.helix.rest.server.resources.AbstractResource;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -233,8 +232,8 @@ public class MetadataStoreDirectoryAccessor extends AbstractResource {
   @Consumes(MediaType.APPLICATION_JSON)
   public Response setRoutingData(String jsonContent) {
     try {
-      Map<String, List<String>> routingData = new ObjectMapper()
-          .readValue(jsonContent, new TypeReference<HashMap<String, List<String>>>() {
+      Map<String, List<String>> routingData =
+          OBJECT_MAPPER.readValue(jsonContent, new TypeReference<HashMap<String, List<String>>>() {
           });
       _metadataStoreDirectory.setNamespaceRoutingData(_namespace, routingData);
     } catch (JsonMappingException | JsonParseException | IllegalArgumentException e) {

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataReader.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataReader.java
@@ -24,12 +24,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.helix.AccessOption;
 import org.apache.helix.TestHelper;
 import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.rest.server.AbstractTestClass;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.zkclient.ZkClient;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -38,23 +38,24 @@ import org.testng.annotations.Test;
 
 
 public class TestZkRoutingDataReader extends AbstractTestClass {
-  private static final String DUMMY_NAMESPACE = "NAMESPACE";
   private MetadataStoreRoutingDataReader _zkRoutingDataReader;
+  private ZkClient _zkClient;
 
   @BeforeClass
-  public void beforeClass() {
-    _zkRoutingDataReader = new ZkRoutingDataReader(DUMMY_NAMESPACE, ZK_ADDR, null);
+  public void beforeClass() throws Exception {
+    _zkClient = ZK_SERVER_MAP.get(_zkAddrTestNS).getZkClient();
+    _zkRoutingDataReader = new ZkRoutingDataReader(TEST_NAMESPACE, _zkAddrTestNS, null);
     clearRoutingDataPath();
   }
 
   @AfterClass
-  public void afterClass() {
+  public void afterClass() throws Exception {
     _zkRoutingDataReader.close();
     clearRoutingDataPath();
   }
 
   @AfterMethod
-  public void afterMethod() {
+  public void afterMethod() throws Exception {
     clearRoutingDataPath();
   }
 
@@ -75,10 +76,14 @@ public class TestZkRoutingDataReader extends AbstractTestClass {
         .setListField(MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY, testShardingKeys2);
 
     // Add both nodes as children nodes to ZkRoutingDataReader.ROUTING_DATA_PATH
-    _baseAccessor.create(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1",
-        testZnRecord1, AccessOption.PERSISTENT);
-    _baseAccessor.create(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress2",
-        testZnRecord2, AccessOption.PERSISTENT);
+    _zkClient
+        .createPersistent(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1");
+    _zkClient.writeData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1",
+        testZnRecord1);
+    _zkClient
+        .createPersistent(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress2");
+    _zkClient.writeData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress2",
+        testZnRecord2);
 
     try {
       Map<String, List<String>> routingData = _zkRoutingDataReader.getRoutingData();
@@ -105,8 +110,10 @@ public class TestZkRoutingDataReader extends AbstractTestClass {
     ZNRecord testZnRecord1 = new ZNRecord("testZnRecord1");
     testZnRecord1.setListField(MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY,
         Collections.emptyList());
-    _baseAccessor.create(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1",
-        testZnRecord1, AccessOption.PERSISTENT);
+    _zkClient
+        .createPersistent(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1");
+    _zkClient.writeData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1",
+        testZnRecord1);
     try {
       Map<String, List<String>> routingData = _zkRoutingDataReader.getRoutingData();
       Assert.assertEquals(routingData.size(), 1);
@@ -116,11 +123,14 @@ public class TestZkRoutingDataReader extends AbstractTestClass {
     }
   }
 
-  private void clearRoutingDataPath() {
-    for (String zkRealm : _baseAccessor
-        .getChildNames(MetadataStoreRoutingConstants.ROUTING_DATA_PATH, AccessOption.PERSISTENT)) {
-      _baseAccessor.remove(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + zkRealm,
-          AccessOption.PERSISTENT);
-    }
+  private void clearRoutingDataPath() throws Exception {
+    Assert.assertTrue(TestHelper.verify(() -> {
+      for (String zkRealm : _zkClient
+          .getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH)) {
+        _zkClient.delete(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + zkRealm);
+      }
+
+      return _zkClient.getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH).isEmpty();
+    }, TestHelper.WAIT_DURATION), "Routing data path should be deleted after the tests.");
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
@@ -25,10 +25,12 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.helix.AccessOption;
+import org.apache.helix.TestHelper;
 import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
+import org.apache.helix.rest.common.HttpConstants;
 import org.apache.helix.rest.server.AbstractTestClass;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.zkclient.ZkClient;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -37,10 +39,11 @@ import org.testng.annotations.Test;
 
 
 public class TestZkRoutingDataWriter extends AbstractTestClass {
-  private static final String DUMMY_NAMESPACE = "NAMESPACE";
   private static final String DUMMY_REALM = "REALM";
   private static final String DUMMY_SHARDING_KEY = "/DUMMY/SHARDING/KEY";
+
   private MetadataStoreRoutingDataWriter _zkRoutingDataWriter;
+  private ZkClient _zkClient;
 
   // MockWriter is used for testing request forwarding features in non-leader situations
   class MockWriter extends ZkRoutingDataWriter {
@@ -60,15 +63,16 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
   }
 
   @BeforeClass
-  public void beforeClass() {
+  public void beforeClass() throws Exception {
+    _zkClient = ZK_SERVER_MAP.get(_zkAddrTestNS).getZkClient();
     System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY,
         getBaseUri().getHost() + ":" + getBaseUri().getPort());
-    _zkRoutingDataWriter = new ZkRoutingDataWriter(DUMMY_NAMESPACE, ZK_ADDR);
+    _zkRoutingDataWriter = new ZkRoutingDataWriter(TEST_NAMESPACE, _zkAddrTestNS);
     clearRoutingDataPath();
   }
 
   @AfterClass
-  public void afterClass() {
+  public void afterClass() throws Exception {
     System.clearProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY);
     _zkRoutingDataWriter.close();
     clearRoutingDataPath();
@@ -77,26 +81,23 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
   @Test
   public void testAddMetadataStoreRealm() {
     _zkRoutingDataWriter.addMetadataStoreRealm(DUMMY_REALM);
-    ZNRecord znRecord = _baseAccessor
-        .get(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + DUMMY_REALM, null,
-            AccessOption.PERSISTENT);
+    ZNRecord znRecord =
+        _zkClient.readData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + DUMMY_REALM);
     Assert.assertNotNull(znRecord);
   }
 
   @Test(dependsOnMethods = "testAddMetadataStoreRealm")
   public void testDeleteMetadataStoreRealm() {
     _zkRoutingDataWriter.deleteMetadataStoreRealm(DUMMY_REALM);
-    Assert.assertFalse(_baseAccessor
-        .exists(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + DUMMY_REALM,
-            AccessOption.PERSISTENT));
+    Assert.assertFalse(
+        _zkClient.exists(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + DUMMY_REALM));
   }
 
   @Test(dependsOnMethods = "testDeleteMetadataStoreRealm")
   public void testAddShardingKey() {
     _zkRoutingDataWriter.addShardingKey(DUMMY_REALM, DUMMY_SHARDING_KEY);
-    ZNRecord znRecord = _baseAccessor
-        .get(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + DUMMY_REALM, null,
-            AccessOption.PERSISTENT);
+    ZNRecord znRecord =
+        _zkClient.readData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + DUMMY_REALM);
     Assert.assertNotNull(znRecord);
     Assert.assertTrue(znRecord.getListField(MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY)
         .contains(DUMMY_SHARDING_KEY));
@@ -105,9 +106,8 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
   @Test(dependsOnMethods = "testAddShardingKey")
   public void testDeleteShardingKey() {
     _zkRoutingDataWriter.deleteShardingKey(DUMMY_REALM, DUMMY_SHARDING_KEY);
-    ZNRecord znRecord = _baseAccessor
-        .get(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + DUMMY_REALM, null,
-            AccessOption.PERSISTENT);
+    ZNRecord znRecord =
+        _zkClient.readData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + DUMMY_REALM);
     Assert.assertNotNull(znRecord);
     Assert.assertFalse(znRecord.getListField(MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY)
         .contains(DUMMY_SHARDING_KEY));
@@ -118,9 +118,8 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
     Map<String, List<String>> testRoutingDataMap =
         ImmutableMap.of(DUMMY_REALM, Collections.singletonList(DUMMY_SHARDING_KEY));
     _zkRoutingDataWriter.setRoutingData(testRoutingDataMap);
-    ZNRecord znRecord = _baseAccessor
-        .get(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + DUMMY_REALM, null,
-            AccessOption.PERSISTENT);
+    ZNRecord znRecord =
+        _zkClient.readData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + DUMMY_REALM);
     Assert.assertNotNull(znRecord);
     Assert.assertEquals(
         znRecord.getListField(MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY).size(), 1);
@@ -130,11 +129,11 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
 
   @Test(dependsOnMethods = "testSetRoutingData")
   public void testAddMetadataStoreRealmNonLeader() {
-    MockWriter mockWriter = new MockWriter(DUMMY_NAMESPACE, ZK_ADDR);
+    MockWriter mockWriter = new MockWriter(TEST_NAMESPACE, _zkAddrTestNS);
     mockWriter.addMetadataStoreRealm(DUMMY_REALM);
-    Assert.assertEquals(mockWriter.calledRequest.getMethod(), "PUT");
+    Assert.assertEquals(mockWriter.calledRequest.getMethod(), HttpConstants.RestVerbs.PUT.name());
     List<String> expectedUrlParams = Arrays
-        .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, DUMMY_NAMESPACE,
+        .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT, DUMMY_REALM);
     String expectedUrl =
         getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
@@ -145,11 +144,12 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
 
   @Test(dependsOnMethods = "testAddMetadataStoreRealmNonLeader")
   public void testDeleteMetadataStoreRealmNonLeader() {
-    MockWriter mockWriter = new MockWriter(DUMMY_NAMESPACE, ZK_ADDR);
+    MockWriter mockWriter = new MockWriter(TEST_NAMESPACE, _zkAddrTestNS);
     mockWriter.deleteMetadataStoreRealm(DUMMY_REALM);
-    Assert.assertEquals(mockWriter.calledRequest.getMethod(), "DELETE");
+    Assert
+        .assertEquals(mockWriter.calledRequest.getMethod(), HttpConstants.RestVerbs.DELETE.name());
     List<String> expectedUrlParams = Arrays
-        .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, DUMMY_NAMESPACE,
+        .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT, DUMMY_REALM);
     String expectedUrl =
         getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
@@ -160,11 +160,11 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
 
   @Test(dependsOnMethods = "testDeleteMetadataStoreRealmNonLeader")
   public void testAddShardingKeyNonLeader() {
-    MockWriter mockWriter = new MockWriter(DUMMY_NAMESPACE, ZK_ADDR);
+    MockWriter mockWriter = new MockWriter(TEST_NAMESPACE, _zkAddrTestNS);
     mockWriter.addShardingKey(DUMMY_REALM, DUMMY_SHARDING_KEY);
-    Assert.assertEquals(mockWriter.calledRequest.getMethod(), "PUT");
+    Assert.assertEquals(mockWriter.calledRequest.getMethod(), HttpConstants.RestVerbs.PUT.name());
     List<String> expectedUrlParams = Arrays
-        .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, DUMMY_NAMESPACE,
+        .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT, DUMMY_REALM,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_SHARDING_KEYS_ENDPOINT, DUMMY_SHARDING_KEY);
     String expectedUrl =
@@ -176,11 +176,12 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
 
   @Test(dependsOnMethods = "testAddShardingKeyNonLeader")
   public void testDeleteShardingKeyNonLeader() {
-    MockWriter mockWriter = new MockWriter(DUMMY_NAMESPACE, ZK_ADDR);
+    MockWriter mockWriter = new MockWriter(TEST_NAMESPACE, _zkAddrTestNS);
     mockWriter.deleteShardingKey(DUMMY_REALM, DUMMY_SHARDING_KEY);
-    Assert.assertEquals(mockWriter.calledRequest.getMethod(), "DELETE");
+    Assert
+        .assertEquals(mockWriter.calledRequest.getMethod(), HttpConstants.RestVerbs.DELETE.name());
     List<String> expectedUrlParams = Arrays
-        .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, DUMMY_NAMESPACE,
+        .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT, DUMMY_REALM,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_SHARDING_KEYS_ENDPOINT, DUMMY_SHARDING_KEY);
     String expectedUrl =
@@ -192,13 +193,13 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
 
   @Test(dependsOnMethods = "testDeleteShardingKeyNonLeader")
   public void testSetRoutingDataNonLeader() {
-    MockWriter mockWriter = new MockWriter(DUMMY_NAMESPACE, ZK_ADDR);
+    MockWriter mockWriter = new MockWriter(TEST_NAMESPACE, _zkAddrTestNS);
     Map<String, List<String>> testRoutingDataMap =
         ImmutableMap.of(DUMMY_REALM, Collections.singletonList(DUMMY_SHARDING_KEY));
     mockWriter.setRoutingData(testRoutingDataMap);
-    Assert.assertEquals(mockWriter.calledRequest.getMethod(), "PUT");
+    Assert.assertEquals(mockWriter.calledRequest.getMethod(), HttpConstants.RestVerbs.PUT.name());
     List<String> expectedUrlParams = Arrays
-        .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, DUMMY_NAMESPACE,
+        .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT);
     String expectedUrl =
         getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
@@ -207,11 +208,14 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
     mockWriter.close();
   }
 
-  private void clearRoutingDataPath() {
-    for (String zkRealm : _baseAccessor
-        .getChildNames(MetadataStoreRoutingConstants.ROUTING_DATA_PATH, AccessOption.PERSISTENT)) {
-      _baseAccessor.remove(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + zkRealm,
-          AccessOption.PERSISTENT);
-    }
+  private void clearRoutingDataPath() throws Exception {
+    Assert.assertTrue(TestHelper.verify(() -> {
+      for (String zkRealm : _zkClient
+          .getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH)) {
+        _zkClient.delete(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + zkRealm);
+      }
+
+      return _zkClient.getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH).isEmpty();
+    }, TestHelper.WAIT_DURATION), "Routing data path should be deleted after the tests.");
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestMetadataStoreDirectoryAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestMetadataStoreDirectoryAccessor.java
@@ -35,7 +35,6 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.rest.server.util.JerseyUriRequestBuilder;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -459,12 +458,12 @@ public class TestMetadataStoreDirectoryAccessor extends MetadataStoreDirectoryAc
     Map<String, List<String>> routingData = new HashMap<>();
     routingData.put(TEST_REALM_1, TEST_SHARDING_KEYS_2);
     routingData.put(TEST_REALM_2, TEST_SHARDING_KEYS_1);
-    String routingDataString = new ObjectMapper().writeValueAsString(routingData);
+    String routingDataString = OBJECT_MAPPER.writeValueAsString(routingData);
 
     Map<String, String> badFormatRoutingData = new HashMap<>();
     badFormatRoutingData.put(TEST_REALM_1, TEST_REALM_2);
     badFormatRoutingData.put(TEST_REALM_2, TEST_REALM_1);
-    String badFormatRoutingDataString = new ObjectMapper().writeValueAsString(badFormatRoutingData);
+    String badFormatRoutingDataString = OBJECT_MAPPER.writeValueAsString(badFormatRoutingData);
 
     // Request that gets not found response.
     put("/namespaces/non-existing-namespace"

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestMetadataStoreDirectoryAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestMetadataStoreDirectoryAccessor.java
@@ -21,6 +21,7 @@ package org.apache.helix.rest.server;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.rest.server.util.JerseyUriRequestBuilder;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -450,6 +452,44 @@ public class TestMetadataStoreDirectoryAccessor extends MetadataStoreDirectoryAc
 
     expectedShardingKeysSet.remove(TEST_SHARDING_KEY);
     Assert.assertEquals(getAllShardingKeysInTestRealm1(), expectedShardingKeysSet);
+  }
+
+  @Test(dependsOnMethods = "testDeleteShardingKey")
+//  @Test
+  public void testSetRoutingData() throws InvalidRoutingDataException, IOException {
+    Map<String, List<String>> routingData = new HashMap<>();
+    routingData.put(TEST_REALM_1, TEST_SHARDING_KEYS_2);
+    routingData.put(TEST_REALM_2, TEST_SHARDING_KEYS_1);
+    String routingDataString = new ObjectMapper().writeValueAsString(routingData);
+
+    Map<String, String> badFormatRoutingData = new HashMap<>();
+    badFormatRoutingData.put(TEST_REALM_1, TEST_REALM_2);
+    badFormatRoutingData.put(TEST_REALM_2, TEST_REALM_1);
+    String badFormatRoutingDataString = new ObjectMapper().writeValueAsString(badFormatRoutingData);
+
+    // Request that gets not found response.
+    put("/namespaces/non-existing-namespace"
+            + MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT, null,
+        Entity.entity(routingDataString, MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.NOT_FOUND.getStatusCode());
+
+    put(TEST_NAMESPACE_URI_PREFIX
+            + MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT, null,
+        Entity.entity("?", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.BAD_REQUEST.getStatusCode());
+
+    put(TEST_NAMESPACE_URI_PREFIX
+            + MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT, null,
+        Entity.entity(badFormatRoutingDataString, MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.BAD_REQUEST.getStatusCode());
+
+    // Successful request.
+    put(TEST_NAMESPACE_URI_PREFIX
+            + MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT, null,
+        Entity.entity(routingDataString, MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.CREATED.getStatusCode());
+
+    Assert.assertEquals(getRawRoutingData(), routingData);
   }
 
   private void verifyRealmShardingKeys(String responseBody) throws IOException {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestMetadataStoreDirectoryAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestMetadataStoreDirectoryAccessor.java
@@ -455,7 +455,6 @@ public class TestMetadataStoreDirectoryAccessor extends MetadataStoreDirectoryAc
   }
 
   @Test(dependsOnMethods = "testDeleteShardingKey")
-//  @Test
   public void testSetRoutingData() throws InvalidRoutingDataException, IOException {
     Map<String, List<String>> routingData = new HashMap<>();
     routingData.put(TEST_REALM_1, TEST_SHARDING_KEYS_2);

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/datamodel/TrieRoutingData.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/datamodel/TrieRoutingData.java
@@ -167,8 +167,8 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
   }
 
   /*
-   * Checks for the edge case when the only sharding key in provided routing data is the delimiter
-   * or an empty string. When this is the case, the trie is valid and contains only one node, which
+   * Checks for the edge case when the only sharding key in provided routing data is the delimiter.
+   * When this is the case, the trie is valid and contains only one node, which
    * is the root node, and the root node is a leaf node with a realm address associated with it.
    * @param routingData - a mapping from "sharding keys" to "realm addresses" to be parsed into a
    *          trie


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #841, #842, #843 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR implements `setRoutingData`, which was an endpoint that was defined but not finished. It allows users to overwrite whatever routing data there is for a namespace and replace it with a new set of data. This endpoint was designed with convenience in mind because it allows users to specify the routing data in one call instead of making multiple calls to create zkrealms and add sharding keys. This endpoint was originally designed to validate the input but now it doesn't, please refer #842 for the reasoning. 

Related to this PR, we also discovered that there are problems related to the construction of `TrieRoutingData` in `MetadataStoreDirectory`. Please see #841 . 

Lastly, we are also fixing the race conditions of writing operations in `MetadataStoreDirectory` which are discovered during the development. Please see #843. 

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 140, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 24.602 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 140, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  53.115 s
[INFO] Finished at: 2020-03-02T14:38:49-08:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml