### PR TITLE
[Backporting] Async write operation should not throw Exception for serializing error (#845)

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZNRecordSerializer.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZNRecordSerializer.java
@@ -24,8 +24,8 @@ import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.Map;
 
+import org.I0Itec.zkclient.exception.ZkMarshallingError;
 import org.I0Itec.zkclient.serialize.ZkSerializer;
-import org.apache.helix.HelixException;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.util.GZipCompressionUtil;
 import org.apache.helix.util.ZNRecordUtil;
@@ -57,7 +57,7 @@ public class ZNRecordSerializer implements ZkSerializer {
       // null is NOT an instance of any class
       LOG.error("Input object must be of type ZNRecord but it is " + data
           + ". Will not write to zk");
-      throw new HelixException("Input object is not of type ZNRecord (was " + data + ")");
+      throw new ZkMarshallingError("Input object is not of type ZNRecord (was " + data + ")");
     }
 
     ZNRecord record = (ZNRecord) data;
@@ -96,7 +96,7 @@ public class ZNRecordSerializer implements ZkSerializer {
       LOG.error(
           "Exception during data serialization. ZNRecord ID: {} will not be written to zk.",
           record.getId(), e);
-      throw new HelixException(e);
+      throw new ZkMarshallingError(e);
     }
 
     int writeSizeLimit = ZNRecordUtil.getSerializerWriteSizeLimit();
@@ -104,7 +104,7 @@ public class ZNRecordSerializer implements ZkSerializer {
       LOG.error("Data size: {} is greater than {} bytes, is compressed: {}, ZNRecord.id: {}."
               + " Data will not be written to Zookeeper.", serializedBytes.length, writeSizeLimit,
           isCompressed, record.getId());
-      throw new HelixException(
+      throw new ZkMarshallingError(
           "Data size: " + serializedBytes.length + " is greater than " + writeSizeLimit
               + " bytes, is compressed: " + isCompressed + ", ZNRecord.id: " + record.getId());
     }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZNRecordStreamingSerializer.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZNRecordStreamingSerializer.java
@@ -29,7 +29,6 @@ import java.util.TreeMap;
 import org.I0Itec.zkclient.exception.ZkMarshallingError;
 import org.I0Itec.zkclient.serialize.ZkSerializer;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.helix.HelixException;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.util.GZipCompressionUtil;
 import org.apache.helix.util.ZNRecordUtil;
@@ -64,7 +63,7 @@ public class ZNRecordStreamingSerializer implements ZkSerializer {
       // null is NOT an instance of any class
       LOG.error("Input object must be of type ZNRecord but it is " + data
           + ". Will not write to zk");
-      throw new HelixException("Input object is not of type ZNRecord (was " + data + ")");
+      throw new ZkMarshallingError("Input object is not of type ZNRecord (was " + data + ")");
     }
 
     // apply retention policy on list field
@@ -165,7 +164,7 @@ public class ZNRecordStreamingSerializer implements ZkSerializer {
       LOG.error(
           "Exception during data serialization. ZNRecord ID: {} will not be written to zk.",
           record.getId(), e);
-      throw new HelixException(e);
+      throw new ZkMarshallingError(e);
     }
     // check size
     int writeSizeLimit = ZNRecordUtil.getSerializerWriteSizeLimit();
@@ -173,7 +172,7 @@ public class ZNRecordStreamingSerializer implements ZkSerializer {
       LOG.error("Data size: {} is greater than {} bytes, is compressed: {}, ZNRecord.id: {}."
               + " Data will not be written to Zookeeper.", serializedBytes.length, writeSizeLimit,
           isCompressed, record.getId());
-      throw new HelixException(
+      throw new ZkMarshallingError(
           "Data size: " + serializedBytes.length + " is greater than " + writeSizeLimit
               + " bytes, is compressed: " + isCompressed + ", ZNRecord.id: " + record.getId());
     }


### PR DESCRIPTION
This is for backporting the fix in the newer version to fix the issue in the older 0.9.x release.

This change will make the async write operations return error through the async callback instead of throwing exceptions. This change will fix the batch write/create failure due to one single node serializing failure.
In addition, according to the serializer interface definition, change ZK related serializers to throw ZkMarshallingError instead of ZkClientException.