### PR TITLE
Make ZkBaseDataAccessor realm-aware

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -1338,30 +1338,30 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
   private RealmAwareZkClient buildRealmAwareZkClient(
       RealmAwareZkClient.RealmAwareZkClientConfig clientConfig, String zkAddress,
       ZkClientType zkClientType) {
-    RealmAwareZkClient zkClient;
-
     try {
-      zkClient = new FederatedZkClient(
+      return new FederatedZkClient(
           new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder().build(), clientConfig);
     } catch (IllegalStateException | IOException | InvalidRoutingDataException e) {
       // Fall back to connect on single-realm mode if failed to connect on multi-realm mode and
       // ZK address is not empty.
       LOG.info("Not able to connect on multi-realm mode, caused by: {}. "
           + "Connecting on single-realm mode to ZK: {}.", e.getMessage(), zkAddress);
+    }
 
-      switch (zkClientType) {
-        case DEDICATED:
-          zkClient = DedicatedZkClientFactory.getInstance().buildZkClient(
-              new HelixZkClient.ZkConnectionConfig(zkAddress),
-              clientConfig.createHelixZkClientConfig());
-          break;
-        case SHARED:
-        default:
-          zkClient = SharedZkClientFactory.getInstance().buildZkClient(
-              new HelixZkClient.ZkConnectionConfig(zkAddress),
-              clientConfig.createHelixZkClientConfig());
-          break;
-      }
+    RealmAwareZkClient zkClient;
+
+    switch (zkClientType) {
+      case DEDICATED:
+        zkClient = DedicatedZkClientFactory.getInstance()
+            .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
+                clientConfig.createHelixZkClientConfig());
+        break;
+      case SHARED:
+      default:
+        zkClient = SharedZkClientFactory.getInstance()
+            .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
+                clientConfig.createHelixZkClientConfig());
+        break;
     }
 
     return zkClient;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -1443,10 +1443,11 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
         zkClient = SharedZkClientFactory.getInstance()
             .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
                 clientConfig.createHelixZkClientConfig());
+
+        zkClient
+            .waitUntilConnected(HelixZkClient.DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
         break;
     }
-
-    zkClient.waitUntilConnected(HelixZkClient.DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
 
     return zkClient;
   }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -1318,6 +1318,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
     }
   }
 
+  // TODO: refactor Builder class to remove duplicate code with other Helix Java APIs
   public static class Builder {
     private String zkAddress;
     private RealmAwareZkClient.RealmMode realmMode;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -144,12 +144,12 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
     switch (builder.realmMode) {
       case MULTI_REALM:
         try {
-          if (builder.zkClientType == ZkBaseDataAccessor.ZkClientType.DEDICATED) {
+          if (builder.zkClientType == ZkClientType.DEDICATED) {
             // Use a realm-aware dedicated zk client
             _zkClient = DedicatedZkClientFactory.getInstance()
                 .buildZkClient(builder.realmAwareZkConnectionConfig,
                     builder.realmAwareZkClientConfig);
-          } else if (builder.zkClientType == ZkBaseDataAccessor.ZkClientType.SHARED) {
+          } else if (builder.zkClientType == ZkClientType.SHARED) {
             // Use a realm-aware shared zk client
             _zkClient = SharedZkClientFactory.getInstance()
                 .buildZkClient(builder.realmAwareZkConnectionConfig,


### PR DESCRIPTION
Draft: to add a test for multi-realm mode and depends on #819 

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Implements #854 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

To make Helix Java APIs realm-aware, we need to make ZkBaseDataAccessor realm-aware to use FederatedZkClient for multi-realm mode.

### Tests

- [x] The following tests are written for this issue:
TestZkBaseDataAccessor covers the cases.

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestPauseSignal.testPauseSignal:106 expected:<true> but was:<false>
[WARNING] Flakes:
[WARNING] org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceNonRack.testLackEnoughInstances(org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceNonRack)
[INFO]   Run 1: PASS
[ERROR]   Run 2: TestCrushAutoRebalanceNonRack.testLackEnoughInstances:250 » ZkClient Failed to...
[INFO]
[INFO]
[ERROR] Tests run: 1082, Failures: 1, Errors: 0, Skipped: 1, Flakes: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:09 h
[INFO] Finished at: 2020-03-11T22:06:21-07:00
[INFO] ------------------------------------------------------------------------

[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.273 s - in org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceNonRack
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.489 s - in org.apache.helix.integration.TestPauseSignal
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)