### PR TITLE
Change DistributedLock interface APIs

### DIFF
--- a/helix-lock/src/main/java/org/apache/helix/lock/DistributedLock.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/DistributedLock.java
@@ -31,9 +31,9 @@ public interface DistributedLock {
   boolean tryLock();
 
   /**
-   * Blocking call to release a lock
+   * Blocking call to unlock a lock
    * @return true if the lock was successfully released or if the locked is not currently locked,
-   * false if the lock is not locked by the user or the release operation failed
+   * false if the lock is not locked by the user or the unlock operation failed
    */
   boolean unlock();
 

--- a/helix-lock/src/main/java/org/apache/helix/lock/DistributedLock.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/DistributedLock.java
@@ -24,18 +24,18 @@ package org.apache.helix.lock;
  */
 public interface DistributedLock {
   /**
-   * Blocking call to acquire a lock
+   * Blocking call to acquire a lock if it is free at the time of request
    * @return true if the lock was successfully acquired,
    * false if the lock could not be acquired
    */
-  boolean acquireLock();
+  boolean tryLock();
 
   /**
    * Blocking call to release a lock
    * @return true if the lock was successfully released or if the locked is not currently locked,
    * false if the lock is not locked by the user or the release operation failed
    */
-  boolean releaseLock();
+  boolean unlock();
 
   /**
    * Retrieve the information of the current lock on the resource this lock object specifies, e.g. lock timeout, lock message, etc.

--- a/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
@@ -19,7 +19,7 @@
 
 package org.apache.helix.lock;
 
-import org.apache.helix.ZNRecord;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
 
 /**

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/HelixLockScope.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/HelixLockScope.java
@@ -22,7 +22,6 @@ package org.apache.helix.lock.helix;
 import java.util.List;
 
 import org.apache.helix.lock.LockScope;
-import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.util.StringTemplate;
 
 

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
@@ -21,15 +21,15 @@ package org.apache.helix.lock.helix;
 
 import java.util.Date;
 
-import org.I0Itec.zkclient.DataUpdater;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.HelixException;
-import org.apache.helix.ZNRecord;
 import org.apache.helix.lock.DistributedLock;
 import org.apache.helix.lock.LockInfo;
 import org.apache.helix.lock.LockScope;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.apache.log4j.Logger;
 
 
@@ -80,7 +80,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock {
   }
 
   @Override
-  public boolean acquireLock() {
+  public boolean tryLock() {
 
     // Set lock information fields
     long deadline;
@@ -96,7 +96,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock {
 
   //TODO: update release lock logic so it would not leave empty znodes after the lock is released
   @Override
-  public boolean releaseLock() {
+  public boolean unlock() {
     // Initialize the lock updater with a default lock info represents the state of a unlocked lock
     LockUpdater updater = new LockUpdater(LockInfo.defaultLockInfo);
     return _baseDataAccessor.update(_lockPath, updater, AccessOption.PERSISTENT);

--- a/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLock.java
+++ b/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLock.java
@@ -27,9 +27,9 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 
 import org.apache.helix.TestHelper;
-import org.apache.helix.ZNRecord;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.lock.LockInfo;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.zookeeper.CreateMode;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -75,7 +75,7 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
   public void testAcquireLock() {
 
     // Acquire lock
-    _lock.acquireLock();
+    _lock.tryLock();
     Assert.assertTrue(_gZkClient.exists(_lockPath));
 
     // Get lock information
@@ -87,7 +87,7 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
     Assert.assertTrue(_lock.isCurrentOwner());
 
     // Release lock
-    _lock.releaseLock();
+    _lock.unlock();
     Assert.assertFalse(_lock.isCurrentOwner());
   }
 
@@ -106,11 +106,11 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
     Assert.assertFalse(_lock.isCurrentOwner());
 
     // Acquire lock
-    Assert.assertFalse(_lock.acquireLock());
+    Assert.assertFalse(_lock.tryLock());
     Assert.assertFalse(_lock.isCurrentOwner());
 
     // Release lock
-    Assert.assertFalse(_lock.releaseLock());
+    Assert.assertFalse(_lock.unlock());
   }
 
   @Test
@@ -125,11 +125,11 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
     _gZkClient.create(_lockPath, fakeRecord, CreateMode.PERSISTENT);
 
     // Acquire lock
-    Assert.assertTrue(_lock.acquireLock());
+    Assert.assertTrue(_lock.tryLock());
     Assert.assertTrue(_lock.isCurrentOwner());
 
     // Release lock
-    Assert.assertTrue(_lock.releaseLock());
+    Assert.assertTrue(_lock.unlock());
     Assert.assertFalse(_lock.isCurrentOwner());
   }
 
@@ -156,7 +156,7 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
 
     @Override
     public Boolean call() throws Exception {
-      return _lock.acquireLock();
+      return _lock.tryLock();
     }
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Current DistributedLock interface API names can be confusing for users, since they are not following java convention. For example: we have acquireLock for both blocking (wait until the lock is release to acquire the lock) and nonblocking locks (return result immediately when called to acquire the lock). 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
API changes:

acquireLock -> tryLock: nonblocking lock
releaseLock -> unlock

API not included in this PR:
aquireLock -> lock: blocking lock
This API is not included in the interface yet, because it is not in the current scope. The API is written here so it is clear that now we will be able to have two different APIs to acquire the lock according to different mechanism.

Also this PR changed some imports for ZooKeeper related APIs because we have a separate module for ZK APIs now.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestStateTransitionTimeoutWithResource.testStateTransitionTimeOut:171 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1122, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:13 h
[INFO] Finished at: 2020-04-22T16:02:23-07:00
[INFO] ------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
