### PR TITLE
Fix the flaky test TestRecurringJobQueue.testCreateStoppedQueue

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestRecurringJobQueue.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestRecurringJobQueue.java
@@ -223,7 +223,7 @@ public class TestRecurringJobQueue extends TaskTestBase {
   }
 
   @Test
-  public void testCreateStoppedQueue() throws InterruptedException {
+  public void testCreateStoppedQueue() throws Exception {
     String queueName = TestHelper.getTestMethodName();
 
     // Create a queue
@@ -238,12 +238,14 @@ public class TestRecurringJobQueue extends TaskTestBase {
 
     _driver.resume(queueName);
 
-    //TaskTestUtil.pollForWorkflowState(_driver, queueName, );
-    WorkflowContext wCtx = TaskTestUtil.pollForWorkflowContext(_driver, queueName);
+    // ensure LAST_SCHEDULED_WORKFLOW field is written to Zookeeper
+    Assert.assertTrue(TestHelper.verify(() -> {
+      WorkflowContext wCtx = TaskTestUtil.pollForWorkflowContext(_driver, queueName);
+      return wCtx.getLastScheduledSingleWorkflow() != null;
+    }, TestHelper.WAIT_DURATION));
 
-    // ensure current schedule is started
-    String scheduledQueue = wCtx.getLastScheduledSingleWorkflow();
-    _driver.pollForWorkflowState(scheduledQueue, TaskState.COMPLETED);
+    WorkflowContext wCtx = TaskTestUtil.pollForWorkflowContext(_driver, queueName);
+    _driver.pollForWorkflowState(wCtx.getLastScheduledSingleWorkflow(), TaskState.COMPLETED);
   }
 
   @Test


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #982 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In this commit, the necessary checks have been added to make sure
we do not hit NullPointerException when checking LastScheduledWorkflow.

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[ERROR]   TestWorkflowTermination.testWorkflowJobFail:223 » Helix Workflow "testWorkflow...
[ERROR]   TestWorkflowTermination.testWorkflowRunningTimeout:131->verifyWorkflowCleanup:257 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1144, Failures: 3, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:24 h
[INFO] Finished at: 2020-05-01T13:15:17-07:00
[INFO] ------------------------------------------------------------------------


The failed tests has passed when I ran it individually. 

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml

