### PR TITLE
Update listClusters() in ZkHelixAdmin

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -954,6 +954,12 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   @Override
   public List<String> getClusters() {
+    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED)
+        || _zkClient instanceof FederatedZkClient) {
+      throw new UnsupportedOperationException(
+          "getClusters() is not supported in multi-realm mode! Use Metadata Store Directory Service instead!");
+    }
+
     List<String> zkToplevelPathes = _zkClient.getChildren("/");
     List<String> result = new ArrayList<String>();
     for (String pathName : zkToplevelPathes) {
@@ -1925,7 +1931,10 @@ public class ZKHelixAdmin implements HelixAdmin {
 
       // Resolve RealmAwareZkClientConfig
       if (realmAwareZkClientConfig == null) {
-        realmAwareZkClientConfig = new RealmAwareZkClient.RealmAwareZkClientConfig();
+        // ZkHelixAdmin should have ZNRecordSerializer set by default
+        realmAwareZkClientConfig = new RealmAwareZkClient.RealmAwareZkClientConfig()
+            .setZkSerializer(
+                new org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer());
       }
 
       // Resolve RealmAwareZkConnectionConfig


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #891 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR updates getClusters() in ZkHelixAdmin in realm-aware mode. It is difficult to reason about getting all clusters - and this method, on single-realm mode, is also broken anyways because in the case users create nested clusters, this method will end up returning nothing. This update is backward-compatible for single-realm users.

Ideally, users should use Metadata Store Directory Service to get the list of all clusters.

### Tests

See https://github.com/apache/helix/pull/892

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)