### PR TITLE
Fix Regression on Flaky Tests in TestResourceAccessor

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
@@ -41,7 +41,6 @@ import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.TestHelper;
-import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
@@ -168,11 +167,11 @@ public class TestResourceAccessor extends AbstractTestClass {
   @Test(dependsOnMethods = "testExternalView")
   public void testPartitionHealth() throws Exception {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
-    // Stop all controllers because this test case creates external views; the external views will
-    // be deleted by the controllers if controllers are not stopped and cause test failures
 
     String clusterName = "TestCluster_1";
     String resourceName = clusterName + "_db_0";
+
+    // Disable the cluster to prevent external view from being removed
     enableCluster(clusterName, false);
 
     // Use mock numbers for testing
@@ -213,16 +212,14 @@ public class TestResourceAccessor extends AbstractTestClass {
     Assert.assertEquals(healthStatus.get("p1"), "PARTIAL_HEALTHY");
     Assert.assertEquals(healthStatus.get("p2"), "UNHEALTHY");
     System.out.println("End test :" + TestHelper.getTestMethodName());
-    // Restart the stopped controllers
+
+    // Re-enable the cluster
     enableCluster(clusterName, true);
   }
 
   @Test(dependsOnMethods = "testPartitionHealth")
   public void testResourceHealth() throws Exception {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
-    // Stop all controllers because this test case creates external views; the external views will
-    // be deleted by the controllers if controllers are not stopped and cause test failures
-//    stopClustersControllers();
 
     String clusterName = "TestCluster_1";
     Map<String, String> idealStateParams = new HashMap<>();
@@ -231,6 +228,8 @@ public class TestResourceAccessor extends AbstractTestClass {
     idealStateParams.put("MaxPartitionsPerInstance", "3");
     idealStateParams.put("Replicas", "3");
     idealStateParams.put("NumPartitions", "3");
+
+    // Disable the cluster to prevent external view from being removed
     enableCluster(clusterName, false);
 
     // Create a healthy resource
@@ -302,7 +301,8 @@ public class TestResourceAccessor extends AbstractTestClass {
     Assert.assertEquals(healthStatus.get(resourceNamePartiallyHealthy), "PARTIAL_HEALTHY");
     Assert.assertEquals(healthStatus.get(resourceNameUnhealthy), "UNHEALTHY");
     System.out.println("End test :" + TestHelper.getTestMethodName());
-    // Restart the stopped controllers
+
+    // Re-enable the cluster
     enableCluster(clusterName, true);
   }
 
@@ -658,14 +658,6 @@ public class TestResourceAccessor extends AbstractTestClass {
     helixDataAccessor.setProperty(helixDataAccessor.keyBuilder().externalView(resourceName),
         externalView);
     System.out.println("End test :" + TestHelper.getTestMethodName());
-  }
-
-  private void stopClustersControllers() {
-    for (ClusterControllerManager cm : _clusterControllerManagers) {
-      if (cm != null && cm.isConnected()) {
-        cm.syncStop();
-      }
-    }
   }
 
   private void enableCluster(String clusterName, boolean enable) {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
@@ -34,14 +34,12 @@ import javax.ws.rs.core.Response;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.AccessOption;
-import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.TestHelper;
-import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.model.ClusterConfig;

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
@@ -172,7 +172,7 @@ public class TestResourceAccessor extends AbstractTestClass {
     String resourceName = clusterName + "_db_0";
 
     // Disable the cluster to prevent external view from being removed
-    enableCluster(clusterName, false);
+    _gSetupTool.getClusterManagementTool().enableCluster(clusterName, false);
 
     // Use mock numbers for testing
     Map<String, String> idealStateParams = new HashMap<>();
@@ -214,7 +214,7 @@ public class TestResourceAccessor extends AbstractTestClass {
     System.out.println("End test :" + TestHelper.getTestMethodName());
 
     // Re-enable the cluster
-    enableCluster(clusterName, true);
+    _gSetupTool.getClusterManagementTool().enableCluster(clusterName, true);
   }
 
   @Test(dependsOnMethods = "testPartitionHealth")
@@ -230,7 +230,7 @@ public class TestResourceAccessor extends AbstractTestClass {
     idealStateParams.put("NumPartitions", "3");
 
     // Disable the cluster to prevent external view from being removed
-    enableCluster(clusterName, false);
+    _gSetupTool.getClusterManagementTool().enableCluster(clusterName, false);
 
     // Create a healthy resource
     String resourceNameHealthy = clusterName + "_db_0";
@@ -303,7 +303,7 @@ public class TestResourceAccessor extends AbstractTestClass {
     System.out.println("End test :" + TestHelper.getTestMethodName());
 
     // Re-enable the cluster
-    enableCluster(clusterName, true);
+    _gSetupTool.getClusterManagementTool().enableCluster(clusterName, true);
   }
 
   /**
@@ -659,10 +659,4 @@ public class TestResourceAccessor extends AbstractTestClass {
         externalView);
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
-
-  private void enableCluster(String clusterName, boolean enable) {
-    HelixAdmin helixAdmin = new ZKHelixAdmin(_gZkClient);
-    helixAdmin.enableCluster(clusterName, enable);
-  }
-
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #958

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The previous fix to the flaky tests might have impacted other tests. It may be caused by stopping the controllers. A better approach is to pause the clusters instead.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 155, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.911 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 155, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  34.510 s
[INFO] Finished at: 2020-04-20T12:02:05-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)