### PR TITLE
Move routing table provider initialization

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/TestCustomizedViewAggregation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestCustomizedViewAggregation.java
@@ -71,9 +71,7 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
   public void beforeClass() throws Exception {
     super.beforeClass();
 
-    String className = TestHelper.getTestClassName();
-    String methodName = TestHelper.getTestMethodName();
-    String clusterName = className + "_" + methodName;
+    String clusterName = TestHelper.getTestClassName();
     int n = 2;
 
     System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
@@ -120,6 +118,23 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
     _localCustomizedView = new HashMap<>();
     _routingTableProviderDataSources = new HashSet<>();
     _aggregationEnabledTypes = new HashSet<>();
+
+    List<String> customizedStateTypes = Arrays
+        .asList(CustomizedStateType.TYPE_A.name(), CustomizedStateType.TYPE_B.name(),
+            CustomizedStateType.TYPE_C.name());
+
+    CustomizedStateConfig.Builder customizedStateConfigBuilder =
+        new CustomizedStateConfig.Builder();
+    customizedStateConfigBuilder.setAggregationEnabledTypes(customizedStateTypes);
+    HelixDataAccessor accessor = _manager.getHelixDataAccessor();
+    accessor.setProperty(accessor.keyBuilder().customizedStateConfig(),
+        customizedStateConfigBuilder.build());
+    _aggregationEnabledTypes.addAll(customizedStateTypes);
+
+    Map<PropertyType, List<String>> dataSource = new HashMap<>();
+    dataSource.put(PropertyType.CUSTOMIZEDVIEW, customizedStateTypes);
+    _routingTableProvider = new RoutingTableProvider(_spectator, dataSource);
+    _routingTableProviderDataSources.addAll(customizedStateTypes);
   }
 
   @AfterClass
@@ -143,7 +158,6 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
         // Get customized view snapshot
         Map<String, RoutingTableSnapshot> fullCustomizedViewSnapshot =
             routingTableSnapshots.get(PropertyType.CUSTOMIZEDVIEW.name());
-        boolean result = false;
 
         if (fullCustomizedViewSnapshot.isEmpty() && !_routingTableProviderDataSources.isEmpty()) {
           return false;
@@ -167,6 +181,11 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
           // If a customized state is not set to be aggregated in config, but is enabled in routing table provider, it will show up in customized view returned to user, but will be empty
           if (!_aggregationEnabledTypes.contains(customizedStateType)
               && customizedViews.size() != 0) {
+            return false;
+          }
+
+          if (_aggregationEnabledTypes.contains(customizedStateType)
+              && customizedViews.size() != localSnapshot.size()) {
             return false;
           }
 
@@ -200,10 +219,7 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
                 // Per instance value
                 String stateMapValue = stateMap.get(instanceName);
                 String localStateMapValue = localStateMap.get(instanceName);
-                if (isEmptyValue(stateMapValue) && isEmptyValue(localStateMapValue)) {
-                } else if ((!isEmptyValue(stateMapValue) && !isEmptyValue(localStateMapValue)
-                    && !stateMapValue.equals(localStateMapValue)) || (isEmptyValue(stateMapValue)
-                    || isEmptyValue(localStateMapValue))) {
+                if (!stateMapValue.equals(localStateMapValue)) {
                   return false;
                 }
               }
@@ -215,10 +231,6 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
     }, 12000);
 
     Assert.assertTrue(result);
-  }
-
-  private boolean isEmptyValue(String value) {
-    return value == null || value.equals("");
   }
 
   /**
@@ -243,12 +255,6 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
       localPerPartition.remove(instanceName);
       if (localPerPartition.isEmpty()) {
         localPerResource.remove(partitionName);
-        if (localPerResource.isEmpty()) {
-          localPerStateType.remove(resourceName);
-          if (localPerStateType.isEmpty()) {
-            _localCustomizedView.remove(customizedStateType.name());
-          }
-        }
       }
     } else {
       localPerPartition.put(instanceName, customizedStateValue.name());
@@ -313,22 +319,6 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
   }
 
   /**
-   * Set the data sources (customized state types) for routing table provider
-   * @param customizedStateTypes list of customized state types that routing table provider will include in the snapshot shown to users
-   */
-  private void setRoutingTableProviderDataSources(List<CustomizedStateType> customizedStateTypes) {
-    List<String> customizedViewSources = new ArrayList<>();
-    _routingTableProviderDataSources.clear();
-    for (CustomizedStateType type : customizedStateTypes) {
-      customizedViewSources.add(type.name());
-      _routingTableProviderDataSources.add(type.name());
-    }
-    Map<PropertyType, List<String>> dataSource = new HashMap<>();
-    dataSource.put(PropertyType.CUSTOMIZEDVIEW, customizedViewSources);
-    _routingTableProvider = new RoutingTableProvider(_spectator, dataSource);
-  }
-
-  /**
    * Set the customized view aggregation config in controller
    * @param aggregationEnabledTypes list of customized state types that the controller will aggregate to customized view
    */
