### PR TITLE
Add more accurate error message for resetPartition 

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -597,11 +597,9 @@ public class ZKHelixAdmin implements HelixAdmin {
       // check if the instance exists in the cluster
       String instanceConfigPath = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
       throw new HelixException(String.format(
-          _zkClient.exists(instanceConfigPath) ? ResetPartitionFailureReason.INSTANCE_NOT_ALIVE
-              .getMessage(resourceName, partitionNames, instanceName, instanceName, clusterName)
-              : ResetPartitionFailureReason.INSTANCE_NON_EXISTENT
-                  .getMessage(resourceName, partitionNames, instanceName, instanceName,
-                      clusterName)));
+          (_zkClient.exists(instanceConfigPath) ? ResetPartitionFailureReason.INSTANCE_NOT_ALIVE
+              : ResetPartitionFailureReason.INSTANCE_NON_EXISTENT)
+              .getMessage(resourceName, partitionNames, instanceName, instanceName, clusterName)));
     }
 
     // check resource group exists

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -566,8 +566,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     RESOURCE_NON_EXISTENT("resource %s is not added to cluster %s"),
     PARTITION_NON_EXISTENT("not all %s exist in cluster %s"),
     PARTITION_NOT_ERROR("%s is NOT found in cluster %s"),
-    STATE_MODEL_NON_EXISTENT("%s is NOT found in cluster %s"),
-    PENDING_MSG("a pending message %s exists for resource %s");
+    STATE_MODEL_NON_EXISTENT("%s is NOT found in cluster %s");
 
     private String message;
 
@@ -652,9 +651,10 @@ public class ZKHelixAdmin implements HelixAdmin {
         continue;
       }
 
-      throw new HelixException(String.format(ResetPartitionFailureReason.PENDING_MSG
-          .getMessage(resourceName, partitionNames, instanceName, message.toString(),
-              message.getResourceName())));
+      throw new HelixException(String.format(
+          "Can't reset state for %s.%s on %s, because a pending message %s exists for resource %s",
+          resourceName, partitionNames, instanceName, message.toString(),
+          message.getResourceName()));
     }
 
     String adminName = null;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -561,12 +561,12 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   private enum ResetPartitionFailureReason {
-    INSTANCE_NOTALIVE("%s is not alive in cluster %s"),
-    INSTANCE_NONEXISTENT("%s does not exist in cluster %s"),
-    RESOURCE_NONEXISTENT("resource %s is not added to cluster %s"),
-    PARTITION_NONEXISTENT("not all %s exist in cluster %s"),
+    INSTANCE_NOT_ALIVE("%s is not alive in cluster %s"),
+    INSTANCE_NON_EXISTENT("%s does not exist in cluster %s"),
+    RESOURCE_NON_EXISTENT("resource %s is not added to cluster %s"),
+    PARTITION_NON_EXISTENT("not all %s exist in cluster %s"),
     PARTITION_NOT_ERROR("%s is NOT found in cluster %s"),
-    STATE_MODEL_NONEXISTENT("%s is NOT found in cluster %s"),
+    STATE_MODEL_NON_EXISTENT("%s is NOT found in cluster %s"),
     PENDING_MSG("a pending message %s exists for resource %s");
 
     private String message;
@@ -576,9 +576,9 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     public String getMessage(String resourceName, List<String> partitionNames, String instanceName,
-        String arg1, String arg2) {
+        String errorStateEntity, String clusterName) {
       return String.format("Can't reset state for %s.%s on %s, because " + message, resourceName,
-          partitionNames, instanceName, arg1, arg2);
+          partitionNames, instanceName, errorStateEntity, clusterName);
     }
   }
 
@@ -598,9 +598,9 @@ public class ZKHelixAdmin implements HelixAdmin {
       // check if the instance exists in the cluster
       String instanceConfigPath = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
       throw new HelixException(String.format(
-          _zkClient.exists(instanceConfigPath) ? ResetPartitionFailureReason.INSTANCE_NOTALIVE
+          _zkClient.exists(instanceConfigPath) ? ResetPartitionFailureReason.INSTANCE_NOT_ALIVE
               .getMessage(resourceName, partitionNames, instanceName, instanceName, clusterName)
-              : ResetPartitionFailureReason.INSTANCE_NONEXISTENT
+              : ResetPartitionFailureReason.INSTANCE_NON_EXISTENT
                   .getMessage(resourceName, partitionNames, instanceName, instanceName,
                       clusterName)));
     }
