### PR TITLE
Replace customized view cache with property cache

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedViewCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedViewCache.java
@@ -76,12 +76,7 @@ public class CustomizedViewCache extends AbstractDataCache<CustomizedView> {
    * @return
    */
   public void refresh(HelixDataAccessor accessor) {
-    long startTime = System.currentTimeMillis();
     _customizedViewCache.refresh(accessor);
-    long endTime = System.currentTimeMillis();
-
-    LOG.info("Refresh " + _customizedViewCache.getPropertyMap().size() + " CustomizedViews of type " + _customizedStateType
-        + " for cluster " + _clusterName + ", took " + (endTime - startTime) + " ms");
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
@@ -66,6 +66,7 @@ public class TestRoutingTableProvider extends ZkTestBase {
   static final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + CLASS_NAME;
   static final int PARTICIPANT_NUMBER = 3;
   static final int PARTICIPANT_START_PORT = 12918;
+  static final long WAIT_DURATION = 5 * 1000L; // 5 seconds
 
   static final int PARTITION_NUMBER = 20;
   static final int REPLICA_NUMBER = 3;
@@ -288,7 +289,7 @@ public class TestRoutingTableProvider extends ZkTestBase {
         customizedView.getRecord(), AccessOption.PERSISTENT);
 
     boolean onCustomizedViewChangeCalled =
-        TestHelper.verify(() -> customizedViewChangeCalled.get(), TestHelper.WAIT_DURATION);
+        TestHelper.verify(() -> customizedViewChangeCalled.get(), WAIT_DURATION);
     Assert.assertTrue(onCustomizedViewChangeCalled);
 
     _spectator.getHelixDataAccessor().getBaseDataAccessor().remove(customizedViewPath,
@@ -363,14 +364,15 @@ public class TestRoutingTableProvider extends ZkTestBase {
             .getStateMap("p1").get("h4");
       } catch (Exception e) {
         // ok because RoutingTable has not been updated yet
+        return false;
       }
       return (routingTableSnapshots.size() == 2
           && routingTableSnapshots.get(PropertyType.CUSTOMIZEDVIEW.name()).size() == 2
           && typeAp1h1.equals("testState1") && typeAp1h2.equals("testState1")
           && typeAp2h1.equals("testState2") && typeAp3h2.equals("testState3")
           && typeBp1h2.equals("testState3") && typeBp1h4.equals("testState2"));
-    }, TestHelper.WAIT_DURATION);
-    Assert.assertTrue(isRoutingTableUpdatedProperly);
+    }, WAIT_DURATION);
+    Assert.assertTrue(isRoutingTableUpdatedProperly, "RoutingTable has been updated properly");
     routingTableProvider.shutdown();
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes #868 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In this PR, the custom implementation of customized view cache has been replaced with property cache implementation.

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 915, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,610.258 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 915, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:00 h
[INFO] Finished at: 2020-03-05T11:59:41-08:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml

