### PR TITLE
Fix ClusterAccessor::createCluster wrt CloudConfig

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -137,10 +137,10 @@ public class ClusterAccessor extends AbstractHelixResource {
   public Response createCluster(@PathParam("clusterId") String clusterId,
       @DefaultValue("false") @QueryParam("recreate") String recreate,
       @DefaultValue("false") @QueryParam("addCloudConfig") String addCloudConfig,
-      String content) {
+      String cloudConfigManifest) {
 
-    boolean recreateIfExists = Boolean.valueOf(recreate);
-    boolean cloudConfigIncluded = Boolean.valueOf(addCloudConfig);
+    boolean recreateIfExists = Boolean.parseBoolean(recreate);
+    boolean cloudConfigIncluded = Boolean.parseBoolean(addCloudConfig);
 
     ClusterSetup clusterSetup = getClusterSetup();
 
@@ -148,21 +148,17 @@ public class ClusterAccessor extends AbstractHelixResource {
     if (cloudConfigIncluded) {
       ZNRecord record;
       try {
-        record = toZNRecord(content);
-      } catch (IOException e) {
-        LOG.error("Failed to deserialize user's input " + content + ", Exception: " + e);
-        return badRequest("Input is not a vaild ZNRecord!");
-      }
-      try {
+        record = toZNRecord(cloudConfigManifest);
         cloudConfig = new CloudConfig.Builder(record).build();
-        clusterSetup.addCluster(clusterId, recreateIfExists, cloudConfig);
-      } catch (Exception ex) {
-        LOG.error("Error in adding a CloudConfig to cluster: " + clusterId, ex);
-        return badRequest(ex.getMessage());
+      } catch (IOException | HelixException e) {
+        String errMsg = "Failed to generate a valid CloudConfig from " + cloudConfigManifest;
+        LOG.error(errMsg, e);
+        return badRequest(errMsg + " Exception: " + e.getMessage());
       }
     }
+
     try {
-      clusterSetup.addCluster(clusterId, recreateIfExists);
+      clusterSetup.addCluster(clusterId, recreateIfExists, cloudConfig);
     } catch (Exception ex) {
       LOG.error("Failed to create cluster {}. Exception: {}.", clusterId, ex);
       return serverError(ex);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #936 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The logic for ClusterAccessor was faulty in that it called createCluster() twice. This PR fixes this.

### Tests

- [x] The following tests are written for this issue:

TestClusterAccessor

- [x] The following is the result of the "mvn test" command on the appropriate module:

mvn test on helix-rest:

```
Tests run: 112, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 25.01 sec - in TestSuite

Results :

Tests run: 112, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  30.430 s
[INFO] Finished at: 2020-04-08T15:13:34-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)

