### PR TITLE
Fix version comparison issue in compatibility check stage

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixManagerProperties.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerProperties.java
@@ -116,6 +116,8 @@ public class HelixManagerProperties {
 
         if (versionNum1 < versionNum2) {
           return false;
+        } else if (versionNum1 > versionNum2) {
+          break;
         }
       } catch (Exception e) {
         // ignore non-numerical strings and strings after non-numerical strings

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CompatibilityCheckStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CompatibilityCheckStage.java
@@ -55,7 +55,7 @@ public class CompatibilityCheckStage extends AbstractBaseStage {
             "incompatible participant. pipeline will not continue. " + "controller: "
                 + manager.getInstanceName() + ", controllerVersion: " + properties.getVersion()
                 + ", minimumSupportedParticipantVersion: "
-                + properties.getProperty("miminum_supported_version.participant")
+                + properties.getProperty("minimum_supported_version.participant")
                 + ", participant: " + liveInstance.getInstanceName() + ", participantVersion: "
                 + participantVersion;
         LogUtil.logError(LOG, event.getEventId(), errorMsg);

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestCompatibilityCheckStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestCompatibilityCheckStage.java
@@ -82,7 +82,7 @@ public class TestCompatibilityCheckStage extends BaseStageTest {
 
   @Test
   public void testCompatible() {
-    prepare("0.4.0", "0.4.0");
+    prepare("1.0.0", "1.0.0", "0.4");
     CompatibilityCheckStage stage = new CompatibilityCheckStage();
     StageContext context = new StageContext();
     stage.init(context);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

(#990 )

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Currently there is a bug in the version comparison logic for compatibility check stage. It worked with all version starting with number "0". However, the comparison check would fail after we release version 1.0.0. The impact is the pipeline that includes compatibility check stage would fail due to the incompatibility error.
This PR fixed the issue by modifying the logic in the loop. If the participant version's digit number is larger than the minimum version digit number, we terminate the loop.

### Tests

- [X] The following tests are written for this issue:

TestCompatibilityCheckStage.

- [X] The following is the result of the "mvn test" command on the appropriate module:
helix-rest
[INFO] Tests run: 159, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 32.061 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 159, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  36.217 s
[INFO] Finished at: 2020-05-03T12:01:15-07:00
[INFO] ------------------------------------------------------------------------

helix-core:
[ERROR] Tests run: 1144, Failures: 1, Errors: 0, Skipped: 1, Time elapsed: 4,742.047 s <<< FAILURE! - in TestSuite
[ERROR] testJobQueueAutoCleanUp(org.apache.helix.integration.task.TestJobQueueCleanUp)  Time elapsed: 300.01 s  <<< FAILURE!
org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testJobQueueAutoCleanUp() didn't finish within the time-out 300000

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[INFO] 
[ERROR] Tests run: 1144, Failures: 1, Errors: 0, Skipped: 1
### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)