### PR TITLE
rename customized state aggregation config to customized state config

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -33,7 +33,7 @@ import org.apache.helix.manager.zk.client.HelixZkClient;
 import org.apache.helix.manager.zk.client.SharedZkClientFactory;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ConfigScope;
-import org.apache.helix.model.CustomizedStateAggregationConfig;
+import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
 import org.apache.helix.model.InstanceConfig;
@@ -562,11 +562,11 @@ public class ConfigAccessor {
   }
 
   /**
-   * Get CustomizedStateAggregationConfig of the given cluster.
+   * Get CustomizedStateConfig of the given cluster.
    * @param clusterName
-   * @return The instance of {@link CustomizedStateAggregationConfig}
+   * @return The instance of {@link CustomizedStateConfig}
    */
-  public CustomizedStateAggregationConfig getCustomizedStateAggregationConfig(String clusterName) {
+  public CustomizedStateConfig getCustomizedStateConfig(String clusterName) {
     if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException(String.format("Failed to get config. cluster: %s is not setup.", clusterName));
     }
@@ -579,7 +579,7 @@ public class ConfigAccessor {
       return null;
     }
 
-    return new CustomizedStateAggregationConfig.Builder(record).build();
+    return new CustomizedStateConfig.Builder(record).build();
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import org.apache.helix.model.ClusterConstraints;
 import org.apache.helix.model.ClusterConstraints.ConstraintType;
 import org.apache.helix.model.ConstraintItem;
-import org.apache.helix.model.CustomizedStateAggregationConfig;
+import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState;
@@ -105,30 +105,30 @@ public interface HelixAdmin {
    */
   void addClusterToGrandCluster(String clusterName, String grandCluster);
 
-  /** Add a CustomizedStateAggregationConfig to a cluster
+  /** Add a CustomizedStateConfig to a cluster
    * @param clusterName
-   * @param customizedStateAggregationConfig
+   * @param customizedStateConfig
    */
-  void addCustomizedStateAggregationConfig(String clusterName,
-      CustomizedStateAggregationConfig customizedStateAggregationConfig);
+  void addCustomizedStateConfig(String clusterName,
+      CustomizedStateConfig customizedStateConfig);
 
   /**
-   * Remove CustomizedStateAggregationConfig from specific cluster
+   * Remove CustomizedStateConfig from specific cluster
    * @param clusterName
    */
-  void removeCustomizedStateAggregationConfig(String clusterName);
+  void removeCustomizedStateConfig(String clusterName);
 
   /**
-   * Add a type to CustomizedStateAggregationConfig of specific cluster
+   * Add a type to CustomizedStateConfig of specific cluster
    * @param clusterName
    */
-  void addTypeToCustomizedStateAggregationConfig(String clusterName, String type);
+  void addTypeToCustomizedStateConfig(String clusterName, String type);
 
   /**
-   * Remove a type from CustomizedStateAggregationConfig of specific cluster
+   * Remove a type from CustomizedStateConfig of specific cluster
    * @param clusterName
    */
-  void removeTypeFromCustomizedStateAggregationConfig(String clusterName, String type);
+  void removeTypeFromCustomizedStateConfig(String clusterName, String type);
 
   /**
    * Add a resource to a cluster, using the default ideal state mode AUTO

--- a/helix-core/src/main/java/org/apache/helix/HelixConstants.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixConstants.java
@@ -30,7 +30,7 @@ public interface HelixConstants {
     CONFIG (PropertyType.CONFIGS),
     INSTANCE_CONFIG (PropertyType.CONFIGS),
     RESOURCE_CONFIG (PropertyType.CONFIGS),
-    CUSTOMIZED_STATE_AGGREGATION_CONFIG (PropertyType.CONFIGS),
+    CUSTOMIZED_STATE_CONFIG (PropertyType.CONFIGS),
     CLUSTER_CONFIG (PropertyType.CONFIGS),
     LIVE_INSTANCE (PropertyType.LIVEINSTANCES),
     CURRENT_STATE (PropertyType.CURRENTSTATES),

--- a/helix-core/src/main/java/org/apache/helix/HelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManager.java
@@ -26,7 +26,7 @@ import org.apache.helix.api.listeners.ClusterConfigChangeListener;
 import org.apache.helix.api.listeners.ConfigChangeListener;
 import org.apache.helix.api.listeners.ControllerChangeListener;
 import org.apache.helix.api.listeners.CurrentStateChangeListener;
-import org.apache.helix.api.listeners.CustomizedStateAggregationConfigChangeListener;
+import org.apache.helix.api.listeners.CustomizedStateConfigChangeListener;
 import org.apache.helix.api.listeners.CustomizedStateChangeListener;
 import org.apache.helix.api.listeners.ExternalViewChangeListener;
 import org.apache.helix.api.listeners.CustomizedViewChangeListener;
@@ -41,7 +41,7 @@ import org.apache.helix.controller.pipeline.Pipeline;
 import org.apache.helix.healthcheck.ParticipantHealthReportCollector;
 import org.apache.helix.manager.zk.ZKHelixManager;
 import org.apache.helix.model.ClusterConfig;
-import org.apache.helix.model.CustomizedStateAggregationConfig;
+import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
 import org.apache.helix.participant.HelixStateMachineEngine;
 import org.apache.helix.participant.StateMachineEngine;
@@ -159,13 +159,13 @@ public interface HelixManager {
   void addResourceConfigChangeListener(ResourceConfigChangeListener listener) throws Exception;
 
   /**
-   * @see CustomizedStateAggregationConfigChangeListener#onCustomizedStateAggregationConfigChange(CustomizedStateAggregationConfig,
+   * @see CustomizedStateConfigChangeListener#onCustomizedStateConfigChange(CustomizedStateConfig,
    *      NotificationContext)
    * @param listener
    */
 
-  void addCustomizedStateAggregationConfigChangeListener(
-      CustomizedStateAggregationConfigChangeListener listener) throws Exception;
+  void addCustomizedStateConfigChangeListener(
+      CustomizedStateConfigChangeListener listener) throws Exception;
 
   /**
    * @see ClusterConfigChangeListener#onClusterConfigChange(ClusterConfig, NotificationContext)

--- a/helix-core/src/main/java/org/apache/helix/PropertyKey.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyKey.java
@@ -26,7 +26,7 @@ import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ClusterConstraints;
 import org.apache.helix.model.ControllerHistory;
 import org.apache.helix.model.CurrentState;
-import org.apache.helix.model.CustomizedStateAggregationConfig;
+import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.CustomizedState;
 import org.apache.helix.model.CustomizedView;
 import org.apache.helix.model.Error;
@@ -243,9 +243,9 @@ public class PropertyKey {
      * Get a property key associated with this customized state aggregation configuration
      * @return {@link PropertyKey}
      */
-    public PropertyKey customizedStateAggregationConfig() {
+    public PropertyKey customizedStateConfig() {
       return new PropertyKey(CONFIGS, ConfigScopeProperty.CUSTOMIZED_STATE_AGGREGATION,
-          CustomizedStateAggregationConfig.class, _clusterName,
+          CustomizedStateConfig.class, _clusterName,
           ConfigScopeProperty.CUSTOMIZED_STATE_AGGREGATION.name(), _clusterName);
     }
 

--- a/helix-core/src/main/java/org/apache/helix/api/listeners/CustomizedStateConfigChangeListener.java
+++ b/helix-core/src/main/java/org/apache/helix/api/listeners/CustomizedStateConfigChangeListener.java
@@ -20,17 +20,17 @@ package org.apache.helix.api.listeners;
  */
 
 import org.apache.helix.NotificationContext;
-import org.apache.helix.model.CustomizedStateAggregationConfig;
+import org.apache.helix.model.CustomizedStateConfig;
 
 /**
  * Interface to implement to listen for changes to customized state aggregation configurations.
  */
-public interface CustomizedStateAggregationConfigChangeListener {
+public interface CustomizedStateConfigChangeListener {
   /**
    * Invoked when customized state aggregation config changes
-   * @param customizedStateAggregationConfig
+   * @param customizedStateConfig
    * @param context
    */
-  void onCustomizedStateAggregationConfigChange(CustomizedStateAggregationConfig customizedStateAggregationConfig,
+  void onCustomizedStateConfigChange(CustomizedStateConfig customizedStateConfig,
       NotificationContext context);
 }

--- a/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedStateCache.java
@@ -27,7 +27,7 @@ import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.common.controllers.ControlContextProvider;
 import org.apache.helix.model.CustomizedState;
-import org.apache.helix.model.CustomizedStateAggregationConfig;
+import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.LiveInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,9 +50,9 @@ public class CustomizedStateCache extends ParticipantStateCache<CustomizedState>
     Set<PropertyKey> participantStateKeys = new HashSet<>();
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
     Set<String> restrictedKeys = new HashSet<>(
-        accessor.getProperty(accessor.keyBuilder().customizedStateAggregationConfig()).getRecord()
+        accessor.getProperty(accessor.keyBuilder().customizedStateConfig()).getRecord()
             .getListFields().get(
-            CustomizedStateAggregationConfig.CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES
+            CustomizedStateConfig.CustomizedStateProperty.AGGREGATION_ENABLED_TYPES
                 .name()));
     for (String instanceName : liveInstanceMap.keySet()) {
       for (String customizedStateType : restrictedKeys) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -65,7 +65,7 @@ import org.apache.helix.model.ClusterConstraints.ConstraintType;
 import org.apache.helix.model.ConstraintItem;
 import org.apache.helix.model.ControllerHistory;
 import org.apache.helix.model.CurrentState;
-import org.apache.helix.model.CustomizedStateAggregationConfig;
+import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState;
@@ -1107,84 +1107,84 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   @Override
-  public void addCustomizedStateAggregationConfig(String clusterName,
-      CustomizedStateAggregationConfig customizedStateAggregationConfig) {
+  public void addCustomizedStateConfig(String clusterName,
+      CustomizedStateConfig customizedStateConfig) {
     logger.info(
-        "Add CustomizedStateAggregationConfig to cluster {}, CustomizedStateAggregationConfig is {}",
-        clusterName, customizedStateAggregationConfig.toString());
+        "Add CustomizedStateConfig to cluster {}, CustomizedStateConfig is {}",
+        clusterName, customizedStateConfig.toString());
 
     if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("cluster " + clusterName + " is not setup yet");
     }
 
-    CustomizedStateAggregationConfig.Builder builder =
-        new CustomizedStateAggregationConfig.Builder(customizedStateAggregationConfig);
-    CustomizedStateAggregationConfig customizedStateAggregationConfigFromBuilder = builder.build();
+    CustomizedStateConfig.Builder builder =
+        new CustomizedStateConfig.Builder(customizedStateConfig);
+    CustomizedStateConfig customizedStateConfigFromBuilder = builder.build();
 
     ZKHelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<ZNRecord>(_zkClient));
     Builder keyBuilder = accessor.keyBuilder();
-    accessor.setProperty(keyBuilder.customizedStateAggregationConfig(),
-        customizedStateAggregationConfigFromBuilder);
+    accessor.setProperty(keyBuilder.customizedStateConfig(),
+        customizedStateConfigFromBuilder);
   }
 
   @Override
-  public void removeCustomizedStateAggregationConfig(String clusterName) {
+  public void removeCustomizedStateConfig(String clusterName) {
     logger.info(
-        "Remove CustomizedStateAggregationConfig from cluster {}.", clusterName);
+        "Remove CustomizedStateConfig from cluster {}.", clusterName);
 
     ZKHelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<ZNRecord>(_zkClient));
     Builder keyBuilder = accessor.keyBuilder();
-    accessor.removeProperty(keyBuilder.customizedStateAggregationConfig());
+    accessor.removeProperty(keyBuilder.customizedStateConfig());
 
   }
 
   @Override
-  public void addTypeToCustomizedStateAggregationConfig(String clusterName, String type) {
-    logger.info("Add type {} to CustomizedStateAggregationConfig of cluster {}", type, clusterName);
+  public void addTypeToCustomizedStateConfig(String clusterName, String type) {
+    logger.info("Add type {} to CustomizedStateConfig of cluster {}", type, clusterName);
 
     if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("cluster " + clusterName + " is not setup yet");
     }
-    CustomizedStateAggregationConfig.Builder builder =
-        new CustomizedStateAggregationConfig.Builder();
+    CustomizedStateConfig.Builder builder =
+        new CustomizedStateConfig.Builder();
 
     builder.addAggregationEnabledType(type);
-    CustomizedStateAggregationConfig customizedStateAggregationConfigFromBuilder = builder.build();
+    CustomizedStateConfig customizedStateConfigFromBuilder = builder.build();
 
     ZKHelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<ZNRecord>(_zkClient));
     Builder keyBuilder = accessor.keyBuilder();
-    accessor.updateProperty(keyBuilder.customizedStateAggregationConfig(),
-        customizedStateAggregationConfigFromBuilder);
+    accessor.updateProperty(keyBuilder.customizedStateConfig(),
+        customizedStateConfigFromBuilder);
   }
 
 
   @Override
-  public void removeTypeFromCustomizedStateAggregationConfig(String clusterName, String type) {
-    logger.info("Remove type {} to CustomizedStateAggregationConfig of cluster {}", type,
+  public void removeTypeFromCustomizedStateConfig(String clusterName, String type) {
+    logger.info("Remove type {} to CustomizedStateConfig of cluster {}", type,
         clusterName);
 
     if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("cluster " + clusterName + " is not setup yet");
     }
 
-    CustomizedStateAggregationConfig.Builder builder = new CustomizedStateAggregationConfig.Builder(
-        _configAccessor.getCustomizedStateAggregationConfig(clusterName));
+    CustomizedStateConfig.Builder builder = new CustomizedStateConfig.Builder(
+        _configAccessor.getCustomizedStateConfig(clusterName));
 
     if (!builder.getAggregationEnabledTypes().contains(type)) {
       throw new HelixException("Type " + type
-          + " is missing from the CustomizedStateAggregationConfig of cluster " + clusterName);
+          + " is missing from the CustomizedStateConfig of cluster " + clusterName);
     }
 
     builder.removeAggregationEnabledType(type);
-    CustomizedStateAggregationConfig customizedStateAggregationConfigFromBuilder = builder.build();
+    CustomizedStateConfig customizedStateConfigFromBuilder = builder.build();
     ZKHelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<ZNRecord>(_zkClient));
     Builder keyBuilder = accessor.keyBuilder();
-    accessor.setProperty(keyBuilder.customizedStateAggregationConfig(),
-        customizedStateAggregationConfigFromBuilder);
+    accessor.setProperty(keyBuilder.customizedStateConfig(),
+        customizedStateConfigFromBuilder);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -56,7 +56,7 @@ import org.apache.helix.api.listeners.ConfigChangeListener;
 import org.apache.helix.api.listeners.ControllerChangeListener;
 import org.apache.helix.api.listeners.CurrentStateChangeListener;
 import org.apache.helix.api.listeners.CustomizedViewChangeListener;
-import org.apache.helix.api.listeners.CustomizedStateAggregationConfigChangeListener;
+import org.apache.helix.api.listeners.CustomizedStateConfigChangeListener;
 import org.apache.helix.api.listeners.CustomizedStateChangeListener;
 import org.apache.helix.api.listeners.ExternalViewChangeListener;
 import org.apache.helix.api.listeners.IdealStateChangeListener;
@@ -472,10 +472,10 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
   }
 
   @Override
-  public void addCustomizedStateAggregationConfigChangeListener(
-      CustomizedStateAggregationConfigChangeListener listener) throws Exception {
-    addListener(listener, new Builder(_clusterName).customizedStateAggregationConfig(),
-        ChangeType.CUSTOMIZED_STATE_AGGREGATION_CONFIG, new EventType[] {
+  public void addCustomizedStateConfigChangeListener(
+      CustomizedStateConfigChangeListener listener) throws Exception {
+    addListener(listener, new Builder(_clusterName).customizedStateConfig(),
+        ChangeType.CUSTOMIZED_STATE_CONFIG, new EventType[] {
             EventType.NodeDataChanged
         });
   }

--- a/helix-core/src/main/java/org/apache/helix/model/CustomizedStateConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/CustomizedStateConfig.java
@@ -28,33 +28,33 @@ import org.apache.helix.ZNRecord;
 /**
  * CustomizedStateAggregation configurations
  */
-public class CustomizedStateAggregationConfig extends HelixProperty {
+public class CustomizedStateConfig extends HelixProperty {
 
-  public static final String CUSTOMIZED_STATE_AGGREGATION_CONFIG_KW =
-      "CustomizedStateAggregationConfig";
+  public static final String CUSTOMIZED_STATE_CONFIG_KW =
+      "CustomizedStateConfig";
 
   /**
    * Indicate which customized states will be aggregated.
    * NOTE: Do NOT use this field name directly, use its corresponding getter/setter in the
-   * CustomizedStateAggregationConfig.
+   * CustomizedStateConfig.
    */
-  public enum CustomizedStateAggregationProperty {
+  public enum CustomizedStateProperty {
     AGGREGATION_ENABLED_TYPES,
   }
 
   /**
-   * Instantiate the CustomizedStateAggregationConfig
+   * Instantiate the CustomizedStateConfig
    */
-  public CustomizedStateAggregationConfig() {
-    super(CUSTOMIZED_STATE_AGGREGATION_CONFIG_KW);
+  public CustomizedStateConfig() {
+    super(CUSTOMIZED_STATE_CONFIG_KW);
   }
 
   /**
    * Instantiate with a pre-populated record
-   * @param record a ZNRecord corresponding to a CustomizedStateAggregationConfig
+   * @param record a ZNRecord corresponding to a CustomizedStateConfig
    */
-  public CustomizedStateAggregationConfig(ZNRecord record) {
-    super(CUSTOMIZED_STATE_AGGREGATION_CONFIG_KW);
+  public CustomizedStateConfig(ZNRecord record) {
+    super(CUSTOMIZED_STATE_CONFIG_KW);
     _record.setSimpleFields(record.getSimpleFields());
     _record.setListFields(record.getListFields());
     _record.setMapFields(record.getMapFields());
@@ -65,7 +65,7 @@ public class CustomizedStateAggregationConfig extends HelixProperty {
    * @param aggregationEnabledTypes
    */
   public void setAggregationEnabledTypes(List<String> aggregationEnabledTypes) {
-    _record.setListField(CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES.name(),
+    _record.setListField(CustomizedStateProperty.AGGREGATION_ENABLED_TYPES.name(),
         aggregationEnabledTypes);
   }
 
@@ -75,22 +75,22 @@ public class CustomizedStateAggregationConfig extends HelixProperty {
    */
   public List<String> getAggregationEnabledTypes() {
     return _record
-        .getListField(CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES.name());
+        .getListField(CustomizedStateProperty.AGGREGATION_ENABLED_TYPES.name());
   }
 
   public static class Builder {
     private ZNRecord _record;
 
 
-    public CustomizedStateAggregationConfig build() {
-      return new CustomizedStateAggregationConfig(_record);
+    public CustomizedStateConfig build() {
+      return new CustomizedStateConfig(_record);
     }
 
     /**
      * Default constructor
      */
     public Builder() {
-      _record = new ZNRecord(CUSTOMIZED_STATE_AGGREGATION_CONFIG_KW);
+      _record = new ZNRecord(CUSTOMIZED_STATE_CONFIG_KW);
     }
 
     /**
@@ -102,43 +102,43 @@ public class CustomizedStateAggregationConfig extends HelixProperty {
     }
 
     /**
-     * Constructor with CustomizedStateAggregationConfig as input
-     * @param customizedStateAggregationConfig
+     * Constructor with CustomizedStateConfig as input
+     * @param customizedStateConfig
      */
-    public Builder(CustomizedStateAggregationConfig customizedStateAggregationConfig) {
-      _record = customizedStateAggregationConfig.getRecord();
+    public Builder(CustomizedStateConfig customizedStateConfig) {
+      _record = customizedStateConfig.getRecord();
     }
 
     public Builder setAggregationEnabledTypes(List<String> aggregationEnabledTypes) {
-      _record.setListField(CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES.name(), aggregationEnabledTypes);
+      _record.setListField(CustomizedStateProperty.AGGREGATION_ENABLED_TYPES.name(), aggregationEnabledTypes);
       return this;
     }
 
     public Builder addAggregationEnabledType(String type) {
       if (_record.getListField(
-          CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES.name()) == null) {
-        _record.setListField(CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES.name(), new ArrayList<String>());
+          CustomizedStateProperty.AGGREGATION_ENABLED_TYPES.name()) == null) {
+        _record.setListField(CustomizedStateProperty.AGGREGATION_ENABLED_TYPES.name(), new ArrayList<String>());
       }
-      List<String> aggregationEnabledTypes = _record.getListField(CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES.name());
+      List<String> aggregationEnabledTypes = _record.getListField(CustomizedStateProperty.AGGREGATION_ENABLED_TYPES.name());
       aggregationEnabledTypes.add(type);
-      _record.setListField(CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES.name(), aggregationEnabledTypes);
+      _record.setListField(CustomizedStateProperty.AGGREGATION_ENABLED_TYPES.name(), aggregationEnabledTypes);
       return this;
     }
 
     public Builder removeAggregationEnabledType(String type) {
-      if (!_record.getListField(CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES.name())
+      if (!_record.getListField(CustomizedStateProperty.AGGREGATION_ENABLED_TYPES.name())
           .contains(type)) {
         throw new HelixException(
-            "Type " + type + " is missing from the CustomizedStateAggregationConfig");
+            "Type " + type + " is missing from the CustomizedStateConfig");
       }
-      _record.getListField(CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES.name())
+      _record.getListField(CustomizedStateProperty.AGGREGATION_ENABLED_TYPES.name())
           .remove(type);
       return this;
     }
 
     public List<String> getAggregationEnabledTypes() {
       return _record
-          .getListField(CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES.name());
+          .getListField(CustomizedStateProperty.AGGREGATION_ENABLED_TYPES.name());
     }
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/DummyClusterManager.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/DummyClusterManager.java
@@ -37,7 +37,7 @@ import org.apache.helix.api.listeners.ClusterConfigChangeListener;
 import org.apache.helix.api.listeners.ConfigChangeListener;
 import org.apache.helix.api.listeners.ControllerChangeListener;
 import org.apache.helix.api.listeners.CurrentStateChangeListener;
-import org.apache.helix.api.listeners.CustomizedStateAggregationConfigChangeListener;
+import org.apache.helix.api.listeners.CustomizedStateConfigChangeListener;
 import org.apache.helix.api.listeners.CustomizedStateChangeListener;
 import org.apache.helix.api.listeners.ExternalViewChangeListener;
 import org.apache.helix.api.listeners.CustomizedViewChangeListener;
@@ -302,7 +302,7 @@ public class DummyClusterManager implements HelixManager {
   }
 
   @Override
-  public void addCustomizedStateAggregationConfigChangeListener(CustomizedStateAggregationConfigChangeListener listener)
+  public void addCustomizedStateConfigChangeListener(CustomizedStateConfigChangeListener listener)
       throws Exception {
     // TODO Auto-generated method stub
 

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -45,7 +45,7 @@ import org.apache.helix.model.ClusterConstraints;
 import org.apache.helix.model.ClusterConstraints.ConstraintAttribute;
 import org.apache.helix.model.ClusterConstraints.ConstraintType;
 import org.apache.helix.model.ConstraintItem;
-import org.apache.helix.model.CustomizedStateAggregationConfig;
+import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
@@ -510,91 +510,91 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
   }
 
   @Test
-  public void testAddCustomizedStateAggregationConfig() {
+  public void testAddCustomizedStateConfig() {
     String className = TestHelper.getTestClassName();
     String methodName = TestHelper.getTestMethodName();
     String clusterName = className + "_" + methodName;
 
     HelixAdmin admin = new ZKHelixAdmin(ZK_ADDR);
     admin.addCluster(clusterName, true);
-    CustomizedStateAggregationConfig.Builder builder =
-        new CustomizedStateAggregationConfig.Builder();
+    CustomizedStateConfig.Builder builder =
+        new CustomizedStateConfig.Builder();
     builder.addAggregationEnabledType("mockType1");
-    CustomizedStateAggregationConfig customizedStateAggregationConfig = builder.build();
+    CustomizedStateConfig customizedStateConfig = builder.build();
 
-    admin.addCustomizedStateAggregationConfig(clusterName, customizedStateAggregationConfig);
+    admin.addCustomizedStateConfig(clusterName, customizedStateConfig);
 
-    // Read CustomizedStateAggregationConfig from Zookeeper and check the content
+    // Read CustomizedStateConfig from Zookeeper and check the content
     ConfigAccessor _configAccessor = new ConfigAccessor(ZK_ADDR);
-    CustomizedStateAggregationConfig configFromZk =
-        _configAccessor.getCustomizedStateAggregationConfig(clusterName);
+    CustomizedStateConfig configFromZk =
+        _configAccessor.getCustomizedStateConfig(clusterName);
     List<String> listTypesFromZk = configFromZk.getAggregationEnabledTypes();
     Assert.assertEquals(listTypesFromZk.get(0), "mockType1");
   }
 
   @Test
-  public void testRemoveCustomizedStateAggregationConfig() throws Exception {
+  public void testRemoveCustomizedStateConfig() throws Exception {
     String className = TestHelper.getTestClassName();
     String methodName = TestHelper.getTestMethodName();
     String clusterName = className + "_" + methodName;
 
     HelixAdmin admin = new ZKHelixAdmin(ZK_ADDR);
     admin.addCluster(clusterName, true);
-    CustomizedStateAggregationConfig.Builder builder =
-        new CustomizedStateAggregationConfig.Builder();
+    CustomizedStateConfig.Builder builder =
+        new CustomizedStateConfig.Builder();
     builder.addAggregationEnabledType("mockType1");
-    CustomizedStateAggregationConfig customizedStateAggregationConfig = builder.build();
+    CustomizedStateConfig customizedStateConfig = builder.build();
 
-    admin.addCustomizedStateAggregationConfig(clusterName, customizedStateAggregationConfig);
+    admin.addCustomizedStateConfig(clusterName, customizedStateConfig);
 
-    // Read CustomizedStateAggregationConfig from Zookeeper and check the content
+    // Read CustomizedStateConfig from Zookeeper and check the content
     ConfigAccessor _configAccessor = new ConfigAccessor(ZK_ADDR);
-    CustomizedStateAggregationConfig configFromZk =
-        _configAccessor.getCustomizedStateAggregationConfig(clusterName);
+    CustomizedStateConfig configFromZk =
+        _configAccessor.getCustomizedStateConfig(clusterName);
     List<String> listTypesFromZk = configFromZk.getAggregationEnabledTypes();
     Assert.assertEquals(listTypesFromZk.get(0), "mockType1");
 
-    // Remove CustomizedStateAggregationConfig Config and make sure it has been removed from
+    // Remove CustomizedStateConfig Config and make sure it has been removed from
     // Zookeeper
-    admin.removeCustomizedStateAggregationConfig(clusterName);
-    configFromZk = _configAccessor.getCustomizedStateAggregationConfig(clusterName);
+    admin.removeCustomizedStateConfig(clusterName);
+    configFromZk = _configAccessor.getCustomizedStateConfig(clusterName);
     Assert.assertNull(configFromZk);
   }
 
   @Test
-  public void testUpdateCustomizedStateAggregationConfig() throws Exception {
+  public void testUpdateCustomizedStateConfig() throws Exception {
     String className = TestHelper.getTestClassName();
     String methodName = TestHelper.getTestMethodName();
     String clusterName = className + "_" + methodName;
 
     HelixAdmin admin = new ZKHelixAdmin(ZK_ADDR);
     admin.addCluster(clusterName, true);
-    CustomizedStateAggregationConfig.Builder builder =
-        new CustomizedStateAggregationConfig.Builder();
+    CustomizedStateConfig.Builder builder =
+        new CustomizedStateConfig.Builder();
     builder.addAggregationEnabledType("mockType1");
-    CustomizedStateAggregationConfig customizedStateAggregationConfig = builder.build();
+    CustomizedStateConfig customizedStateConfig = builder.build();
 
-    admin.addCustomizedStateAggregationConfig(clusterName, customizedStateAggregationConfig);
+    admin.addCustomizedStateConfig(clusterName, customizedStateConfig);
 
-    // Read CustomizedStateAggregationConfig from Zookeeper and check the content
+    // Read CustomizedStateConfig from Zookeeper and check the content
     ConfigAccessor _configAccessor = new ConfigAccessor(ZK_ADDR);
-    CustomizedStateAggregationConfig configFromZk =
-        _configAccessor.getCustomizedStateAggregationConfig(clusterName);
+    CustomizedStateConfig configFromZk =
+        _configAccessor.getCustomizedStateConfig(clusterName);
     List<String> listTypesFromZk = configFromZk.getAggregationEnabledTypes();
     Assert.assertEquals(listTypesFromZk.get(0), "mockType1");
 
-    admin.addTypeToCustomizedStateAggregationConfig(clusterName, "mockType2");
-    admin.addTypeToCustomizedStateAggregationConfig(clusterName, "mockType3");
+    admin.addTypeToCustomizedStateConfig(clusterName, "mockType2");
+    admin.addTypeToCustomizedStateConfig(clusterName, "mockType3");
     configFromZk =
-        _configAccessor.getCustomizedStateAggregationConfig(clusterName);
+        _configAccessor.getCustomizedStateConfig(clusterName);
     listTypesFromZk = configFromZk.getAggregationEnabledTypes();
     Assert.assertEquals(listTypesFromZk.get(0), "mockType1");
     Assert.assertEquals(listTypesFromZk.get(1), "mockType2");
     Assert.assertEquals(listTypesFromZk.get(2), "mockType3");
 
-    admin.removeTypeFromCustomizedStateAggregationConfig(clusterName, "mockType1");
+    admin.removeTypeFromCustomizedStateConfig(clusterName, "mockType1");
     configFromZk =
-        _configAccessor.getCustomizedStateAggregationConfig(clusterName);
+        _configAccessor.getCustomizedStateConfig(clusterName);
     listTypesFromZk = configFromZk.getAggregationEnabledTypes();
     Assert.assertEquals(listTypesFromZk.get(0), "mockType2");
     Assert.assertEquals(listTypesFromZk.get(1), "mockType3");

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -34,7 +34,7 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ClusterConstraints;
 import org.apache.helix.model.ConstraintItem;
-import org.apache.helix.model.CustomizedStateAggregationConfig;
+import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState;
@@ -143,23 +143,23 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   @Override
-  public void addCustomizedStateAggregationConfig(String clusterName,
-      CustomizedStateAggregationConfig customizedStateAggregationConfig) {
+  public void addCustomizedStateConfig(String clusterName,
+      CustomizedStateConfig customizedStateConfig) {
 
   }
 
   @Override
-  public void removeCustomizedStateAggregationConfig(String clusterName) {
+  public void removeCustomizedStateConfig(String clusterName) {
 
   }
 
   @Override
-  public void addTypeToCustomizedStateAggregationConfig(String clusterName, String type) {
+  public void addTypeToCustomizedStateConfig(String clusterName, String type) {
 
   }
 
   @Override
-  public void removeTypeFromCustomizedStateAggregationConfig(String clusterName, String type) {
+  public void removeTypeFromCustomizedStateConfig(String clusterName, String type) {
 
   }
 

--- a/helix-core/src/test/java/org/apache/helix/mock/MockManager.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockManager.java
@@ -40,7 +40,7 @@ import org.apache.helix.api.listeners.ConfigChangeListener;
 import org.apache.helix.api.listeners.ControllerChangeListener;
 import org.apache.helix.api.listeners.CurrentStateChangeListener;
 import org.apache.helix.api.listeners.CustomizedViewChangeListener;
-import org.apache.helix.api.listeners.CustomizedStateAggregationConfigChangeListener;
+import org.apache.helix.api.listeners.CustomizedStateConfigChangeListener;
 import org.apache.helix.api.listeners.CustomizedStateChangeListener;
 import org.apache.helix.api.listeners.ExternalViewChangeListener;
 import org.apache.helix.api.listeners.IdealStateChangeListener;
@@ -173,7 +173,7 @@ public class MockManager implements HelixManager {
   }
 
   @Override
-  public void addCustomizedStateAggregationConfigChangeListener(CustomizedStateAggregationConfigChangeListener listener)
+  public void addCustomizedStateConfigChangeListener(CustomizedStateConfigChangeListener listener)
       throws Exception {
 
   }

--- a/helix-core/src/test/java/org/apache/helix/model/TestCustomizedStateConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestCustomizedStateConfig.java
@@ -31,70 +31,70 @@ import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-public class TestCustomizedStateAggregationConfig extends ZkUnitTestBase {
+public class TestCustomizedStateConfig extends ZkUnitTestBase {
 
   @Test(expectedExceptions = HelixException.class)
-  public void TestCustomizedStateAggregationConfigNonExistentCluster() {
+  public void TestCustomizedStateConfigNonExistentCluster() {
     String className = getShortClassName();
     String clusterName = "CLUSTER_" + className;
-    // Read CustomizedStateAggregationConfig from Zookeeper and get exception since cluster in not setup yet
+    // Read CustomizedStateConfig from Zookeeper and get exception since cluster in not setup yet
     ConfigAccessor _configAccessor = new ConfigAccessor(ZK_ADDR);
-    CustomizedStateAggregationConfig customizedStateAggregationConfig =
-        _configAccessor.getCustomizedStateAggregationConfig(clusterName);
+    CustomizedStateConfig customizedStateConfig =
+        _configAccessor.getCustomizedStateConfig(clusterName);
   }
 
-  @Test(dependsOnMethods = "TestCustomizedStateAggregationConfigNonExistentCluster")
-  public void testCustomizedStateAggregationConfigNull() {
+  @Test(dependsOnMethods = "TestCustomizedStateConfigNonExistentCluster")
+  public void testCustomizedStateConfigNull() {
     String className = getShortClassName();
     String clusterName = "CLUSTER_" + className;
     TestHelper.setupEmptyCluster(_gZkClient, clusterName);
-    // Read CustomizedStateAggregationConfig from Zookeeper
+    // Read CustomizedStateConfig from Zookeeper
     ConfigAccessor _configAccessor = new ConfigAccessor(ZK_ADDR);
-    CustomizedStateAggregationConfig customizedStateAggregationConfigFromZk =
-        _configAccessor.getCustomizedStateAggregationConfig(clusterName);
-    Assert.assertNull(customizedStateAggregationConfigFromZk);
+    CustomizedStateConfig customizedStateConfigFromZk =
+        _configAccessor.getCustomizedStateConfig(clusterName);
+    Assert.assertNull(customizedStateConfigFromZk);
   }
 
-  @Test(dependsOnMethods = "testCustomizedStateAggregationConfigNull")
-  public void testCustomizedStateAggregationConfig() {
+  @Test(dependsOnMethods = "testCustomizedStateConfigNull")
+  public void testCustomizedStateConfig() {
     String className = getShortClassName();
     String clusterName = "CLUSTER_" + className;
     TestHelper.setupEmptyCluster(_gZkClient, clusterName);
 
-    // Create dummy CustomizedStateAggregationConfig object
-    CustomizedStateAggregationConfig.Builder customizedStateAggregationConfigBuilder =
-        new CustomizedStateAggregationConfig.Builder();
+    // Create dummy CustomizedStateConfig object
+    CustomizedStateConfig.Builder customizedStateConfigBuilder =
+        new CustomizedStateConfig.Builder();
     List<String> aggregationEnabledTypes = new ArrayList<String>();
     aggregationEnabledTypes.add("mockType1");
     aggregationEnabledTypes.add("mockType2");
-    customizedStateAggregationConfigBuilder.setAggregationEnabledTypes(aggregationEnabledTypes);
-    CustomizedStateAggregationConfig customizedStateAggregationConfig =
-        customizedStateAggregationConfigBuilder.build();
+    customizedStateConfigBuilder.setAggregationEnabledTypes(aggregationEnabledTypes);
+    CustomizedStateConfig customizedStateConfig =
+        customizedStateConfigBuilder.build();
 
-    // Write the CustomizedStateAggregationConfig to Zookeeper
+    // Write the CustomizedStateConfig to Zookeeper
     ZKHelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor(ZK_ADDR));
     Builder keyBuilder = accessor.keyBuilder();
-    accessor.setProperty(keyBuilder.customizedStateAggregationConfig(),
-        customizedStateAggregationConfig);
+    accessor.setProperty(keyBuilder.customizedStateConfig(),
+        customizedStateConfig);
 
-    // Read CustomizedStateAggregationConfig from Zookeeper and check the content
+    // Read CustomizedStateConfig from Zookeeper and check the content
     ConfigAccessor _configAccessor = new ConfigAccessor(ZK_ADDR);
-    CustomizedStateAggregationConfig customizedStateAggregationConfigFromZk =
-        _configAccessor.getCustomizedStateAggregationConfig(clusterName);
-    Assert.assertEquals(customizedStateAggregationConfigFromZk.getAggregationEnabledTypes().size(),
+    CustomizedStateConfig customizedStateConfigFromZk =
+        _configAccessor.getCustomizedStateConfig(clusterName);
+    Assert.assertEquals(customizedStateConfigFromZk.getAggregationEnabledTypes().size(),
         2);
     Assert.assertEquals(aggregationEnabledTypes.get(0), "mockType1");
     Assert.assertEquals(aggregationEnabledTypes.get(1), "mockType2");
   }
 
-  @Test(dependsOnMethods = "testCustomizedStateAggregationConfig")
-  public void testCustomizedStateAggregationConfigBuilder() {
+  @Test(dependsOnMethods = "testCustomizedStateConfig")
+  public void testCustomizedStateConfigBuilder() {
     String className = getShortClassName();
     String clusterName = "CLUSTER_" + className;
     TestHelper.setupEmptyCluster(_gZkClient, clusterName);
-    CustomizedStateAggregationConfig.Builder builder =
-        new CustomizedStateAggregationConfig.Builder();
+    CustomizedStateConfig.Builder builder =
+        new CustomizedStateConfig.Builder();
     builder.addAggregationEnabledType("mockType1");
     builder.addAggregationEnabledType("mockType2");
 
@@ -104,20 +104,20 @@ public class TestCustomizedStateAggregationConfig extends ZkUnitTestBase {
     Assert.assertEquals(aggregationEnabledTypes.get(0), "mockType1");
     Assert.assertEquals(aggregationEnabledTypes.get(1), "mockType2");
 
-    CustomizedStateAggregationConfig customizedStateAggregationConfig = builder.build();
+    CustomizedStateConfig customizedStateConfig = builder.build();
 
     ZKHelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor(ZK_ADDR));
     Builder keyBuilder = accessor.keyBuilder();
-    accessor.setProperty(keyBuilder.customizedStateAggregationConfig(),
-        customizedStateAggregationConfig);
+    accessor.setProperty(keyBuilder.customizedStateConfig(),
+        customizedStateConfig);
 
-    // Read CustomizedStateAggregationConfig from Zookeeper and check the content
+    // Read CustomizedStateConfig from Zookeeper and check the content
     ConfigAccessor _configAccessor = new ConfigAccessor(ZK_ADDR);
-    CustomizedStateAggregationConfig customizedStateAggregationConfigFromZk =
-        _configAccessor.getCustomizedStateAggregationConfig(clusterName);
+    CustomizedStateConfig customizedStateConfigFromZk =
+        _configAccessor.getCustomizedStateConfig(clusterName);
     List<String> aggregationEnabledTypesFromZk =
-        customizedStateAggregationConfigFromZk.getAggregationEnabledTypes();
+        customizedStateConfigFromZk.getAggregationEnabledTypes();
     Assert.assertEquals(aggregationEnabledTypesFromZk.get(0), "mockType1");
     Assert.assertEquals(aggregationEnabledTypesFromZk.get(1), "mockType2");
   }

--- a/helix-core/src/test/java/org/apache/helix/participant/MockZKHelixManager.java
+++ b/helix-core/src/test/java/org/apache/helix/participant/MockZKHelixManager.java
@@ -39,7 +39,7 @@ import org.apache.helix.api.listeners.ConfigChangeListener;
 import org.apache.helix.api.listeners.ControllerChangeListener;
 import org.apache.helix.api.listeners.CurrentStateChangeListener;
 import org.apache.helix.api.listeners.CustomizedViewChangeListener;
-import org.apache.helix.api.listeners.CustomizedStateAggregationConfigChangeListener;
+import org.apache.helix.api.listeners.CustomizedStateConfigChangeListener;
 import org.apache.helix.api.listeners.CustomizedStateChangeListener;
 import org.apache.helix.api.listeners.ExternalViewChangeListener;
 import org.apache.helix.api.listeners.IdealStateChangeListener;
@@ -126,7 +126,7 @@ public class MockZKHelixManager implements HelixManager {
   }
 
   @Override
-  public void addCustomizedStateAggregationConfigChangeListener(CustomizedStateAggregationConfigChangeListener listener)
+  public void addCustomizedStateConfigChangeListener(CustomizedStateConfigChangeListener listener)
       throws Exception {
     // TODO Auto-generated method stub
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -49,7 +49,7 @@ import org.apache.helix.manager.zk.ZKUtil;
 import org.apache.helix.manager.zk.client.HelixZkClient;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ControllerHistory;
-import org.apache.helix.model.CustomizedStateAggregationConfig;
+import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.MaintenanceSignal;
@@ -271,7 +271,7 @@ public class ClusterAccessor extends AbstractHelixResource {
 
   @PUT
   @Path("{clusterId}/customized-state-aggregation-config")
-  public Response addCustomizedStateAggregationConfig(@PathParam("clusterId") String clusterId,
+  public Response addCustomizedStateConfig(@PathParam("clusterId") String clusterId,
       String content) {
     if (!doesClusterExist(clusterId)) {
       return notFound(String.format("Cluster %s does not exist", clusterId));
@@ -286,11 +286,11 @@ public class ClusterAccessor extends AbstractHelixResource {
     }
 
     try {
-      CustomizedStateAggregationConfig customizedStateAggregationConfig =
-          new CustomizedStateAggregationConfig.Builder(record).build();
-      admin.addCustomizedStateAggregationConfig(clusterId, customizedStateAggregationConfig);
+      CustomizedStateConfig customizedStateConfig =
+          new CustomizedStateConfig.Builder(record).build();
+      admin.addCustomizedStateConfig(clusterId, customizedStateConfig);
     } catch (Exception ex) {
-      _logger.error("Cannot add CustomizedStateAggregationConfig to cluster: {} Exception: {}",
+      _logger.error("Cannot add CustomizedStateConfig to cluster: {} Exception: {}",
           clusterId, ex);
       return serverError(ex);
     }
@@ -300,17 +300,17 @@ public class ClusterAccessor extends AbstractHelixResource {
 
   @DELETE
   @Path("{clusterId}/customized-state-aggregation-config")
-  public Response removeCustomizedStateAggregationConfig(@PathParam("clusterId") String clusterId) {
+  public Response removeCustomizedStateConfig(@PathParam("clusterId") String clusterId) {
     if (!doesClusterExist(clusterId)) {
       return notFound(String.format("Cluster %s does not exist", clusterId));
     }
 
     HelixAdmin admin = getHelixAdmin();
     try {
-      admin.removeCustomizedStateAggregationConfig(clusterId);
+      admin.removeCustomizedStateConfig(clusterId);
     } catch (Exception ex) {
       _logger.error(
-          "Cannot remove CustomizedStateAggregationConfig from cluster: {}, Exception: {}",
+          "Cannot remove CustomizedStateConfig from cluster: {}, Exception: {}",
           clusterId, ex);
       return serverError(ex);
     }
@@ -320,17 +320,17 @@ public class ClusterAccessor extends AbstractHelixResource {
 
   @GET
   @Path("{clusterId}/customized-state-aggregation-config")
-  public Response getCustomizedStateAggregationConfig(@PathParam("clusterId") String clusterId) {
+  public Response getCustomizedStateConfig(@PathParam("clusterId") String clusterId) {
     if (!doesClusterExist(clusterId)) {
       return notFound(String.format("Cluster %s does not exist", clusterId));
     }
 
     ConfigAccessor configAccessor = getConfigAccessor();
-    CustomizedStateAggregationConfig customizedStateAggregationConfig =
-        configAccessor.getCustomizedStateAggregationConfig(clusterId);
+    CustomizedStateConfig customizedStateConfig =
+        configAccessor.getCustomizedStateConfig(clusterId);
 
-    if (customizedStateAggregationConfig != null) {
-      return JSONRepresentation(customizedStateAggregationConfig.getRecord());
+    if (customizedStateConfig != null) {
+      return JSONRepresentation(customizedStateConfig.getRecord());
     }
 
     return notFound();
@@ -338,7 +338,7 @@ public class ClusterAccessor extends AbstractHelixResource {
 
   @POST
   @Path("{clusterId}/customized-state-aggregation-config")
-  public Response updateCustomizedStateAggregationConfig(@PathParam("clusterId") String clusterId,
+  public Response updateCustomizedStateConfig(@PathParam("clusterId") String clusterId,
       @QueryParam("command") String commandStr, @QueryParam("type") String type) {
     if (!doesClusterExist(clusterId)) {
       return notFound(String.format("Cluster %s does not exist", clusterId));
@@ -360,16 +360,16 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       switch (command) {
       case delete:
-        admin.removeTypeFromCustomizedStateAggregationConfig(clusterId, type);
+        admin.removeTypeFromCustomizedStateConfig(clusterId, type);
         break;
       case add:
-        admin.addTypeToCustomizedStateAggregationConfig(clusterId, type);
+        admin.addTypeToCustomizedStateConfig(clusterId, type);
         break;
       default:
         return badRequest("Unsupported command " + commandStr);
       }
     } catch (Exception ex) {
-      _logger.error("Failed to {} CustomizedStateAggregationConfig for cluster {} new type: {}, Exception: {}", command, clusterId, type, ex);
+      _logger.error("Failed to {} CustomizedStateConfig for cluster {} new type: {}, Exception: {}", command, clusterId, type, ex);
       return serverError(ex);
     }
     return OK();

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -44,7 +44,7 @@ import org.apache.helix.integration.manager.ClusterDistributedController;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZKUtil;
 import org.apache.helix.model.ClusterConfig;
-import org.apache.helix.model.CustomizedStateAggregationConfig;
+import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
@@ -569,11 +569,11 @@ public class TestClusterAccessor extends AbstractTestClass {
   public void testAddCustomizedConfigNonExistedCluster() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String urlBase = "clusters/TestCluster/customized-state-aggregation-config/";
-    ZNRecord record = new ZNRecord("TestCustomizedStateAggregationConfig");
+    ZNRecord record = new ZNRecord("TestCustomizedStateConfig");
     List<String> testList = new ArrayList<String>();
     testList.add("mockType1");
     record.setListField(
-        CustomizedStateAggregationConfig.CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES
+        CustomizedStateConfig.CustomizedStateProperty.AGGREGATION_ENABLED_TYPES
             .name(),
         testList);
 
@@ -589,12 +589,12 @@ public class TestClusterAccessor extends AbstractTestClass {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     _gSetupTool.addCluster("TestClusterCustomized", true);
     String urlBase = "clusters/TestClusterCustomized/customized-state-aggregation-config/";
-    ZNRecord record = new ZNRecord("TestCustomizedStateAggregationConfig");
+    ZNRecord record = new ZNRecord("TestCustomizedStateConfig");
     List<String> testList = new ArrayList<String>();
     testList.add("mockType1");
     testList.add("mockType2");
     record.setListField(
-        CustomizedStateAggregationConfig.CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES
+        CustomizedStateConfig.CustomizedStateProperty.AGGREGATION_ENABLED_TYPES
             .name(),
         testList);
 
@@ -602,21 +602,21 @@ public class TestClusterAccessor extends AbstractTestClass {
         Entity.entity(OBJECT_MAPPER.writeValueAsString(record), MediaType.APPLICATION_JSON_TYPE),
         Response.Status.OK.getStatusCode());
 
-    // Read CustomizedStateAggregationConfig from Zookeeper and check the content
+    // Read CustomizedStateConfig from Zookeeper and check the content
     ConfigAccessor _configAccessor = new ConfigAccessor(ZK_ADDR);
-    CustomizedStateAggregationConfig customizedConfigFromZk = _configAccessor.getCustomizedStateAggregationConfig("TestClusterCustomized");
+    CustomizedStateConfig customizedConfigFromZk = _configAccessor.getCustomizedStateConfig("TestClusterCustomized");
     List<String> listTypesFromZk = customizedConfigFromZk.getAggregationEnabledTypes();
     Assert.assertEquals(listTypesFromZk.get(0), "mockType1");
     Assert.assertEquals(listTypesFromZk.get(1), "mockType2");
 
-    // Now test the getCustomizedStateAggregationConfig method.
+    // Now test the getCustomizedStateConfig method.
     String body = get(urlBase, null, Response.Status.OK.getStatusCode(), true);
 
     ZNRecord recordFromRest = new ObjectMapper().reader(ZNRecord.class).readValue(body);
-    CustomizedStateAggregationConfig customizedConfigRest = new CustomizedStateAggregationConfig.Builder(recordFromRest).build();
-    CustomizedStateAggregationConfig customizedConfigZk = _configAccessor.getCustomizedStateAggregationConfig("TestClusterCustomized");
+    CustomizedStateConfig customizedConfigRest = new CustomizedStateConfig.Builder(recordFromRest).build();
+    CustomizedStateConfig customizedConfigZk = _configAccessor.getCustomizedStateConfig("TestClusterCustomized");
 
-    // Check that the CustomizedStateAggregationConfig from Zk and REST get method are equal
+    // Check that the CustomizedStateConfig from Zk and REST get method are equal
     Assert.assertEquals(customizedConfigRest, customizedConfigZk);
 
     // Check the fields individually
@@ -632,11 +632,11 @@ public class TestClusterAccessor extends AbstractTestClass {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     _gSetupTool.addCluster("TestClusterCustomized", true);
     String urlBase = "clusters/TestClusterCustomized/customized-state-aggregation-config/";
-    ZNRecord record = new ZNRecord("TestCustomizedStateAggregationConfig");
+    ZNRecord record = new ZNRecord("TestCustomizedStateConfig");
     List<String> testList = new ArrayList<String>();
     testList.add("mockType1");
     record.setListField(
-        CustomizedStateAggregationConfig.CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES
+        CustomizedStateConfig.CustomizedStateProperty.AGGREGATION_ENABLED_TYPES
             .name(),
         testList);
 
@@ -644,14 +644,14 @@ public class TestClusterAccessor extends AbstractTestClass {
         Entity.entity(OBJECT_MAPPER.writeValueAsString(record), MediaType.APPLICATION_JSON_TYPE),
         Response.Status.OK.getStatusCode());
 
-    // Read CustomizedStateAggregationConfig from Zookeeper and make sure it exists
+    // Read CustomizedStateConfig from Zookeeper and make sure it exists
     ConfigAccessor _configAccessor = new ConfigAccessor(ZK_ADDR);
-    CustomizedStateAggregationConfig customizedConfigFromZk = _configAccessor.getCustomizedStateAggregationConfig("TestClusterCustomized");
+    CustomizedStateConfig customizedConfigFromZk = _configAccessor.getCustomizedStateConfig("TestClusterCustomized");
     Assert.assertNotNull(customizedConfigFromZk);
 
     delete(urlBase, Response.Status.OK.getStatusCode());
 
-    customizedConfigFromZk = _configAccessor.getCustomizedStateAggregationConfig("TestClusterCustomized");
+    customizedConfigFromZk = _configAccessor.getCustomizedStateConfig("TestClusterCustomized");
     Assert.assertNull(customizedConfigFromZk);
 
     System.out.println("End test :" + TestHelper.getTestMethodName());
@@ -663,11 +663,11 @@ public class TestClusterAccessor extends AbstractTestClass {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     _gSetupTool.addCluster("TestClusterCustomized", true);
     String urlBase = "clusters/TestClusterCustomized/customized-state-aggregation-config/";
-    ZNRecord record = new ZNRecord("TestCustomizedStateAggregationConfig");
+    ZNRecord record = new ZNRecord("TestCustomizedStateConfig");
     List<String> testList = new ArrayList<String>();
     testList.add("mockType1");
     record.setListField(
-        CustomizedStateAggregationConfig.CustomizedStateAggregationProperty.AGGREGATION_ENABLED_TYPES
+        CustomizedStateConfig.CustomizedStateProperty.AGGREGATION_ENABLED_TYPES
             .name(),
         testList);
 
@@ -675,12 +675,12 @@ public class TestClusterAccessor extends AbstractTestClass {
         Entity.entity(OBJECT_MAPPER.writeValueAsString(record), MediaType.APPLICATION_JSON_TYPE),
         Response.Status.OK.getStatusCode());
 
-    // Read CustomizedStateAggregationConfig from Zookeeper and make sure it exists
+    // Read CustomizedStateConfig from Zookeeper and make sure it exists
     ConfigAccessor _configAccessor = new ConfigAccessor(ZK_ADDR);
-    CustomizedStateAggregationConfig customizedConfigFromZk = _configAccessor.getCustomizedStateAggregationConfig("TestClusterCustomized");
+    CustomizedStateConfig customizedConfigFromZk = _configAccessor.getCustomizedStateConfig("TestClusterCustomized");
     Assert.assertNotNull(customizedConfigFromZk);
 
-    // Add new type to CustomizedStateAggregationConfig
+    // Add new type to CustomizedStateConfig
     Map<String, String> map1 = new HashMap<>();
     map1.put("command", Command.add.name());
     map1.put("type", "mockType2");
@@ -689,12 +689,12 @@ public class TestClusterAccessor extends AbstractTestClass {
         Response.Status.OK.getStatusCode());
 
     customizedConfigFromZk =
-        _configAccessor.getCustomizedStateAggregationConfig("TestClusterCustomized");
+        _configAccessor.getCustomizedStateConfig("TestClusterCustomized");
     List<String> listTypesFromZk = customizedConfigFromZk.getAggregationEnabledTypes();
     Assert.assertEquals(listTypesFromZk.get(0), "mockType1");
     Assert.assertEquals(listTypesFromZk.get(1), "mockType2");
 
-    // Remove a type to CustomizedStateAggregationConfig
+    // Remove a type to CustomizedStateConfig
     Map<String, String> map2 = new HashMap<>();
     map2.put("command", Command.delete.name());
     map2.put("type", "mockType1");
@@ -703,7 +703,7 @@ public class TestClusterAccessor extends AbstractTestClass {
         Response.Status.OK.getStatusCode());
 
     customizedConfigFromZk =
-        _configAccessor.getCustomizedStateAggregationConfig("TestClusterCustomized");
+        _configAccessor.getCustomizedStateConfig("TestClusterCustomized");
     listTypesFromZk = customizedConfigFromZk.getAggregationEnabledTypes();
     Assert.assertEquals(listTypesFromZk.get(0), "mockType2");
     Assert.assertFalse(listTypesFromZk.contains("mockType1"));


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

(#850 )

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Rename the customized state aggregation config to customize state config throughout the code base. The main reason for this change is that we may use the config to represent other feature for customized state in addition to aggregation feature.

### Tests

- [X] The following is the result of the "mvn test" command on the appropriate module:
[INFO] Tests run: 909, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,438.097 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 909, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X] My diff has been formatted using helix-style.xml