### PR TITLE
Fix incorrect exception type and confusing assertion messages

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZNRecordSizeLimit.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZNRecordSizeLimit.java
@@ -45,7 +45,7 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
   private static Logger LOG = LoggerFactory.getLogger(TestZNRecordSizeLimit.class);
 
   private static final String ASSERTION_MESSAGE =
-      "Should succeed because compressed data is smaller than 1M";
+      "Should succeed because compressed data is smaller than 1M. Caused by: ";
 
   @Test
   public void testZNRecordSizeLimitUseZNRecordSerializer() {
@@ -90,7 +90,7 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
     try {
       _gZkClient.writeData(path2, largeRecord);
     } catch (ZkMarshallingError e) {
-      Assert.fail(ASSERTION_MESSAGE);
+      Assert.fail(ASSERTION_MESSAGE + e);
     }
     record = _gZkClient.readData(path2);
     Assert.assertNotNull(record);
@@ -100,7 +100,7 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
     try {
       _gZkClient.writeData(path1, largeRecord);
     } catch (ZkMarshallingError e) {
-      Assert.fail(ASSERTION_MESSAGE);
+      Assert.fail(ASSERTION_MESSAGE + e);
     }
     ZNRecord recordNew = _gZkClient.readData(path1);
     try {
@@ -108,7 +108,7 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
       byte[] arrNew = serializer.serialize(recordNew);
       Assert.assertFalse(Arrays.equals(arr, arrNew));
     } catch (ZkMarshallingError e) {
-      Assert.fail(ASSERTION_MESSAGE);
+      Assert.fail(ASSERTION_MESSAGE + e);
     }
 
     // test ZkDataAccessor
@@ -151,7 +151,7 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
     try {
       Assert.assertTrue(serializer.serialize(record).length > 900 * 1024);
     } catch (ZkMarshallingError e) {
-      Assert.fail(ASSERTION_MESSAGE);
+      Assert.fail(ASSERTION_MESSAGE + e);
     }
 
     // oversized data should not update existing data on zk
@@ -171,7 +171,7 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
       byte[] arrNew = serializer.serialize(recordNew);
       Assert.assertFalse(Arrays.equals(arr, arrNew));
     } catch (ZkMarshallingError e) {
-      Assert.fail(ASSERTION_MESSAGE);
+      Assert.fail(ASSERTION_MESSAGE + e);
     }
 
     System.out.println("END testZNRecordSizeLimitUseZNRecordSerializer at " + new Date(
@@ -214,7 +214,7 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
       try {
         Assert.assertTrue(serializer.serialize(record).length > 900 * 1024);
       } catch (ZkMarshallingError e) {
-        Assert.fail(ASSERTION_MESSAGE);
+        Assert.fail(ASSERTION_MESSAGE + e);
       }
 
       // oversized data doesn't create any data on zk
@@ -229,7 +229,7 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
       try {
         zkClient.writeData(path2, largeRecord);
       } catch (ZkMarshallingError e) {
-        Assert.fail(ASSERTION_MESSAGE);
+        Assert.fail(ASSERTION_MESSAGE + e);
       }
       record = zkClient.readData(path2);
       Assert.assertNotNull(record);
@@ -239,7 +239,7 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
       try {
         zkClient.writeData(path1, largeRecord);
       } catch (ZkMarshallingError e) {
-        Assert.fail(ASSERTION_MESSAGE);
+        Assert.fail(ASSERTION_MESSAGE + e);
       }
       ZNRecord recordNew = zkClient.readData(path1);
       try {
@@ -247,7 +247,7 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
         byte[] arrNew = serializer.serialize(recordNew);
         Assert.assertFalse(Arrays.equals(arr, arrNew));
       } catch (ZkMarshallingError e) {
-        Assert.fail(ASSERTION_MESSAGE);
+        Assert.fail(ASSERTION_MESSAGE + e);
       }
 
       // test ZkDataAccessor
@@ -306,8 +306,8 @@ public class TestZNRecordSizeLimit extends ZkUnitTestBase {
         byte[] arr = serializer.serialize(record);
         byte[] arrNew = serializer.serialize(recordNew);
         Assert.assertFalse(Arrays.equals(arr, arrNew));
-      } catch (ZkMarshallingError ex) {
-        Assert.fail(ASSERTION_MESSAGE);
+      } catch (ZkMarshallingError e) {
+        Assert.fail(ASSERTION_MESSAGE + e);
       }
     } finally {
       zkClient.close();


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #975 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The message should be "Should succeed because data size is **smaller** than 1M since compression applied"
`HelixException` should be `ZkMarshallingError` because the exception type is changed in ZNRecord serializer.

### Tests

- [x] The following tests are written for this issue:

TestZNRecordSizeLimit

- [x] The following is the result of the "mvn test" command on the appropriate module:

Doesn't change any other code. Just ran this test.

Default Suite
Total tests run: 4, Failures: 0, Skips: 0

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)