### PR TITLE
Add integration test for Helix Java APIs using different MSDS endpoints

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -573,24 +573,29 @@ public class TestMultiZkHelixJavaApis {
     String clusterFourPath = formPath(CLUSTER_FOUR, methodName);
     ZNRecord record = new ZNRecord(methodName);
 
-    firstDataAccessor.create(clusterOnePath, record, AccessOption.PERSISTENT);
-    secondDataAccessor.create(clusterFourPath, record, AccessOption.PERSISTENT);
+    try {
+      firstDataAccessor.create(clusterOnePath, record, AccessOption.PERSISTENT);
+      secondDataAccessor.create(clusterFourPath, record, AccessOption.PERSISTENT);
 
-    // Verify data accessors that they could only talk to their own configured MSDS endpoint:
-    // either being set in builder or system property.
-    Assert.assertTrue(firstDataAccessor.exists(clusterOnePath, AccessOption.PERSISTENT));
-    verifyMsdsZkRealm(CLUSTER_FOUR, false,
-        () -> firstDataAccessor.exists(clusterFourPath, AccessOption.PERSISTENT));
+      // Verify data accessors that they could only talk to their own configured MSDS endpoint:
+      // either being set in builder or system property.
+      Assert.assertTrue(firstDataAccessor.exists(clusterOnePath, AccessOption.PERSISTENT));
+      verifyMsdsZkRealm(CLUSTER_FOUR, false,
+          () -> firstDataAccessor.exists(clusterFourPath, AccessOption.PERSISTENT));
 
-    Assert.assertTrue(secondDataAccessor.exists(clusterFourPath, AccessOption.PERSISTENT));
-    verifyMsdsZkRealm(CLUSTER_ONE, false,
-        () -> secondDataAccessor.exists(clusterOnePath, AccessOption.PERSISTENT));
+      Assert.assertTrue(secondDataAccessor.exists(clusterFourPath, AccessOption.PERSISTENT));
+      verifyMsdsZkRealm(CLUSTER_ONE, false,
+          () -> secondDataAccessor.exists(clusterOnePath, AccessOption.PERSISTENT));
 
-    firstDataAccessor.remove(clusterOnePath, AccessOption.PERSISTENT);
-    secondDataAccessor.remove(clusterFourPath, AccessOption.PERSISTENT);
+      firstDataAccessor.remove(clusterOnePath, AccessOption.PERSISTENT);
+      secondDataAccessor.remove(clusterFourPath, AccessOption.PERSISTENT);
 
-    Assert.assertFalse(firstDataAccessor.exists(clusterOnePath, AccessOption.PERSISTENT));
-    Assert.assertFalse(secondDataAccessor.exists(clusterFourPath, AccessOption.PERSISTENT));
+      Assert.assertFalse(firstDataAccessor.exists(clusterOnePath, AccessOption.PERSISTENT));
+      Assert.assertFalse(secondDataAccessor.exists(clusterFourPath, AccessOption.PERSISTENT));
+    } finally {
+      firstDataAccessor.close();
+      secondDataAccessor.close();
+    }
   }
 
   private void verifyClusterSetupMsdsEndpoint(

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/mock/MockMetadataStoreDirectoryServer.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/mock/MockMetadataStoreDirectoryServer.java
@@ -109,6 +109,10 @@ public class MockMetadataStoreDirectoryServer {
         "Stopped MockMetadataStoreDirectoryServer at " + _hostname + ":" + _mockServerPort + "!");
   }
 
+  public String getEndpoint() {
+    return "http://" + _hostname + ":" + _mockServerPort + REST_PREFIX + _namespace;
+  }
+
   /**
    * Dynamically generates HTTP server contexts based on the routing data given.
    */


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Implements #947 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

- What
Metadatastore directory service(MSDS) provides routing functionality for requests to multi realm zookeeper servers. Java APIs talks to MSDS to fetch routing data when they are constructed.

- Why
To make sure Helix Java API is connecting to the correct MSDS endpoint, we would like to add an integration test. This test verifies that each API only connects to the configured MSDS endpoint but not other endpoints.

- How
 1. Create 2 MSDS servers;
 2. Create 2 instances of each Helix Java APIs: one is constructed with MSDS endpoint configured in system property, the other one is constructed with a RealmAwareZkConnectionConfig that has MSDS endpoint configured.
 3. The Java API instances should only talk to its configured MSDS. Check the thrown exception when the instance is talking to an incorrect MSDS.

### Tests

- [x] The following tests are written for this issue:

TestMultiZkHelixJavaApis.testDifferentMsdsEndpointConfigs

- [x] The following is the result of the "mvn test" command on the appropriate module:

No change in main code so no impact on other tests. Running this integration test is enough.

```
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.754 s - in org.apache.helix.integration.multizk.TestMultiZkHelixJavaApis
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  17.507 s
[INFO] Finished at: 2020-04-10T17:52:27-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)