### PR TITLE
Stabilizing 4 flaky tests

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailure.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailure.java
@@ -74,7 +74,7 @@ public final class TestJobFailure extends TaskSynchronizedTestBase {
   @Test(dataProvider = "testJobFailureInput")
   public void testNormalJobFailure(String comment, List<String> taskStates,
       List<String> expectedTaskEndingStates, String expectedJobEndingStates,
-      String expectedWorkflowEndingStates) throws InterruptedException {
+      String expectedWorkflowEndingStates) throws Exception {
     final String JOB_NAME = "test_job";
     final String WORKFLOW_NAME = TestHelper.getTestMethodName() + testNum++;
     System.out.println("Test case comment: " + comment);
@@ -118,8 +118,15 @@ public final class TestJobFailure extends TaskSynchronizedTestBase {
   }
 
   private Map<String, Map<String, String>> createPartitionConfig(List<String> taskStates,
-      List<String> expectedTaskEndingStates) {
+      List<String> expectedTaskEndingStates) throws Exception {
     Map<String, Map<String, String>> targetPartitionConfigs = new HashMap<>();
+    // Make sure external view is has been created to the resource
+    boolean isExternalViewCreated = TestHelper.verify(() -> {
+      ExternalView externalView =
+          _manager.getClusterManagmentTool().getResourceExternalView(CLUSTER_NAME, DB_NAME);
+      return (externalView != null);
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(isExternalViewCreated);
     ExternalView externalView =
         _manager.getClusterManagmentTool().getResourceExternalView(CLUSTER_NAME, DB_NAME);
     Set<String> partitionSet = externalView.getPartitionSet();

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailure.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailure.java
@@ -120,7 +120,7 @@ public final class TestJobFailure extends TaskSynchronizedTestBase {
   private Map<String, Map<String, String>> createPartitionConfig(List<String> taskStates,
       List<String> expectedTaskEndingStates) throws Exception {
     Map<String, Map<String, String>> targetPartitionConfigs = new HashMap<>();
-    // Make sure external view is has been created to the resource
+    // Make sure external view is has been created for the resource
     boolean isExternalViewCreated = TestHelper.verify(() -> {
       ExternalView externalView =
           _manager.getClusterManagmentTool().getResourceExternalView(CLUSTER_NAME, DB_NAME);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailure.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailure.java
@@ -124,7 +124,7 @@ public final class TestJobFailure extends TaskSynchronizedTestBase {
     Assert.assertTrue(TestHelper.verify(() -> {
       ExternalView externalView =
           _manager.getClusterManagmentTool().getResourceExternalView(CLUSTER_NAME, DB_NAME);
-      return (externalView != null);
+      return externalView != null;
     }, TestHelper.WAIT_DURATION));
 
     ExternalView externalView =

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailure.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailure.java
@@ -120,13 +120,13 @@ public final class TestJobFailure extends TaskSynchronizedTestBase {
   private Map<String, Map<String, String>> createPartitionConfig(List<String> taskStates,
       List<String> expectedTaskEndingStates) throws Exception {
     Map<String, Map<String, String>> targetPartitionConfigs = new HashMap<>();
-    // Make sure external view is has been created for the resource
-    boolean isExternalViewCreated = TestHelper.verify(() -> {
+    // Make sure external view has been created for the resource
+    Assert.assertTrue(TestHelper.verify(() -> {
       ExternalView externalView =
           _manager.getClusterManagmentTool().getResourceExternalView(CLUSTER_NAME, DB_NAME);
       return (externalView != null);
-    }, TestHelper.WAIT_DURATION);
-    Assert.assertTrue(isExternalViewCreated);
+    }, TestHelper.WAIT_DURATION));
+
     ExternalView externalView =
         _manager.getClusterManagmentTool().getResourceExternalView(CLUSTER_NAME, DB_NAME);
     Set<String> partitionSet = externalView.getPartitionSet();

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestRebalanceRunningTask.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestRebalanceRunningTask.java
@@ -269,6 +269,9 @@ public final class TestRebalanceRunningTask extends TaskSynchronizedTestBase {
       HashSet<String> masterInstances = new HashSet<>();
       ExternalView externalView =
           _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, DATABASE);
+      if (externalView == null) {
+        return false;
+      }
       Map<String, String> stateMap0 = externalView.getStateMap(DATABASE + "_0");
       Map<String, String> stateMap1 = externalView.getStateMap(DATABASE + "_1");
       for (Map.Entry<String, String> entry : stateMap0.entrySet()) {

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestRebalanceRunningTask.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestRebalanceRunningTask.java
@@ -264,16 +264,21 @@ public final class TestRebalanceRunningTask extends TaskSynchronizedTestBase {
             .setResources(Sets.newHashSet(DATABASE)).build();
     Assert.assertTrue(clusterVerifier.verify(10 * 1000));
 
-    // Wait until master is switched to new instance and two masters existed on two different instance
+    // Wait until master is switched to new instance and two masters exist on two different instances
     boolean isMasterOnTwoDifferentNodes = TestHelper.verify(() -> {
-      HashSet<String> masterInstances = new HashSet<>();
+      Set<String> masterInstances = new HashSet<>();
       ExternalView externalView =
           _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, DATABASE);
       if (externalView == null) {
         return false;
       }
+
       Map<String, String> stateMap0 = externalView.getStateMap(DATABASE + "_0");
       Map<String, String> stateMap1 = externalView.getStateMap(DATABASE + "_1");
+      if (stateMap0 == null || stateMap1 == null) {
+        return false;
+      }
+
       for (Map.Entry<String, String> entry : stateMap0.entrySet()) {
         if (entry.getValue().equals("MASTER")) {
           masterInstances.add(entry.getKey());
@@ -284,7 +289,7 @@ public final class TestRebalanceRunningTask extends TaskSynchronizedTestBase {
           masterInstances.add(entry.getKey());
         }
       }
-      return (masterInstances.size() == 2);
+      return masterInstances.size() == 2;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(isMasterOnTwoDifferentNodes);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerStopResume.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerStopResume.java
@@ -503,7 +503,8 @@ public class TestTaskRebalancerStopResume extends TaskTestBase {
     builder.addJob(job2Name, job2);
 
     _driver.start(builder.build());
-    Thread.sleep(1000);
+    _driver.pollForWorkflowState(workflowName, TaskState.IN_PROGRESS);
+    _driver.pollForJobState(workflowName, TaskUtil.getNamespacedJobName(workflowName, job1Name), TaskState.IN_PROGRESS);
     _driver.stop(workflowName);
     _driver.pollForWorkflowState(workflowName, TaskState.STOPPING);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
@@ -143,11 +143,10 @@ public class TestTaskSchedulingTwoCurrentStates extends TaskTestBase {
     boolean isMasterSwitchedToCorrectInstance = TestHelper.verify(() -> {
       ExternalView externalView = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, DATABASE);
       Map <String, String> stateMap = externalView.getStateMap(DATABASE + "_0");
-      String state = stateMap.getOrDefault(PARTICIPANT_PREFIX + "_" + (_startPort + 1), null);
-      if (state == null) {
+      if (!stateMap.containsKey(PARTICIPANT_PREFIX + "_" + (_startPort + 1))) {
         return false;
       }
-      return (state.equals("MASTER"));
+      return stateMap.get(PARTICIPANT_PREFIX + "_" + (_startPort + 1)).equals("MASTER");
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(isMasterSwitchedToCorrectInstance);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
@@ -141,12 +141,16 @@ public class TestTaskSchedulingTwoCurrentStates extends TaskTestBase {
 
     // Make sure master has been correctly switched to Participant1
     boolean isMasterSwitchedToCorrectInstance = TestHelper.verify(() -> {
-      ExternalView externalView = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, DATABASE);
-      Map <String, String> stateMap = externalView.getStateMap(DATABASE + "_0");
+      ExternalView externalView =
+          _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, DATABASE);
+      if (externalView == null) {
+        return false;
+      }
+      Map<String, String> stateMap = externalView.getStateMap(DATABASE + "_0");
       if (!stateMap.containsKey(PARTICIPANT_PREFIX + "_" + (_startPort + 1))) {
         return false;
       }
-      return stateMap.get(PARTICIPANT_PREFIX + "_" + (_startPort + 1)).equals("MASTER");
+      return "MASTER".equals(stateMap.get(PARTICIPANT_PREFIX + "_" + (_startPort + 1)));
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(isMasterSwitchedToCorrectInstance);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
@@ -147,9 +147,6 @@ public class TestTaskSchedulingTwoCurrentStates extends TaskTestBase {
         return false;
       }
       Map<String, String> stateMap = externalView.getStateMap(DATABASE + "_0");
-      if (!stateMap.containsKey(PARTICIPANT_PREFIX + "_" + (_startPort + 1))) {
-        return false;
-      }
       return "MASTER".equals(stateMap.get(PARTICIPANT_PREFIX + "_" + (_startPort + 1)));
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(isMasterSwitchedToCorrectInstance);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
@@ -147,6 +147,9 @@ public class TestTaskSchedulingTwoCurrentStates extends TaskTestBase {
         return false;
       }
       Map<String, String> stateMap = externalView.getStateMap(DATABASE + "_0");
+      if (stateMap == null) {
+        return false;
+      }
       return "MASTER".equals(stateMap.get(PARTICIPANT_PREFIX + "_" + (_startPort + 1)));
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(isMasterSwitchedToCorrectInstance);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
@@ -36,6 +36,7 @@ import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.MasterSlaveSMD;
 import org.apache.helix.model.Partition;
@@ -137,6 +138,18 @@ public class TestTaskSchedulingTwoCurrentStates extends TaskTestBase {
 
     JobQueue.Builder jobQueue = TaskTestUtil.buildJobQueue(jobQueueName);
     jobQueue.enqueueJob("JOB0", jobBuilder0);
+
+    // Make sure master has been correctly switched to Participant1
+    boolean isMasterSwitchedToCorrectInstance = TestHelper.verify(() -> {
+      ExternalView externalView = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, DATABASE);
+      Map <String, String> stateMap = externalView.getStateMap(DATABASE + "_0");
+      String state = stateMap.getOrDefault(PARTICIPANT_PREFIX + "_" + (_startPort + 1), null);
+      if (state == null) {
+        return false;
+      }
+      return (state.equals("MASTER"));
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(isMasterSwitchedToCorrectInstance);
 
     _driver.start(jobQueue.build());
 


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #977 
Fixes #978 
Fixes #979 
Fixes #980 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

TestJobFailure was unstable because we get ExternalView of a resources and if the ExternalView is not populated yet by the controller, we hit NullPointerException.

TestRebalanceRunningTask was unstable. In this PR, we make sure that the master is existed in two different nodes (master is switched to new instance) and then we check the assigned participants.

TestRebalanceStopAndResume was unstable because of Thread.Sleep usage. Instead of stopping the workflow after some time, we first make sure that workflow and job is IN_PROGRESS and then stop the workflow.

TestTaskSchedulingTwoCurrent has been stabilized by making sure that master has been switched to new instance after modifying IS. After that we make sure that task is assigned to the correct instance and make sure it does not switched to new instance and cancel is not being called incorrectly.


### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:
Test Result:
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestTaskRebalancer.timeouts:200 expected:<true> but was:<false>
[ERROR]   TestWorkflowTermination.testWorkflowRunningTimeout:131->verifyWorkflowCleanup:257 expected:<true> but was:<false>
[ERROR]   TestClusterVerifier.testResourceSubset:225 expected:<false> but was:<true>
[INFO] 
[ERROR] Tests run: 1144, Failures: 3, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:18 h
[INFO] Finished at: 2020-04-29T11:25:52-07:00
[INFO] ------------------------------------------------------------------------

The failed tests has passed when I ran it individually. The failed tests also need to be stabilized later

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml