### PR TITLE
Add cache update/delete in customized view aggregation stage

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedViewCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/CustomizedViewCache.java
@@ -86,4 +86,12 @@ public class CustomizedViewCache extends AbstractDataCache<CustomizedView> {
   public Map<String, CustomizedView> getCustomizedViewMap() {
     return Collections.unmodifiableMap(_customizedViewCache.getPropertyMap());
   }
+
+  /**
+   * Return customized view cache as a property cache.
+   * @return
+   */
+  public PropertyCache<CustomizedView> getCustomizedViewCache() {
+    return _customizedViewCache;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -264,15 +264,13 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
    */
   public void updateCustomizedViews(String customizedStateType,
       List<CustomizedView> customizedViews) {
+    if (!_customizedViewCacheMap.containsKey(customizedStateType)) {
+      CustomizedViewCache customizedViewCache =
+          new CustomizedViewCache(getClusterName(), customizedStateType);
+      _customizedViewCacheMap.put(customizedStateType, customizedViewCache);
+    }
     for (CustomizedView cv : customizedViews) {
-      if (_customizedViewCacheMap.containsKey(customizedStateType)) {
-        _customizedViewCacheMap.get(customizedStateType).getCustomizedViewCache().setProperty(cv);
-      } else {
-        CustomizedViewCache customizedViewCache =
-            new CustomizedViewCache(getClusterName(), customizedStateType);
-        customizedViewCache.getCustomizedViewCache().setProperty(cv);
-        _customizedViewCacheMap.put(customizedStateType, customizedViewCache);
-      }
+      _customizedViewCacheMap.get(customizedStateType).getCustomizedViewCache().setProperty(cv);
     }
   }
 
@@ -312,6 +310,10 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
    * @param resourceNames the names of resources whose customized view is stale
    */
   public void removeCustomizedViews(String stateType, List<String> resourceNames) {
+    if (!_customizedViewCacheMap.containsKey(stateType)) {
+      logger.warn(String.format("The customized state type : %s is not in the cache", stateType));
+      return;
+    }
     for (String resourceName : resourceNames) {
       _customizedViewCacheMap.get(stateType).getCustomizedViewCache()
           .deletePropertyByName(resourceName);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

(#942  )

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds the customized view cache update/delete operation in customized view aggregation stage. Previously, we depend on routing table provider to update customized view cache, as the controller is NOT listening to customized view change, and we found there're some cases we see inconsistency between cache and zk due to the lag between routing table provider and controller. To handle cache in the customized view aggregation stage could avoid such problems.

Detailed race condition:
Assume the customized state config changes, and it triggers a customized view update, before the router catches the change and processes the customized view change and updates cache, there's another customized state config change happen, in the customized view aggregation stage, we compare the new change with that in the cache, which is stale, and we will make the wrong decision.

### Tests

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X ] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)