### PR TITLE
Fix MetadataStoreDirectory routing data cache refresh bug

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -322,14 +322,19 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
     }
 
     Map<String, List<String>> rawRoutingData;
+    // Remove the raw data first in case of failure on creation
+    _realmToShardingKeysMap.remove(namespace);
     try {
       rawRoutingData = _routingDataReaderMap.get(namespace).getRoutingData();
       _realmToShardingKeysMap.put(namespace, rawRoutingData);
     } catch (InvalidRoutingDataException e) {
+      _routingDataMap.remove(namespace);
       LOG.error("Failed to refresh cached routing data for namespace {}", namespace, e);
       return;
     }
 
+    // Remove routing data first in case of failure on creation
+    _routingDataMap.remove(namespace);
     try {
       _routingDataMap.put(namespace, new TrieRoutingData(rawRoutingData));
     } catch (InvalidRoutingDataException e) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -321,20 +321,20 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
       return;
     }
 
-    Map<String, List<String>> rawRoutingData;
     // Remove the raw data first in case of failure on creation
     _realmToShardingKeysMap.remove(namespace);
+    // Remove routing data first in case of failure on creation
+    _routingDataMap.remove(namespace);
+
+    Map<String, List<String>> rawRoutingData;
     try {
       rawRoutingData = _routingDataReaderMap.get(namespace).getRoutingData();
       _realmToShardingKeysMap.put(namespace, rawRoutingData);
     } catch (InvalidRoutingDataException e) {
-      _routingDataMap.remove(namespace);
       LOG.error("Failed to refresh cached routing data for namespace {}", namespace, e);
       return;
     }
 
-    // Remove routing data first in case of failure on creation
-    _routingDataMap.remove(namespace);
     try {
       _routingDataMap.put(namespace, new TrieRoutingData(rawRoutingData));
     } catch (InvalidRoutingDataException e) {

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/datamodel/TrieRoutingData.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/datamodel/TrieRoutingData.java
@@ -48,6 +48,10 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
       throw new InvalidRoutingDataException("routingData cannot be null or empty");
     }
 
+    if (!containsShardingKey(routingData)) {
+      throw new InvalidRoutingDataException("routingData needs at least 1 sharding key");
+    }
+
     if (isRootShardingKey(routingData)) {
       Map.Entry<String, List<String>> entry = routingData.entrySet().iterator().next();
       _rootNode = new TrieNode(Collections.emptyMap(), "/", true, entry.getKey());
@@ -164,6 +168,21 @@ public class TrieRoutingData implements MetadataStoreRoutingData {
       curNode = nextNode;
     }
     return curNode;
+  }
+
+  /*
+   * Checks if there is any sharding key in the routing data
+   * @param routingData - a mapping from "sharding keys" to "realm addresses" to be parsed into a
+   *          trie
+   * @return whether there is any sharding key
+   */
+  private boolean containsShardingKey(Map<String, List<String>> routingData) {
+    for (Map.Entry<String, List<String>> entry : routingData.entrySet()) {
+      if (entry.getValue().size() > 0) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /*

--- a/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/datamodel/TestTrieRoutingData.java
+++ b/metadata-store-directory-common/src/test/java/org/apache/helix/msdcommon/datamodel/TestTrieRoutingData.java
@@ -48,6 +48,14 @@ public class TestTrieRoutingData {
     } catch (InvalidRoutingDataException e) {
       Assert.assertTrue(e.getMessage().contains("routingData cannot be null or empty"));
     }
+    Map<String, List<String>> routingData = new HashMap<>();
+    routingData.put("realmAddress", Collections.emptyList());
+    try {
+      new TrieRoutingData(routingData);
+      Assert.fail("Expecting InvalidRoutingDataException");
+    } catch (InvalidRoutingDataException e) {
+      Assert.assertTrue(e.getMessage().contains("routingData needs at least 1 sharding key"));
+    }
   }
 
   /**


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #927 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR fixes the MetadataStoreDirectory routing data cache refresh bug. In `ZkMetadataStoreDirectory`, it is now ensured that routing data cache is cleared before updating; when an exception is raised, the old data is still erased correctly. 

Also, this PR fixes an edge case during `TrieRoutingData` creation. When there are zkRealms defined without a single sharding key, `TrieRoutingData` now correctly identifies the raw routing data as invalid and raise an exception. 

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[ERROR] Tests run: 145, Failures: 1, Errors: 0, Skipped: 7, Time elapsed: 28.895 s <<< FAILURE! - in TestSuite
[ERROR] testResourceHealth(org.apache.helix.rest.server.TestResourceAccessor)  Time elapsed: 0.295 s  <<< FAILURE!
java.lang.AssertionError: expected:<HEALTHY> but was:<UNHEALTHY>
	at org.apache.helix.rest.server.TestResourceAccessor.testResourceHealth(TestResourceAccessor.java:289)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestResourceAccessor.testResourceHealth:289 expected:<HEALTHY> but was:<UNHEALTHY>
[INFO] 
[ERROR] Tests run: 145, Failures: 1, Errors: 0, Skipped: 7
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33.443 s
[INFO] Finished at: 2020-04-03T13:47:22-07:00
[INFO] ------------------------------------------------------------------------
```
The failed test is known flaky and is tracked by https://github.com/apache/helix/issues/932. 


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)