### PR TITLE
Fix unexpceted partition movements in the CrushEd strategy.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -314,14 +314,14 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
   }
 
   /**
-   * Return the cached stable partition list of the specified resource. If no such cached item,
-   * return empty list.
    * This is for a backward compatible workaround to fix https://github.com/apache/helix/issues/940.
    *
    * @param resourceName
+   * @return the cached stable partition list of the specified resource. If no such cached item,
+   * return null.
    */
   public List<String> getStablePartitionList(String resourceName) {
-    return _stablePartitionListCache.getOrDefault(resourceName, Collections.EMPTY_LIST);
+    return _stablePartitionListCache.get(resourceName);
   }
 
   /**
@@ -335,8 +335,8 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
     for (String resourceName : idealStateMap.keySet()) {
       Set<String> newPartitionSet = idealStateMap.get(resourceName).getPartitionSet();
       List<String> cachedPartitionList = getStablePartitionList(resourceName);
-      if (cachedPartitionList.size() != newPartitionSet.size() || !newPartitionSet
-          .containsAll(cachedPartitionList)) {
+      if (cachedPartitionList == null || cachedPartitionList.size() != newPartitionSet.size()
+          || !newPartitionSet.containsAll(cachedPartitionList)) {
         _stablePartitionListCache.put(resourceName, new ArrayList<>(newPartitionSet));
       }
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
@@ -426,14 +426,12 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
       IdealState currentIdealState) {
     List<String> partitions =
         clusterData.getStablePartitionList(currentIdealState.getResourceName());
-    Set<String> currentPartitionSet = currentIdealState.getPartitionSet();
-    if (partitions.size() != currentPartitionSet.size() || !currentPartitionSet
-        .containsAll(partitions)) {
+    if (partitions == null) {
+      Set<String> currentPartitionSet = currentIdealState.getPartitionSet();
       // In theory, the cached stable partition list must have contains all items in the current
       // partition set. Add one more check to avoid any intermediate change that modifies the list.
-      LOG.warn("The current partition set {} has been modified and it is different from the cached "
-              + "stable list {}. Use the current partition set.", currentPartitionSet.toString(),
-          partitions.toString());
+      LOG.warn("The current partition set {} has not been cached in the stable partition list. "
+              + "Use the IdealState partition set directly.", currentPartitionSet.toString());
       partitions = new ArrayList<>(currentPartitionSet);
     }
     return partitions;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.internal.MappingCalculator;
@@ -46,6 +45,7 @@ import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.util.HelixUtil;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -416,5 +416,26 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
 
       return p1.compareTo(p2);
     }
+  }
+
+  // This is for a backward compatible workaround to fix
+  // https://github.com/apache/helix/issues/940.
+  // TODO: remove the workaround once we are able to apply the simple fix without majorly
+  // TODO: impacting user's clusters.
+  protected List<String> getStablePartitionList(ResourceControllerDataProvider clusterData,
+      IdealState currentIdealState) {
+    List<String> partitions =
+        clusterData.getStablePartitionList(currentIdealState.getResourceName());
+    Set<String> currentPartitionSet = currentIdealState.getPartitionSet();
+    if (partitions.size() != currentPartitionSet.size() || !currentPartitionSet
+        .containsAll(partitions)) {
+      // In theory, the cached stable partition list must have contains all items in the current
+      // partition set. Add one more check to avoid any intermediate change that modifies the list.
+      LOG.warn("The current partition set {} has been modified and it is different from the cached "
+              + "stable list {}. Use the current partition set.", currentPartitionSet.toString(),
+          partitions.toString());
+      partitions = new ArrayList<>(currentPartitionSet);
+    }
+    return partitions;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
@@ -28,13 +28,13 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.helix.HelixException;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.IdealState.RebalanceMode;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.StateModelDefinition;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +64,12 @@ public class AutoRebalancer extends AbstractRebalancer<ResourceControllerDataPro
 
     LOG.info("Computing IdealState for " + resourceName);
 
-    List<String> partitions = new ArrayList<>(currentIdealState.getPartitionSet());
+    // This is part of the backward compatible workaround to fix
+    // https://github.com/apache/helix/issues/940.
+    // TODO: remove the workaround once we are able to apply the simple fix without majorly
+    // TODO: impacting user's clusters.
+    List<String> partitions =
+        clusterData.getOrSetStablePartitionList(resourceName, currentIdealState.getPartitionSet());
     String stateModelName = currentIdealState.getStateModelDefRef();
     StateModelDefinition stateModelDef = clusterData.getStateModelDef(stateModelName);
     if (stateModelDef == null) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
@@ -64,12 +64,7 @@ public class AutoRebalancer extends AbstractRebalancer<ResourceControllerDataPro
 
     LOG.info("Computing IdealState for " + resourceName);
 
-    // This is part of the backward compatible workaround to fix
-    // https://github.com/apache/helix/issues/940.
-    // TODO: remove the workaround once we are able to apply the simple fix without majorly
-    // TODO: impacting user's clusters.
-    List<String> partitions =
-        clusterData.getOrSetStablePartitionList(resourceName, currentIdealState.getPartitionSet());
+    List<String> partitions = getStablePartitionList(clusterData, currentIdealState);
     String stateModelName = currentIdealState.getStateModelDefRef();
     StateModelDefinition stateModelDef = clusterData.getStateModelDef(stateModelName);
     if (stateModelDef == null) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -66,7 +66,12 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
 
     LOG.info("Computing IdealState for " + resourceName);
 
-    List<String> allPartitions = new ArrayList<>(currentIdealState.getPartitionSet());
+    // This is part of the backward compatible workaround to fix
+    // https://github.com/apache/helix/issues/940.
+    // TODO: remove the workaround once we are able to apply the simple fix without majorly
+    // TODO: impacting user's clusters.
+    List<String> allPartitions =
+        clusterData.getOrSetStablePartitionList(resourceName, currentIdealState.getPartitionSet());
     if (allPartitions.size() == 0) {
       LOG.info("Partition count is 0 for resource " + resourceName
           + ", stop calculate ideal mapping for the resource.");

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -66,12 +66,7 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
 
     LOG.info("Computing IdealState for " + resourceName);
 
-    // This is part of the backward compatible workaround to fix
-    // https://github.com/apache/helix/issues/940.
-    // TODO: remove the workaround once we are able to apply the simple fix without majorly
-    // TODO: impacting user's clusters.
-    List<String> allPartitions =
-        clusterData.getOrSetStablePartitionList(resourceName, currentIdealState.getPartitionSet());
+    List<String> allPartitions = getStablePartitionList(clusterData, currentIdealState);
     if (allPartitions.size() == 0) {
       LOG.info("Partition count is 0 for resource " + resourceName
           + ", stop calculate ideal mapping for the resource.");

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -85,6 +85,12 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
         compute(event, resourceMap, currentStateOutput);
     event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
 
+    // This is part of the backward compatible workaround to fix
+    // https://github.com/apache/helix/issues/940.
+    // TODO: remove the workaround once we are able to apply the simple fix without majorly
+    // TODO: impacting user's clusters.
+    cache.retainStablePartitionListCache(resourceMap.keySet());
+
     final Map<String, InstanceConfig> instanceConfigMap = cache.getInstanceConfigMap();
     final Map<String, StateModelDefinition> stateModelDefMap = cache.getStateModelDefMap();
     asyncExecute(cache.getAsyncTasksThreadPool(), new Callable<Object>() {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -85,12 +85,6 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
         compute(event, resourceMap, currentStateOutput);
     event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
 
-    // This is part of the backward compatible workaround to fix
-    // https://github.com/apache/helix/issues/940.
-    // TODO: remove the workaround once we are able to apply the simple fix without majorly
-    // TODO: impacting user's clusters.
-    cache.retainStablePartitionListCache(resourceMap.keySet());
-
     final Map<String, InstanceConfig> instanceConfigMap = cache.getInstanceConfigMap();
     final Map<String, StateModelDefinition> stateModelDefMap = cache.getStateModelDefMap();
     asyncExecute(cache.getAsyncTasksThreadPool(), new Callable<Object>() {

--- a/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestResourceControllerDataProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestResourceControllerDataProvider.java
@@ -1,0 +1,71 @@
+package org.apache.helix.controller.dataproviders;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestResourceControllerDataProvider {
+  @Test
+  public void testStablePartitionListCache() {
+    ResourceControllerDataProvider dataProvider = new ResourceControllerDataProvider();
+    String resourceName = "TestResource";
+    Set<String> partitionSetA = ImmutableSet.of("Partiton1", "Partiton2", "Partiton3");
+    Set<String> partitionSetB = ImmutableSet.of("Partiton1", "Partiton2", "Partiton4");
+
+    // 1. Test get the stable list
+    List<String> cachedPartitionListA =
+        dataProvider.getOrSetStablePartitionList(resourceName, partitionSetA);
+    Assert.assertTrue(cachedPartitionListA.size() == partitionSetA.size() && cachedPartitionListA
+        .containsAll(partitionSetA));
+
+    Set<String> partitionSetAWithDifferentOrder = new LinkedHashSet<>();
+    partitionSetAWithDifferentOrder.add("Partiton3");
+    partitionSetAWithDifferentOrder.add("Partiton2");
+    partitionSetAWithDifferentOrder.add("Partiton1");
+    // Verify that iterating this list will generate a different result
+    List<String> tmpPartitionList = new ArrayList<>(partitionSetAWithDifferentOrder);
+    Assert.assertFalse(cachedPartitionListA.equals(tmpPartitionList));
+    // Verify that the cached stable partition list still return a list with the same order.
+    Assert.assertTrue(
+        dataProvider.getOrSetStablePartitionList(resourceName, partitionSetAWithDifferentOrder)
+            .equals(cachedPartitionListA));
+
+    // 2. Test update
+    List<String> cachedPartitionListB =
+        dataProvider.getOrSetStablePartitionList(resourceName, partitionSetB);
+    Assert.assertTrue(cachedPartitionListB.size() == partitionSetB.size() && cachedPartitionListB
+        .containsAll(partitionSetB));
+
+    // 3. Test retain
+    dataProvider.retainStablePartitionListCache(Collections.emptySet());
+    // Now, since the cache has been cleaned, the get will return different order.
+    Assert.assertFalse(
+        dataProvider.getOrSetStablePartitionList(resourceName, partitionSetAWithDifferentOrder)
+            .equals(cachedPartitionListA));
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestResourceControllerDataProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestResourceControllerDataProvider.java
@@ -50,7 +50,7 @@ public class TestResourceControllerDataProvider {
 
     List<String> cachedPartitionList =
         dataProvider.getStablePartitionList(resourceName);
-    Assert.assertTrue(cachedPartitionList.isEmpty());
+    Assert.assertTrue(cachedPartitionList == null);
 
     // 1. Test refresh and get stable list
     dataProvider.refreshStablePartitionList(idealStateMap);
@@ -86,6 +86,6 @@ public class TestResourceControllerDataProvider {
     dataProvider.refreshStablePartitionList(idealStateMap);
     // Now, since the cache has been cleaned, the get will return different order.
     Assert.assertTrue(
-        dataProvider.getStablePartitionList(resourceName).isEmpty());
+        dataProvider.getStablePartitionList(resourceName) == null);
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#940 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This is a workaround fix to ensure backward compatibility. An additional cache map is used to keep the stable partition list so as to remove the randomness in the algorithm input.
Note that the right fix would be cleaner that we sort the list inside the strategy class. However, that will also change all existing cluster assignments in production.

### Tests

- [x] The following tests are written for this issue:

TestResourceControllerDataProvider.testStablePartitionListCache
* Note that integration test is not quite doable unless we have a way to let JDK keySet() method return the same set with different iteration orders. Please comment if any good idea.

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures:
[ERROR]   TestRebalancePipeline.testMsgTriggeredRebalance:208 expected:<true> but was:<false>
[ERROR] org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceTopoplogyAwareDisabled.testLackEnoughLiveInstances(org.apache.helix.integration.rebalancer.CrushRebalancers.TestCrushAutoRebalanceTopoplogyAwareDisabled)
[ERROR]   Run 1: TestCrushAutoRebalanceTopoplogyAwareDisabled.testLackEnoughLiveInstances:79->TestCrushAutoRebalanceNonRack.testLackEnoughLiveInstances:228->TestCrushAutoRebalanceNonRack.validateIsolation:301 expected:<2> but was:<1>
[INFO]   Run 2: PASS
[INFO]
[INFO]
[ERROR] Tests run: 1119, Failures: 2, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:14 h
[INFO] Finished at: 2020-04-10T16:17:10-07:00
[INFO] ------------------------------------------------------------------------

Rerun failed test

[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.316 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 43.478 s
[INFO] Finished at: 2020-04-10T16:32:30-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)