### PR TITLE
Stabilize TestWorkflowTimeout and TestTaskRebalancer

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowTimeout.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowTimeout.java
@@ -102,18 +102,23 @@ public class TestWorkflowTimeout extends TaskTestBase {
   }
 
   @Test
-  public void testWorkflowTimeoutWhenWorkflowCompleted() throws InterruptedException {
+  public void testWorkflowTimeoutWhenWorkflowCompleted() throws Exception {
     String workflowName = TestHelper.getTestMethodName();
+    long expiry = 2000L;
     _jobBuilder.setWorkflow(workflowName);
     _jobBuilder.setJobCommandConfigMap(Collections.<String, String> emptyMap());
     Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName)
         .setWorkflowConfig(new WorkflowConfig.Builder(workflowName).setTimeout(0).build())
-        .addJob(JOB_NAME, _jobBuilder).setExpiry(2000L);
+        .addJob(JOB_NAME, _jobBuilder).setExpiry(expiry);
 
+    // Since workflow's Timeout is 0, the workflow goes to TIMED_OUT state right away
+    long startTime = System.currentTimeMillis();
     _driver.start(workflowBuilder.build());
-    // Pause the queue
-    Thread.sleep(2500);
-    Assert.assertNull(_driver.getWorkflowConfig(workflowName));
-    Assert.assertNull(_driver.getJobContext(workflowName));
+
+    Assert.assertTrue(TestHelper.verify(() -> (_driver.getWorkflowConfig(workflowName) == null
+        && _driver.getWorkflowContext(workflowName) == null), TestHelper.WAIT_DURATION));
+
+    long cleanUpTime = System.currentTimeMillis();
+    Assert.assertTrue(cleanUpTime - startTime >= expiry);
   }
 }


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #989 
Fixes #988 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In this commit, two tests have been stabilized.
These tests are TestWorkflowTimeout and TestTaskRebalancer.
These tests are unstable because they are relying on Thread.Sleep()

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:
[INFO] Tests run: 1144, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4,776.334 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1144, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:19 h
[INFO] Finished at: 2020-05-03T12:35:00-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml



