### PR TITLE
Add REST APIs for get, set, update RestConfig

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -655,8 +655,7 @@ public class ConfigAccessor {
     // Create "/{clusterId}/CONFIGS/REST" if it does not exist
     String parentPath = HelixUtil.getZkParentPath(zkPath);
     if (!_zkClient.exists(parentPath)) {
-      return;
-    }
+      throw new HelixException("fail to delete REST config. cluster: " + clusterName + " is NOT setup.");    }
 
     ZKUtil.dropChildren(_zkClient, parentPath, new ZNRecord(clusterName));
   }

--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -633,7 +633,7 @@ public class ConfigAccessor {
 
     // Create "/{clusterId}/CONFIGS/REST" if it does not exist
     String parentPath = HelixUtil.getZkParentPath(zkPath);
-    if (!_zkClient.exists(HelixUtil.getZkParentPath(zkPath))) {
+    if (!_zkClient.exists(parentPath)) {
       ZKUtil.createOrMerge(_zkClient, parentPath, new ZNRecord(parentPath), true, true);
     }
 
@@ -642,6 +642,23 @@ public class ConfigAccessor {
     } else {
       ZKUtil.createOrUpdate(_zkClient, zkPath, restConfig.getRecord(), true, true);
     }
+  }
+
+  public void deleteRESTConfig(String clusterName) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
+      throw new HelixException("fail to delete REST config. cluster: " + clusterName + " is NOT setup.");
+    }
+
+    HelixConfigScope scope = new HelixConfigScopeBuilder(ConfigScopeProperty.REST).forCluster(clusterName).build();
+    String zkPath = scope.getZkPath();
+
+    // Create "/{clusterId}/CONFIGS/REST" if it does not exist
+    String parentPath = HelixUtil.getZkParentPath(zkPath);
+    if (!_zkClient.exists(parentPath)) {
+      return;
+    }
+
+    ZKUtil.dropChildren(_zkClient, parentPath, new ZNRecord(clusterName));
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -37,6 +37,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.RESTConfig;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
+import org.apache.helix.util.HelixUtil;
 import org.apache.helix.util.StringTemplate;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
@@ -602,6 +603,45 @@ public class ConfigAccessor {
     }
 
     return new RESTConfig(record);
+  }
+
+  /**
+   * Set RestConfig of a given cluster
+   * @param clusterName the cluster id
+   * @param restConfig the RestConfig to be set to the cluster
+   */
+  public void setRESTConfig(String clusterName, RESTConfig restConfig) {
+    updateRESTConfig(clusterName, restConfig, true);
+  }
+
+  /**
+   * Update RestConfig of a given cluster
+   * @param clusterName the cluster id
+   * @param restConfig the new RestConfig to be set to the cluster
+   */
+  public void updateRESTConfig(String clusterName, RESTConfig restConfig) {
+    updateRESTConfig(clusterName, restConfig, false);
+  }
+
+  private void updateRESTConfig(String clusterName, RESTConfig restConfig, boolean overwrite) {
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
+      throw new HelixException("fail to update REST config. cluster: " + clusterName + " is NOT setup.");
+    }
+
+    HelixConfigScope scope = new HelixConfigScopeBuilder(ConfigScopeProperty.REST).forCluster(clusterName).build();
+    String zkPath = scope.getZkPath();
+
+    // Create "/{clusterId}/CONFIGS/REST" if it does not exist
+    String parentPath = HelixUtil.getZkParentPath(zkPath);
+    if (!_zkClient.exists(HelixUtil.getZkParentPath(zkPath))) {
+      ZKUtil.createOrMerge(_zkClient, parentPath, new ZNRecord(parentPath), true, true);
+    }
+
+    if (overwrite) {
+      ZKUtil.createOrReplace(_zkClient, zkPath, restConfig.getRecord(), true);
+    } else {
+      ZKUtil.createOrUpdate(_zkClient, zkPath, restConfig.getRecord(), true, true);
+    }
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -625,7 +625,7 @@ public class ConfigAccessor {
 
   private void updateRESTConfig(String clusterName, RESTConfig restConfig, boolean overwrite) {
     if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
-      throw new HelixException("fail to update REST config. cluster: " + clusterName + " is NOT setup.");
+      throw new HelixException("Fail to update REST config. cluster: " + clusterName + " is NOT setup.");
     }
 
     HelixConfigScope scope = new HelixConfigScopeBuilder(ConfigScopeProperty.REST).forCluster(clusterName).build();
@@ -646,16 +646,16 @@ public class ConfigAccessor {
 
   public void deleteRESTConfig(String clusterName) {
     if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
-      throw new HelixException("fail to delete REST config. cluster: " + clusterName + " is NOT setup.");
+      throw new HelixException("Fail to delete REST config. cluster: " + clusterName + " is NOT setup.");
     }
 
     HelixConfigScope scope = new HelixConfigScopeBuilder(ConfigScopeProperty.REST).forCluster(clusterName).build();
     String zkPath = scope.getZkPath();
 
-    // Create "/{clusterId}/CONFIGS/REST" if it does not exist
+    // Check if "/{clusterId}/CONFIGS/REST" exists
     String parentPath = HelixUtil.getZkParentPath(zkPath);
     if (!_zkClient.exists(parentPath)) {
-      throw new HelixException("fail to delete REST config. cluster: " + clusterName + " is NOT setup.");    }
+      throw new HelixException("Fail to delete REST config. cluster: " + clusterName + " does not have a rest config.");    }
 
     ZKUtil.dropChildren(_zkClient, parentPath, new ZNRecord(clusterName));
   }

--- a/helix-core/src/test/java/org/apache/helix/TestConfigAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/TestConfigAccessor.java
@@ -33,6 +33,7 @@ import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+
 public class TestConfigAccessor extends ZkUnitTestBase {
   @Test
   public void testBasic() throws Exception {
@@ -116,9 +117,8 @@ public class TestConfigAccessor extends ZkUnitTestBase {
         "should be [HELIX_ENABLED, HELIX_ENABLED_TIMESTAMP, HELIX_HOST, HELIX_PORT, participantConfigKey]");
     Assert.assertEquals(keys.get(4), "participantConfigKey");
 
-    keys =
-        configAccessor.getKeys(ConfigScopeProperty.PARTITION, clusterName, "testResource",
-            "testPartition");
+    keys = configAccessor
+        .getKeys(ConfigScopeProperty.PARTITION, clusterName, "testResource", "testPartition");
     Assert.assertEquals(keys.size(), 1, "should be [partitionConfigKey]");
     Assert.assertEquals(keys.get(0), "partitionConfigKey");
 
@@ -166,7 +166,6 @@ public class TestConfigAccessor extends ZkUnitTestBase {
     configAccessor.close();
     configAccessorZkAddr.close();
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
-
   }
 
   // HELIX-25: set participant Config should check existence of instance
@@ -186,8 +185,8 @@ public class TestConfigAccessor extends ZkUnitTestBase {
 
     try {
       configAccessor.set(participantScope, "participantConfigKey", "participantConfigValue");
-      Assert
-          .fail("Except fail to set participant-config because participant: localhost_12918 is not added to cluster yet");
+      Assert.fail(
+          "Except fail to set participant-config because participant: localhost_12918 is not added to cluster yet");
     } catch (HelixException e) {
       // OK
     }
@@ -196,8 +195,8 @@ public class TestConfigAccessor extends ZkUnitTestBase {
     try {
       configAccessor.set(participantScope, "participantConfigKey", "participantConfigValue");
     } catch (Exception e) {
-      Assert
-          .fail("Except succeed to set participant-config because participant: localhost_12918 has been added to cluster");
+      Assert.fail(
+          "Except succeed to set participant-config because participant: localhost_12918 has been added to cluster");
     }
 
     String participantConfigValue = configAccessor.get(participantScope, "participantConfigKey");
@@ -217,7 +216,8 @@ public class TestConfigAccessor extends ZkUnitTestBase {
     ZKHelixAdmin admin = new ZKHelixAdmin(ZK_ADDR);
     admin.addCluster(clusterName, true);
     ConfigAccessor configAccessor = new ConfigAccessor(ZK_ADDR);
-    HelixConfigScope scope = new HelixConfigScopeBuilder(ConfigScopeProperty.REST).forCluster(clusterName).build();
+    HelixConfigScope scope =
+        new HelixConfigScopeBuilder(ConfigScopeProperty.REST).forCluster(clusterName).build();
     Assert.assertNull(configAccessor.getRESTConfig(clusterName));
 
     RESTConfig restConfig = new RESTConfig(clusterName);
@@ -226,7 +226,7 @@ public class TestConfigAccessor extends ZkUnitTestBase {
     Assert.assertEquals(restConfig, configAccessor.getRESTConfig(clusterName));
   }
 
-  @Test (expectedExceptions = HelixException.class)
+  @Test
   public void testUpdateAndDeleteRestConfig() {
     String className = TestHelper.getTestClassName();
     String methodName = TestHelper.getTestMethodName();
@@ -235,9 +235,11 @@ public class TestConfigAccessor extends ZkUnitTestBase {
     ZKHelixAdmin admin = new ZKHelixAdmin(ZK_ADDR);
     admin.addCluster(clusterName, true);
     ConfigAccessor configAccessor = new ConfigAccessor(ZK_ADDR);
-    HelixConfigScope scope = new HelixConfigScopeBuilder(ConfigScopeProperty.REST).forCluster(clusterName).build();
+    HelixConfigScope scope =
+        new HelixConfigScopeBuilder(ConfigScopeProperty.REST).forCluster(clusterName).build();
     Assert.assertNull(configAccessor.getRESTConfig(clusterName));
 
+    // Update
     // No rest config exist
     RESTConfig restConfig = new RESTConfig(clusterName);
     restConfig.set(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL, "TEST_URL");
@@ -249,14 +251,29 @@ public class TestConfigAccessor extends ZkUnitTestBase {
     configAccessor.updateRESTConfig(clusterName, restConfig);
     Assert.assertEquals(restConfig, configAccessor.getRESTConfig(clusterName));
 
+    // Delete
     // Existing rest config
     configAccessor.deleteRESTConfig(clusterName);
     Assert.assertNull(configAccessor.getRESTConfig(clusterName));
 
     // Nonexisting rest config
-    String antherClusterName = "anotherCluster";
-    scope = new HelixConfigScopeBuilder(ConfigScopeProperty.REST).forCluster(antherClusterName).build();
-    restConfig = new RESTConfig(antherClusterName);
-    configAccessor.deleteRESTConfig(antherClusterName);
+    admin.addCluster(clusterName, true);
+    try {
+      configAccessor.deleteRESTConfig(clusterName);
+      Assert.fail("Helix exception expected.");
+    } catch (HelixException e) {
+      Assert.assertEquals(e.getMessage(),
+          "Fail to delete REST config. cluster: " + clusterName + " does not have a rest config.");
+    }
+
+    // Nonexisting cluster
+    String anotherClusterName = "anotherCluster";
+    try {
+      configAccessor.deleteRESTConfig(anotherClusterName);
+      Assert.fail("Helix exception expected.");
+    } catch (HelixException e) {
+      Assert.assertEquals(e.getMessage(),
+          "Fail to delete REST config. cluster: " + anotherClusterName + " is NOT setup.");
+    }
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/TestConfigAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/TestConfigAccessor.java
@@ -226,8 +226,8 @@ public class TestConfigAccessor extends ZkUnitTestBase {
     Assert.assertEquals(restConfig, configAccessor.getRESTConfig(clusterName));
   }
 
-  @Test
-  public void testUpdateRestConfig() {
+  @Test (expectedExceptions = HelixException.class)
+  public void testUpdateAndDeleteRestConfig() {
     String className = TestHelper.getTestClassName();
     String methodName = TestHelper.getTestMethodName();
     String clusterName = className + "_" + methodName;
@@ -248,5 +248,15 @@ public class TestConfigAccessor extends ZkUnitTestBase {
     restConfig.set(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL, "TEST_URL_2");
     configAccessor.updateRESTConfig(clusterName, restConfig);
     Assert.assertEquals(restConfig, configAccessor.getRESTConfig(clusterName));
+
+    // Existing rest config
+    configAccessor.deleteRESTConfig(clusterName);
+    Assert.assertNull(configAccessor.getRESTConfig(clusterName));
+
+    // Nonexisting rest config
+    String antherClusterName = "anotherCluster";
+    scope = new HelixConfigScopeBuilder(ConfigScopeProperty.REST).forCluster(antherClusterName).build();
+    restConfig = new RESTConfig(antherClusterName);
+    configAccessor.deleteRESTConfig(antherClusterName);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/TestConfigAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/TestConfigAccessor.java
@@ -24,9 +24,12 @@ import java.util.List;
 
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.model.ConfigScope;
+import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.RESTConfig;
 import org.apache.helix.model.builder.ConfigScopeBuilder;
+import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -203,5 +206,47 @@ public class TestConfigAccessor extends ZkUnitTestBase {
     admin.dropCluster(clusterName);
     configAccessor.close();
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
+  }
+
+  @Test
+  public void testSetRestConfig() {
+    String className = TestHelper.getTestClassName();
+    String methodName = TestHelper.getTestMethodName();
+    String clusterName = className + "_" + methodName;
+
+    ZKHelixAdmin admin = new ZKHelixAdmin(ZK_ADDR);
+    admin.addCluster(clusterName, true);
+    ConfigAccessor configAccessor = new ConfigAccessor(ZK_ADDR);
+    HelixConfigScope scope = new HelixConfigScopeBuilder(ConfigScopeProperty.REST).forCluster(clusterName).build();
+    Assert.assertNull(configAccessor.getRESTConfig(clusterName));
+
+    RESTConfig restConfig = new RESTConfig(clusterName);
+    restConfig.set(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL, "TEST_URL");
+    configAccessor.setRESTConfig(clusterName, restConfig);
+    Assert.assertEquals(restConfig, configAccessor.getRESTConfig(clusterName));
+  }
+
+  @Test
+  public void testUpdateRestConfig() {
+    String className = TestHelper.getTestClassName();
+    String methodName = TestHelper.getTestMethodName();
+    String clusterName = className + "_" + methodName;
+
+    ZKHelixAdmin admin = new ZKHelixAdmin(ZK_ADDR);
+    admin.addCluster(clusterName, true);
+    ConfigAccessor configAccessor = new ConfigAccessor(ZK_ADDR);
+    HelixConfigScope scope = new HelixConfigScopeBuilder(ConfigScopeProperty.REST).forCluster(clusterName).build();
+    Assert.assertNull(configAccessor.getRESTConfig(clusterName));
+
+    // No rest config exist
+    RESTConfig restConfig = new RESTConfig(clusterName);
+    restConfig.set(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL, "TEST_URL");
+    configAccessor.updateRESTConfig(clusterName, restConfig);
+    Assert.assertEquals(restConfig, configAccessor.getRESTConfig(clusterName));
+
+    // Rest config exists
+    restConfig.set(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL, "TEST_URL_2");
+    configAccessor.updateRESTConfig(clusterName, restConfig);
+    Assert.assertEquals(restConfig, configAccessor.getRESTConfig(clusterName));
   }
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -567,10 +567,6 @@ public class ClusterAccessor extends AbstractHelixResource {
       return badRequest("Input is not a valid ZNRecord!");
     }
 
-    if (!record.getId().equals(clusterId)) {
-      return badRequest("ID does not match the cluster name in input!");
-    }
-
     RESTConfig config = new RESTConfig(record);
     ConfigAccessor configAccessor = getConfigAccessor();
     try {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -525,7 +525,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       record = toZNRecord(content);
     } catch (IOException e) {
-      _logger.error("Failed to deserialize user's input " + content + ", Exception: " + e);
+      LOG.error("Failed to deserialize user's input " + content + ", Exception: " + e);
       return badRequest("Input is not a valid ZNRecord!");
     }
 
@@ -541,7 +541,7 @@ public class ClusterAccessor extends AbstractHelixResource {
       // TODO: Could use a more generic error for HelixException
       return notFound(ex.getMessage());
     } catch (Exception ex) {
-      _logger.error("Failed to create rest config, cluster " + clusterId + " new config: " + content
+      LOG.error("Failed to create rest config, cluster " + clusterId + " new config: " + content
           + ", Exception: " + ex);
       return serverError(ex);
     }
@@ -552,6 +552,7 @@ public class ClusterAccessor extends AbstractHelixResource {
   @Path("{clusterId}/restconfig")
   public Response updateRESTConfig(@PathParam("clusterId") String clusterId,
       @QueryParam("command") String commandStr, String content) {
+    //TODO: abstract out the logic that is duplicated from cluster config methods
     Command command;
     try {
       command = getCommand(commandStr);
@@ -563,7 +564,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       record = toZNRecord(content);
     } catch (IOException e) {
-      _logger.error("Failed to deserialize user's input " + content + ", Exception: " + e);
+      LOG.error("Failed to deserialize user's input " + content + ", Exception: " + e);
       return badRequest("Input is not a valid ZNRecord!");
     }
 
@@ -587,7 +588,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     } catch (HelixException ex) {
       return notFound(ex.getMessage());
     } catch (Exception ex) {
-      _logger.error(
+      LOG.error(
           "Failed to " + command + " rest config, cluster " + clusterId + " new config: " + content
               + ", Exception: " + ex);
       return serverError(ex);
@@ -603,11 +604,11 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       config = accessor.getRESTConfig(clusterId);
     } catch (HelixException ex) {
-      _logger.info(
+      LOG.info(
           "Failed to get rest config for cluster " + clusterId + ", cluster not found, Exception: "
               + ex);
     } catch (Exception ex) {
-      _logger.error("Failed to get rest config for cluster " + clusterId + " Exception: " + ex);
+      LOG.error("Failed to get rest config for cluster " + clusterId + " Exception: " + ex);
       return serverError(ex);
     }
     if (config == null) {
@@ -623,10 +624,11 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       accessor.deleteRESTConfig(clusterId);
     } catch (HelixException ex) {
-      _logger.info("Failed to delete rest config for cluster " + clusterId
+      LOG.info("Failed to delete rest config for cluster " + clusterId
           + ", cluster rest config is not found, Exception: " + ex);
+      return notFound(ex.getMessage());
     } catch (Exception ex) {
-      _logger.error("Failed to delete rest config, cluster " + clusterId + ", Exception: " + ex);
+      LOG.error("Failed to delete rest config, cluster " + clusterId + ", Exception: " + ex);
       return serverError(ex);
     }
     return OK();

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -579,7 +579,10 @@ public class ClusterAccessor extends AbstractHelixResource {
           configAccessor.updateRESTConfig(clusterId, config);
           break;
         case delete: {
-          configAccessor.deleteRESTConfig(clusterId);
+          HelixConfigScope scope =
+              new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.REST)
+                  .forCluster(clusterId).build();
+          configAccessor.remove(scope, config.getRecord());
         }
         break;
         default:
@@ -615,6 +618,22 @@ public class ClusterAccessor extends AbstractHelixResource {
       return notFound();
     }
     return JSONRepresentation(config.getRecord());
+  }
+
+  @DELETE
+  @Path("{clusterId}/restconfig")
+  public Response deleteClusterRESTConfig(@PathParam("clusterId") String clusterId) {
+    ConfigAccessor accessor = getConfigAccessor();
+    try {
+      accessor.deleteRESTConfig(clusterId);
+    } catch (HelixException ex) {
+      _logger.info("Failed to delete rest config for cluster " + clusterId
+          + ", cluster rest config is not found, Exception: " + ex);
+    } catch (Exception ex) {
+      _logger.error("Failed to delete rest config, cluster " + clusterId + ", Exception: " + ex);
+      return serverError(ex);
+    }
+    return OK();
   }
 
   @GET

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -538,11 +538,11 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       configAccessor.setRESTConfig(clusterId, config);
     } catch (HelixException ex) {
+      // TODO: Could use a more generic error for HelixException
       return notFound(ex.getMessage());
     } catch (Exception ex) {
-      _logger.error(
-          "Failed to create rest config, cluster " + clusterId + " new config: " + content
-              + ", Exception: " + ex);
+      _logger.error("Failed to create rest config, cluster " + clusterId + " new config: " + content
+          + ", Exception: " + ex);
       return serverError(ex);
     }
     return OK();
@@ -570,11 +570,11 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       configAccessor.updateRESTConfig(clusterId, config);
     } catch (HelixException ex) {
+      // TODO: Could use a more generic error for HelixException
       return notFound(ex.getMessage());
     } catch (Exception ex) {
-      _logger.error(
-          "Failed to update rest config, cluster " + clusterId + " new config: " + content
-              + ", Exception: " + ex);
+      _logger.error("Failed to update rest config, cluster " + clusterId + " new config: " + content
+          + ", Exception: " + ex);
       return serverError(ex);
     }
     return OK();
@@ -588,8 +588,9 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       config = accessor.getRESTConfig(clusterId);
     } catch (HelixException ex) {
-      _logger.info("Failed to get rest config for cluster " + clusterId
-          + ", cluster not found, Exception: " + ex);
+      _logger.info(
+          "Failed to get rest config for cluster " + clusterId + ", cluster not found, Exception: "
+              + ex);
     } catch (Exception ex) {
       _logger.error("Failed to get rest config for cluster " + clusterId + " Exception: " + ex);
       return serverError(ex);
@@ -598,6 +599,23 @@ public class ClusterAccessor extends AbstractHelixResource {
       return notFound();
     }
     return JSONRepresentation(config.getRecord());
+  }
+
+  @DELETE
+  @Path("{clusterId}/restconfig")
+  public Response deleteClusterRESTConfig(@PathParam("clusterId") String clusterId) {
+    ConfigAccessor accessor = getConfigAccessor();
+    try {
+      accessor.deleteRESTConfig(clusterId);
+    } catch (HelixException ex) {
+      _logger.info(
+          "Failed to delete rest config for cluster " + clusterId + ", cluster rest config is not found, Exception: "
+              + ex);
+    } catch (Exception ex) {
+      _logger.error("Failed to delete rest config, cluster " + clusterId + ", Exception: " + ex);
+      return serverError(ex);
+    }
+    return OK();
   }
 
   @GET

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -519,7 +519,7 @@ public class ClusterAccessor extends AbstractHelixResource {
 
   @PUT
   @Path("{clusterId}/restconfig")
-  public Response createClusterRESTConfig(@PathParam("clusterId") String clusterId,
+  public Response createRESTConfig(@PathParam("clusterId") String clusterId,
       String content) {
     ZNRecord record;
     try {
@@ -550,7 +550,7 @@ public class ClusterAccessor extends AbstractHelixResource {
 
   @POST
   @Path("{clusterId}/restconfig")
-  public Response updateClusterRESTConfig(@PathParam("clusterId") String clusterId,
+  public Response updateRESTConfig(@PathParam("clusterId") String clusterId,
       @QueryParam("command") String commandStr, String content) {
     Command command;
     try {
@@ -601,7 +601,7 @@ public class ClusterAccessor extends AbstractHelixResource {
 
   @GET
   @Path("{clusterId}/restconfig")
-  public Response getClusterRESTConfig(@PathParam("clusterId") String clusterId) {
+  public Response getRESTConfig(@PathParam("clusterId") String clusterId) {
     ConfigAccessor accessor = getConfigAccessor();
     RESTConfig config = null;
     try {
@@ -622,7 +622,7 @@ public class ClusterAccessor extends AbstractHelixResource {
 
   @DELETE
   @Path("{clusterId}/restconfig")
-  public Response deleteClusterRESTConfig(@PathParam("clusterId") String clusterId) {
+  public Response deleteRESTConfig(@PathParam("clusterId") String clusterId) {
     ConfigAccessor accessor = getConfigAccessor();
     try {
       accessor.deleteRESTConfig(clusterId);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -525,7 +525,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       record = toZNRecord(content);
     } catch (IOException e) {
-      LOG.error("Failed to deserialize user's input " + content + ", Exception: " + e);
+      LOG.error("Failed to deserialize user's input {}. Exception: {}.", content, e);
       return badRequest("Input is not a valid ZNRecord!");
     }
 
@@ -541,8 +541,7 @@ public class ClusterAccessor extends AbstractHelixResource {
       // TODO: Could use a more generic error for HelixException
       return notFound(ex.getMessage());
     } catch (Exception ex) {
-      LOG.error("Failed to create rest config, cluster " + clusterId + " new config: " + content
-          + ", Exception: " + ex);
+      LOG.error("Failed to create rest config, cluster {}, new config: {}. Exception: {}.", clusterId, content, ex);
       return serverError(ex);
     }
     return OK();
@@ -564,7 +563,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       record = toZNRecord(content);
     } catch (IOException e) {
-      LOG.error("Failed to deserialize user's input " + content + ", Exception: " + e);
+      LOG.error("Failed to deserialize user's input {}. Exception: {}", content, e);
       return badRequest("Input is not a valid ZNRecord!");
     }
 
@@ -589,8 +588,7 @@ public class ClusterAccessor extends AbstractHelixResource {
       return notFound(ex.getMessage());
     } catch (Exception ex) {
       LOG.error(
-          "Failed to " + command + " rest config, cluster " + clusterId + " new config: " + content
-              + ", Exception: " + ex);
+          "Failed to {} rest config, cluster {}, new config: {}. Exception: {}", command, clusterId, content, ex);
       return serverError(ex);
     }
     return OK();
@@ -605,10 +603,9 @@ public class ClusterAccessor extends AbstractHelixResource {
       config = accessor.getRESTConfig(clusterId);
     } catch (HelixException ex) {
       LOG.info(
-          "Failed to get rest config for cluster " + clusterId + ", cluster not found, Exception: "
-              + ex);
+          "Failed to get rest config for cluster {}, cluster not found. Exception: {}.", clusterId, ex);
     } catch (Exception ex) {
-      LOG.error("Failed to get rest config for cluster " + clusterId + " Exception: " + ex);
+      LOG.error("Failed to get rest config for cluster {}. Exception: {}.", clusterId, ex);
       return serverError(ex);
     }
     if (config == null) {
@@ -624,11 +621,10 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       accessor.deleteRESTConfig(clusterId);
     } catch (HelixException ex) {
-      LOG.info("Failed to delete rest config for cluster " + clusterId
-          + ", cluster rest config is not found, Exception: " + ex);
+      LOG.info("Failed to delete rest config for cluster {}, cluster rest config is not found. Exception: {}.", clusterId, ex);
       return notFound(ex.getMessage());
     } catch (Exception ex) {
-      LOG.error("Failed to delete rest config, cluster " + clusterId + ", Exception: " + ex);
+      LOG.error("Failed to delete rest config, cluster {}, Exception: {}.", clusterId, ex);
       return serverError(ex);
     }
     return OK();

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -578,7 +578,7 @@ public class TestClusterAccessor extends AbstractTestClass {
   }
 
   @Test
-  public void testCreateClusterRESTConfig() throws IOException {
+  public void testCreateRESTConfig() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String cluster = _clusters.iterator().next();
     RESTConfig restConfigRest = new RESTConfig(cluster);
@@ -593,8 +593,8 @@ public class TestClusterAccessor extends AbstractTestClass {
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
-  @Test(dependsOnMethods = "testCreateClusterRESTConfig")
-  public void testUpdateClusterRESTConfig() throws IOException {
+  @Test(dependsOnMethods = "testCreateRESTConfig")
+  public void testUpdateRESTConfig() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String cluster = _clusters.iterator().next();
     RESTConfig restConfigRest = new RESTConfig(cluster);
@@ -619,7 +619,6 @@ public class TestClusterAccessor extends AbstractTestClass {
     Assert.assertEquals(restConfigZK, new RESTConfig(cluster),
         "rest config from response: " + new RESTConfig(cluster) + " vs rest config actually: "
             + restConfigZK);
-    System.out.println("End test :" + TestHelper.getTestMethodName());
 
     // Update a cluster rest config that the cluster does not exist
     String wrongClusterId = "wrong_cluster_id";
@@ -630,15 +629,17 @@ public class TestClusterAccessor extends AbstractTestClass {
     post("clusters/" + wrongClusterId + "/restconfig",
         ImmutableMap.of("command", Command.update.name()), entity,
         Response.Status.NOT_FOUND.getStatusCode());
+    System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
-  @Test(dependsOnMethods = "testUpdateClusterRESTConfig")
-  public void testDeleteClusterRESTConfig() {
+  @Test(dependsOnMethods = "testUpdateRESTConfig")
+  public void testDeleteRESTConfig() {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String cluster = _clusters.iterator().next();
     delete("clusters/" + cluster + "/restconfig", Response.Status.OK.getStatusCode());
     get("clusters/" + cluster + "/restconfig", null, Response.Status.NOT_FOUND.getStatusCode(), true);
     delete("clusters/" + cluster + "/restconfig", Response.Status.OK.getStatusCode());
+    System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
   private ClusterConfig getClusterConfigFromRest(String cluster) throws IOException {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -583,12 +583,13 @@ public class TestClusterAccessor extends AbstractTestClass {
     String cluster = _clusters.iterator().next();
     RESTConfig restConfigRest = new RESTConfig(cluster);
     restConfigRest.set(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL, "http://*:00");
-    put("clusters/" + cluster + "/restconfig", null,
-        Entity.entity(OBJECT_MAPPER.writeValueAsString(restConfigRest.getRecord()), MediaType.APPLICATION_JSON_TYPE),
-        Response.Status.OK.getStatusCode());
+    put("clusters/" + cluster + "/restconfig", null, Entity
+        .entity(OBJECT_MAPPER.writeValueAsString(restConfigRest.getRecord()),
+            MediaType.APPLICATION_JSON_TYPE), Response.Status.OK.getStatusCode());
     RESTConfig restConfigZK = _configAccessor.getRESTConfig(cluster);
     Assert.assertEquals(restConfigZK, restConfigRest,
-        "rest config from response: " + restConfigRest + " vs rest config actually: " + restConfigZK);
+        "rest config from response: " + restConfigRest + " vs rest config actually: "
+            + restConfigZK);
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
@@ -598,12 +599,13 @@ public class TestClusterAccessor extends AbstractTestClass {
     String cluster = _clusters.iterator().next();
     RESTConfig restConfigRest = new RESTConfig(cluster);
     restConfigRest.set(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL, "http://*:01");
-    post("clusters/" + cluster + "/restconfig", null,
-        Entity.entity(OBJECT_MAPPER.writeValueAsString(restConfigRest.getRecord()), MediaType.APPLICATION_JSON_TYPE),
-        Response.Status.OK.getStatusCode());
+    post("clusters/" + cluster + "/restconfig", ImmutableMap.of("command", Command.update.name()),
+        Entity.entity(OBJECT_MAPPER.writeValueAsString(restConfigRest.getRecord()),
+            MediaType.APPLICATION_JSON_TYPE), Response.Status.OK.getStatusCode());
     RESTConfig restConfigZK = _configAccessor.getRESTConfig(cluster);
     Assert.assertEquals(restConfigZK, restConfigRest,
-        "rest config from response: " + restConfigRest + " vs rest config actually: " + restConfigZK);
+        "rest config from response: " + restConfigRest + " vs rest config actually: "
+            + restConfigZK);
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
@@ -611,22 +613,30 @@ public class TestClusterAccessor extends AbstractTestClass {
   public void testGetClusterRESTConfig() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String cluster = _clusters.iterator().next();
-    String body = get("clusters/" + cluster + "/restconfig", null, Response.Status.OK.getStatusCode(), true);
+    String body =
+        get("clusters/" + cluster + "/restconfig", null, Response.Status.OK.getStatusCode(), true);
     RESTConfig restConfigRest = new RESTConfig(cluster);
     restConfigRest.set(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL, "http://*:01");
     ZNRecord record = new ObjectMapper().reader(ZNRecord.class).readValue(body);
     ClusterConfig restConfigZk = new ClusterConfig(record);
     Assert.assertEquals(restConfigZk, restConfigRest,
-        "rest config from response: " + restConfigRest + " vs rest config actually: " + restConfigZk);
+        "rest config from response: " + restConfigRest + " vs rest config actually: "
+            + restConfigZk);
   }
 
   @Test(dependsOnMethods = "testGetClusterRESTConfig")
-  public void testDeleteClusterRESTConfig() {
+  public void testDeleteClusterRESTConfig() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String cluster = _clusters.iterator().next();
-    delete("clusters/" + cluster + "/restconfig", Response.Status.OK.getStatusCode());
-    get("clusters/" + cluster + "/restconfig", null, Response.Status.NOT_FOUND.getStatusCode(), true);
-    delete("clusters/" + cluster + "/restconfig", Response.Status.OK.getStatusCode());
+    Entity entity = Entity
+        .entity(OBJECT_MAPPER.writeValueAsString(new RESTConfig(cluster).getRecord()),
+            MediaType.APPLICATION_JSON_TYPE);
+    post("clusters/" + cluster + "/restconfig", ImmutableMap.of("command", Command.delete.name()),
+        entity, Response.Status.OK.getStatusCode());
+    get("clusters/" + cluster + "/restconfig", null, Response.Status.NOT_FOUND.getStatusCode(),
+        true);
+    post("clusters/" + cluster + "/restconfig", ImmutableMap.of("command", Command.delete.name()),
+        entity, Response.Status.OK.getStatusCode());
   }
 
   private ClusterConfig getClusterConfigFromRest(String cluster) throws IOException {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -620,6 +620,15 @@ public class TestClusterAccessor extends AbstractTestClass {
         "rest config from response: " + restConfigRest + " vs rest config actually: " + restConfigZk);
   }
 
+  @Test(dependsOnMethods = "testGetClusterRESTConfig")
+  public void testDeleteClusterRESTConfig() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String cluster = _clusters.iterator().next();
+    delete("clusters/" + cluster + "/restconfig", Response.Status.OK.getStatusCode());
+    get("clusters/" + cluster + "/restconfig", null, Response.Status.NOT_FOUND.getStatusCode(), true);
+    delete("clusters/" + cluster + "/restconfig", Response.Status.OK.getStatusCode());
+  }
+
   private ClusterConfig getClusterConfigFromRest(String cluster) throws IOException {
     String body = get("clusters/" + cluster + "/configs", null, Response.Status.OK.getStatusCode(), true);
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#848 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Added PUT to create, POST to upate, and GET to get the RestConfig for each cluster under CONFIGS.
Tested by unit tests.

### Tests

- [x] The following tests are written for this issue:
testSetRestConfig, testUpdateRestConfig

testCreateClusterRESTConfig, testUpdateClusterRESTConfig, testGetClusterRESTConfig

- [x] The following is the result of the "mvn test" command on the appropriate module:

Tests run: 102, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  34.405 s
[INFO] Finished at: 2020-03-03T15:48:27-08:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)