### PR TITLE
Modify data providers and add customized view aggregation stage

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedStateCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedStateCache.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 
 public class CustomizedStateCache extends ParticipantStateCache<CustomizedState> {
   private static final Logger LOG = LoggerFactory.getLogger(CurrentStateCache.class.getName());
-  private final Set<String> _aggregationEnabledTypes;
+  private Set<String> _aggregationEnabledTypes;
 
   public CustomizedStateCache(String clusterName, Set<String> aggregationEnabledTypes) {
     this(createDefaultControlContextProvider(clusterName), aggregationEnabledTypes);
@@ -59,5 +59,9 @@ public class CustomizedStateCache extends ParticipantStateCache<CustomizedState>
       }
     }
     return participantStateKeys;
+  }
+
+  public void setAggregationEnabledTypes(Set<String> aggregationEnabledTypes) {
+    _aggregationEnabledTypes = aggregationEnabledTypes;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -89,7 +89,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
   // Property caches
   private final PropertyCache<ResourceConfig> _resourceConfigCache;
   private final PropertyCache<InstanceConfig> _instanceConfigCache;
-  protected final PropertyCache<LiveInstance> _liveInstanceCache;
+  private final PropertyCache<LiveInstance> _liveInstanceCache;
   private final PropertyCache<IdealState> _idealStateCache;
   private final PropertyCache<ClusterConstraints> _clusterConstraintsCache;
   private final PropertyCache<StateModelDefinition> _stateModelDefinitionCache;
@@ -750,6 +750,10 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     sb.append(String.format("currentStateCache: %s", _currentStateCache)).append("\n");
     sb.append(String.format("clusterConfig: %s", _clusterConfig)).append("\n");
     return sb;
+  }
+
+  protected PropertyCache<LiveInstance> getLiveInstanceCache() {
+    return _liveInstanceCache;
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -286,7 +286,6 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     }
   }
 
-
   private void updateMaintenanceInfo(final HelixDataAccessor accessor) {
     _maintenanceSignal = accessor.getProperty(accessor.keyBuilder().maintenance());
     _isMaintenanceModeEnabled = _maintenanceSignal != null;

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -299,8 +299,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
       CustomizedStateConfig customizedStateConfig =
           accessor.getProperty(accessor.keyBuilder().customizedStateConfig());
       if (customizedStateConfig != null) {
-        _aggregationEnabledTypes = new HashSet<>(customizedStateConfig.getRecord().getListFields()
-            .get(CustomizedStateConfig.CustomizedStateProperty.AGGREGATION_ENABLED_TYPES.name()));
+        _aggregationEnabledTypes =
+            new HashSet<>(customizedStateConfig.getAggregationEnabledTypes());
       }
       LogUtil.logInfo(logger, getClusterEventId(), String
           .format("Reloaded CustomizedStateConfig for cluster %s, %s pipeline.",
@@ -393,7 +393,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
           "InstanceConfigs: " + getInstanceConfigMap().keySet());
       LogUtil.logDebug(logger, getClusterEventId(), "ClusterConfigs: " + getClusterConfig());
       LogUtil.logDebug(logger, getClusterEventId(),
-          "CustomizedStateConfig: " + getCustomizedStateConfig());
+          "CustomizedStateConfig: " + getAggregationEnabledCustomizedStateTypes());
     }
   }
 
@@ -405,11 +405,11 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     _clusterConfig = clusterConfig;
   }
 
