### PR TITLE
Fix the concurrent modification error happens during the HelixManager initHandlers() call

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -1005,7 +1005,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     synchronized (this) {
       if (handlers != null) {
         // get a copy of the list and iterate over the copy list
-        // in case handler.init() modify the original handler list
+        // in case handler.init() modifies the original handler list
         List<CallbackHandler> tmpHandlers = new ArrayList<>(handlers);
         for (CallbackHandler handler : tmpHandlers) {
           handler.init();
@@ -1019,7 +1019,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     synchronized (this) {
       if (_handlers != null) {
         // get a copy of the list and iterate over the copy list
-        // in case handler.reset() modify the original handler list
+        // in case handler.reset() modifies the original handler list
         List<CallbackHandler> tmpHandlers = new ArrayList<>(_handlers);
         for (CallbackHandler handler : tmpHandlers) {
           handler.reset(isShutdown);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -1004,7 +1004,10 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
   void initHandlers(List<CallbackHandler> handlers) {
     synchronized (this) {
       if (handlers != null) {
-        for (CallbackHandler handler : handlers) {
+        // get a copy of the list and iterate over the copy list
+        // in case handler.init() modify the original handler list
+        List<CallbackHandler> tmpHandlers = new ArrayList<>(handlers);
+        for (CallbackHandler handler : tmpHandlers) {
           handler.init();
           LOG.info("init handler: " + handler.getPath() + ", " + handler.getListener());
         }
@@ -1017,9 +1020,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
       if (_handlers != null) {
         // get a copy of the list and iterate over the copy list
         // in case handler.reset() modify the original handler list
-        List<CallbackHandler> tmpHandlers = new ArrayList<>();
-        tmpHandlers.addAll(_handlers);
-
+        List<CallbackHandler> tmpHandlers = new ArrayList<>(_handlers);
         for (CallbackHandler handler : tmpHandlers) {
           handler.reset(isShutdown);
           LOG.info("reset handler: " + handler.getPath() + ", " + handler.getListener());


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#903

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fix the concurrent modification error that happens during the HelixManager initHandlers() call.

### Tests

- [x] The following tests are written for this issue:

TestHandleSession.testConcurrentInitCallbackHandlers()

- [x] The following is the result of the "mvn test" command on the appropriate module:

Failed tests: 
  TestResourceChangeDetector.testRemoveInstance:284 » ZkClient Failed to delete ...
  TestDeleteJobFromJobQueue.testForceDeleteJobFromJobQueue:75 » ZkClient Failed ...
  TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
  TestWorkflowTermination.testWorkflowPausedTimeout:170->verifyWorkflowCleanup:257 expected:<true> but was:<false>

Tests run: 1092, Failures: 4, Errors: 0, Skipped: 4

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------

Rerun:

Results :
Tests run: 19, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:26 min
[INFO] Finished at: 2020-03-20T16:18:55-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)