### PR TITLE
Fix testInstancesStoppable_zoneBased

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
@@ -284,18 +284,20 @@ public class InstanceValidationUtil {
               .format("Partition %s of resource %s does not have an ideal state partition map",
                   partition, idealStateName));
         }
-        Map<String, String> evPartitionMap = externalView.getStateMap(partition);
-        if (evPartitionMap == null) {
-          throw new HelixException(String
-              .format("Partition %s of resource %s does not have an external view partition map",
-                  partition, idealStateName));
-        }
-        if (isPartitionMap.containsKey(instanceName) && (!evPartitionMap.containsKey(instanceName)
-            || !evPartitionMap.get(instanceName).equals(isPartitionMap.get(instanceName)))) {
-          // only checks the state from IS matches EV. Return false when
-          // 1. This partition not has current state on this instance
-          // 2. The state does not match the state on ideal state
-          return false;
+        if (isPartitionMap.containsKey(instanceName)) {
+          Map<String, String> evPartitionMap = externalView.getStateMap(partition);
+          if (evPartitionMap == null) {
+            throw new HelixException(String
+                .format("Partition %s of resource %s does not have an external view partition map",
+                    partition, idealStateName));
+          }
+          if (!evPartitionMap.containsKey(instanceName)
+              || !evPartitionMap.get(instanceName).equals(isPartitionMap.get(instanceName))) {
+            // only checks the state from IS matches EV. Return false when
+            // 1. This partition not has current state on this instance
+            // 2. The state does not match the state on ideal state
+            return false;
+          }
         }
       }
     }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #879

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The changes merged in https://github.com/apache/helix/pull/858 broke `testInstancesStoppable_zoneBased`. The test didn't create external views at all, which will encounter exceptions with the new logic. 
The logic added wasn't supposed to break the tests because the logic is to perform null checks before an if condition that utilizes maps. However, the tests were passing because in the "and" if condition, it failed at `isPartitionMap.containsKey(instanceName)` without accessing the second part of the "and" condition. Therefore, even though the second part could cause a null pointer failure, it was never an issue. The fix is to reorder the logic such that the conditions are performed separately with null checks right before each map access. 

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:
Tests run: 99, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.142 sec - in TestSuite

Results :

Tests run: 99, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  25.069 s
[INFO] Finished at: 2020-03-09T20:25:23-07:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml