### PR TITLE
Use updaters to update read messages to ZK

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -540,6 +540,7 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
         @Override
         public ZNRecord update(ZNRecord currentData) {
           if (currentData == null) {
+            LOG.warn("Message {} targets at {} has already been removed before it is set as READ on instance {}", msg.getId(), msg.getTgtName(), instanceName);
             return null;
           }
           return msg.getRecord();

--- a/helix-core/src/test/java/org/apache/helix/MockAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/MockAccessor.java
@@ -245,8 +245,7 @@ public class MockAccessor implements HelixDataAccessor {
   @Override
   public <T extends HelixProperty> boolean[] updateChildren(List<String> paths,
       List<DataUpdater<ZNRecord>> updaters, int options) {
-    // TODO Auto-generated method stub
-    throw new HelixException("Method not implemented!");
+    return _baseDataAccessor.updateChildren(paths, updaters, options);
   }
 
   @Override


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#1001

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR uses an updater to replace set, so it checks whether there is a message in the path beforehand, and only write the "READ" state message to ZK if there is a message, to avoid write back a message which is already removed.

### Tests

- [x] The following tests are written for this issue:

TestHelixTaskExecutor -> testNoWriteReadStateForRemovedMessage

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestWorkflowTermination.testWorkflowRunningTimeout:131->verifyWorkflowCleanup:257 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1147, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:15 h
[INFO] Finished at: 2020-05-12T18:59:45-07:00

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)