### PR TITLE
Fix setRoutingData boolean handling; fix leader forwarding url construction

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/common/HttpConstants.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/common/HttpConstants.java
@@ -28,5 +28,4 @@ public class HttpConstants {
   }
 
   public static final String HTTP_PROTOCOL_PREFIX = "http://";
-  public static final String REST_ENDPOINT_PREFIX = "/admin/v2";
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/common/HttpConstants.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/common/HttpConstants.java
@@ -28,4 +28,5 @@ public class HttpConstants {
   }
 
   public static final String HTTP_PROTOCOL_PREFIX = "http://";
+  public static final String REST_ENDPOINT_PREFIX = "/admin/v2";
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
@@ -342,8 +342,9 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
   }
 
   private String constructUrlSuffix(String... urlParams) {
-    List<String> allUrlParameters = new ArrayList<>(
-        Arrays.asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, "/", _namespace));
+    List<String> allUrlParameters = new ArrayList<>(Arrays
+        .asList(HttpConstants.REST_ENDPOINT_PREFIX,
+            MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, "/", _namespace));
     for (String urlParam : urlParams) {
       if (urlParam.charAt(0) != '/') {
         urlParam = "/" + urlParam;

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
@@ -94,7 +94,7 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
     String hostName = System.getProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY);
     if (hostName == null || hostName.isEmpty()) {
       throw new IllegalStateException(
-          "Unable to get the hostname of this server instance or the hostname is empty. System.getProperty fails to fetch "
+          "Hostname is not set or is empty. System.getProperty fails to fetch "
               + MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY + ".");
     }
     _myHostName = HttpConstants.HTTP_PROTOCOL_PREFIX + hostName;

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
@@ -22,6 +22,7 @@ package org.apache.helix.rest.metadatastore.accessor;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -59,6 +60,10 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
   private static final Logger LOG = LoggerFactory.getLogger(ZkRoutingDataWriter.class);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
+  private static final String SIMPLE_FIELD_KEY_HOSTNAME = "hostname";
+  private static final String SIMPLE_FIELD_KEY_PORT = "port";
+  private static final String SIMPLE_FIELD_KEY_CONTEXT_URL_PREFIX = "contextUrlPrefix";
+
   private final String _namespace;
   private final HelixZkClient _zkClient;
   private final ZkDistributedLeaderElection _leaderElection;
@@ -87,19 +92,29 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
 
     // Get the hostname (REST endpoint) from System property
     String hostName = System.getProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY);
-    String port = System.getProperty(MetadataStoreRoutingConstants.MSDS_SERVER_PORT_KEY);
     if (hostName == null || hostName.isEmpty()) {
       throw new IllegalStateException(
           "Unable to get the hostname of this server instance or the hostname is empty. System.getProperty fails to fetch "
               + MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY + ".");
     }
-    if (port == null || port.isEmpty()) {
-      throw new IllegalStateException(
-          "Unable to get the port of this server instance or the port is empty. System.getProperty fails to fetch "
-              + MetadataStoreRoutingConstants.MSDS_SERVER_PORT_KEY + ".");
+    _myHostName = HttpConstants.HTTP_PROTOCOL_PREFIX + hostName;
+
+    ZNRecord myServerInfo = new ZNRecord(hostName);
+    myServerInfo.setSimpleField(SIMPLE_FIELD_KEY_HOSTNAME, hostName);
+
+    String port = System.getProperty(MetadataStoreRoutingConstants.MSDS_SERVER_PORT_KEY);
+    if (port != null && !port.isEmpty()) {
+      myServerInfo.setSimpleField(SIMPLE_FIELD_KEY_PORT, port);
     }
-    _myHostName = HttpConstants.HTTP_PROTOCOL_PREFIX + hostName + ":" + port;
-    ZNRecord myServerInfo = new ZNRecord(_myHostName);
+
+    // One example of context url prefix is "/admin/v2". With the prefix specified, we want to
+    // make sure the final url is "/admin/v2/namespaces/NAMESPACE/some/endpoint"; without it
+    // being specified, we will skip it and go with "/namespaces/NAMESPACE/some/endpoint".
+    String contextUrlPrefix =
+        System.getProperty(MetadataStoreRoutingConstants.MSDS_CONTEXT_URL_PREFIX_KEY);
+    if (contextUrlPrefix != null && !contextUrlPrefix.isEmpty()) {
+      myServerInfo.setSimpleField(SIMPLE_FIELD_KEY_CONTEXT_URL_PREFIX, contextUrlPrefix);
+    }
 
     _leaderElection = new ZkDistributedLeaderElection(_zkClient,
         MetadataStoreRoutingConstants.LEADER_ELECTION_ZNODE, myServerInfo);
@@ -217,8 +232,7 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
       return true;
     }
 
