### PR TITLE
Standardize the logging message format in ClusterAccessor and ConfigAccessor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -44,6 +44,7 @@ import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * Provides access to the persistent configuration of the cluster, the instances that live on it,
  * and the logical resources assigned to it.
@@ -52,6 +53,7 @@ public class ConfigAccessor {
   private static Logger LOG = LoggerFactory.getLogger(ConfigAccessor.class);
 
   private static final StringTemplate template = new StringTemplate();
+
   static {
     // @formatter:off
     template.addEntry(ConfigScopeProperty.CLUSTER, 1, "/{clusterName}/CONFIGS/CLUSTER");
@@ -94,9 +96,9 @@ public class ConfigAccessor {
    * @param zkAddress
    */
   public ConfigAccessor(String zkAddress) {
-    _zkClient = SharedZkClientFactory.getInstance().buildZkClient(
-        new HelixZkClient.ZkConnectionConfig(zkAddress),
-        new HelixZkClient.ZkClientConfig().setZkSerializer(new ZNRecordSerializer()));
+    _zkClient = SharedZkClientFactory.getInstance()
+        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
+            new HelixZkClient.ZkClientConfig().setZkSerializer(new ZNRecordSerializer()));
     _usesExternalZkClient = false;
   }
 
@@ -157,7 +159,6 @@ public class ConfigAccessor {
       }
     }
     return map;
-
   }
 
   /**
@@ -184,13 +185,13 @@ public class ConfigAccessor {
    */
   public Map<String, String> get(HelixConfigScope scope, List<String> keys) {
     if (scope == null || scope.getType() == null || !scope.isFullKey()) {
-      LOG.error("fail to get configs. invalid config scope. scope: " + scope + ", keys: " + keys);
+      LOG.error("fail to get configs. invalid config scope. scope: {}, keys: {}.", scope, keys);
       return null;
     }
     ZNRecord record = getConfigZnRecord(scope);
 
     if (record == null) {
-      LOG.warn("No config found at " + scope.getZkPath());
+      LOG.warn("No config found at {}.", scope.getZkPath());
       return null;
     }
 
@@ -205,7 +206,7 @@ public class ConfigAccessor {
     } else {
       Map<String, String> configMap = record.getMapField(mapKey);
       if (configMap == null) {
-        LOG.warn("No map-field found in " + record + " using mapKey: " + mapKey);
+        LOG.warn("No map-field found in {} using mapKey: {}.", record, mapKey);
         return null;
       }
 
@@ -251,7 +252,7 @@ public class ConfigAccessor {
   @Deprecated
   public void set(ConfigScope scope, Map<String, String> keyValueMap) {
     if (scope == null || scope.getScope() == null) {
-      LOG.error("Scope can't be null");
+      LOG.error("Scope can't be null.");
       return;
     }
 
@@ -265,8 +266,8 @@ public class ConfigAccessor {
       String instanceName = scopeStr.substring(scopeStr.lastIndexOf('/') + 1);
       if (!ZKUtil.isInstanceSetup(_zkClient, scope.getClusterName(), instanceName,
           InstanceType.PARTICIPANT)) {
-        throw new HelixException("instance: " + instanceName + " is NOT setup in cluster: "
-            + clusterName);
+        throw new HelixException(
+            "instance: " + instanceName + " is NOT setup in cluster: " + clusterName);
       }
     }
 
@@ -314,7 +315,7 @@ public class ConfigAccessor {
    */
   public void set(HelixConfigScope scope, Map<String, String> keyValueMap) {
     if (scope == null || scope.getType() == null || !scope.isFullKey()) {
-      LOG.error("fail to set config. invalid config scope. scope: {}", scope);
+      LOG.error("fail to set config. invalid config scope. Scope: {}.", scope);
       return;
     }
 
@@ -364,7 +365,7 @@ public class ConfigAccessor {
   @Deprecated
   public void remove(ConfigScope scope, List<String> keys) {
     if (scope == null || scope.getScope() == null) {
-      LOG.error("Scope can't be null");
+      LOG.error("Scope can't be null.");
       return;
     }
 
@@ -414,7 +415,7 @@ public class ConfigAccessor {
    */
   public void remove(HelixConfigScope scope, List<String> keys) {
     if (scope == null || scope.getType() == null || !scope.isFullKey()) {
-      LOG.error("fail to remove. invalid scope: " + scope + ", keys: " + keys);
+      LOG.error("fail to remove. invalid scope: {}, keys: {}", scope, keys);
       return;
     }
 
@@ -452,7 +453,7 @@ public class ConfigAccessor {
    */
   public void remove(HelixConfigScope scope, ZNRecord recordToRemove) {
     if (scope == null || scope.getType() == null || !scope.isFullKey()) {
-      LOG.error("fail to remove. invalid scope: " + scope);
+      LOG.error("fail to remove. invalid scope: {}.", scope);
       return;
     }
 
@@ -476,13 +477,13 @@ public class ConfigAccessor {
   @Deprecated
   public List<String> getKeys(ConfigScopeProperty type, String clusterName, String... keys) {
     if (type == null || clusterName == null) {
-      LOG.error("clusterName|scope can't be null");
+      LOG.error("ClusterName|scope can't be null.");
       return Collections.emptyList();
     }
 
     try {
       if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
-        LOG.error("cluster " + clusterName + " is not setup yet");
+        LOG.error("cluster {} is not setup yet.", clusterName);
         return Collections.emptyList();
       }
 
@@ -499,7 +500,6 @@ public class ConfigAccessor {
 
         if (splits[1].startsWith("SIMPLEKEYS")) {
           retKeys = new ArrayList<String>(record.getSimpleFields().keySet());
-
         } else if (splits[1].startsWith("MAPKEYS")) {
           retKeys = new ArrayList<String>(record.getMapFields().keySet());
         } else if (splits[1].startsWith("MAPMAPKEYS")) {
@@ -507,7 +507,7 @@ public class ConfigAccessor {
         }
       }
       if (retKeys == null) {
-        LOG.error("Invalid scope: " + type + " or keys: " + Arrays.toString(args));
+        LOG.error("Invalid scope: {} or keys: {}.", type, Arrays.toString(args));
         return Collections.emptyList();
       }
 
@@ -516,7 +516,6 @@ public class ConfigAccessor {
     } catch (Exception e) {
       return Collections.emptyList();
     }
-
   }
 
   /**
@@ -526,12 +525,12 @@ public class ConfigAccessor {
    */
   public List<String> getKeys(HelixConfigScope scope) {
     if (scope == null || scope.getType() == null) {
-      LOG.error("fail to getKeys. invalid config scope: " + scope);
+      LOG.error("Fail to getKeys. Invalid config scope: {}.", scope);
       return null;
     }
 
     if (!ZKUtil.isClusterSetup(scope.getClusterName(), _zkClient)) {
-      LOG.error("fail to getKeys. cluster " + scope.getClusterName() + " is not setup yet");
+      LOG.error("Fail to getKeys. Cluster {} is not setup yet.", scope.getClusterName());
       return Collections.emptyList();
     }
 
@@ -578,7 +577,7 @@ public class ConfigAccessor {
     ZNRecord record = getConfigZnRecord(scope);
 
     if (record == null) {
-      LOG.warn("No config found at " + scope.getZkPath());
+      LOG.warn("No config found at {}.", scope.getZkPath());
       return null;
     }
 
@@ -598,7 +597,7 @@ public class ConfigAccessor {
     ZNRecord record = getConfigZnRecord(scope);
 
     if (record == null) {
-      LOG.warn("No rest config found at " + scope.getZkPath());
+      LOG.warn("No rest config found at {}.", scope.getZkPath());
       return null;
     }
 
@@ -638,8 +637,8 @@ public class ConfigAccessor {
     updateClusterConfig(clusterName, clusterConfig, false);
   }
 
-
-  private void updateClusterConfig(String clusterName, ClusterConfig clusterConfig, boolean overwrite) {
+  private void updateClusterConfig(String clusterName, ClusterConfig clusterConfig,
+      boolean overwrite) {
     if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("fail to update config. cluster: " + clusterName + " is NOT setup.");
     }
@@ -670,7 +669,7 @@ public class ConfigAccessor {
     ZNRecord record = getConfigZnRecord(scope);
 
     if (record == null) {
-      LOG.warn("No config found at " + scope.getZkPath());
+      LOG.warn("No config found at {}.", scope.getZkPath());
       return null;
     }
 
@@ -754,7 +753,7 @@ public class ConfigAccessor {
     ZNRecord record = getConfigZnRecord(scope);
 
     if (record == null) {
-      LOG.warn("No config found at " + scope.getZkPath());
+      LOG.warn("No config found at {}.", scope.getZkPath());
       return null;
     }
 
@@ -775,7 +774,6 @@ public class ConfigAccessor {
   public void setInstanceConfig(String clusterName, String instanceName,
       InstanceConfig instanceConfig) {
     updateInstanceConfig(clusterName, instanceName, instanceConfig, true);
-
   }
 
   /**

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
 
 @Path("/clusters")
 public class ClusterAccessor extends AbstractHelixResource {
-  private static Logger _logger = LoggerFactory.getLogger(ClusterAccessor.class.getName());
+  private static Logger LOG = LoggerFactory.getLogger(ClusterAccessor.class.getName());
 
   public enum ClusterProperties {
     controller,
@@ -140,7 +140,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       clusterSetup.addCluster(clusterId, recreateIfExists);
     } catch (Exception ex) {
-      _logger.error("Failed to create cluster {}. Exception: {}.", clusterId, ex);
+      LOG.error("Failed to create cluster {}. Exception: {}.", clusterId, ex);
       return serverError(ex);
     }
 
@@ -155,12 +155,12 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       clusterSetup.deleteCluster(clusterId);
     } catch (HelixException ex) {
-      _logger
+      LOG
           .info("Failed to delete cluster {}, cluster is still in use. Exception: {}.", clusterId,
               ex);
       return badRequest(ex.getMessage());
     } catch (Exception ex) {
-      _logger.error("Failed to delete cluster {}. Exception: {}.", clusterId, ex);
+      LOG.error("Failed to delete cluster {}. Exception: {}.", clusterId, ex);
       return serverError(ex);
     }
 
@@ -190,7 +190,7 @@ public class ClusterAccessor extends AbstractHelixResource {
         try {
           clusterSetup.activateCluster(clusterId, superCluster, true);
         } catch (Exception ex) {
-          _logger.error("Failed to add cluster {} to super cluster {}.", clusterId, superCluster);
+          LOG.error("Failed to add cluster {} to super cluster {}.", clusterId, superCluster);
           return serverError(ex);
         }
         break;
@@ -199,7 +199,7 @@ public class ClusterAccessor extends AbstractHelixResource {
         try {
           clusterSetup.expandCluster(clusterId);
         } catch (Exception ex) {
-          _logger.error("Failed to expand cluster {}.", clusterId);
+          LOG.error("Failed to expand cluster {}.", clusterId);
           return serverError(ex);
         }
         break;
@@ -208,7 +208,7 @@ public class ClusterAccessor extends AbstractHelixResource {
         try {
           helixAdmin.enableCluster(clusterId, true);
         } catch (Exception ex) {
-          _logger.error("Failed to enable cluster {}.", clusterId);
+          LOG.error("Failed to enable cluster {}.", clusterId);
           return serverError(ex);
         }
         break;
@@ -217,7 +217,7 @@ public class ClusterAccessor extends AbstractHelixResource {
         try {
           helixAdmin.enableCluster(clusterId, false);
         } catch (Exception ex) {
-          _logger.error("Failed to disable cluster {}.", clusterId);
+          LOG.error("Failed to disable cluster {}.", clusterId);
           return serverError(ex);
         }
         break;
@@ -266,10 +266,10 @@ public class ClusterAccessor extends AbstractHelixResource {
       config = accessor.getClusterConfig(clusterId);
     } catch (HelixException ex) {
       // cluster not found.
-      _logger.info("Failed to get cluster config for cluster {}, cluster not found. Exception: {}.",
+      LOG.info("Failed to get cluster config for cluster {}, cluster not found. Exception: {}.",
           clusterId, ex);
     } catch (Exception ex) {
-      _logger.error("Failed to get cluster config for cluster {}. Exception: {}", clusterId, ex);
+      LOG.error("Failed to get cluster config for cluster {}. Exception: {}", clusterId, ex);
       return serverError(ex);
     }
     if (config == null) {
@@ -305,7 +305,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       record = toZNRecord(content);
     } catch (IOException e) {
-      _logger.error("Failed to deserialize user's input {}. Exception: {}.", content, e);
+      LOG.error("Failed to deserialize user's input {}. Exception: {}.", content, e);
       return badRequest("Input is not a valid ZNRecord!");
     }
 
@@ -334,7 +334,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     } catch (HelixException ex) {
       return notFound(ex.getMessage());
     } catch (Exception ex) {
-      _logger
+      LOG
           .error("Failed to {} cluster config, cluster {}, new config: {}. Exception: {}.", command,
               clusterId, content, ex);
       return serverError(ex);
@@ -450,7 +450,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       record = toZNRecord(content);
     } catch (IOException e) {
-      _logger.error("Failed to deserialize user's input {}. Exception: {}.", content, e);
+      LOG.error("Failed to deserialize user's input {}. Exception: {}.", content, e);
       return badRequest("Input is not a valid ZNRecord!");
     }
     HelixZkClient zkClient = getHelixZkClient();
@@ -458,7 +458,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       ZKUtil.createChildren(zkClient, path, record);
     } catch (Exception e) {
-      _logger.error("Failed to create zk node with path {}. Exception: {}", path, e);
+      LOG.error("Failed to create zk node with path {}. Exception: {}", path, e);
       return badRequest("Failed to create a Znode for stateModel! " + e);
     }
 
@@ -473,7 +473,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       record = toZNRecord(content);
     } catch (IOException e) {
-      _logger.error("Failed to deserialize user's input {}. Exception: {}.", content, e);
+      LOG.error("Failed to deserialize user's input {}. Exception: {}.", content, e);
       return badRequest("Input is not a valid ZNRecord!");
     }
 
@@ -485,7 +485,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       retcode = dataAccessor.setProperty(key, stateModelDefinition);
     } catch (Exception e) {
-      _logger.error("Failed to set StateModelDefinition key: {}. Exception: {}.", key, e);
+      LOG.error("Failed to set StateModelDefinition key: {}. Exception: {}.", key, e);
       return badRequest("Failed to set the content " + content);
     }
 
@@ -507,7 +507,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       retcode = dataAccessor.removeProperty(key);
     } catch (Exception e) {
-      _logger.error("Failed to remove StateModelDefinition key: {}. Exception: {}.", key, e);
+      LOG.error("Failed to remove StateModelDefinition key: {}. Exception: {}.", key, e);
       retcode = false;
     }
     if (!retcode) {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

This PR takes advantage of parameterized message provided by slf4j to form logging messages in ClusterAccessor and ConfigAccessor. The parameterized message gives a clear syntax than simply concatenating the strings and variables.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

All the logging messages inside ClusterAccessor class and ConfigAccessor class are changed to parameterized messages. Auto-reformatted the two classes.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

Results :

Tests run: 99, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  39.919 s
[INFO] Finished at: 2020-03-11T13:08:59-07:00
[INFO] ------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)