### PR TITLE
Fix flaky tests in TestResourceAccessor

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
@@ -40,6 +40,7 @@ import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.model.ClusterConfig;
@@ -165,6 +166,9 @@ public class TestResourceAccessor extends AbstractTestClass {
   @Test(dependsOnMethods = "testExternalView")
   public void testPartitionHealth() throws Exception {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
+    // Stop all controllers because this test case creates external views; the external views will
+    // be deleted by the controllers if controllers are not stopped and cause test failures
+    stopClustersControllers();
 
     String clusterName = "TestCluster_1";
     String resourceName = clusterName + "_db_0";
@@ -207,11 +211,16 @@ public class TestResourceAccessor extends AbstractTestClass {
     Assert.assertEquals(healthStatus.get("p1"), "PARTIAL_HEALTHY");
     Assert.assertEquals(healthStatus.get("p2"), "UNHEALTHY");
     System.out.println("End test :" + TestHelper.getTestMethodName());
+    // Restart the stopped controllers
+    startClustersControllers();
   }
 
   @Test(dependsOnMethods = "testPartitionHealth")
   public void testResourceHealth() throws Exception {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
+    // Stop all controllers because this test case creates external views; the external views will
+    // be deleted by the controllers if controllers are not stopped and cause test failures
+    stopClustersControllers();
 
     String clusterName = "TestCluster_1";
     Map<String, String> idealStateParams = new HashMap<>();
@@ -290,6 +299,8 @@ public class TestResourceAccessor extends AbstractTestClass {
     Assert.assertEquals(healthStatus.get(resourceNamePartiallyHealthy), "PARTIAL_HEALTHY");
     Assert.assertEquals(healthStatus.get(resourceNameUnhealthy), "UNHEALTHY");
     System.out.println("End test :" + TestHelper.getTestMethodName());
+    // Restart the stopped controllers
+    startClustersControllers();
   }
 
   /**
@@ -644,5 +655,21 @@ public class TestResourceAccessor extends AbstractTestClass {
     helixDataAccessor.setProperty(helixDataAccessor.keyBuilder().externalView(resourceName),
         externalView);
     System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  private void stopClustersControllers() {
+    for (ClusterControllerManager cm : _clusterControllerManagers) {
+      if (cm != null && cm.isConnected()) {
+        cm.syncStop();
+      }
+    }
+  }
+
+  private void startClustersControllers() {
+    for (ClusterControllerManager cm : _clusterControllerManagers) {
+      if (cm != null && cm.isConnected()) {
+        cm.syncStart();
+      }
+    }
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #933

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR fixes the flaky tests in `TestResourceAccessor`, namely `testPartitionHealth` and `testResourceHealth`. The tests have been failing because the external views created during the tests could be sometimes removed before the health check, causing health checks to fail. How to reproduce: add time delay before health check calls will always fail the test cases. 

We believe that the reason behind external view removal is due to the controllers, and disabling the controllers on the test clusters has made the tests pass even with the time delay. 

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
Tests run: 112, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 121.159 sec - in TestSuite

Results :

Tests run: 112, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:04 min
[INFO] Finished at: 2020-04-08T13:54:02-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)