-    String leaderHostName = _leaderElection.getCurrentLeaderInfo().getId();
-    String url = leaderHostName + constructUrlSuffix(
+    String url = constructLeaderEndpoint() + constructUrlSuffix(
         MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT);
     HttpPut httpPut = new HttpPut(url);
     String routingDataJsonString;
@@ -233,7 +247,7 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
       return false;
     }
     httpPut.setEntity(new StringEntity(routingDataJsonString, ContentType.APPLICATION_JSON));
-    return sendRequestToLeader(httpPut, Response.Status.CREATED.getStatusCode(), leaderHostName);
+    return sendRequestToLeader(httpPut, Response.Status.CREATED.getStatusCode());
   }
 
   @Override
@@ -346,11 +360,6 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
   private String constructUrlSuffix(String... urlParams) {
     List<String> allUrlParameters = new ArrayList<>(
         Arrays.asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, "/", _namespace));
-    String contextUrlPrefix =
-        System.getProperty(MetadataStoreRoutingConstants.MSDS_CONTEXT_URL_PREFIX_KEY);
-    if (contextUrlPrefix != null && !contextUrlPrefix.isEmpty()) {
-      allUrlParameters.add(0, contextUrlPrefix);
-    }
     for (String urlParam : urlParams) {
       if (urlParam.charAt(0) != '/') {
         urlParam = "/" + urlParam;
@@ -360,11 +369,27 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
     return String.join("", allUrlParameters);
   }
 
+  private String constructLeaderEndpoint() {
+    List<String> urlComponents =
+        new ArrayList<>(Collections.singletonList(HttpConstants.HTTP_PROTOCOL_PREFIX));
+    ZNRecord znRecord = _leaderElection.getCurrentLeaderInfo();
+    urlComponents.add(znRecord.getSimpleField(SIMPLE_FIELD_KEY_HOSTNAME));
+    String port = znRecord.getSimpleField(SIMPLE_FIELD_KEY_PORT);
+    if (port != null && !port.isEmpty()) {
+      urlComponents.add(":");
+      urlComponents.add(port);
+    }
+    String contextUrlPrefix = znRecord.getSimpleField(SIMPLE_FIELD_KEY_CONTEXT_URL_PREFIX);
+    if (contextUrlPrefix != null && !contextUrlPrefix.isEmpty()) {
+      urlComponents.add(contextUrlPrefix);
+    }
+    return String.join("", urlComponents);
+  }
+
   private boolean buildAndSendRequestToLeader(String urlSuffix,
       HttpConstants.RestVerbs requestMethod, int expectedResponseCode)
       throws IllegalArgumentException {
-    String leaderHostName = _leaderElection.getCurrentLeaderInfo().getId();
-    String url = leaderHostName + urlSuffix;
+    String url = constructLeaderEndpoint() + urlSuffix;
     HttpUriRequest request;
     switch (requestMethod) {
       case PUT:
@@ -377,19 +402,18 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
         throw new IllegalArgumentException("Unsupported requestMethod: " + requestMethod.name());
     }
 
-    return sendRequestToLeader(request, expectedResponseCode, leaderHostName);
+    return sendRequestToLeader(request, expectedResponseCode);
   }
 
   // Set to be protected for testing purposes
-  protected boolean sendRequestToLeader(HttpUriRequest request, int expectedResponseCode,
-      String leaderHostName) {
+  protected boolean sendRequestToLeader(HttpUriRequest request, int expectedResponseCode) {
     try {
       HttpResponse response = _forwardHttpClient.execute(request);
       if (response.getStatusLine().getStatusCode() != expectedResponseCode) {
         HttpEntity respEntity = response.getEntity();
         String errorLog = "The forwarded request to leader has failed. Uri: " + request.getURI()
             + ". Error code: " + response.getStatusLine().getStatusCode() + " Current hostname: "
-            + _myHostName + " Leader hostname: " + leaderHostName;
+            + _myHostName;
         if (respEntity != null) {
           errorLog += " Response: " + EntityUtils.toString(respEntity);
         }
@@ -398,8 +422,8 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
       }
     } catch (IOException e) {
       LOG.error(
-          "The forwarded request to leader raised an exception. Uri: {} Current hostname: {} Leader hostname: {}",
-          request.getURI(), _myHostName, leaderHostName, e);
+          "The forwarded request to leader raised an exception. Uri: {} Current hostname: {} ",
+          request.getURI(), _myHostName, e);
       return false;
     }
     return true;

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/metadatastore/MetadataStoreDirectoryAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/metadatastore/MetadataStoreDirectoryAccessor.java
@@ -235,7 +235,9 @@ public class MetadataStoreDirectoryAccessor extends AbstractResource {
       Map<String, List<String>> routingData =
           OBJECT_MAPPER.readValue(jsonContent, new TypeReference<HashMap<String, List<String>>>() {
           });
-      _metadataStoreDirectory.setNamespaceRoutingData(_namespace, routingData);
+      if (!_metadataStoreDirectory.setNamespaceRoutingData(_namespace, routingData)) {
+        return serverError();
+      }
     } catch (JsonMappingException | JsonParseException | IllegalArgumentException e) {
       return badRequest(e.getMessage());
     } catch (IOException e) {

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java
@@ -104,7 +104,9 @@ public class TestZkMetadataStoreDirectory extends AbstractTestClass {
     });
 
     System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY,
-        getBaseUri().getHost() + ":" + getBaseUri().getPort());
+        getBaseUri().getHost());
+    System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_PORT_KEY,
+        Integer.toString(getBaseUri().getPort()));
 
     // Create metadataStoreDirectory
     for (Map.Entry<String, String> entry : _routingZkAddrMap.entrySet()) {
@@ -118,6 +120,7 @@ public class TestZkMetadataStoreDirectory extends AbstractTestClass {
     _metadataStoreDirectory.close();
     clearRoutingData();
     System.clearProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY);
+    System.clearProperty(MetadataStoreRoutingConstants.MSDS_SERVER_PORT_KEY);
   }
 
   @Test

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
@@ -55,8 +55,7 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
 
     // This method does not call super() because the http call should not be actually made
     @Override
