### PR TITLE
Remove possible score-tie between two AssignableNodes

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -125,7 +125,7 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
             String instanceName2 = nodeEntry2.getKey().getInstanceName();
             int idleScore1 = busyInstances.contains(instanceName1) ? 0 : 1;
             int idleScore2 = busyInstances.contains(instanceName2) ? 0 : 1;
-            return idleScore1 != idleScore2 ? idleScore1 - idleScore2
+            return idleScore1 != idleScore2 ? (idleScore1 - idleScore2)
                 : - instanceName1.compareTo(instanceName2);
           } else {
             return scoreCompareResult;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -126,7 +126,7 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
             int idleScore1 = busyInstances.contains(instanceName1) ? 0 : 1;
             int idleScore2 = busyInstances.contains(instanceName2) ? 0 : 1;
             return idleScore1 != idleScore2 ? idleScore1 - idleScore2
-                : 0 - instanceName1.compareTo(instanceName2);
+                : - instanceName1.compareTo(instanceName2);
           } else {
             return scoreCompareResult;
           }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -63,8 +63,7 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
   }
 
   @Override
-  public OptimalAssignment calculate(ClusterModel clusterModel)
-      throws HelixRebalanceException {
+  public OptimalAssignment calculate(ClusterModel clusterModel) throws HelixRebalanceException {
     OptimalAssignment optimalAssignment = new OptimalAssignment();
     List<AssignableNode> nodes = new ArrayList<>(clusterModel.getAssignableNodes().values());
     Set<String> busyInstances =
@@ -122,9 +121,12 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
           if (scoreCompareResult == 0) {
             // If the evaluation scores of 2 nodes are the same, the algorithm assigns the replica
             // to the idle node first.
-            int idleScore1 = busyInstances.contains(nodeEntry1.getKey().getInstanceName()) ? 0 : 1;
-            int idleScore2 = busyInstances.contains(nodeEntry2.getKey().getInstanceName()) ? 0 : 1;
-            return idleScore1 - idleScore2;
+            String instanceName1 = nodeEntry1.getKey().getInstanceName();
+            String instanceName2 = nodeEntry2.getKey().getInstanceName();
+            int idleScore1 = busyInstances.contains(instanceName1) ? 0 : 1;
+            int idleScore2 = busyInstances.contains(instanceName2) ? 0 : 1;
+            return idleScore1 != idleScore2 ? idleScore1 - idleScore2
+                : 0 - instanceName1.compareTo(instanceName2);
           } else {
             return scoreCompareResult;
           }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
@@ -196,9 +196,8 @@ public abstract class AbstractTestClusterModel {
 
   protected Set<AssignableNode> generateNodes(ResourceControllerDataProvider testCache) {
     Set<AssignableNode> nodeSet = new HashSet<>();
-    testCache.getInstanceConfigMap().values().stream()
-        .forEach(config -> nodeSet.add(new AssignableNode(testCache.getClusterConfig(),
-            testCache.getInstanceConfigMap().get(_testInstanceId), config.getInstanceName())));
+    testCache.getInstanceConfigMap().values().forEach(config -> nodeSet
+        .add(new AssignableNode(testCache.getClusterConfig(), config, config.getInstanceName())));
     return nodeSet;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelTestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelTestHelper.java
@@ -21,15 +21,40 @@ package org.apache.helix.controller.rebalancer.waged.model;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.model.InstanceConfig;
+
+import static org.mockito.Mockito.when;
+
 
 public class ClusterModelTestHelper extends AbstractTestClusterModel {
+  public static final String TEST_INSTANCE_ID_1 = "TestInstanceId1";
+  public static final String TEST_INSTANCE_ID_2 = "TestInstanceId2";
 
   public ClusterModel getDefaultClusterModel() throws IOException {
     initialize();
     ResourceControllerDataProvider testCache = setupClusterDataCache();
+    Set<AssignableReplica> assignableReplicas = generateReplicas(testCache);
+    Set<AssignableNode> assignableNodes = generateNodes(testCache);
+
+    ClusterContext context =
+        new ClusterContext(assignableReplicas, assignableNodes, Collections.emptyMap(), Collections.emptyMap());
+    return new ClusterModel(context, assignableReplicas, assignableNodes);
+  }
+
+  public ClusterModel getMultiNodeClusterModel() throws IOException {
+    initialize();
+    ResourceControllerDataProvider testCache = setupClusterDataCache();
+    InstanceConfig testInstanceConfig1 = createMockInstanceConfig(TEST_INSTANCE_ID_1);
+    InstanceConfig testInstanceConfig2 = createMockInstanceConfig(TEST_INSTANCE_ID_2);
+    Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
+    instanceConfigMap.put(TEST_INSTANCE_ID_1, testInstanceConfig1);
+    instanceConfigMap.put(TEST_INSTANCE_ID_2, testInstanceConfig2);
+    when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
     Set<AssignableReplica> assignableReplicas = generateReplicas(testCache);
     Set<AssignableNode> assignableNodes = generateNodes(testCache);
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #772 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When a single resource is scaled up or down, we noticed dramatic divergence between Baseline and Best possible assignments. We concluded initially that it could be caused by some unexpected randomness in the algorithm, and we found out this potential score-tie during node evaluation. This PR fixes a potential situation where two AssignableNodes will receive the same score; the fix makes the algorithm more deterministic. 

After further experiments and discussions, we realized that the divergence might be caused by Baseline recalculation after IdealState changes. See #772. This topic will be explored further in another issue. 

### Tests

- [x] The following tests are written for this issue:

TestConstraintBasedAlgorithm.testCalculateScoreDeterminism

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
Failed tests: 
  TestResourceChangeDetector.testRemoveInstance:284 Â» ZkClient Failed to delete ...
  TestControllerLeadershipChange.testMissingTopStateDurationMonitoring:262 expected:<true> but was:<false>

Tests run: 1088, Failures: 2, Errors: 0, Skipped: 5

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:06 h
[INFO] Finished at: 2020-03-12T13:12:33-07:00
[INFO] ------------------------------------------------------------------------
```

(Rerun)
```
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 36.204 sec - in TestSuite

Results :

Tests run: 14, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  40.600 s
[INFO] Finished at: 2020-03-12T13:30:22-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)