### PR TITLE
fix customized state provider

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProviderFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProviderFactory.java
@@ -19,9 +19,9 @@ package org.apache.helix.customizedstate;
  * under the License.
  */
 
-import java.util.HashMap;
-import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,9 +30,6 @@ import org.slf4j.LoggerFactory;
  */
 public class CustomizedStateProviderFactory {
   private static Logger LOG = LoggerFactory.getLogger(CustomizedStateProvider.class);
-  private final HashMap<String, CustomizedStateProvider> _customizedStateProviderMap =
-      new HashMap<>();
-  private HelixManager _helixManager;
 
   protected CustomizedStateProviderFactory() {
   }
@@ -46,34 +43,28 @@ public class CustomizedStateProviderFactory {
     return SingletonHelper.INSTANCE;
   }
 
-  public CustomizedStateProvider buildCustomizedStateProvider(String instanceName) {
-    if (_helixManager == null) {
-      throw new HelixException("Helix Manager has not been set yet.");
-    }
-    return buildCustomizedStateProvider(_helixManager, instanceName);
+  /**
+   * Build a customized state provider based on user input.
+   * @param instanceName The name of the instance
+   * @param clusterName The name of the cluster that has the instance
+   * @param zkAddress The zookeeper address of the cluster
+   * @return CustomizedStateProvider
+   */
+  public CustomizedStateProvider buildCustomizedStateProvider(String instanceName,
+      String clusterName, String zkAddress) {
+    HelixManager helixManager = HelixManagerFactory
+        .getZKHelixManager(clusterName, instanceName, InstanceType.ADMINISTRATOR, zkAddress);
+    return new CustomizedStateProvider(helixManager, instanceName);
   }
 
   /**
-   * Build a customized state provider based on the specified input. If the instance already has a
-   * provider, return it. Otherwise, build a new one and put it in the map.
-   * @param helixManager The helix manager that belongs to the instance
+   * Build a customized state provider based on user input.
    * @param instanceName The name of the instance
+   * @param helixManager Helix manager provided by user
    * @return CustomizedStateProvider
    */
   public CustomizedStateProvider buildCustomizedStateProvider(HelixManager helixManager,
       String instanceName) {
-    synchronized (_customizedStateProviderMap) {
-      if (_customizedStateProviderMap.get(instanceName) != null) {
-        return _customizedStateProviderMap.get(instanceName);
-      }
-      CustomizedStateProvider customizedStateProvider =
-          new CustomizedStateProvider(helixManager, instanceName);
-      _customizedStateProviderMap.put(instanceName, customizedStateProvider);
-      return customizedStateProvider;
-    }
-  }
-
-  public void setHelixManager(HelixManager helixManager) {
-    _helixManager = helixManager;
+    return new CustomizedStateProvider(helixManager, instanceName);
   }
 }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

(#888 )

### Description
This PR changes the customized state provider factory to allow customer to build the provider based on either zkaddress, cluster name, instance name or helix manager and instance name. If customer chooses to build the provider with the first option, Helix will provide a manager for it.

### Tests

- [X] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)