### PR TITLE
Fix MSD routing data refreshing

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataReader.java
@@ -29,7 +29,6 @@ import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.rest.metadatastore.ZkMetadataStoreDirectory;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
-import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
@@ -141,7 +141,6 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
                       .setZkSerializer(new ZNRecordSerializer()));
               LOG.info("ServerContext: FederatedZkClient created successfully!");
             } catch (IOException | InvalidRoutingDataException | IllegalStateException e) {
-              LOG.error("Failed to create FederatedZkClient!", e);
               throw new HelixException("Failed to create FederatedZkClient!", e);
             }
           } else {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -174,9 +174,8 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       clusterSetup.deleteCluster(clusterId);
     } catch (HelixException ex) {
-      LOG
-          .info("Failed to delete cluster {}, cluster is still in use. Exception: {}.", clusterId,
-              ex);
+      LOG.info("Failed to delete cluster {}, cluster is still in use. Exception: {}.", clusterId,
+          ex);
       return badRequest(ex.getMessage());
     } catch (Exception ex) {
       LOG.error("Failed to delete cluster {}. Exception: {}.", clusterId, ex);

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java
@@ -170,7 +170,7 @@ public class TestZkMetadataStoreDirectory extends AbstractTestClass {
     routingDataMap.put(TEST_REALM_2, TEST_SHARDING_KEYS_1);
 
     for (String namespace : _routingZkAddrMap.keySet()) {
-      _metadataStoreDirectory.setNamespaceRoutingData(namespace, routingDataMap);
+      Assert.assertTrue(_metadataStoreDirectory.setNamespaceRoutingData(namespace, routingDataMap));
       Assert
           .assertEquals(_metadataStoreDirectory.getNamespaceRoutingData(namespace), routingDataMap);
     }
@@ -181,7 +181,8 @@ public class TestZkMetadataStoreDirectory extends AbstractTestClass {
     originalRoutingDataMap.put(TEST_REALM_2, TEST_SHARDING_KEYS_2);
 
     for (String namespace : _routingZkAddrMap.keySet()) {
-      _metadataStoreDirectory.setNamespaceRoutingData(namespace, originalRoutingDataMap);
+      Assert.assertTrue(
+          _metadataStoreDirectory.setNamespaceRoutingData(namespace, originalRoutingDataMap));
       Assert.assertEquals(_metadataStoreDirectory.getNamespaceRoutingData(namespace),
           originalRoutingDataMap);
     }
@@ -337,12 +338,14 @@ public class TestZkMetadataStoreDirectory extends AbstractTestClass {
     Assert.assertTrue(TestHelper.verify(() -> {
       for (String namespace : _routingZkAddrMap.keySet()) {
         try {
-          _metadataStoreDirectory.getMetadataStoreRealm(namespace, "anyKey");
+          _metadataStoreDirectory.getMetadataStoreRealm(namespace, TEST_SHARDING_KEYS_1.get(0));
+          // Metadata store realm is not yet refreshed. Retry.
           return false;
         } catch (IllegalStateException e) {
+          // If other IllegalStateException, it is unexpected and this test should fail.
           if (!e.getMessage().equals("Failed to get metadata store realm: Namespace " + namespace
               + " contains either empty or invalid routing data!")) {
-            return false;
+            throw e;
           }
         }
       }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes part of #939 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

1. Routing data update methods in ZkMetadataStoreDirectory writes routing data to ZK and refresh routing cache. However, it should not refresh routing data if writing to ZK fails. Refreshing routing should only be proceeded if writing to ZK is successful.

2. The test is flaky because of removing namespace when refreshing routing data. It is caused by race condition between the read request after updating and data change callback to refresh routing (which is second refresh). Namespace should only be removed when exception is thrown.

### Tests

- [x] The following tests are written for this issue:

Fix TestZkMetadataStoreDirectory

- [x] The following is the result of the "mvn test" command on the appropriate module:
Before: TestZkMetadataStoreDirectory failed within 5 attempts.
After: 50 attempts of running TestZkMetadataStoreDirectory passed

In helix-rest:

```
[INFO] Tests run: 155, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 40.216 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 155, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  47.437 s
[INFO] Finished at: 2020-04-22T17:39:58-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)