-    protected boolean sendRequestToLeader(HttpUriRequest request, int expectedResponseCode,
-        String leaderHostName) {
+    protected boolean sendRequestToLeader(HttpUriRequest request, int expectedResponseCode) {
       calledRequest = request;
       return false;
     }

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
@@ -135,9 +135,8 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
     List<String> expectedUrlParams = Arrays
         .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT, DUMMY_REALM);
-    String expectedUrl =
-        getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
-            .substring(1);
+    String expectedUrl = getBaseUri().toString() + HttpConstants.REST_ENDPOINT_PREFIX + String
+        .join("/", expectedUrlParams).replaceAll("//", "/").substring(1);
     Assert.assertEquals(mockWriter.calledRequest.getURI().toString(), expectedUrl);
     mockWriter.close();
   }
@@ -151,9 +150,8 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
     List<String> expectedUrlParams = Arrays
         .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT, DUMMY_REALM);
-    String expectedUrl =
-        getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
-            .substring(1);
+    String expectedUrl = getBaseUri().toString() + HttpConstants.REST_ENDPOINT_PREFIX + String
+        .join("/", expectedUrlParams).replaceAll("//", "/").substring(1);
     Assert.assertEquals(mockWriter.calledRequest.getURI().toString(), expectedUrl);
     mockWriter.close();
   }
