### PR TITLE
Fix failed tests in helix-rest

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataReader.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataReader.java
@@ -29,7 +29,6 @@ import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.rest.server.AbstractTestClass;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.helix.zookeeper.zkclient.ZkClient;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -39,11 +38,9 @@ import org.testng.annotations.Test;
 
 public class TestZkRoutingDataReader extends AbstractTestClass {
   private MetadataStoreRoutingDataReader _zkRoutingDataReader;
-  private ZkClient _zkClient;
 
   @BeforeClass
   public void beforeClass() throws Exception {
-    _zkClient = ZK_SERVER_MAP.get(_zkAddrTestNS).getZkClient();
     _zkRoutingDataReader = new ZkRoutingDataReader(TEST_NAMESPACE, _zkAddrTestNS, null);
     clearRoutingDataPath();
   }
@@ -76,14 +73,13 @@ public class TestZkRoutingDataReader extends AbstractTestClass {
         .setListField(MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY, testShardingKeys2);
 
     // Add both nodes as children nodes to ZkRoutingDataReader.ROUTING_DATA_PATH
-    _zkClient
-        .createPersistent(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1");
-    _zkClient.writeData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1",
-        testZnRecord1);
-    _zkClient
-        .createPersistent(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress2");
-    _zkClient.writeData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress2",
-        testZnRecord2);
+    _gZkClientTestNS
+        .createPersistent(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1",
+            testZnRecord1);
+
+    _gZkClientTestNS
+        .createPersistent(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress2",
+            testZnRecord2);
 
     try {
       Map<String, List<String>> routingData = _zkRoutingDataReader.getRoutingData();
@@ -110,10 +106,10 @@ public class TestZkRoutingDataReader extends AbstractTestClass {
     ZNRecord testZnRecord1 = new ZNRecord("testZnRecord1");
     testZnRecord1.setListField(MetadataStoreRoutingConstants.ZNRECORD_LIST_FIELD_KEY,
         Collections.emptyList());
-    _zkClient
-        .createPersistent(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1");
-    _zkClient.writeData(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1",
-        testZnRecord1);
+    _gZkClientTestNS
+        .createPersistent(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/testRealmAddress1",
+            testZnRecord1);
+
     try {
       Map<String, List<String>> routingData = _zkRoutingDataReader.getRoutingData();
       Assert.assertEquals(routingData.size(), 1);
@@ -125,12 +121,12 @@ public class TestZkRoutingDataReader extends AbstractTestClass {
 
   private void clearRoutingDataPath() throws Exception {
     Assert.assertTrue(TestHelper.verify(() -> {
-      for (String zkRealm : _zkClient
+      for (String zkRealm : _gZkClientTestNS
           .getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH)) {
-        _zkClient.delete(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + zkRealm);
+        _gZkClientTestNS.delete(MetadataStoreRoutingConstants.ROUTING_DATA_PATH + "/" + zkRealm);
       }
 
-      return _zkClient.getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH).isEmpty();
+      return _gZkClientTestNS.getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH).isEmpty();
     }, TestHelper.WAIT_DURATION), "Routing data path should be deleted after the tests.");
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #965 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

 - In these tests, the zkClient is trying to read/write ZNRecords, but zkClient's serializer is not a `ZNRecordSerializer` but a `BasicZkSerializer`. So when read/write a ZNRecord, a `ZkMarshallingError` is thrown and causes the tests failed.
- Some developers don't see these failures, because the ordering of running tests are different on different environments (different maven version, OS). And the zkClient's is a based one and its serializer type is changed to ZNRecordSerializer in other tests. So if other tests are run before TestZkRoutingDataWriter, the tests pass. Otherwise, some developers would see the failures.
 - Change the zkClient to `_gZkClientTestNS` which uses ZNRecordSerializer


### Tests

- [x] The following tests are written for this issue:

Fix tests:
 - TestZkRoutingDataWriter
 - TestZkRoutingDataReader

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 159, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 44.264 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 159, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  50.445 s
[INFO] Finished at: 2020-04-23T13:12:15-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)