-  public Set<String> getCustomizedStateConfig() {
+  public Set<String> getAggregationEnabledCustomizedStateTypes() {
     return _aggregationEnabledTypes;
   }
 
-  public void setCustomizedStateConfig(Set<String> aggregationEnabledTypes) {
+  public void SetAggregationEnabledCustomizedStateTypes(Set<String> aggregationEnabledTypes) {
     _aggregationEnabledTypes = aggregationEnabledTypes;
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -166,14 +166,21 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
     // refreshed once during the cache's first refresh() call, or when full refresh is required
     List<String> stateTypes = accessor.getChildNames(accessor.keyBuilder().customizedViews());
     if (_propertyDataChangedMap.get(HelixConstants.ChangeType.CUSTOMIZED_VIEW).getAndSet(false)) {
-      for (String stateType: stateTypes) {
-        _customizedViewCacheMap.get(stateType).refresh(accessor);
+      for (String stateType : stateTypes) {
+        if (!_customizedViewCacheMap.containsKey(stateType)) {
+          CustomizedViewCache newCustomizedViewCache =
+              new CustomizedViewCache(getClusterName(), stateType);
+          newCustomizedViewCache.refresh(accessor);
+          _customizedViewCacheMap.put(stateType, newCustomizedViewCache);
+        } else {
+          _customizedViewCacheMap.get(stateType).refresh(accessor);
+        }
       }
-    }
-    for (String stateType : _customizedViewCacheMap.keySet()) {
-      if (!stateTypes.contains(stateType)) {
-        logger.info("Remove customizedView for state: " + stateType);
-        _customizedViewCacheMap.remove(stateType);
+      for (String stateType : _customizedViewCacheMap.keySet()) {
+        if (!stateTypes.contains(stateType)) {
+          logger.info("Remove customizedView for state: " + stateType);
+          _customizedViewCacheMap.remove(stateType);
+        }
       }
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -166,6 +166,7 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
       } else {
         _aggregationEnabledTypes.clear();
       }
+      _customizedStateCache.setAggregationEnabledTypes(_aggregationEnabledTypes);
       LogUtil.logInfo(logger, getClusterEventId(), String
           .format("Reloaded CustomizedStateConfig for cluster %s, %s pipeline.",
               getClusterName(), getPipelineName()));
@@ -228,7 +229,7 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
     return _aggregationEnabledTypes;
   }
 
-  protected void SetAggregationEnabledCustomizedStateTypes(Set<String> aggregationEnabledTypes) {
+  protected void setAggregationEnabledCustomizedStateTypes(Set<String> aggregationEnabledTypes) {
     _aggregationEnabledTypes = aggregationEnabledTypes;
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -137,7 +137,8 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
 
     // Refresh resource controller specific property caches
     refreshCustomizedStateConfig(accessor);
-    _customizedStateCache.refresh(accessor, _liveInstanceCache.getPropertyMap());
+    _customizedStateCache.setAggregationEnabledTypes(_aggregationEnabledTypes);
+    _customizedStateCache.refresh(accessor, getLiveInstanceCache().getPropertyMap());
     refreshExternalViews(accessor);
     refreshTargetExternalViews(accessor);
     refreshCustomizedViewMap(accessor);
@@ -166,7 +167,6 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
       } else {
         _aggregationEnabledTypes.clear();
       }
-      _customizedStateCache.setAggregationEnabledTypes(_aggregationEnabledTypes);
       LogUtil.logInfo(logger, getClusterEventId(), String
           .format("Reloaded CustomizedStateConfig for cluster %s, %s pipeline.",
               getClusterName(), getPipelineName()));

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -30,6 +30,7 @@ import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.common.caches.AbstractDataCache;
+import org.apache.helix.common.caches.CustomizedViewCache;
 import org.apache.helix.common.caches.PropertyCache;
 import org.apache.helix.controller.LogUtil;
 import org.apache.helix.controller.pipeline.Pipeline;
@@ -52,6 +53,8 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
   // Resource control specific property caches
   private final PropertyCache<ExternalView> _externalViewCache;
   private final PropertyCache<ExternalView> _targetExternalViewCache;
+  // a map from customized state type to customized view cache
+  private final Map<String, CustomizedViewCache> _customizedViewCacheMap;
 
   // maintain a cache of bestPossible assignment across pipeline runs
   // TODO: this is only for customRebalancer, remove it and merge it with _idealMappingCache.
@@ -106,6 +109,7 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
     _idealMappingCache = new HashMap<>();
     _missingTopStateMap = new HashMap<>();
     _lastTopStateLocationMap = new HashMap<>();
+    _customizedViewCacheMap = new HashMap<>();
   }
 
   public synchronized void refresh(HelixDataAccessor accessor) {
@@ -125,6 +129,7 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
     // Refresh resource controller specific property caches
     refreshExternalViews(accessor);
     refreshTargetExternalViews(accessor);
+    refreshCustomizedViewMap(accessor);
     LogUtil.logInfo(logger, getClusterEventId(), String.format(
         "END: ResourceControllerDataProvider.refresh() for cluster %s, started at %d took %d for %s pipeline",
         getClusterName(), startTime, System.currentTimeMillis() - startTime, getPipelineName()));
@@ -156,6 +161,23 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
     }
   }
 
+  public void refreshCustomizedViewMap(final HelixDataAccessor accessor) {
+    // As we are not listening on customized view change, customized view will be
+    // refreshed once during the cache's first refresh() call, or when full refresh is required
+    List<String> stateTypes = accessor.getChildNames(accessor.keyBuilder().customizedViews());
+    if (_propertyDataChangedMap.get(HelixConstants.ChangeType.CUSTOMIZED_VIEW).getAndSet(false)) {
+      for (String stateType: stateTypes) {
+        _customizedViewCacheMap.get(stateType).refresh(accessor);
+      }
+    }
+    for (String stateType : _customizedViewCacheMap.keySet()) {
+      if (!stateTypes.contains(stateType)) {
+        logger.info("Remove customizedView for state: " + stateType);
+        _customizedViewCacheMap.remove(stateType);
+      }
+    }
+  }
+
   public ExternalView getTargetExternalView(String resourceName) {
     return _targetExternalViewCache.getPropertyByName(resourceName);
   }
@@ -183,6 +205,14 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
   }
 
   /**
+   * Get local cached customized view map
+   * @return
+   */
+  public Map<String, CustomizedViewCache> getCustomizedViewCacheMap() {
+    return _customizedViewCacheMap;
+  }
+
+  /**
    * Remove dead external views from map
    * @param resourceNames
    */
@@ -190,6 +220,17 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
   public void removeExternalViews(List<String> resourceNames) {
     for (String resourceName : resourceNames) {
       _externalViewCache.deletePropertyByName(resourceName);
+    }
+  }
+
+  /**
+   * Remove dead customized views for certain state types from map
+   * @param stateTypeNames
+   */
+
+  public void removeCustomizedViewTypes(List<String> stateTypeNames) {
+    for (String stateType : stateTypeNames) {
+      _customizedViewCacheMap.remove(stateType);
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -202,11 +202,9 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
         if (!_customizedViewCacheMap.containsKey(stateType)) {
           CustomizedViewCache newCustomizedViewCache =
               new CustomizedViewCache(getClusterName(), stateType);
-          newCustomizedViewCache.refresh(accessor);
           _customizedViewCacheMap.put(stateType, newCustomizedViewCache);
-        } else {
-          _customizedViewCacheMap.get(stateType).refresh(accessor);
         }
+        _customizedViewCacheMap.get(stateType).refresh(accessor);
       }
       Set<String> previousCachedStateTypes = _customizedViewCacheMap.keySet();
       previousCachedStateTypes.removeAll(newStateTypes);
@@ -284,7 +282,7 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
    * @param stateTypeNames
    */
 
-  public void removeCustomizedViewTypes(List<String> stateTypeNames) {
+  private void removeCustomizedViewTypes(List<String> stateTypeNames) {
     for (String stateType : stateTypeNames) {
       _customizedViewCacheMap.remove(stateType);
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/pipeline/AsyncWorkerType.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/pipeline/AsyncWorkerType.java
@@ -31,5 +31,6 @@ public enum AsyncWorkerType {
   PersistAssignmentWorker,
   ExternalViewComputeWorker,
   MaintenanceRecoveryWorker,
-  TaskJobPurgeWorker
+  TaskJobPurgeWorker,
+  CustomizedStateViewComputeWorker
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
@@ -19,16 +19,13 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.helix.HelixManager;
 import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
 import org.apache.helix.controller.pipeline.AbstractBaseStage;
 import org.apache.helix.controller.pipeline.StageException;
 import org.apache.helix.model.CustomizedState;
-import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
@@ -41,21 +38,11 @@ public class CustomizedStateComputationStage extends AbstractBaseStage {
 
   @Override
   public void process(ClusterEvent event) throws Exception {
-    HelixManager helixManager = event.getAttribute(AttributeName.helixmanager.name());
-    Set<String> aggregationEnabledTypes = new HashSet<>();
-    if (helixManager.getHelixDataAccessor().getProperty(
-        helixManager.getHelixDataAccessor().keyBuilder().customizedStateConfig())
-        != null) {
-      aggregationEnabledTypes = new HashSet<>(helixManager.getHelixDataAccessor().getProperty(
-          helixManager.getHelixDataAccessor().keyBuilder().customizedStateConfig())
-          .getRecord().getListFields().get(
-              CustomizedStateConfig.CustomizedStateProperty.AGGREGATION_ENABLED_TYPES
-                  .name()));
-    }
     _eventId = event.getEventId();
     BaseControllerDataProvider cache =
         event.getAttribute(AttributeName.ControllerDataProvider.name());
     final Map<String, Resource> resourceMap = event.getAttribute(AttributeName.RESOURCES.name());
+    Set<String> aggregationEnabledTypes = cache.getAggregationEnabledCustomizedStateTypes();
 
     if (cache == null || resourceMap == null) {
       throw new StageException(

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
@@ -1,0 +1,107 @@
+package org.apache.helix.controller.stages;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.helix.HelixManager;
+import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
+import org.apache.helix.controller.pipeline.AbstractBaseStage;
+import org.apache.helix.controller.pipeline.StageException;
+import org.apache.helix.model.CustomizedState;
+import org.apache.helix.model.CustomizedStateConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.Partition;
+import org.apache.helix.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class CustomizedStateComputationStage extends AbstractBaseStage {
+  private static Logger LOG = LoggerFactory.getLogger(CustomizedStateComputationStage.class);
+
+  @Override
+  public void process(ClusterEvent event) throws Exception {
+    HelixManager helixManager = event.getAttribute(AttributeName.helixmanager.name());
+    Set<String> aggregationEnabledTypes = new HashSet<>();
+    if (helixManager.getHelixDataAccessor().getProperty(
+        helixManager.getHelixDataAccessor().keyBuilder().customizedStateConfig())
+        != null) {
+      aggregationEnabledTypes = new HashSet<>(helixManager.getHelixDataAccessor().getProperty(
+          helixManager.getHelixDataAccessor().keyBuilder().customizedStateConfig())
+          .getRecord().getListFields().get(
+              CustomizedStateConfig.CustomizedStateProperty.AGGREGATION_ENABLED_TYPES
+                  .name()));
+    }
+    _eventId = event.getEventId();
+    BaseControllerDataProvider cache =
+        event.getAttribute(AttributeName.ControllerDataProvider.name());
+    final Map<String, Resource> resourceMap = event.getAttribute(AttributeName.RESOURCES.name());
+
+    if (cache == null || resourceMap == null) {
+      throw new StageException(
+          "Missing attributes in event:" + event + ". Requires DataCache|RESOURCE");
+    }
+
+    Map<String, LiveInstance> liveInstances = cache.getLiveInstances();
+    final CustomizedStateOutput customizedStateOutput = new CustomizedStateOutput();
+
+    for (LiveInstance instance : liveInstances.values()) {
+      String instanceName = instance.getInstanceName();
+      // update customized states.
+      for (String customizedStateType : aggregationEnabledTypes) {
+        Map<String, CustomizedState> customizedStateMap =
+            cache.getCustomizedState(instanceName, customizedStateType);
+        updateCustomizedStates(instance, customizedStateType, customizedStateMap,
+            customizedStateOutput, resourceMap);
+      }
+    }
+    event.addAttribute(AttributeName.CUSTOMIZED_STATE.name(), customizedStateOutput);
+  }
+
+  // update customized state in CustomizedStateOutput
+  private void updateCustomizedStates(LiveInstance instance, String customizedStateType,
+      Map<String, CustomizedState> customizedStates, CustomizedStateOutput customizedStateOutput,
+      Map<String, Resource> resourceMap) {
+    String instanceName = instance.getInstanceName();
+
+    // for each CustomizedState, update corresponding entry in CustomizedStateOutput
+    for (CustomizedState customizedState : customizedStates.values()) {
+      String resourceName = customizedState.getResourceName();
+      Resource resource = resourceMap.get(resourceName);
+      if (resource == null) {
+        continue;
+      }
+
+      Map<String, String> partitionStateMap = customizedState
+          .getPartitionStateMap(CustomizedState.CustomizedStateProperty.CURRENT_STATE);
+      for (String partitionName : partitionStateMap.keySet()) {
+        Partition partition = resource.getPartition(partitionName);
+        if (partition != null) {
+          customizedStateOutput
+              .setCustomizedState(customizedStateType, resourceName, partition, instanceName,
+                  customizedState.getState(partitionName));
+        }
+      }
+    }
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
@@ -41,7 +41,8 @@ public class CustomizedStateComputationStage extends AbstractBaseStage {
     _eventId = event.getEventId();
     ResourceControllerDataProvider cache =
         event.getAttribute(AttributeName.ControllerDataProvider.name());
-    final Map<String, Resource> resourceMap = event.getAttribute(AttributeName.RESOURCES.name());
+    final Map<String, Resource> resourceMap =
+        event.getAttribute(AttributeName.RESOURCES_TO_REBALANCE.name());
     Set<String> aggregationEnabledTypes = cache.getAggregationEnabledCustomizedStateTypes();
 
     if (cache == null || resourceMap == null) {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
@@ -22,7 +22,7 @@ package org.apache.helix.controller.stages;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.pipeline.AbstractBaseStage;
 import org.apache.helix.controller.pipeline.StageException;
 import org.apache.helix.model.CustomizedState;
@@ -39,7 +39,7 @@ public class CustomizedStateComputationStage extends AbstractBaseStage {
   @Override
   public void process(ClusterEvent event) throws Exception {
     _eventId = event.getEventId();
-    BaseControllerDataProvider cache =
+    ResourceControllerDataProvider cache =
         event.getAttribute(AttributeName.ControllerDataProvider.name());
     final Map<String, Resource> resourceMap = event.getAttribute(AttributeName.RESOURCES.name());
     Set<String> aggregationEnabledTypes = cache.getAggregationEnabledCustomizedStateTypes();
@@ -58,7 +58,7 @@ public class CustomizedStateComputationStage extends AbstractBaseStage {
       for (String customizedStateType : aggregationEnabledTypes) {
         Map<String, CustomizedState> customizedStateMap =
             cache.getCustomizedState(instanceName, customizedStateType);
-        updateCustomizedStates(instance, customizedStateType, customizedStateMap,
+        updateCustomizedStates(instance.getLiveInstance(), customizedStateType, customizedStateMap,
             customizedStateOutput, resourceMap);
       }
     }
@@ -66,11 +66,9 @@ public class CustomizedStateComputationStage extends AbstractBaseStage {
   }
 
   // update customized state in CustomizedStateOutput
-  private void updateCustomizedStates(LiveInstance instance, String customizedStateType,
+  private void updateCustomizedStates(String instanceName, String customizedStateType,
       Map<String, CustomizedState> customizedStates, CustomizedStateOutput customizedStateOutput,
       Map<String, Resource> resourceMap) {
-    String instanceName = instance.getInstanceName();
-
     // for each CustomizedState, update corresponding entry in CustomizedStateOutput
     for (CustomizedState customizedState : customizedStates.values()) {
       String resourceName = customizedState.getResourceName();

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
@@ -58,7 +58,7 @@ public class CustomizedStateComputationStage extends AbstractBaseStage {
       for (String customizedStateType : aggregationEnabledTypes) {
         Map<String, CustomizedState> customizedStateMap =
             cache.getCustomizedState(instanceName, customizedStateType);
-        updateCustomizedStates(instance.getLiveInstance(), customizedStateType, customizedStateMap,
+        updateCustomizedStates(instanceName, customizedStateType, customizedStateMap,
             customizedStateOutput, resourceMap);
       }
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedViewAggregateStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedViewAggregateStage.java
@@ -1,0 +1,171 @@
+package org.apache.helix.controller.stages;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixException;
+import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.common.caches.CustomizedViewCache;
+import org.apache.helix.controller.LogUtil;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.pipeline.AbstractAsyncBaseStage;
+import org.apache.helix.controller.pipeline.AsyncWorkerType;
+import org.apache.helix.controller.pipeline.StageException;
+import org.apache.helix.model.CustomizedView;
+import org.apache.helix.model.Partition;
+import org.apache.helix.model.Resource;
+import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class CustomizedViewAggregateStage extends AbstractAsyncBaseStage {
+  private static Logger LOG = LoggerFactory.getLogger(CustomizedViewAggregateStage.class);
+
+  @Override
+  public AsyncWorkerType getAsyncWorkerType() {
+    return AsyncWorkerType.CustomizedStateViewComputeWorker;
+  }
+
+  @Override
+  public void execute(final ClusterEvent event) throws Exception {
+    _eventId = event.getEventId();
+    HelixManager manager = event.getAttribute(AttributeName.helixmanager.name());
+    Map<String, Resource> resourceMap =
+        event.getAttribute(AttributeName.RESOURCES_TO_REBALANCE.name());
+    ResourceControllerDataProvider cache =
+        event.getAttribute(AttributeName.ControllerDataProvider.name());
+
+    if (manager == null || resourceMap == null || cache == null) {
+      throw new StageException(
+          "Missing attributes in event:" + event + ". Requires ClusterManager|RESOURCES|DataCache");
+    }
+
+    HelixDataAccessor dataAccessor = manager.getHelixDataAccessor();
+    PropertyKey.Builder keyBuilder = dataAccessor.keyBuilder();
+
+    CustomizedStateOutput customizedStateOutput =
+        event.getAttribute(AttributeName.CUSTOMIZED_STATE.name());
+    ClusterStatusMonitor clusterStatusMonitor =
+        event.getAttribute(AttributeName.clusterStatusMonitor.name());
+
+    List<CustomizedView> newCustomizedViews = new ArrayList<>();
+    Set<String> monitoringResources = new HashSet<>();
+
+    Map<String, CustomizedViewCache> customizedViewCacheMap = cache.getCustomizedViewCacheMap();
+    cache.refreshCustomizedViewMap(dataAccessor);
+
+    // remove stale customized view type from ZK and cache
+    List<String> customizedViewTypesToRemove = new ArrayList<>();
+    for (String stateType : customizedViewCacheMap.keySet()) {
+      if (!customizedStateOutput.getAllStateTypes().contains(stateType)) {
+        LogUtil.logInfo(LOG, _eventId, "Remove customizedView for stateType: " + stateType);
+        dataAccessor.removeProperty(keyBuilder.customizedView(stateType));
+        customizedViewTypesToRemove.add(stateType);
+      }
+    }
+
+    cache.removeCustomizedViewTypes(customizedViewTypesToRemove);
+
+    // update customized view
+    for (String stateType : customizedStateOutput.getAllStateTypes()) {
+      Map<String, CustomizedView> curCustomizedViews = new HashMap<>();
+      CustomizedViewCache customizedViewCache = customizedViewCacheMap.get(stateType);
+      if (customizedViewCache != null) {
+        curCustomizedViews = customizedViewCache.getCustomizedViewMap();
+      } else {
+        customizedViewCache = new CustomizedViewCache(event.getClusterName(), stateType);
+      }
+
+      for (Resource resource : resourceMap.values()) {
+        try {
+          computeCustomizedStateView(resource, stateType, customizedStateOutput, curCustomizedViews,
+              newCustomizedViews);
+          // Keep MBeans for existing resources and unregister MBeans for dropped resources
+          if (clusterStatusMonitor != null) {
+            clusterStatusMonitor.retainResourceMonitor(monitoringResources);
+          }
+
+          List<PropertyKey> keys = new ArrayList<>();
+          for (Iterator<CustomizedView> it = newCustomizedViews.iterator(); it.hasNext(); ) {
+            CustomizedView view = it.next();
+            String resourceName = view.getResourceName();
+            keys.add(keyBuilder.customizedView(stateType, resourceName));
+          }
+          // add/update customized-views
+          if (newCustomizedViews.size() > 0) {
+            dataAccessor.setChildren(keys, newCustomizedViews);
+            customizedViewCache.refresh(dataAccessor);
+          }
+
+          List<String> customizedViewsToRemove = new ArrayList<>();
+
+          // remove stale customized views
+          for (String resourceName : curCustomizedViews.keySet()) {
+            if (!resourceMap.keySet().contains(resourceName)) {
+              LogUtil.logInfo(LOG, _eventId, "Remove customizedView for resource: " + resourceName);
+              dataAccessor.removeProperty(keyBuilder.customizedView(stateType, resourceName));
+              customizedViewsToRemove.add(resourceName);
+            }
+          }
+          customizedViewCache.removeCustomizedView(customizedViewsToRemove);
+        } catch (HelixException ex) {
+          LogUtil.logError(LOG, _eventId,
+              "Failed to calculate customized view for resource " + resource.getResourceName(), ex);
+        }
+      }
+    }
+  }
+
+  private void computeCustomizedStateView(final Resource resource, final String stateType,
+      CustomizedStateOutput customizedStateOutput,
+      final Map<String, CustomizedView> curCustomizedViews,
+      List<CustomizedView> newCustomizedViews) {
+    String resourceName = resource.getResourceName();
+    CustomizedView view = new CustomizedView(resource.getResourceName());
+
+    for (Partition partition : resource.getPartitions()) {
+      Map<String, String> customizedStateMap =
+          customizedStateOutput.getPartitionCustomizedStateMap(stateType, resourceName, partition);
+      if (customizedStateMap != null && customizedStateMap.size() > 0) {
+        for (String instance : customizedStateMap.keySet()) {
+          view.setState(partition.getPartitionName(), instance, customizedStateMap.get(instance));
+        }
+      }
+    }
+
+    CustomizedView curCustomizedView = curCustomizedViews.get(resourceName);
+
+    // compare the new customized view with current one, set only on different
+    if (curCustomizedView == null || !curCustomizedView.getRecord().equals(view.getRecord())) {
+      // Add customized view to the list which will be written to ZK later.
+      newCustomizedViews.add(view);
+    }
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedViewAggregationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedViewAggregationStage.java
@@ -45,8 +45,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class CustomizedViewAggregateStage extends AbstractAsyncBaseStage {
-  private static Logger LOG = LoggerFactory.getLogger(CustomizedViewAggregateStage.class);
+public class CustomizedViewAggregationStage extends AbstractAsyncBaseStage {
+  private static Logger LOG = LoggerFactory.getLogger(CustomizedViewAggregationStage.class);
 
   @Override
   public AsyncWorkerType getAsyncWorkerType() {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedViewAggregationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedViewAggregationStage.java
@@ -40,7 +40,6 @@ import org.apache.helix.controller.pipeline.StageException;
 import org.apache.helix.model.CustomizedView;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
-import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,14 +71,12 @@ public class CustomizedViewAggregationStage extends AbstractAsyncBaseStage {
 
     CustomizedStateOutput customizedStateOutput =
         event.getAttribute(AttributeName.CUSTOMIZED_STATE.name());
-    ClusterStatusMonitor clusterStatusMonitor =
-        event.getAttribute(AttributeName.clusterStatusMonitor.name());
 
     List<CustomizedView> newCustomizedViews = new ArrayList<>();
     Set<String> monitoringResources = new HashSet<>();
 
-    Map<String, CustomizedViewCache> customizedViewCacheMap = cache.getCustomizedViewCacheMap();
     cache.refreshCustomizedViewMap(dataAccessor);
+    Map<String, CustomizedViewCache> customizedViewCacheMap = cache.getCustomizedViewCacheMap();
 
     // remove stale customized view type from ZK and cache
     List<String> customizedViewTypesToRemove = new ArrayList<>();
@@ -107,10 +104,6 @@ public class CustomizedViewAggregationStage extends AbstractAsyncBaseStage {
         try {
           computeCustomizedStateView(resource, stateType, customizedStateOutput, curCustomizedViews,
               newCustomizedViews);
-          // Keep MBeans for existing resources and unregister MBeans for dropped resources
-          if (clusterStatusMonitor != null) {
-            clusterStatusMonitor.retainResourceMonitor(monitoringResources);
-          }
 
           List<PropertyKey> keys = new ArrayList<>();
           for (Iterator<CustomizedView> it = newCustomizedViews.iterator(); it.hasNext(); ) {

--- a/helix-core/src/main/java/org/apache/helix/model/CustomizedStateConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/CustomizedStateConfig.java
@@ -26,7 +26,7 @@ import org.apache.helix.HelixProperty;
 import org.apache.helix.ZNRecord;
 
 /**
- * CustomizedStateAggregation configurations
+ * Customized state configurations
  */
 public class CustomizedStateConfig extends HelixProperty {
 

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestCustomizedStateComputationStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestCustomizedStateComputationStage.java
@@ -1,0 +1,102 @@
+package org.apache.helix.controller.stages;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.helix.PropertyKey;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.model.CustomizedState;
+import org.apache.helix.model.CustomizedStateConfig;
+import org.apache.helix.model.Partition;
+import org.apache.helix.model.Resource;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+
+public class TestCustomizedStateComputationStage extends BaseStageTest {
+  private final String RESOURCE_NAME = "testResourceName";
+  private final String PARTITION_NAME = "testResourceName_0";
+  private final String CUSTOMIZED_STATE_NAME = "customizedState1";
+  private final String INSTANCE_NAME = "localhost_1";
+
+  @Test
+  public void testEmptyCustomizedState() {
+    Map<String, Resource> resourceMap = getResourceMap();
+    event.addAttribute(AttributeName.RESOURCES.name(), resourceMap);
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), resourceMap);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider(_clusterName));
+    CustomizedStateComputationStage stage = new CustomizedStateComputationStage();
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, stage);
+    CustomizedStateOutput output = event.getAttribute(AttributeName.CUSTOMIZED_STATE.name());
+    AssertJUnit.assertEquals(output
+        .getPartitionCustomizedStateMap(CUSTOMIZED_STATE_NAME, RESOURCE_NAME,
+            new Partition("testResourceName_0")).size(), 0);
+  }
+
+  @Test
+  public void testSimpleCustomizedState() {
+    // setup resource
+    Map<String, Resource> resourceMap = getResourceMap();
+
+    setupLiveInstances(5);
+
+    // Add CustomizedStateAggregation Config
+    CustomizedStateConfig config = new CustomizedStateConfig();
+    List<String> aggregationEnabledTypes = new ArrayList<>();
+    aggregationEnabledTypes.add(CUSTOMIZED_STATE_NAME);
+
+    config.setAggregationEnabledTypes(aggregationEnabledTypes);
+
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    accessor.setProperty(keyBuilder.customizedStateConfig(), config);
+
+    event.addAttribute(AttributeName.RESOURCES.name(), resourceMap);
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), resourceMap);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider(_clusterName));
+    CustomizedStateComputationStage stage = new CustomizedStateComputationStage();
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, stage);
+    CustomizedStateOutput output1 = event.getAttribute(AttributeName.CUSTOMIZED_STATE.name());
+    AssertJUnit.assertEquals(output1
+        .getPartitionCustomizedStateMap(CUSTOMIZED_STATE_NAME, RESOURCE_NAME,
+            new Partition(PARTITION_NAME)).size(), 0);
+
+    // Add a customized state
+    CustomizedState customizedState = new CustomizedState(RESOURCE_NAME);
+    customizedState.setState(PARTITION_NAME, "STARTED");
+    accessor.setProperty(
+        keyBuilder.customizedState(INSTANCE_NAME, CUSTOMIZED_STATE_NAME, RESOURCE_NAME),
+        customizedState);
+
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, stage);
+    CustomizedStateOutput output2 = event.getAttribute(AttributeName.CUSTOMIZED_STATE.name());
+    Partition partition = new Partition(PARTITION_NAME);
+    AssertJUnit.assertEquals(output2
+        .getPartitionCustomizedState(CUSTOMIZED_STATE_NAME, RESOURCE_NAME, partition,
+            INSTANCE_NAME), "STARTED");
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestCustomizedViewStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestCustomizedViewStage.java
@@ -1,0 +1,106 @@
+package org.apache.helix.controller.stages;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.TestHelper;
+import org.apache.helix.ZkUnitTestBase;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.pipeline.Pipeline;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.model.CustomizedState;
+import org.apache.helix.model.CustomizedStateConfig;
+import org.apache.helix.model.CustomizedView;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestCustomizedViewStage extends ZkUnitTestBase {
+  private final String RESOURCE_NAME = "testResourceName";
+  private final String PARTITION_NAME = "testResourceName_0";
+  private final String CUSTOMIZED_STATE_NAME = "customizedState1";
+  private final String INSTANCE_NAME = "localhost_1";
+
+  @Test
+  public void testCachedCustomizedViews() throws Exception {
+    String clusterName = "CLUSTER_" + TestHelper.getTestMethodName();
+
+    HelixDataAccessor accessor =
+        new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_gZkClient));
+    HelixManager manager = new DummyClusterManager(clusterName, accessor);
+
+    setupLiveInstances(clusterName, new int[]{0, 1});
+    setupStateModel(clusterName);
+
+    ClusterEvent event = new ClusterEvent(ClusterEventType.Unknown);
+    ResourceControllerDataProvider cache = new ResourceControllerDataProvider(clusterName);
+    event.addAttribute(AttributeName.helixmanager.name(), manager);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(), cache);
+
+    CustomizedStateConfig config = new CustomizedStateConfig();
+    List<String> aggregationEnabledTypes = new ArrayList<>();
+    aggregationEnabledTypes.add(CUSTOMIZED_STATE_NAME);
+    config.setAggregationEnabledTypes(aggregationEnabledTypes);
+
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    accessor.setProperty(keyBuilder.customizedStateConfig(), config);
+
+    CustomizedState customizedState = new CustomizedState(RESOURCE_NAME);
+    customizedState.setState(PARTITION_NAME, "STARTED");
+    accessor
+        .setProperty(keyBuilder.customizedState(INSTANCE_NAME, "customizedState1", RESOURCE_NAME),
+            customizedState);
+
+    CustomizedViewAggregationStage customizedViewComputeStage =
+        new CustomizedViewAggregationStage();
+    Pipeline dataRefresh = new Pipeline();
+    dataRefresh.addStage(new ReadClusterDataStage());
+    runPipeline(event, dataRefresh);
+    runStage(event, new ResourceComputationStage());
+    runStage(event, new CustomizedStateComputationStage());
+    runStage(event, customizedViewComputeStage);
+    Assert.assertEquals(cache.getCustomizedViewCacheMap().values(),
+        accessor.getChildValues(accessor.keyBuilder().customizedViews()));
+
+    // Assure there is no customized view got updated when running the stage again
+    List<CustomizedView> oldCustomizedViews =
+        accessor.getChildValues(accessor.keyBuilder().customizedViews());
+    runStage(event, customizedViewComputeStage);
+    List<CustomizedView> newCustomizedViews =
+        accessor.getChildValues(accessor.keyBuilder().customizedViews());
+    Assert.assertEquals(oldCustomizedViews, newCustomizedViews);
+    for (int i = 0; i < oldCustomizedViews.size(); i++) {
+      Assert.assertEquals(oldCustomizedViews.get(i).getStat().getVersion(),
+          newCustomizedViews.get(i).getStat().getVersion());
+    }
+
+    if (manager.isConnected()) {
+      manager.disconnect(); // For DummyClusterManager, this is not necessary
+    }
+    deleteLiveInstances(clusterName);
+    deleteCluster(clusterName);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestControllerDataProviderSelectiveUpdate.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestControllerDataProviderSelectiveUpdate.java
@@ -49,7 +49,7 @@ public class TestControllerDataProviderSelectiveUpdate extends ZkStandAloneCMTes
     Assert.assertEquals(accessor.getReadCount(PropertyType.EXTERNALVIEW), 1);
     Assert.assertEquals(accessor.getReadCount(PropertyType.LIVEINSTANCES), NODE_NR);
     Assert.assertEquals(accessor.getReadCount(PropertyType.CURRENTSTATES), NODE_NR);
-    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), NODE_NR + 1);
+    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), NODE_NR + 2);
 
     accessor.clearReadCounters();
 
@@ -94,7 +94,7 @@ public class TestControllerDataProviderSelectiveUpdate extends ZkStandAloneCMTes
     Assert.assertEquals(accessor.getReadCount(PropertyType.EXTERNALVIEW), 1);
     Assert.assertEquals(accessor.getReadCount(PropertyType.LIVEINSTANCES), NODE_NR);
     Assert.assertEquals(accessor.getReadCount(PropertyType.CURRENTSTATES), NODE_NR);
-    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), NODE_NR + 1);
+    Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), NODE_NR + 2);
 
     accessor.clearReadCounters();
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

(#850 )

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
To support customized view aggregation, we need to change the current data providers to add the refresh for customized state and customized view. We also need to have two extra stages that perform computation from customized state to customized view. 

### Tests

- [X] The following is the result of the "mvn test" command on the appropriate module:
[INFO] Tests run: 909, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3,438.097 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 909, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X] My diff has been formatted using helix-style.xml