### PR TITLE
Change the REST call for delete CloudConfig 

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -587,7 +587,6 @@ public class ClusterAccessor extends AbstractHelixResource {
   @DELETE
   @Path("{clusterId}/cloudconfig")
   public Response deleteCloudConfig(@PathParam("clusterId") String clusterId) {
-    HelixZkClient zkClient = getHelixZkClient();
     HelixAdmin admin = getHelixAdmin();
     admin.removeCloudConfig(clusterId);
     return OK();

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -584,6 +584,15 @@ public class ClusterAccessor extends AbstractHelixResource {
     return notFound();
   }
 
+  @DELETE
+  @Path("{clusterId}/cloudconfig")
+  public Response deleteCloudConfig(@PathParam("clusterId") String clusterId) {
+    HelixZkClient zkClient = getHelixZkClient();
+    HelixAdmin admin = getHelixAdmin();
+    admin.removeCloudConfig(clusterId);
+    return OK();
+  }
+
   @POST
   @Path("{clusterId}/cloudconfig")
   public Response updateCloudConfig(@PathParam("clusterId") String clusterId,
@@ -617,10 +626,6 @@ public class ClusterAccessor extends AbstractHelixResource {
     }
     try {
       switch (command) {
-      case delete: {
-        admin.removeCloudConfig(clusterId);
-      }
-      break;
       case update: {
         try {
           CloudConfig cloudConfig = new CloudConfig.Builder(record).build();


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes #881 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In this PR, the necessary changes has been made to the REST API call for cloud config deletion.
Previously we were using POST (command.delete) to delete the cloud config. With this new change, we can use DELETE request to delete the cloud config. 
The tests has been changed accordingly.

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:

helix-core:
[INFO] Results:
[INFO]
[INFO] Tests run: 906, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  57:50 min
[INFO] Finished at: 2020-03-09T21:16:59-07:00
[INFO] ------------------------------------------------------------------------

helix-rest:
[INFO] Tests run: 99, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 26.976 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 99, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  32.417 s
[INFO] Finished at: 2020-03-09T21:32:04-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml

