### PR TITLE
Fix failure of dropping instance in TestCrushAutoRebalanceNonRack

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -238,7 +238,7 @@ public class ZKHelixAdmin implements HelixAdmin {
         } else {
           String errorMessage = "Failed to drop instance: " + instanceConfig.getInstanceName()
               + ". Retry times: " + retryCnt;
-          logger.error(errorMessage, retryCnt, e.getCause());
+          logger.error(errorMessage, e);
           throw new HelixException(errorMessage, e);
         }
       }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -40,6 +40,7 @@ import org.apache.helix.util.HelixUtil;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.exception.ZkClientException;
 import org.apache.helix.zookeeper.impl.client.FederatedZkClient;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
 import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
@@ -703,8 +704,8 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
           e.getMessage());
       try {
         _zkClient.deleteRecursively(path);
-      } catch (HelixException he) {
-        LOG.error("Failed to delete {} recursively with opts {}.", path, options, he);
+      } catch (ZkClientException zce) {
+        LOG.error("Failed to delete {} recursively with opts {}.", path, options, zce);
         return false;
       }
     }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fix one part of #939

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

 - What
TestCrushAutoRebalanceNonRack is flaky. It could fail because of dropping instance failure.
```
2020-04-13 01:01:32,366 [main] ERROR org.apache.helix.zookeeper.zkclient.ZkClient - Failed to delete /CLUSTER_TestCrushAutoRebalanceNonRack/INSTANCES/localhost_12921/MESSAGES
org.apache.helix.zookeeper.zkclient.exception.ZkException: org.apache.zookeeper.KeeperException$NotEmptyException: KeeperErrorCode = Directory not empty for /CLUSTER_TestCrushAutoRebalanceNonRack/INSTANCES/localhost_12921/MESSAGES
```
- Why
`ZkHelixAdmin.dropInstance()` has a retry. But in the log retry is not executed. The root cause is `ZkClient.deleteRecursively()` changes the throwing exception from HelixException to ZkClientException but `ZkHelixAdmin.dropInstance()` is still catching HelixException to retry. So ZkClientException is not caught and no retry to delete the path.
- How
To fix this, we need to catch `ZkClientException` instead of `HelixException`. And to make ZkHelixAdmin backward compatible, we also need to convert `ZkClientException` to `HelixException` to be re-thrown.

### Tests

- [x] The following tests are written for this issue:

Enhance existing tests to verify the scenario when `ZkClientException` is thrown from ZkClient:
 - TestZkHelixAdmin.testZkHelixAdmin
 - TestZkBaseDataAccessor.testSyncRemove

Enhance below to wait for the dropping instance to be offline:
 - TestCrushAutoRebalanceNonRack.testLackEnoughInstances

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[ERROR]   TestRebalanceRunningTask.testFixedTargetTaskAndDisabledRebalanceAndNodeAdded:265 expected:<true> but was:<false>
[ERROR]   TestRecurringJobQueue.testDeletingRecurrentQueueWithHistory:296 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1119, Failures: 3, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:21 h
[INFO] Finished at: 2020-04-13T17:23:52-07:00
[INFO] ------------------------------------------------------------------------

SKIPPED test:
TestDelayedAutoRebalanceWithDisabledInstance.testDelayedPartitionMovement

[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 46.486 s - in org.apache.helix.integration.rebalancer.DelayedAutoRebalancer.TestDelayedAutoRebalanceWithDisabledInstance
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  52.180 s
[INFO] Finished at: 2020-04-13T17:29:15-07:00
[INFO] ------------------------------------------------------------------------



[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.638 s - in org.apache.helix.integration.task.TestRebalanceRunningTask
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  27.661 s
[INFO] Finished at: 2020-04-13T17:31:55-07:00
[INFO] ------------------------------------------------------------------------



[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 164.283 s - in org.apache.helix.integration.task.TestRecurringJobQueue
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:50 min
[INFO] Finished at: 2020-04-13T17:35:16-07:00
[INFO] ------------------------------------------------------------------------



[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 13.051 s - in org.apache.helix.integration.task.TestJobQueueCleanUp
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18.771 s
[INFO] Finished at: 2020-04-13T17:38:40-07:00
[INFO] ------------------------------------------------------------------------

```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)