@@ -348,9 +338,7 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
   }
 
   @Test
-  public void testCustomizedStateViewAggregation() throws Exception {
-    setAggregationEnabledTypes(
-        Arrays.asList(CustomizedStateType.TYPE_A, CustomizedStateType.TYPE_B));
+  public void testCustomizedViewAggregation() throws Exception {
 
     update(INSTANCE_0, CustomizedStateType.TYPE_A, RESOURCE_0, PARTITION_00,
         CurrentStateValues.TYPE_A_0);
@@ -370,16 +358,6 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
         CurrentStateValues.TYPE_C_2);
     update(INSTANCE_1, CustomizedStateType.TYPE_A, RESOURCE_1, PARTITION_11,
         CurrentStateValues.TYPE_A_1);
-
-    // Aggregation enabled types: A, B; Routing table provider data sources: A, B, C; should show TypeA, TypeB customized views
-    setRoutingTableProviderDataSources(Arrays
-        .asList(CustomizedStateType.TYPE_A, CustomizedStateType.TYPE_B,
-            CustomizedStateType.TYPE_C));
-    validateAggregationSnapshot();
-
-    // Aggregation enabled types: A, B; Routing table provider data sources: A, B, C; should show TypeA, TypeB customized views
-    setAggregationEnabledTypes(Arrays.asList(CustomizedStateType.TYPE_A, CustomizedStateType.TYPE_B,
-        CustomizedStateType.TYPE_C));
     validateAggregationSnapshot();
 
     Assert.assertNull(_customizedStateProvider_participant0
@@ -395,8 +373,9 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
     updateLocalCustomizedViewMap(INSTANCE_1, CustomizedStateType.TYPE_A, RESOURCE_1, PARTITION_10,
         CurrentStateValues.TYPE_A_2);
 
-    // Aggregation enabled types: A, B, C; Routing table provider data sources: A; should only show TypeA customized view
-    setRoutingTableProviderDataSources(Arrays.asList(CustomizedStateType.TYPE_A));
+    validateAggregationSnapshot();
+
+    setAggregationEnabledTypes(Arrays.asList(CustomizedStateType.TYPE_A));
     validateAggregationSnapshot();
 
     // Test get customized state and get per partition customized state via customized state provider, this part of test doesn't change customized view
@@ -431,17 +410,7 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
     // Customized view only reflect CURRENT_STATE field
     updateLocalCustomizedViewMap(INSTANCE_1, CustomizedStateType.TYPE_A, RESOURCE_1, PARTITION_10,
         null);
-    validateAggregationSnapshot();
 
-    //Aggregation enabled types: B; Routing table provider data sources: A, B, C; should show TypeB customized views
-    setAggregationEnabledTypes(Arrays.asList(CustomizedStateType.TYPE_B));
-    setRoutingTableProviderDataSources(Arrays
-        .asList(CustomizedStateType.TYPE_A, CustomizedStateType.TYPE_B,
-            CustomizedStateType.TYPE_C));
-    validateAggregationSnapshot();
-
-    //Aggregation enabled types: B; Routing table provider data sources: A; should show empty customized view
-    setRoutingTableProviderDataSources(Arrays.asList(CustomizedStateType.TYPE_A));
     validateAggregationSnapshot();
 
     // Update some customized states and verify
@@ -450,6 +419,10 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
 
     // delete a customize state that does not exist
     delete(INSTANCE_1, CustomizedStateType.TYPE_A, RESOURCE_1, PARTITION_10);
+    validateAggregationSnapshot();
+
+    setAggregationEnabledTypes(Arrays.asList(CustomizedStateType.TYPE_A, CustomizedStateType.TYPE_B,
+        CustomizedStateType.TYPE_C));
     validateAggregationSnapshot();
 
     update(INSTANCE_0, CustomizedStateType.TYPE_B, RESOURCE_0, PARTITION_01,


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
In current test we initialize routing table provider after updating customized state, and there are several re-initialization of routing table provider at different places during the test to set different data sources. Although routing table provider will fetch correct results in this way, it does not represent a common way how our customers should use routing table provider. This PR fixes this problem.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR moves the initialization of routing table provider to before class so it is initialized before any updates. In addition, in this PR re-initializations of routing table provider during the test are removed. Also, added several checks into the validation method to cover some edge cases. 

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)