@@ -167,9 +165,8 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
         .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT, DUMMY_REALM,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_SHARDING_KEYS_ENDPOINT, DUMMY_SHARDING_KEY);
-    String expectedUrl =
-        getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
-            .substring(1);
+    String expectedUrl = getBaseUri().toString() + HttpConstants.REST_ENDPOINT_PREFIX + String
+        .join("/", expectedUrlParams).replaceAll("//", "/").substring(1);
     Assert.assertEquals(mockWriter.calledRequest.getURI().toString(), expectedUrl);
     mockWriter.close();
   }
@@ -184,9 +181,8 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
         .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT, DUMMY_REALM,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_SHARDING_KEYS_ENDPOINT, DUMMY_SHARDING_KEY);
-    String expectedUrl =
-        getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
-            .substring(1);
+    String expectedUrl = getBaseUri().toString() + HttpConstants.REST_ENDPOINT_PREFIX + String
+        .join("/", expectedUrlParams).replaceAll("//", "/").substring(1);
     Assert.assertEquals(mockWriter.calledRequest.getURI().toString(), expectedUrl);
     mockWriter.close();
   }
@@ -201,9 +197,8 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
     List<String> expectedUrlParams = Arrays
         .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT);
-    String expectedUrl =
-        getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
-            .substring(1);
+    String expectedUrl = getBaseUri().toString() + HttpConstants.REST_ENDPOINT_PREFIX + String
+        .join("/", expectedUrlParams).replaceAll("//", "/").substring(1);
     Assert.assertEquals(mockWriter.calledRequest.getURI().toString(), expectedUrl);
     mockWriter.close();
   }

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
@@ -66,7 +66,9 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
   public void beforeClass() throws Exception {
     _zkClient = ZK_SERVER_MAP.get(_zkAddrTestNS).getZkClient();
     System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY,
-        getBaseUri().getHost() + ":" + getBaseUri().getPort());
+        getBaseUri().getHost());
+    System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_PORT_KEY,
+        Integer.toString(getBaseUri().getPort()));
     _zkRoutingDataWriter = new ZkRoutingDataWriter(TEST_NAMESPACE, _zkAddrTestNS);
     clearRoutingDataPath();
   }
@@ -74,6 +76,7 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
   @AfterClass
   public void afterClass() throws Exception {
     System.clearProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY);
+    System.clearProperty(MetadataStoreRoutingConstants.MSDS_SERVER_PORT_KEY);
     _zkRoutingDataWriter.close();
     clearRoutingDataPath();
   }

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
@@ -135,8 +135,9 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
     List<String> expectedUrlParams = Arrays
         .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT, DUMMY_REALM);
-    String expectedUrl = getBaseUri().toString() + HttpConstants.REST_ENDPOINT_PREFIX + String
-        .join("/", expectedUrlParams).replaceAll("//", "/").substring(1);
+    String expectedUrl =
+        getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
+            .substring(1);
     Assert.assertEquals(mockWriter.calledRequest.getURI().toString(), expectedUrl);
     mockWriter.close();
   }
@@ -150,8 +151,9 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
     List<String> expectedUrlParams = Arrays
         .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT, DUMMY_REALM);
-    String expectedUrl = getBaseUri().toString() + HttpConstants.REST_ENDPOINT_PREFIX + String
-        .join("/", expectedUrlParams).replaceAll("//", "/").substring(1);
+    String expectedUrl =
+        getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
+            .substring(1);
     Assert.assertEquals(mockWriter.calledRequest.getURI().toString(), expectedUrl);
     mockWriter.close();
   }
@@ -165,8 +167,9 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
         .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT, DUMMY_REALM,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_SHARDING_KEYS_ENDPOINT, DUMMY_SHARDING_KEY);
-    String expectedUrl = getBaseUri().toString() + HttpConstants.REST_ENDPOINT_PREFIX + String
-        .join("/", expectedUrlParams).replaceAll("//", "/").substring(1);
+    String expectedUrl =
+        getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
+            .substring(1);
     Assert.assertEquals(mockWriter.calledRequest.getURI().toString(), expectedUrl);
     mockWriter.close();
   }
@@ -181,8 +184,9 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
         .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT, DUMMY_REALM,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_SHARDING_KEYS_ENDPOINT, DUMMY_SHARDING_KEY);
-    String expectedUrl = getBaseUri().toString() + HttpConstants.REST_ENDPOINT_PREFIX + String
-        .join("/", expectedUrlParams).replaceAll("//", "/").substring(1);
+    String expectedUrl =
+        getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
+            .substring(1);
     Assert.assertEquals(mockWriter.calledRequest.getURI().toString(), expectedUrl);
     mockWriter.close();
   }
@@ -197,8 +201,9 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
     List<String> expectedUrlParams = Arrays
         .asList(MetadataStoreRoutingConstants.MSDS_NAMESPACES_URL_PREFIX, TEST_NAMESPACE,
             MetadataStoreRoutingConstants.MSDS_GET_ALL_ROUTING_DATA_ENDPOINT);
-    String expectedUrl = getBaseUri().toString() + HttpConstants.REST_ENDPOINT_PREFIX + String
-        .join("/", expectedUrlParams).replaceAll("//", "/").substring(1);
+    String expectedUrl =
+        getBaseUri().toString() + String.join("/", expectedUrlParams).replaceAll("//", "/")
+            .substring(1);
     Assert.assertEquals(mockWriter.calledRequest.getURI().toString(), expectedUrl);
     mockWriter.close();
   }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/MetadataStoreDirectoryAccessorTestBase.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/MetadataStoreDirectoryAccessorTestBase.java
@@ -96,12 +96,15 @@ public class MetadataStoreDirectoryAccessorTestBase extends AbstractTestClass {
     _routingDataReader = new ZkRoutingDataReader(TEST_NAMESPACE, _zkAddrTestNS, null);
 
     System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY,
-        getBaseUri().getHost() + ":" + getBaseUri().getPort());
+        getBaseUri().getHost());
+    System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_PORT_KEY,
+        Integer.toString(getBaseUri().getPort()));
   }
 
   @AfterClass
   public void afterClass() throws Exception {
     System.clearProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY);
+    System.clearProperty(MetadataStoreRoutingConstants.MSDS_SERVER_PORT_KEY);
     _routingDataReader.close();
     clearRoutingData();
   }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestMSDAccessorLeaderElection.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestMSDAccessorLeaderElection.java
@@ -36,6 +36,7 @@ import org.apache.helix.rest.common.ContextPropertyKeys;
 import org.apache.helix.rest.common.HelixRestNamespace;
 import org.apache.helix.rest.common.HttpConstants;
 import org.apache.helix.rest.common.ServletType;
+import org.apache.helix.rest.metadatastore.accessor.ZkRoutingDataWriter;
 import org.apache.helix.rest.server.auditlog.AuditLogger;
 import org.apache.helix.rest.server.filters.CORSFilter;
 import org.apache.helix.rest.server.mock.MockMetadataStoreDirectoryAccessor;
