### PR TITLE
Add construction of domain in Helix participant logic

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformationProcessor.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformationProcessor.java
@@ -144,9 +144,6 @@ public class AzureCloudInstanceInformationProcessor
         String vmssName = computeNode.path(INSTANCE_SET_NAME).getValueAsText();
         String azureTopology = AzureConstants.AZURE_TOPOLOGY;
         String[] parts = azureTopology.trim().split("/");
-        if (parts.length != 2) {
-          throw new HelixException("Invalid Azure topology definition: " + azureTopology);
-        }
         //The hostname will be filled in by each participant
         String domain = parts[0] + "=" + platformFaultDomain + "," + parts[1] + "=";
 

--- a/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformationProcessor.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformationProcessor.java
@@ -142,8 +142,16 @@ public class AzureCloudInstanceInformationProcessor
         String vmName = computeNode.path(INSTANCE_NAME).getTextValue();
         String platformFaultDomain = computeNode.path(DOMAIN).getTextValue();
         String vmssName = computeNode.path(INSTANCE_SET_NAME).getValueAsText();
+        String azureTopology = AzureConstants.AZURE_TOPOLOGY;
+        String[] parts = azureTopology.trim().split("/");
+        if (parts.length != 2) {
+          throw new HelixException("Invalid Azure topology definition: " + azureTopology);
+        }
+        //The hostname will be filled in by each participant
+        String domain = parts[0] + "=" + platformFaultDomain + "," + parts[1] + "=";
+
         AzureCloudInstanceInformation.Builder builder = new AzureCloudInstanceInformation.Builder();
-        builder.setInstanceName(vmName).setFaultDomain(platformFaultDomain)
+        builder.setInstanceName(vmName).setFaultDomain(domain)
             .setInstanceSetName(vmssName);
         azureCloudInstanceInformation = builder.build();
       }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -45,7 +45,6 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.ZNRecordBucketizer;
 import org.apache.helix.api.cloud.CloudInstanceInformation;
 import org.apache.helix.api.cloud.CloudInstanceInformationProcessor;
-import org.apache.helix.controller.rebalancer.topology.Topology;
 import org.apache.helix.manager.zk.client.HelixZkClient;
 import org.apache.helix.messaging.DefaultMessagingService;
 import org.apache.helix.model.CurrentState;
@@ -178,8 +177,8 @@ public class ParticipantManager {
         } else {
           LOG.info(_instanceName + " is auto-registering cluster: " + _clusterName);
           CloudInstanceInformation cloudInstanceInformation = getCloudInstanceInformation();
-          String domain = ConstructDomainField(cloudInstanceInformation
-              .get(CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name()));
+          String domain = cloudInstanceInformation
+              .get(CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name()) + _instanceName;
 
           // Disable the verification for now
           /*String cloudIdInRemote = cloudInstanceInformation
@@ -199,22 +198,6 @@ public class ParticipantManager {
         }
       }
     }
-  }
-
-  private String ConstructDomainField(String faultDomain) {
-    Boolean topologyEnabled = _configAccessor.getClusterConfig(_clusterName).isTopologyAwareEnabled();
-    if (!topologyEnabled) {
-      throw new HelixException("Topology is not enabled, so Helix cannot do auto "
-          + "registration");
-    }
-    String topologyDef = _configAccessor.getClusterConfig(_clusterName).getTopology();
-    String[] parts = topologyDef.trim().split("/");
-    if (parts.length != 2) {
-      throw new HelixException("Invalid cluster topology definition, so Helix cannot do auto "
-          + "registration" + topologyDef);
-    }
-    String domain = parts[0] + "=" + faultDomain + "," + parts[1] + "=" + _instanceName;
-    return domain;
   }
 
   private CloudInstanceInformation getCloudInstanceInformation() {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -45,6 +45,7 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.ZNRecordBucketizer;
 import org.apache.helix.api.cloud.CloudInstanceInformation;
 import org.apache.helix.api.cloud.CloudInstanceInformationProcessor;
+import org.apache.helix.controller.rebalancer.topology.Topology;
 import org.apache.helix.manager.zk.client.HelixZkClient;
 import org.apache.helix.messaging.DefaultMessagingService;
 import org.apache.helix.model.CurrentState;
@@ -177,8 +178,8 @@ public class ParticipantManager {
         } else {
           LOG.info(_instanceName + " is auto-registering cluster: " + _clusterName);
           CloudInstanceInformation cloudInstanceInformation = getCloudInstanceInformation();
-          String domain = cloudInstanceInformation
-              .get(CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name());
+          String domain = ConstructDomainField(cloudInstanceInformation
+              .get(CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name()));
 
           // Disable the verification for now
           /*String cloudIdInRemote = cloudInstanceInformation
@@ -198,6 +199,22 @@ public class ParticipantManager {
         }
       }
     }
+  }
+
+  private String ConstructDomainField(String faultDomain) {
+    Boolean topologyEnabled = _configAccessor.getClusterConfig(_clusterName).isTopologyAwareEnabled();
+    if (!topologyEnabled) {
+      throw new HelixException("Topology is not enabled, so Helix cannot do auto "
+          + "registration");
+    }
+    String topologyDef = _configAccessor.getClusterConfig(_clusterName).getTopology();
+    String[] parts = topologyDef.trim().split("/");
+    if (parts.length != 2) {
+      throw new HelixException("Invalid cluster topology definition, so Helix cannot do auto "
+          + "registration" + topologyDef);
+    }
+    String domain = parts[0] + "=" + faultDomain + "," + parts[1] + "=" + _instanceName;
+    return domain;
   }
 
   private CloudInstanceInformation getCloudInstanceInformation() {


### PR DESCRIPTION
### Issues

- [X ] My PR addresses the following Helix issues and references them in the PR description:

(#875 )

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Helix has a topology defined in cluster config, e.g., "TOPOLOGY": "/zone/host", and it will be used to construct the "domain" field in participant config, e.g. ""DOMAIN": "zone=0,host=host1". In Azure, Helix will provide a default topology value for the cluster, and the format is /faultDomain/hostName. In this pR, we add the construction function in Participant manager to construct the domain field based on this topology.

### Tests

- [X] The following is the result of the "mvn test" command on the appropriate module:

### Commits

- [X ] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X ] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)