### PR TITLE
Fix type cast in TestRawZkClient

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1721,7 +1721,7 @@ public class ZkClient implements Watcher {
   public void asyncCreate(final String path, Object datat, final CreateMode mode,
       final ZkAsyncCallbacks.CreateCallbackHandler cb) {
     final long startT = System.currentTimeMillis();
-    byte[] data = null;
+    final byte[] data;
     try {
       data = (datat == null ? null : serialize(datat, path));
     } catch (ZkMarshallingError e) {
@@ -1729,13 +1729,12 @@ public class ZkClient implements Watcher {
           new ZkAsyncCallbacks.ZkAsyncCallContext(_monitor, startT, 0, false), null);
       return;
     }
-    final byte[] finalData = data;
     retryUntilConnected(() -> {
       ((ZkConnection) getConnection()).getZookeeper()
-          .create(path, finalData, ZooDefs.Ids.OPEN_ACL_UNSAFE,
+          .create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE,
               // Arrays.asList(DEFAULT_ACL),
               mode, cb, new ZkAsyncCallbacks.ZkAsyncCallContext(_monitor, startT,
-                  finalData == null ? 0 : finalData.length, false));
+                  data == null ? 0 : data.length, false));
       return null;
     });
   }
@@ -1744,7 +1743,7 @@ public class ZkClient implements Watcher {
   public void asyncSetData(final String path, Object datat, final int version,
       final ZkAsyncCallbacks.SetDataCallbackHandler cb) {
     final long startT = System.currentTimeMillis();
-    byte[] data = null;
+    final byte[] data;
     try {
       data = serialize(datat, path);
     } catch (ZkMarshallingError e) {
@@ -1752,11 +1751,10 @@ public class ZkClient implements Watcher {
           new ZkAsyncCallbacks.ZkAsyncCallContext(_monitor, startT, 0, false), null);
       return;
     }
-    final byte[] finalData = data;
     retryUntilConnected(() -> {
-      ((ZkConnection) getConnection()).getZookeeper().setData(path, finalData, version, cb,
+      ((ZkConnection) getConnection()).getZookeeper().setData(path, data, version, cb,
           new ZkAsyncCallbacks.ZkAsyncCallContext(_monitor, startT,
-              finalData == null ? 0 : finalData.length, false));
+              data == null ? 0 : data.length, false));
       return null;
     });
   }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #852 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The type cast is unexpected. We would like to make the test accurate and expected.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
Results :

Failed tests:
  TestResourceChangeDetector.testRemoveInstance:284 » ZkClient Failed to delete ...
org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceTopoplogyAwareDisabled.testLackEnoughInstances(org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceTopoplogyAwareDisabled)
  Run 1: PASS
  Run 2: TestCrushAutoRebalanceTopoplogyAwareDisabled.testLackEnoughInstances:86->TestCrushAutoRebalanceNonRack.testLackEnoughInstances:250 » ZkClient


Tests run: 1085, Failures: 2, Errors: 0, Skipped: 5

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:06 h
[INFO] Finished at: 2020-03-03T23:16:15-08:00
[INFO] ------------------------------------------------------------------------


Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 27.375 sec - in org.apache.helix.controller.changedetector.TestResourceChangeDetector

Results :

Tests run: 10, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  31.612 s
[INFO] Finished at: 2020-03-04T00:05:03-08:00
[INFO] ------------------------------------------------------------------------


Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.908 sec - in org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceTopoplogyAwareDisabled

Results :

Tests run: 8, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  23.248 s
[INFO] Finished at: 2020-03-04T00:07:46-08:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)