### PR TITLE
Downgrade the log level to INFO when isInstanceSetup() fails

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -146,7 +146,7 @@ public final class ZKUtil {
       for (String path : requiredPaths) {
         if (!zkclient.exists(path)) {
           isValid = false;
-          logger.error("Invalid instance setup, missing znode path: {}", path);
+          logger.info("Invalid instance setup, missing znode path: {}", path);
         }
       }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#692 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Follow the log convention in ZKUtil class and downgrade the log level to INFO when isInstanceSetup() fails. This change avoids verbose error log that misleads the users.

### Tests

- [ ] The following tests are written for this issue:

NA

- [ ] The following is the result of the "mvn test" command on the appropriate module:

NA, log change only.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)