### PR TITLE
Make ZkCacheBaseDataAccessor and ZkHelixPropertyStore realm-aware

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -104,7 +104,8 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
   private static Logger LOG = LoggerFactory.getLogger(ZkBaseDataAccessor.class);
 
   private final RealmAwareZkClient _zkClient;
-  // true if ZkBaseDataAccessor was instantiated with a HelixZkClient, false otherwise
+
+  // true if ZkBaseDataAccessor was instantiated with a RealmAwareZkClient, false otherwise
   // This is used for close() to determine how ZkBaseDataAccessor should close the underlying
   // ZkClient
   private final boolean _usesExternalZkClient;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -58,6 +58,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
 
   // Designates which mode ZkBaseDataAccessor should be created in. If not specified, it will be
   // created on SHARED mode.
+  // TODO: move this to RealmAwareZkClient
   public enum ZkClientType {
     /*
      * When ZkBaseDataAccessor is created with the DEDICATED type, it supports ephemeral node
@@ -70,7 +71,12 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
      * When ZkBaseDataAccessor is created with the SHARED type, it only supports CRUD
      * functionalities. This will be the default mode of creation.
      */
-    SHARED
+    SHARED,
+    /*
+     * Uses FederatedZkClient (applicable on multi-realm mode only) that queries Metadata Store
+     * Directory Service for routing data
+     */
+    FEDERATED
   }
 
   enum RetCode {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -183,8 +183,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
         } catch (IOException | InvalidRoutingDataException | IllegalStateException e) {
           // Note: IllegalStateException is for HttpRoutingDataReader if MSDS endpoint cannot be
           // found
-          // Fall back to single-realm mode using SharedZkClient (HelixZkClient)
-          // This is to preserve backward-compatibility
+          throw new HelixException("Failed to create ZkCacheBaseDataAccessor!", e);
         }
       case SINGLE_REALM:
         switch (builder._zkClientType) {
@@ -982,6 +981,11 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       if (_realmMode == RealmAwareZkClient.RealmMode.SINGLE_REALM && !isZkAddressSet) {
         throw new HelixException(
             "ZkCacheBaseDataAccessor: RealmMode cannot be single-realm without a valid ZkAddress set!");
+      }
+
+      if (_realmMode == RealmAwareZkClient.RealmMode.MULTI_REALM && isZkAddressSet) {
+        throw new HelixException(
+            "ZkCacheBaseDataAccessor: You cannot set the ZkAddress on multi-realm mode!");
       }
 
       if (_realmMode == null) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -84,10 +84,12 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
 
   private RealmAwareZkClient _zkClient;
 
+  @Deprecated
   public ZkCacheBaseDataAccessor(ZkBaseDataAccessor<T> baseAccessor, List<String> wtCachePaths) {
     this(baseAccessor, null, wtCachePaths, null);
   }
 
+  @Deprecated
   public ZkCacheBaseDataAccessor(ZkBaseDataAccessor<T> baseAccessor, String chrootPath,
       List<String> wtCachePaths, List<String> zkCachePaths) {
     _baseAccessor = baseAccessor;
@@ -105,18 +107,21 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
     start();
   }
 
+  @Deprecated
   public ZkCacheBaseDataAccessor(String zkAddress, ZkSerializer serializer, String chrootPath,
       List<String> wtCachePaths, List<String> zkCachePaths) {
     this(zkAddress, serializer, chrootPath, wtCachePaths, zkCachePaths, null, null,
         ZkBaseDataAccessor.ZkClientType.SHARED);
   }
 
+  @Deprecated
   public ZkCacheBaseDataAccessor(String zkAddress, ZkSerializer serializer, String chrootPath,
       List<String> wtCachePaths, List<String> zkCachePaths, String monitorType, String monitorkey) {
     this(zkAddress, serializer, chrootPath, wtCachePaths, zkCachePaths, monitorType, monitorkey,
         ZkBaseDataAccessor.ZkClientType.SHARED);
   }
 
+  @Deprecated
   public ZkCacheBaseDataAccessor(String zkAddress, ZkSerializer serializer, String chrootPath,
       List<String> wtCachePaths, List<String> zkCachePaths, String monitorType, String monitorkey,
       ZkBaseDataAccessor.ZkClientType zkClientType) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -198,7 +198,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
             zkClient = new FederatedZkClient(builder._realmAwareZkConnectionConfig,
                 builder._realmAwareZkClientConfig);
           }
-          break; // Must break out of the switch statement here
+          break; // Must break out of the switch statement here since zkClient has been created
         } catch (IOException | InvalidRoutingDataException | IllegalStateException e) {
           // Note: IllegalStateException is for HttpRoutingDataReader if MSDS endpoint cannot be
           // found
@@ -220,8 +220,8 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
                     builder._realmAwareZkClientConfig.createHelixZkClientConfig());
             zkClient.waitUntilConnected(HelixZkClient.DEFAULT_CONNECTION_TIMEOUT,
                 TimeUnit.MILLISECONDS);
+            break;
         }
-        break;
       default:
         throw new HelixException("Invalid RealmMode given: " + builder._realmMode);
     }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #862 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This commit makes both ZkCacheBaseDataAccessor and ZkHelixPropertyStore realm-aware by choosing the appropriate realm-aware ZkClients in the constructor. Also, we add a Builder here to give users options to set Connection config and Client config.
Note that ZkHelixPropertyStore extends CacheBaseDataAccessor so there is no change needed.

### Tests

- [x] The following tests are written for this issue:

The following tests cover ZkCacheBaseDataAccessor:

TestZkCacheAsyncOpSingleThread,TestZkCacheSyncOpSingleThread,TestWtCacheSyncOpSingleThread,TestWtCacheAsyncOpMultiThread

- [x] The following is the result of the "mvn test" command on the appropriate module:

`mvn test -Dtest=TestZkCacheAsyncOpSingleThread,TestZkCacheSyncOpSingleThread,TestWtCacheSyncOpSingleThread,TestWtCacheAsyncOpMultiThread`

> [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.875 s - in TestSuite
> [INFO] 
> [INFO] Results:
> [INFO] 
> [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
> [INFO] 
> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD SUCCESS
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time:  49.191 s
> [INFO] Finished at: 2020-03-04T20:33:05-08:00
> [INFO] ------------------------------------------------------------------------

**helix-core:**

```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:108 expected:<true> but was:<false>
[ERROR]   TestControllerLeadershipChange.testMissingTopStateDurationMonitoring:262 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1083, Failures: 2, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:09 h
[INFO] Finished at: 2020-03-04T21:54:11-08:00
[INFO] ------------------------------------------------------------------------
```

`mvn test -Dtest=TestEnableCompression,TestControllerLeadershipChange`

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.611 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:15 min
[INFO] Finished at: 2020-03-04T21:56:37-08:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)