### PR TITLE
Async write operation should not throw Exception for serializing error

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestRawZkClient.java
@@ -780,12 +780,14 @@ public class TestRawZkClient extends ZkUnitTestBase {
       zkClient.asyncCreate("/tmp/async", null, CreateMode.PERSISTENT, createCallback);
       createCallback.waitForSuccess();
       Assert.assertEquals(createCallback.getRc(), 0);
+      Assert.assertTrue(zkClient.exists("/tmp/async"));
 
       // try to create oversize node, should fail
       zkClient.asyncCreate("/tmp/asyncOversize", oversizeZNRecord, CreateMode.PERSISTENT,
           createCallback);
       createCallback.waitForSuccess();
       Assert.assertEquals(createCallback.getRc(), KeeperException.Code.MarshallingError);
+      Assert.assertFalse(zkClient.exists("/tmp/asyncOversize"));
 
       ZNRecord normalZNRecord = new ZNRecord("normal");
       normalZNRecord.setSimpleField("key", buf);
@@ -799,6 +801,7 @@ public class TestRawZkClient extends ZkUnitTestBase {
       zkClient.asyncSetData("/tmp/async", oversizeZNRecord, -1, setDataCallbackHandler);
       setDataCallbackHandler.waitForSuccess();
       Assert.assertEquals(setDataCallbackHandler.getRc(), KeeperException.Code.MarshallingError);
+      Assert.assertEquals(zkClient.readData("/tmp/async"), normalZNRecord);
     } finally {
       if (originSizeLimit == null) {
         System.clearProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZNRecordSizeLimit.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZNRecordSizeLimit.java
@@ -35,6 +35,7 @@ import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.IdealState.RebalanceMode;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -306,139 +307,136 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
     final String thresholdProperty =
         System.getProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES);
 
-    ZNRecordSerializer serializer = new ZNRecordSerializer();
-
-    String root = getShortClassName();
-
-    byte[] buf = new byte[1024];
-    for (int i = 0; i < 1024; i++) {
-      buf[i] = 'a';
-    }
-    String bufStr = new String(buf);
-
-    // 1. legal-sized data gets written to zk
-    // write a znode of size less than writeSizeLimit
-    int rawZnRecordSize = 700;
-    int writeSizeLimitKb = 800;
-    int writeSizeLimit = writeSizeLimitKb * 1024;
-    System.setProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES,
-        String.valueOf(writeSizeLimit));
-
-    final ZNRecord normalSizeRecord = new ZNRecord("normal-size");
-    for (int i = 0; i < rawZnRecordSize; i++) {
-      normalSizeRecord.setSimpleField(Integer.toString(i), bufStr);
-    }
-
-    String path = "/" + root + "/normal";
-    _gZkClient.createPersistent(path, true);
-    _gZkClient.writeData(path, normalSizeRecord);
-
-    ZNRecord record = _gZkClient.readData(path);
-
-    // Successfully reads the same data.
-    Assert.assertEquals(normalSizeRecord, record);
-
-    int length = serializer.serialize(record).length;
-
-    // Less than writeSizeLimit so it is written to ZK.
-    Assert.assertTrue(length < writeSizeLimit);
-
-    // 2. Large size data is not allowed to write to ZK
-    // Set raw record size to be large enough so its serialized data exceeds the writeSizeLimit.
-    rawZnRecordSize = 2000;
-    // Set the writeSizeLimit to very small so serialized data size exceeds the writeSizeLimit.
-    writeSizeLimitKb = 1;
-    writeSizeLimit = writeSizeLimitKb * 1024;
-    System.setProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES,
-        String.valueOf(writeSizeLimit));
-
-    final ZNRecord largeRecord = new ZNRecord("large-size");
-    for (int i = 0; i < rawZnRecordSize; i++) {
-      largeRecord.setSimpleField(Integer.toString(i), bufStr);
-    }
-
-    path = "/" + root + "/large";
-    _gZkClient.createPersistent(path, true);
-
     try {
-      _gZkClient.writeData(path, largeRecord);
-      Assert.fail("Data should not be written to ZK because data size exceeds writeSizeLimit!");
-    } catch (ZkClientException expected) {
-      Assert.assertTrue(
-          expected.getMessage().contains(" is greater than " + writeSizeLimit + " bytes"));
-    }
+      ZNRecordSerializer serializer = new ZNRecordSerializer();
 