@@ -608,7 +608,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     // check resource group exists
     IdealState idealState = accessor.getProperty(keyBuilder.idealStates(resourceName));
     if (idealState == null) {
-      throw new HelixException(String.format(ResetPartitionFailureReason.RESOURCE_NONEXISTENT
+      throw new HelixException(String.format(ResetPartitionFailureReason.RESOURCE_NON_EXISTENT
           .getMessage(resourceName, partitionNames, instanceName, resourceName, clusterName)));
     }
 
@@ -618,7 +618,7 @@ public class ZKHelixAdmin implements HelixAdmin {
         (idealState.getRebalanceMode() == RebalanceMode.CUSTOMIZED) ? idealState.getRecord()
             .getMapFields().keySet() : idealState.getRecord().getListFields().keySet();
     if (!partitions.containsAll(resetPartitionNames)) {
-      throw new HelixException(String.format(ResetPartitionFailureReason.PARTITION_NONEXISTENT
+      throw new HelixException(String.format(ResetPartitionFailureReason.PARTITION_NON_EXISTENT
           .getMessage(resourceName, partitionNames, instanceName, partitionNames.toString(),
               clusterName)));
     }
@@ -639,7 +639,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     String stateModelDef = idealState.getStateModelDefRef();
     StateModelDefinition stateModel = accessor.getProperty(keyBuilder.stateModelDef(stateModelDef));
     if (stateModel == null) {
-      throw new HelixException(String.format(ResetPartitionFailureReason.STATE_MODEL_NONEXISTENT
+      throw new HelixException(String.format(ResetPartitionFailureReason.STATE_MODEL_NON_EXISTENT
           .getMessage(resourceName, partitionNames, instanceName, stateModelDef, clusterName)));
     }
 

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -638,6 +638,24 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     // clean up
     manager.disconnect();
     admin.dropCluster(clusterName);
+
+    // verify the cluster has been removed successfully
+    HelixDataAccessor dataAccessor = new ZKHelixDataAccessor(className, new ZkBaseDataAccessor<>(_gZkClient));
+    try {
+      Assert.assertTrue(TestHelper.verify(() -> dataAccessor.getChildNames(dataAccessor.keyBuilder().liveInstances()).isEmpty(), 1000));
+    } catch (Exception e) {
+      e.printStackTrace();
+      System.out.println("There're live instances not cleaned up yet");
+      assert false;
+    }
+
+    try {
+      Assert.assertTrue(TestHelper.verify(() -> dataAccessor.getChildNames(dataAccessor.keyBuilder().clusterConfig()).isEmpty(), 1000));
+    } catch (Exception e) {
+      e.printStackTrace();
+      System.out.println("The cluster is not cleaned up yet");
+      assert false;
+    }
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -606,9 +606,9 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
       Assert.fail("Should throw HelixException");
     } catch (HelixException expected) {
       // This exception is expected because the instance is not alive.
-      Assert.assertEquals(expected.getMessage(), String.format(
-          "Can't reset state for %s.[1, 2] on %s, because %s is not alive in cluster %s",
-          testResource, instanceName, instanceName, clusterName));
+      Assert.assertEquals(expected.getMessage(), String
+          .format("Can't reset state for %s.[1, 2] on %s, because %s is not alive in cluster %s",
+              testResource, instanceName, instanceName, clusterName));
     }
 
     HelixManager manager = initializeHelixManager(clusterName, instanceConfig.getInstanceName());
@@ -620,9 +620,9 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
       Assert.fail("Should throw HelixException");
     } catch (HelixException expected) {
       // This exception is expected because the resource is not added.
-      Assert.assertEquals(expected.getMessage(), String
-          .format("Can't reset state for %s.[1, 2] on %s, because resource %s is not added", wrongTestResource,
-              instanceName, wrongTestResource));
+      Assert.assertEquals(expected.getMessage(), String.format(
+          "Can't reset state for %s.[1, 2] on %s, because resource %s is not added to cluster %s",
+          wrongTestResource, instanceName, wrongTestResource, clusterName));
     }
 
     try {
@@ -630,9 +630,9 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
       Assert.fail("Should throw HelixException");
     } catch (HelixException expected) {
       // This exception is expected because partitions do not exist.
-      Assert.assertEquals(expected.getMessage(), String
-          .format("Can't reset state for %s.[1, 2] on %s, because not all [1, 2] exist",
-              testResource, instanceName));
+      Assert.assertEquals(expected.getMessage(), String.format(
+          "Can't reset state for %s.[1, 2] on %s, because not all [1, 2] exist in cluster %s",
+          testResource, instanceName, clusterName));
     }
 
     // clean up

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -561,7 +561,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
   }
 
   @Test
-  public void testResetPartition() {
+  public void testResetPartition() throws Exception {
     String className = TestHelper.getTestClassName();
     String methodName = TestHelper.getTestMethodName();
     String clusterName = className + "_" + methodName;
@@ -576,47 +576,40 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     InstanceConfig instanceConfig = admin.getInstanceConfig(clusterName, instanceName);
 
     // Test the sanity check for resetPartition.
-    // resetPartition is expected to throw an exception when provided with a non-exist instance.
+    // resetPartition is expected to throw an exception when provided with a nonexist instance.
     try {
-      admin.resetPartition(clusterName, "WrongTestInstance", testResource,
-          Arrays.asList("1", "2"));
+      admin.resetPartition(clusterName, "WrongTestInstance", testResource, Arrays.asList("1", "2"));
       Assert.fail("Should throw HelixException");
     } catch (HelixException expected) {
       // This exception is expected because the instance name is made up.
-      Assert.assertEquals(expected.getMessage(),
-          "Can't reset state for " + testResource  + "/[1, 2] on WrongTestInstance," +
-              " because WrongTestInstance never existed in cluster " + clusterName);
+      Assert.assertEquals(expected.getMessage(), String.format(
+          "Can't reset state for %s.[1, 2] on WrongTestInstance, because WrongTestInstance"
+              + " has never existed in cluster %s", testResource, clusterName));
     }
 
-    // resetPartition is expected to throw an exception when provided with a non-alive instance.
+    // resetPartition is expected to throw an exception when provided with a non-live instance.
     try {
-      admin.resetPartition(clusterName, instanceName, testResource,
-          Arrays.asList("1", "2"));
+      admin.resetPartition(clusterName, instanceName, testResource, Arrays.asList("1", "2"));
       Assert.fail("Should throw HelixException");
     } catch (HelixException expected) {
       // This exception is expected because the instance is not alive.
-      Assert.assertEquals(expected.getMessage(),
-          "Can't reset state for " + testResource  + "/[1, 2] on " + instanceName
-              + ", because " + instanceName + " is not alive in cluster " + clusterName + " anymore");
+      Assert.assertEquals(expected.getMessage(), String.format(
+          "Can't reset state for %s.[1, 2] on %s, because %s does not live in cluster %s anymore",
+          testResource, instanceName, instanceName, clusterName));
     }
 
     HelixManager manager = initializeHelixManager(clusterName, instanceConfig.getInstanceName());
-    try {
-      manager.connect();
-    } catch (Exception e) {
-      Assert.fail("HelixManager failed connecting");
-    }
+    manager.connect();
 
     // resetPartition is expected to throw an exception when provided with a non-exist resource.
     try {
-      admin.resetPartition(clusterName, instanceName, testResource,
-          Arrays.asList("1", "2"));
+      admin.resetPartition(clusterName, instanceName, testResource, Arrays.asList("1", "2"));
       Assert.fail("Should throw HelixException");
     } catch (HelixException expected) {
       // This exception is expected because the resource is not added.
-      Assert.assertEquals(expected.getMessage(),
-          "Can't reset state for " + testResource + "/[1, 2] on " + instanceName
-              + ", because " + testResource + " is not added");
+      Assert.assertEquals(expected.getMessage(), String
+          .format("Can't reset state for %s.[1, 2] on %s, because %s is not added", testResource,
+              instanceName, testResource));
     }
 
     IdealState idealState = new IdealState(testResource);
@@ -628,21 +621,17 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
 
     admin.enableResource(clusterName, testResource, true);
     try {
-      admin.resetPartition(clusterName, instanceName, testResource,
-          Arrays.asList("1", "2"));
+      admin.resetPartition(clusterName, instanceName, testResource, Arrays.asList("1", "2"));
       Assert.fail("Should throw HelixException");
     } catch (HelixException expected) {
       // This exception is expected because partitions do not exist.
-      Assert.assertEquals(expected.getMessage(), "Can't reset state for " + testResource
-          + "/[1, 2] on "+ instanceName + ", because not all [1, 2] exist");
+      Assert.assertEquals(expected.getMessage(), String
+          .format("Can't reset state for %s.[1, 2] on %s, because not all [1, 2] exist",
+              testResource, instanceName));
     }
 
     // clean up
-    try {
-      manager.disconnect();
-    } catch (Exception e) {
-      Assert.fail("HelixManager failed disconnecting");
-    }
+    manager.disconnect();
     admin.dropCluster(clusterName);
   }
 

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -567,6 +567,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     String clusterName = className + "_" + methodName;
     String instanceName = "TestInstance";
     String testResource = "TestResource";
+    String wrongTestInstance = "WrongTestInstance";
     System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
     HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
     admin.addCluster(clusterName, true);
@@ -576,15 +577,15 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     InstanceConfig instanceConfig = admin.getInstanceConfig(clusterName, instanceName);
 
     // Test the sanity check for resetPartition.
-    // resetPartition is expected to throw an exception when provided with a nonexist instance.
+    // resetPartition is expected to throw an exception when provided with a nonexistent instance.
     try {
-      admin.resetPartition(clusterName, "WrongTestInstance", testResource, Arrays.asList("1", "2"));
+      admin.resetPartition(clusterName, wrongTestInstance, testResource, Arrays.asList("1", "2"));
       Assert.fail("Should throw HelixException");
     } catch (HelixException expected) {
       // This exception is expected because the instance name is made up.
       Assert.assertEquals(expected.getMessage(), String.format(
-          "Can't reset state for %s.[1, 2] on WrongTestInstance, because WrongTestInstance"
-              + " has never existed in cluster %s", testResource, clusterName));
+          "Can't reset state for %s.[1, 2] on WrongTestInstance, because %s has never existed in cluster %s",
+          testResource, wrongTestInstance, clusterName));
     }
 
     // resetPartition is expected to throw an exception when provided with a non-live instance.
@@ -594,21 +595,21 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     } catch (HelixException expected) {
       // This exception is expected because the instance is not alive.
       Assert.assertEquals(expected.getMessage(), String.format(
-          "Can't reset state for %s.[1, 2] on %s, because %s does not live in cluster %s anymore",
+          "Can't reset state for %s.[1, 2] on %s, because %s is not live in cluster %s anymore",
           testResource, instanceName, instanceName, clusterName));
     }
 
     HelixManager manager = initializeHelixManager(clusterName, instanceConfig.getInstanceName());
     manager.connect();
 
-    // resetPartition is expected to throw an exception when provided with a non-exist resource.
+    // resetPartition is expected to throw an exception when provided with a nonexistent resource.
     try {
       admin.resetPartition(clusterName, instanceName, testResource, Arrays.asList("1", "2"));
       Assert.fail("Should throw HelixException");
     } catch (HelixException expected) {
       // This exception is expected because the resource is not added.
       Assert.assertEquals(expected.getMessage(), String
-          .format("Can't reset state for %s.[1, 2] on %s, because %s is not added", testResource,
+          .format("Can't reset state for %s.[1, 2] on %s, because resource %s is not added", testResource,
               instanceName, testResource));
     }
 
@@ -634,7 +635,6 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     manager.disconnect();
     admin.dropCluster(clusterName);
   }
-
 
   /**
    * Test addResourceWithWeight() and validateResourcesForWagedRebalance() by trying to add a resource with incomplete ResourceConfig.

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -585,7 +585,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     admin.enableResource(clusterName, testResource, true);
 
     /*
-     * This is an unit test for sanity check in resetPartition().
+     * This is a unit test for sanity check in resetPartition().
      * There is no running controller in this test. We have end-to-end tests for resetPartition()
      * under webapp/TestResetPartitionState and integration/TestResetPartitionState.
      */


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Address #1003

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

When user reset one or more particular partition(s) using resetPartition API, Helix will throw an exception if the given instance can not be found under aliveInstance path. This could be caused by either of of the following reasons:
1. The instance was part of given cluster but is not alive now, or
2. The instance is not part of this cluster ever.
This PR differentiate these two causes for better debuggability.

This PR also adds a unit test for resetPartition since there is no existing test for it previously.

### Tests

- [X] The following tests are written for this issue:

testResetPartition

- The following is the result of the "mvn test" command on the appropriate module:

> [ERROR] Failures: 
[ERROR]   TestControllerLeadershipChange.testMissingTopStateDurationMonitoring:262 expected:<true> but was:<false>
[ERROR]   TestMessagingService.TestMessageSimpleSendReceiveAsync:240
[ERROR]   TestStateTransitionTimeout.testStateTransitionTimeOut:166 expected:<true> but was:<false>
[ERROR]   TestRebalanceRunningTask.testFixedTargetTaskAndDisabledRebalanceAndNodeAdded:297 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1146, Failures: 4, Errors: 0, Skipped: 1
rerun:
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.992 s - in org.apache.helix.integration.controller.TestControllerLeadershipChange
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.445 s - in org.apache.helix.integration.messaging.TestMessagingService
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.014 s - in org.apache.helix.integration.paticipant.TestStateTransitionTimeout
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.551 s - in org.apache.helix.integration.task.TestRebalanceRunningTask


### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [X] In case of new functionality, my PR adds documentation in the following wiki page:X

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)