### PR TITLE
Support enableCompression in workflow and job configs

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/JobConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobConfig.java
@@ -35,6 +35,8 @@ import org.apache.helix.HelixProperty;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.task.beans.JobBean;
 import org.apache.helix.task.beans.TaskBean;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+
 
 /**
  * Provides a typed interface to job configurations.
@@ -455,6 +457,7 @@ public class JobConfig extends ResourceConfig {
     private boolean _ignoreDependentJobFailure = DEFAULT_IGNORE_DEPENDENT_JOB_FAILURE;
     private int _numberOfTasks = DEFAULT_NUMBER_OF_TASKS;
     private boolean _rebalanceRunningTask = DEFAULT_REBALANCE_RUNNING_TASK;
+    private boolean _enableCompression = TaskConstants.DEFAULT_TASK_ENABLE_COMPRESSION;
 
     public JobConfig build() {
       if (_targetResource == null && _taskConfigMap.isEmpty()) {
@@ -536,11 +539,11 @@ public class JobConfig extends ResourceConfig {
       }
       if (cfg.containsKey(JobConfigProperty.DisableExternalView.name())) {
         b.setDisableExternalView(
-            Boolean.valueOf(cfg.get(JobConfigProperty.DisableExternalView.name())));
+            Boolean.parseBoolean(cfg.get(JobConfigProperty.DisableExternalView.name())));
       }
       if (cfg.containsKey(JobConfigProperty.IgnoreDependentJobFailure.name())) {
         b.setIgnoreDependentJobFailure(
-            Boolean.valueOf(cfg.get(JobConfigProperty.IgnoreDependentJobFailure.name())));
+            Boolean.parseBoolean(cfg.get(JobConfigProperty.IgnoreDependentJobFailure.name())));
       }
       if (cfg.containsKey(JobConfigProperty.JobType.name())) {
         b.setJobType(cfg.get(JobConfigProperty.JobType.name()));
@@ -553,7 +556,11 @@ public class JobConfig extends ResourceConfig {
       }
       if (cfg.containsKey(JobConfigProperty.RebalanceRunningTask.name())) {
         b.setRebalanceRunningTask(
-            Boolean.valueOf(cfg.get(JobConfigProperty.RebalanceRunningTask.name())));
+            Boolean.parseBoolean(cfg.get(JobConfigProperty.RebalanceRunningTask.name())));
+      }
+      if (cfg.containsKey(ZNRecord.ENABLE_COMPRESSION_BOOLEAN_FIELD)) {
+        b.setEnableCompression(
+            Boolean.parseBoolean(cfg.get(ZNRecord.ENABLE_COMPRESSION_BOOLEAN_FIELD)));
       }
       return b;
     }
@@ -689,6 +696,11 @@ public class JobConfig extends ResourceConfig {
       return this;
     }
 
+    public Builder setEnableCompression(boolean enabled) {
+      _enableCompression = enabled;
+      return this;
+    }
+
     private void validate() {
       if (_taskConfigMap.isEmpty() && _targetResource == null) {
         throw new IllegalArgumentException(
@@ -760,7 +772,8 @@ public class JobConfig extends ResourceConfig {
           .setIgnoreDependentJobFailure(jobBean.ignoreDependentJobFailure)
           .setNumberOfTasks(jobBean.numberOfTasks).setExecutionDelay(jobBean.executionDelay)
           .setExecutionStart(jobBean.executionStart)
-          .setRebalanceRunningTask(jobBean.rebalanceRunningTask);
+          .setRebalanceRunningTask(jobBean.rebalanceRunningTask)
+          .setEnableCompression(jobBean.enableCompression);
 
       if (jobBean.jobCommandConfigMap != null) {
         b.setJobCommandConfigMap(jobBean.jobCommandConfigMap);
@@ -790,6 +803,7 @@ public class JobConfig extends ResourceConfig {
       if (jobBean.instanceGroupTag != null) {
         b.setInstanceGroupTag(jobBean.instanceGroupTag);
       }
+      b.setEnableCompression(jobBean.enableCompression);
       return b;
     }
 

--- a/helix-core/src/main/java/org/apache/helix/task/TaskConstants.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskConstants.java
@@ -48,5 +48,5 @@ public class TaskConstants {
 
   public static final String PREV_RA_NODE = "PreviousResourceAssignment";
 
-
+  public static final boolean DEFAULT_TASK_ENABLE_COMPRESSION = false;
 }

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowConfig.java
@@ -31,6 +31,7 @@ import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.task.beans.WorkflowBean;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -338,6 +339,7 @@ public class WorkflowConfig extends ResourceConfig {
     private long _jobPurgeInterval = DEFAULT_JOB_PURGE_INTERVAL;
     private boolean _allowOverlapJobAssignment = DEFAULT_ALLOW_OVERLAP_JOB_ASSIGNMENT;
     private long _timeout = TaskConstants.DEFAULT_NEVER_TIMEOUT;
+    private boolean _enableCompression = TaskConstants.DEFAULT_TASK_ENABLE_COMPRESSION;
 
     public WorkflowConfig build() {
       validate();
@@ -492,6 +494,11 @@ public class WorkflowConfig extends ResourceConfig {
       return this;
     }
 
+    public Builder setEnableCompression(boolean enableCompression) {
+      _enableCompression = enableCompression;
+      return this;
+    }
+
     @Deprecated
     public static Builder fromMap(Map<String, String> cfg) {
       Builder builder = new Builder();
@@ -550,6 +557,11 @@ public class WorkflowConfig extends ResourceConfig {
         if (threshold >= 0) {
           setFailureThreshold(threshold);
         }
+      }
+
+      if (cfg.containsKey(ZNRecord.ENABLE_COMPRESSION_BOOLEAN_FIELD)) {
+        setEnableCompression(
+            Boolean.parseBoolean(cfg.get(ZNRecord.ENABLE_COMPRESSION_BOOLEAN_FIELD)));
       }
 
       // Parse schedule-specific configs, if they exist
@@ -625,6 +637,7 @@ public class WorkflowConfig extends ResourceConfig {
       }
       b.setExpiry(workflowBean.expiry);
       b.setWorkFlowType(workflowBean.workflowType);
+      b.setEnableCompression(workflowBean.enableCompression);
       return b;
     }
 

--- a/helix-core/src/main/java/org/apache/helix/task/beans/JobBean.java
+++ b/helix-core/src/main/java/org/apache/helix/task/beans/JobBean.java
@@ -51,4 +51,5 @@ public class JobBean {
   public boolean ignoreDependentJobFailure = JobConfig.DEFAULT_IGNORE_DEPENDENT_JOB_FAILURE;
   public int numberOfTasks = JobConfig.DEFAULT_NUMBER_OF_TASKS;
   public boolean rebalanceRunningTask = JobConfig.DEFAULT_REBALANCE_RUNNING_TASK;
+  public boolean enableCompression = TaskConstants.DEFAULT_TASK_ENABLE_COMPRESSION;
 }

--- a/helix-core/src/main/java/org/apache/helix/task/beans/WorkflowBean.java
+++ b/helix-core/src/main/java/org/apache/helix/task/beans/WorkflowBean.java
@@ -21,6 +21,7 @@ package org.apache.helix.task.beans;
 
 import java.util.List;
 
+import org.apache.helix.task.TaskConstants;
 import org.apache.helix.task.WorkflowConfig;
 
 /**
@@ -32,4 +33,5 @@ public class WorkflowBean {
   public ScheduleBean schedule;
   public long expiry = WorkflowConfig.DEFAULT_EXPIRY;
   public String workflowType;
+  public boolean enableCompression = TaskConstants.DEFAULT_TASK_ENABLE_COMPRESSION;
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #884 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Previously, there was no way for users to set enableCompression in workflows and jobs configs. This allows them to set that field in the Builder.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
Failed tests: 
  TestEnableCompression.testEnableCompressionResource:108 expected:<true> but was:<false>
  TestHelixAdminCli.testDeactivateCluster:604 » Helix There are still LEADER in ...

Tests run: 1087, Failures: 2, Errors: 0, Skipped: 1

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:08 h
[INFO] Finished at: 2020-03-11T23:48:14-07:00
[INFO] ------------------------------------------------------------------------
```

```
Results :

Tests run: 11, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  47.491 s
[INFO] Finished at: 2020-03-12T09:48:20-07:00
[INFO] ------------------------------------------------------------------------
```


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