-    // test ZkDataAccessor
-    ZKHelixAdmin admin = new ZKHelixAdmin(ZK_ADDR);
-    admin.addCluster(root, true);
-    InstanceConfig instanceConfig = new InstanceConfig("localhost_12918");
-    admin.addInstance(root, instanceConfig);
+      String root = getShortClassName();
 
-    // Set the writeSizeLimit to 10KB so serialized data size does not exceed writeSizeLimit.
-    writeSizeLimitKb = 10;
-    writeSizeLimit = writeSizeLimitKb * 1024;
-    System.setProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES,
-        String.valueOf(writeSizeLimit));
+      byte[] buf = new byte[1024];
+      for (int i = 0; i < 1024; i++) {
+        buf[i] = 'a';
+      }
+      String bufStr = new String(buf);
 
-    // oversized data should not create any new data on zk
-    ZKHelixDataAccessor accessor = new ZKHelixDataAccessor(root, new ZkBaseDataAccessor<>(ZK_ADDR));
-    Builder keyBuilder = accessor.keyBuilder();
+      // 1. legal-sized data gets written to zk
+      // write a znode of size less than writeSizeLimit
+      int rawZnRecordSize = 700;
+      int writeSizeLimitKb = 800;
+      int writeSizeLimit = writeSizeLimitKb * 1024;
+      System.setProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES, String.valueOf(writeSizeLimit));
 
-    IdealState idealState = new IdealState("currentState");
-    idealState.setStateModelDefRef("MasterSlave");
-    idealState.setRebalanceMode(RebalanceMode.SEMI_AUTO);
-    idealState.setNumPartitions(10);
+      final ZNRecord normalSizeRecord = new ZNRecord("normal-size");
+      for (int i = 0; i < rawZnRecordSize; i++) {
+        normalSizeRecord.setSimpleField(Integer.toString(i), bufStr);
+      }
 
-    for (int i = 0; i < 1024; i++) {
-      idealState.getRecord().setSimpleField(Integer.toString(i), bufStr);
-    }
-    boolean succeed = accessor.setProperty(keyBuilder.idealStates("TestDB0"), idealState);
-    Assert.assertTrue(succeed);
-    HelixProperty property = accessor.getProperty(
-        keyBuilder.stateTransitionStatus("localhost_12918", "session_1", "partition_1"));
-    Assert.assertNull(property);
+      String path = "/" + root + "/normal";
+      _gZkClient.createPersistent(path, true);
+      _gZkClient.writeData(path, normalSizeRecord);
 
-    // legal sized data gets written to zk
-    idealState.getRecord().getSimpleFields().clear();
-    idealState.setStateModelDefRef("MasterSlave");
-    idealState.setRebalanceMode(RebalanceMode.SEMI_AUTO);
-    idealState.setNumPartitions(10);
+      ZNRecord record = _gZkClient.readData(path);
 
-    for (int i = 0; i < 900; i++) {
-      idealState.getRecord().setSimpleField(Integer.toString(i), bufStr);
-    }
-    succeed = accessor.setProperty(keyBuilder.idealStates("TestDB1"), idealState);
-    Assert.assertTrue(succeed);
-    record = accessor.getProperty(keyBuilder.idealStates("TestDB1")).getRecord();
-    Assert.assertTrue(serializer.serialize(record).length < writeSizeLimit);
+      // Successfully reads the same data.
+      Assert.assertEquals(normalSizeRecord, record);
 
-    // Set small write size limit so writing does not succeed.
-    writeSizeLimitKb = 1;
-    writeSizeLimit = writeSizeLimitKb * 1024;
-    System.setProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES,
-        String.valueOf(writeSizeLimit));
+      int length = serializer.serialize(record).length;
 
-    // oversized data should not update existing data on zk
-    idealState.setStateModelDefRef("MasterSlave");
-    idealState.setRebalanceMode(RebalanceMode.SEMI_AUTO);
-    idealState.setNumPartitions(10);
-    for (int i = 900; i < 1024; i++) {
-      idealState.getRecord().setSimpleField(Integer.toString(i), bufStr);
-    }
+      // Less than writeSizeLimit so it is written to ZK.
+      Assert.assertTrue(length < writeSizeLimit);
 
-    succeed = accessor.updateProperty(keyBuilder.idealStates("TestDB1"), idealState);
-    Assert.assertFalse(succeed,
-        "Update property should not succeed because data exceeds znode write limit!");
+      // 2. Large size data is not allowed to write to ZK
+      // Set raw record size to be large enough so its serialized data exceeds the writeSizeLimit.
+      rawZnRecordSize = 2000;
+      // Set the writeSizeLimit to very small so serialized data size exceeds the writeSizeLimit.
+      writeSizeLimitKb = 1;
+      writeSizeLimit = writeSizeLimitKb * 1024;
+      System.setProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES, String.valueOf(writeSizeLimit));
 
-    // Delete the nodes.
-    deletePath(_gZkClient, "/" + root);
+      final ZNRecord largeRecord = new ZNRecord("large-size");
+      for (int i = 0; i < rawZnRecordSize; i++) {
+        largeRecord.setSimpleField(Integer.toString(i), bufStr);
+      }
 
-    // Reset: add the properties back to system properties if they were originally available.
-    if (thresholdProperty != null) {
-      System.setProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES,
-          thresholdProperty);
-    } else {
-      System.clearProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES);
+      path = "/" + root + "/large";
+      _gZkClient.createPersistent(path, true);
+
+      try {
+        _gZkClient.writeData(path, largeRecord);
+        Assert.fail("Data should not be written to ZK because data size exceeds writeSizeLimit!");
+      } catch (ZkMarshallingError expected) {
+        Assert.assertTrue(
+            expected.getMessage().contains(" is greater than " + writeSizeLimit + " bytes"));
+      }
+
+      // test ZkDataAccessor
+      ZKHelixAdmin admin = new ZKHelixAdmin(ZK_ADDR);
+      admin.addCluster(root, true);
+      InstanceConfig instanceConfig = new InstanceConfig("localhost_12918");
+      admin.addInstance(root, instanceConfig);
+
+      // Set the writeSizeLimit to 10KB so serialized data size does not exceed writeSizeLimit.
+      writeSizeLimitKb = 10;
+      writeSizeLimit = writeSizeLimitKb * 1024;
+      System.setProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES, String.valueOf(writeSizeLimit));
+
+      // oversized data should not create any new data on zk
+      ZKHelixDataAccessor accessor = new ZKHelixDataAccessor(root, new ZkBaseDataAccessor<>(ZK_ADDR));
+      Builder keyBuilder = accessor.keyBuilder();
+
+      IdealState idealState = new IdealState("currentState");
+      idealState.setStateModelDefRef("MasterSlave");
+      idealState.setRebalanceMode(RebalanceMode.SEMI_AUTO);
+      idealState.setNumPartitions(10);
+
+      for (int i = 0; i < 1024; i++) {
+        idealState.getRecord().setSimpleField(Integer.toString(i), bufStr);
+      }
+      boolean succeed = accessor.setProperty(keyBuilder.idealStates("TestDB0"), idealState);
+      Assert.assertTrue(succeed);
+      HelixProperty property = accessor.getProperty(keyBuilder.stateTransitionStatus("localhost_12918", "session_1", "partition_1"));
+      Assert.assertNull(property);
+
+      // legal sized data gets written to zk
+      idealState.getRecord().getSimpleFields().clear();
+      idealState.setStateModelDefRef("MasterSlave");
+      idealState.setRebalanceMode(RebalanceMode.SEMI_AUTO);
+      idealState.setNumPartitions(10);
+
+      for (int i = 0; i < 900; i++) {
+        idealState.getRecord().setSimpleField(Integer.toString(i), bufStr);
+      }
+      succeed = accessor.setProperty(keyBuilder.idealStates("TestDB1"), idealState);
+      Assert.assertTrue(succeed);
+      record = accessor.getProperty(keyBuilder.idealStates("TestDB1")).getRecord();
+      Assert.assertTrue(serializer.serialize(record).length < writeSizeLimit);
+
+      // Set small write size limit so writing does not succeed.
+      writeSizeLimitKb = 1;
+      writeSizeLimit = writeSizeLimitKb * 1024;
+      System.setProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES, String.valueOf(writeSizeLimit));
+
+      // oversized data should not update existing data on zk
+      idealState.setStateModelDefRef("MasterSlave");
+      idealState.setRebalanceMode(RebalanceMode.SEMI_AUTO);
+      idealState.setNumPartitions(10);
+      for (int i = 900; i < 1024; i++) {
+        idealState.getRecord().setSimpleField(Integer.toString(i), bufStr);
+      }
+
+      succeed = accessor.updateProperty(keyBuilder.idealStates("TestDB1"), idealState);
+      Assert.assertFalse(succeed,
+          "Update property should not succeed because data exceeds znode write limit!");
+
+      // Delete the nodes.
+      deletePath(_gZkClient, "/" + root);
+    } finally {
+      // Reset: add the properties back to system properties if they were originally available.
+      if (thresholdProperty != null) {
+        System.setProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES,
+            thresholdProperty);
+      } else {
+        System.clearProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES);
+      }
     }
   }
 
@@ -516,7 +514,7 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
       try {
         zkClient.writeData(path, largeRecord);
         Assert.fail("Data should not written to ZK because data size exceeds writeSizeLimit!");
-      } catch (ZkClientException expected) {
+      } catch (ZkMarshallingError expected) {
         Assert.assertTrue(
             expected.getMessage().contains(" is greater than " + writeSizeLimit + " bytes"));
       }
@@ -588,14 +586,13 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
       deletePath(zkClient, "/" + root);
     } finally {
       zkClient.close();
-    }
-
-    // Reset: add the properties back to system properties if they were originally available.
-    if (thresholdProperty != null) {
-      System.setProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES,
-          thresholdProperty);
-    } else {
-      System.clearProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES);
+      // Reset: add the properties back to system properties if they were originally available.
+      if (thresholdProperty != null) {
+        System.setProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES,
+            thresholdProperty);
+      } else {
+        System.clearProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES);
+      }
     }
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/serializer/ZNRecordJacksonSerializer.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/serializer/ZNRecordJacksonSerializer.java
@@ -22,7 +22,6 @@ package org.apache.helix.zookeeper.datamodel.serializer;
 import java.io.IOException;
 
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.helix.zookeeper.exception.ZkClientException;
 import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -39,14 +38,14 @@ public class ZNRecordJacksonSerializer implements ZkSerializer {
   public byte[] serialize(Object record) throws ZkMarshallingError {
     if (!(record instanceof ZNRecord)) {
       // null is NOT an instance of any class
-      throw new ZkClientException("Input object is not of type ZNRecord (was " + record + ")");
+      throw new ZkMarshallingError("Input object is not of type ZNRecord (was " + record + ")");
     }
     ZNRecord znRecord = (ZNRecord) record;
 
     try {
       return OBJECT_MAPPER.writeValueAsBytes(znRecord);
     } catch (IOException e) {
-      throw new ZkClientException(
+      throw new ZkMarshallingError(
           String.format("Exception during serialization. ZNRecord id: %s", znRecord.getId()), e);
     }
   }
@@ -62,7 +61,7 @@ public class ZNRecordJacksonSerializer implements ZkSerializer {
     try {
       record = OBJECT_MAPPER.readValue(bytes, ZNRecord.class);
     } catch (IOException e) {
-      throw new ZkClientException("Exception during deserialization!", e);
+      throw new ZkMarshallingError("Exception during deserialization!", e);
     }
     return record;
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/serializer/ZNRecordSerializer.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/serializer/ZNRecordSerializer.java
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.helix.zookeeper.exception.ZkClientException;
 import org.apache.helix.zookeeper.util.GZipCompressionUtil;
 import org.apache.helix.zookeeper.util.ZNRecordUtil;
+import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.codehaus.jackson.map.DeserializationConfig;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -58,7 +58,7 @@ public class ZNRecordSerializer implements ZkSerializer {
       // null is NOT an instance of any class
       LOG.error("Input object must be of type ZNRecord but it is " + data
           + ". Will not write to zk");
-      throw new ZkClientException("Input object is not of type ZNRecord (was " + data + ")");
+      throw new ZkMarshallingError("Input object is not of type ZNRecord (was " + data + ")");
     }
 
     ZNRecord record = (ZNRecord) data;
@@ -97,7 +97,7 @@ public class ZNRecordSerializer implements ZkSerializer {
       LOG.error(
           "Exception during data serialization. ZNRecord ID: {} will not be written to zk.",
           record.getId(), e);
-      throw new ZkClientException(e);
+      throw new ZkMarshallingError(e);
     }
 
     int writeSizeLimit = ZNRecordUtil.getSerializerWriteSizeLimit();
@@ -105,7 +105,7 @@ public class ZNRecordSerializer implements ZkSerializer {
       LOG.error("Data size: {} is greater than {} bytes, is compressed: {}, ZNRecord.id: {}."
               + " Data will not be written to Zookeeper.", serializedBytes.length, writeSizeLimit,
           isCompressed, record.getId());
-      throw new ZkClientException(
+      throw new ZkMarshallingError(
           "Data size: " + serializedBytes.length + " is greater than " + writeSizeLimit
               + " bytes, is compressed: " + isCompressed + ", ZNRecord.id: " + record.getId());
     }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/serializer/ZNRecordStreamingSerializer.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/serializer/ZNRecordStreamingSerializer.java
@@ -29,7 +29,6 @@ import java.util.TreeMap;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.helix.zookeeper.exception.ZkClientException;
 import org.apache.helix.zookeeper.util.GZipCompressionUtil;
 import org.apache.helix.zookeeper.util.ZNRecordUtil;
 import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
@@ -64,7 +63,7 @@ public class ZNRecordStreamingSerializer implements ZkSerializer {
       // null is NOT an instance of any class
       LOG.error("Input object must be of type ZNRecord but it is " + data
           + ". Will not write to zk");
-      throw new ZkClientException("Input object is not of type ZNRecord (was " + data + ")");
+      throw new ZkMarshallingError("Input object is not of type ZNRecord (was " + data + ")");
     }
 
     // apply retention policy on list field
@@ -165,7 +164,7 @@ public class ZNRecordStreamingSerializer implements ZkSerializer {
       LOG.error(
           "Exception during data serialization. ZNRecord ID: {} will not be written to zk.",
           record.getId(), e);
-      throw new ZkClientException(e);
+      throw new ZkMarshallingError(e);
     }
     // check size
     int writeSizeLimit = ZNRecordUtil.getSerializerWriteSizeLimit();
@@ -173,7 +172,7 @@ public class ZNRecordStreamingSerializer implements ZkSerializer {
       LOG.error("Data size: {} is greater than {} bytes, is compressed: {}, ZNRecord.id: {}."
               + " Data will not be written to Zookeeper.", serializedBytes.length, writeSizeLimit,
           isCompressed, record.getId());
-      throw new ZkClientException(
+      throw new ZkMarshallingError(
           "Data size: " + serializedBytes.length + " is greater than " + writeSizeLimit
               + " bytes, is compressed: " + isCompressed + ", ZNRecord.id: " + record.getId());
     }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#805 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This change will make the async write operations return error through the async callback instead of throwing exceptions. This change will fix the batch write/create failure due to one single node serializing failure.
In addition, according to serializer interface definition, change ZK related serializers to throw ZkMarshallingError instead of ZkClientException.

### Tests

- [x] The following tests are written for this issue:

testAsyncWriteOperations

- [x] The following is the result of the "mvn test" command on the appropriate module:

Failed tests: 
  TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
  TestWorkflowTermination.testWorkflowJobFail:251->verifyWorkflowCleanup:257 expected:<true> but was:<false>

Tests run: 1086, Failures: 2, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------

retrun:

Tests run: 8, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 57.613 s
[INFO] Finished at: 2020-03-02T16:43:29-08:00
[INFO] ------------------------------------------------------------------------



### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)