@@ -219,8 +220,11 @@ public class TestMSDAccessorLeaderElection extends MetadataStoreDirectoryAccesso
         MetadataStoreRoutingConstants.LEADER_ELECTION_ZNODE + "/" + leaderSelectionNodes.get(0));
     ZNRecord secondEphemeralNode = _zkClient.readData(
         MetadataStoreRoutingConstants.LEADER_ELECTION_ZNODE + "/" + leaderSelectionNodes.get(1));
-    Assert.assertEquals(firstEphemeralNode.getId(), _leaderBaseUri);
-    Assert.assertEquals(secondEphemeralNode.getId(), _mockBaseUri);
+    Assert.assertEquals(ZkRoutingDataWriter.buildEndpointFromLeaderElectionNode(firstEphemeralNode),
+        _leaderBaseUri);
+    Assert
+        .assertEquals(ZkRoutingDataWriter.buildEndpointFromLeaderElectionNode(secondEphemeralNode),
+            _mockBaseUri);
 
     // Make sure the operation is not done by the follower instance
     Assert.assertFalse(MockMetadataStoreDirectoryAccessor.operatedOnZk);

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestMSDAccessorLeaderElection.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestMSDAccessorLeaderElection.java
@@ -99,7 +99,9 @@ public class TestMSDAccessorLeaderElection extends MetadataStoreDirectoryAccesso
 
     // Set the new uri to be used in leader election
     System.setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_HOSTNAME_KEY,
-        getBaseUri().getHost() + ":" + newPort);
+        getBaseUri().getHost());
+    System
+        .setProperty(MetadataStoreRoutingConstants.MSDS_SERVER_PORT_KEY, Integer.toString(newPort));
 
     // Start http client for testing
     _httpClient = HttpClients.createDefault();

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
@@ -78,7 +78,16 @@ public class MetadataStoreRoutingConstants {
   // MSDS resource get all sharding keys endpoint string
   public static final String MSDS_GET_ALL_SHARDING_KEYS_ENDPOINT = "/sharding-keys";
 
-  // The key for system properties that contains the hostname of of the
+  // The key for system properties that contains the hostname of the
   // MetadataStoreDirectoryService server instance
   public static final String MSDS_SERVER_HOSTNAME_KEY = "msds_hostname";
+
+  // The key for system properties that contains the port of the
+  // MetadataStoreDirectoryService server instance
+  public static final String MSDS_SERVER_PORT_KEY = "msds_port";
+
+  // This is added for helix-rest 2.0. For example, without this value, the url will be
+  // "localhost:9998"; with this value, the url will be "localhost:9998/admin/v2" if this
+  // value is "/admin/v2".
+  public static final String MSDS_CONTEXT_URL_PREFIX_KEY = "msds_context_url_prefix";
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #901 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

3 issues were uncovered by the second round of MetadataStoreDirectory Service manual testing:
1. `SetRoutingData` does not respect the return value of the underlying function. 
2. The port of each instance is not considered when forwarding requests, therefore failing all the forwarded requests.
3. "/admin/v2" is not added when forwarding requests, therefore (would be) failing the forwarded requests. 
Fixes: return 500 when false; add mechanism to read ports from system configs (just like hostname); add mechanism to read url prefixes from system configs (just like hostname).

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[ERROR] Tests run: 143, Failures: 1, Errors: 0, Skipped: 7, Time elapsed: 26.41 s <<< FAILURE! - in TestSuite
[ERROR] testResourceHealth(org.apache.helix.rest.server.TestResourceAccessor)  Time elapsed: 0.266 s  <<< FAILURE!
java.lang.AssertionError: expected:<HEALTHY> but was:<UNHEALTHY>
	at org.apache.helix.rest.server.TestResourceAccessor.testResourceHealth(TestResourceAccessor.java:289)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestResourceAccessor.testResourceHealth:289 expected:<HEALTHY> but was:<UNHEALTHY>
[INFO] 
[ERROR] Tests run: 143, Failures: 1, Errors: 0, Skipped: 7
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)