### PR TITLE
Refresh live instance while fetching the current state information in the RoutingTableProvider

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -79,6 +79,17 @@ class RoutingDataCache extends BasicClusterDataCache {
         .get(HelixConstants.ChangeType.CURRENT_STATE)) {
       long start = System.currentTimeMillis();
       _propertyDataChangedMap.put(HelixConstants.ChangeType.CURRENT_STATE, false);
+      /**
+       * Workaround of https://github.com/apache/helix/issues/919.
+       * Why it is workaround?
+       * 1. Before a larger scale refactoring, to minimize the impact on cache logic, this change
+       * introduces extra read to update the liveInstance list before processing current states.
+       * 2. This change does not handle the corresponding callback handlers, which should also be
+       * registered when a new liveInstance node is found.
+       * TODO: Refactor cache processing logic and also refine the callback handler registration
+       * TODO: logic.
+       **/
+      _liveInstancePropertyCache.refresh(accessor);
       Map<String, LiveInstance> liveInstanceMap = getLiveInstances();
       _currentStateCache.refresh(accessor, liveInstanceMap);
       LOG.info("Reload CurrentStates. Takes " + (System.currentTimeMillis() - start) + " ms");


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#919 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change is a workaround to fix helix-919.
The additional read is to prevent the provider from reading the stale current states.

### Tests

- [X] The following tests are written for this issue:

TestRoutingTableProviderFromCurrentStates.TestInconsistentStateEventProcessing

- [x] The following is the result of the "mvn test" command on the appropriate module:

Results :

Failed tests: 
org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceTopoplogyAwareDisabled.testLackEnoughInstances(org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceTopoplogyAwareDisabled)
  Run 1: PASS
  Run 2: TestCrushAutoRebalanceTopoplogyAwareDisabled.testLackEnoughInstances:86->TestCrushAutoRebalanceNonRack.testLackEnoughInstances:250 » ZkClient

  TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....

Tests run: 1091, Failures: 2, Errors: 0, Skipped: 0

Rerun:

Results :

Tests run: 11, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 38.339 s
[INFO] Finished at: 2020-03-30T23:50:22-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)
- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)