### PR TITLE
Update customize state using updater

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
@@ -113,7 +113,7 @@ public class CustomizedStateProvider {
   /**
    * Delete the customized state for a specified resource and a specified partition
    */
-  public void deletePerPartitionCustomizedState(String customizedStateName, String resourceName,
+  public synchronized void deletePerPartitionCustomizedState(String customizedStateName, String resourceName,
       String partitionName) {
     PropertyKey.Builder keyBuilder = _helixDataAccessor.keyBuilder();
     PropertyKey propertyKey =

--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
@@ -50,7 +50,7 @@ public class CustomizedStateProvider {
    * Update a specific customized state based on the resource name and partition name. The
    * customized state is input as a single string
    */
-  public synchronized void updateCustomizedState(String customizedStateName, String resourceName,
+  public void updateCustomizedState(String customizedStateName, String resourceName,
       String partitionName, String customizedState) {
     Map<String, String> customizedStateMap = new HashMap<>();
     customizedStateMap.put(CustomizedState.CustomizedStateProperty.CURRENT_STATE.name(), customizedState);
@@ -61,29 +61,16 @@ public class CustomizedStateProvider {
    * Update a specific customized state based on the resource name and partition name. The
    * customized state is input as a map
    */
-  public synchronized void updateCustomizedState(String customizedStateName, String resourceName,
+  public void updateCustomizedState(String customizedStateName, String resourceName,
       String partitionName, Map<String, String> customizedStateMap) {
     PropertyKey.Builder keyBuilder = _helixDataAccessor.keyBuilder();
     PropertyKey propertyKey =
         keyBuilder.customizedState(_instanceName, customizedStateName, resourceName);
     ZNRecord record = new ZNRecord(resourceName);
-    Map<String, Map<String, String>> mapFields = new HashMap<>();
-    CustomizedState existingState = getCustomizedState(customizedStateName, resourceName);
-    if (existingState != null
-        && existingState.getRecord().getMapFields().containsKey(partitionName)) {
-      Map<String, String> existingMap = new HashMap<>();
-      for (String key : customizedStateMap.keySet()) {
-        existingMap.put(key, customizedStateMap.get(key));
-      }
-
-      mapFields.put(partitionName, existingMap);
-    } else {
-      mapFields.put(partitionName, customizedStateMap);
-    }
-    record.setMapFields(mapFields);
+    record.setMapField(partitionName, customizedStateMap);
     if (!_helixDataAccessor.updateProperty(propertyKey, new CustomizedState(record))) {
-      throw new HelixException(
-          String.format("Failed to persist customized state %s to zk for instance %s, resource %s",
+      throw new HelixException(String
+          .format("Failed to persist customized state %s to zk for instance %s, resource %s",
               customizedStateName, _instanceName, record.getId()));
     }
   }
@@ -113,7 +100,7 @@ public class CustomizedStateProvider {
   /**
    * Delete the customized state for a specified resource and a specified partition
    */
-  public synchronized void deletePerPartitionCustomizedState(String customizedStateName, String resourceName,
+  public void deletePerPartitionCustomizedState(String customizedStateName, String resourceName,
       String partitionName) {
     PropertyKey.Builder keyBuilder = _helixDataAccessor.keyBuilder();
     PropertyKey propertyKey =


### PR DESCRIPTION
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently the update customized state method is made synchronized for concurrency control. This PR modifies the implementation of update to leave the responsibility of concurrency control to ZooKeeper by using updater to update the customize state. With delete method already implemented with updater, we can prevent unexpected change of the customize state data.

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:
===============================================
Default Suite
Total tests run: 6, Failures: 0, Skips: 0
===============================================

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)