### PR TITLE
Add CRUD endpoints to TaskDriver for configurable thread pool size support

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -1142,8 +1142,8 @@ public class TaskDriver {
   }
 
   /**
-   * Get the target task thread pool size of an instance, which is used to construct a task thread
-   * pool. This value is specified by users.
+   * Get the target task thread pool size of an instance, a value that's used to construct the task
+   * thread pool and is created by users.
    * @param instanceName - name of the instance
    * @return the target task thread pool size of the instance
    */
@@ -1159,9 +1159,9 @@ public class TaskDriver {
   }
 
   /**
-   * Set the target task thread pool size of an instance, which is used to construct a task thread
-   * pool. The value is applied on per-instance level towards InstanceConfig. The construction of
-   * thread pool requires JVM restart.
+   * Set the target task thread pool size of an instance. The target task thread pool size goes to
+   * InstanceConfig, and is used to construct the task thread pool. The construction of thread pool
+   * requires JVM restart after the target value has been set.
    * @param instanceName - name of the instance
    * @param targetTaskThreadPoolSize - the target task thread pool size of the instance
    */
@@ -1177,9 +1177,8 @@ public class TaskDriver {
   }
 
   /**
-   * Get the global target task thread pool size of the cluster; the global value is used to
-   * construct task thread pools if the per-instance level target thread pool size is not defined in
-   * InstanceConfigs. This value is specified by users.
+   * Get the global target task thread pool size of the cluster, a value that's used to construct
+   * task thread pools for the cluster's instances and is created by users.
    * @return the global target task thread pool size of the cluster
    */
   public int getGlobalTargetTaskThreadPoolSize() {
@@ -1192,9 +1191,12 @@ public class TaskDriver {
   }
 
   /**
-   * Set the global target task thread pool size of the cluster; the global value is used to
-   * construct task thread pools if the per-instance level target thread pool size is not defined in
-   * InstanceConfigs. The construction of thread pools requires JVM restart.
+   * Set the global target task thread pool size of the cluster. The global target task thread pool
+   * size goes to ClusterConfig, and is applied to all instances of the cluster. If an instance
+   * doesn't specify its target thread pool size in InstanceConfig, then this value in ClusterConfig
+   * will be used to construct its task thread pool. The construction of thread pools requires JVM
+   * restart. If none of the global and per-instance target thread pool sizes are set, a default
+   * size will be used.
    * @param globalTargetTaskThreadPoolSize - the global target task thread pool size of the cluster
    */
   public void setGlobalTargetTaskThreadPoolSize(int globalTargetTaskThreadPoolSize) {

--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -1148,32 +1148,30 @@ public class TaskDriver {
    * @return the target task thread pool size of the instance
    */
   public int getTargetTaskThreadPoolSize(String instanceName) {
-    InstanceConfig instanceConfig =
-        _accessor.getProperty(_accessor.keyBuilder().instanceConfig(instanceName));
-    if (instanceConfig == null) {
-      throw new IllegalArgumentException(
-          "Failed to find InstanceConfig with provided instance name " + instanceName);
-    }
-
+    InstanceConfig instanceConfig = getInstanceConfig(instanceName);
     return instanceConfig.getTargetTaskThreadPoolSize();
   }
 
   /**
    * Set the target task thread pool size of an instance. The target task thread pool size goes to
-   * InstanceConfig, and is used to construct the task thread pool. The construction of thread pool
-   * requires JVM restart after the target value has been set.
+   * InstanceConfig, and is used to construct the task thread pool. The newly-set target task
+   * thread pool size will take effect upon a JVM restart.
    * @param instanceName - name of the instance
    * @param targetTaskThreadPoolSize - the target task thread pool size of the instance
    */
   public void setTargetTaskThreadPoolSize(String instanceName, int targetTaskThreadPoolSize) {
+    InstanceConfig instanceConfig = getInstanceConfig(instanceName);
+    instanceConfig.setTargetTaskThreadPoolSize(targetTaskThreadPoolSize);
+  }
+
+  private InstanceConfig getInstanceConfig(String instanceName) {
     InstanceConfig instanceConfig =
         _accessor.getProperty(_accessor.keyBuilder().instanceConfig(instanceName));
     if (instanceConfig == null) {
       throw new IllegalArgumentException(
           "Failed to find InstanceConfig with provided instance name " + instanceName + "!");
     }
-
-    instanceConfig.setTargetTaskThreadPoolSize(targetTaskThreadPoolSize);
+    return instanceConfig;
   }
 
   /**
@@ -1182,11 +1180,7 @@ public class TaskDriver {
    * @return the global target task thread pool size of the cluster
    */
   public int getGlobalTargetTaskThreadPoolSize() {
-    ClusterConfig clusterConfig = _accessor.getProperty(_accessor.keyBuilder().clusterConfig());
-    if (clusterConfig == null) {
-      throw new IllegalStateException("Failed to find ClusterConfig!");
-    }
-
+    ClusterConfig clusterConfig = getClusterConfig();
     return clusterConfig.getGlobalTargetTaskThreadPoolSize();
   }
 
@@ -1194,18 +1188,23 @@ public class TaskDriver {
    * Set the global target task thread pool size of the cluster. The global target task thread pool
    * size goes to ClusterConfig, and is applied to all instances of the cluster. If an instance
    * doesn't specify its target thread pool size in InstanceConfig, then this value in ClusterConfig
-   * will be used to construct its task thread pool. The construction of thread pools requires JVM
-   * restart. If none of the global and per-instance target thread pool sizes are set, a default
-   * size will be used.
+   * will be used to construct its task thread pool. The newly-set target task thread pool size will
+   * take effect upon a JVM restart. If none of the global and per-instance target thread pool sizes
+   * are set, a default size will be used.
    * @param globalTargetTaskThreadPoolSize - the global target task thread pool size of the cluster
    */
   public void setGlobalTargetTaskThreadPoolSize(int globalTargetTaskThreadPoolSize) {
+    ClusterConfig clusterConfig = getClusterConfig();
+    clusterConfig.setGlobalTargetTaskThreadPoolSize(globalTargetTaskThreadPoolSize);
+  }
+
+  private ClusterConfig getClusterConfig() {
     ClusterConfig clusterConfig = _accessor.getProperty(_accessor.keyBuilder().clusterConfig());
     if (clusterConfig == null) {
-      throw new IllegalStateException("Failed to find ClusterConfig!");
+      throw new IllegalStateException(
+          "Failed to find ClusterConfig for cluster " + _clusterName + "!");
     }
-
-    clusterConfig.setGlobalTargetTaskThreadPoolSize(globalTargetTaskThreadPoolSize);
+    return clusterConfig;
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/task/TestTaskDriver.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestTaskDriver.java
@@ -1,0 +1,108 @@
+package org.apache.helix.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.InstanceConfig;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestTaskDriver extends TaskTestBase {
+  // Use a thread pool size that's different from the default value for test
+  private static final int TEST_THREAD_POOL_SIZE = TaskConstants.DEFAULT_TASK_THREAD_POOL_SIZE + 1;
+  private static final String NON_EXISTENT_INSTANCE_NAME = "NON_EXISTENT_INSTANCE_NAME";
+
+  private TaskDriver _taskDriver;
+  private ConfigAccessor _configAccessor;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    super.beforeClass();
+
+    _taskDriver = new TaskDriver(_controller);
+    _configAccessor = _controller.getConfigAccessor();
+  }
+
+  @Test
+  public void testGetTargetTaskThreadPoolSize() {
+    String validInstanceName = _participants[0].getInstanceName();
+    InstanceConfig instanceConfig =
+        _configAccessor.getInstanceConfig(CLUSTER_NAME, validInstanceName);
+    instanceConfig.setTargetTaskThreadPoolSize(TEST_THREAD_POOL_SIZE);
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, validInstanceName, instanceConfig);
+
+    Assert.assertEquals(_taskDriver.getTargetTaskThreadPoolSize(validInstanceName),
+        TEST_THREAD_POOL_SIZE);
+  }
+
+  @Test(dependsOnMethods = "testGetTargetTaskThreadPoolSize", expectedExceptions = IllegalArgumentException.class)
+  public void testGetTargetTaskThreadPoolSizeWrongInstanceName() {
+    _taskDriver.getTargetTaskThreadPoolSize(NON_EXISTENT_INSTANCE_NAME);
+  }
+
+  @Test(dependsOnMethods = "testGetTargetTaskThreadPoolSizeWrongInstanceName")
+  public void testSetTargetTaskThreadPoolSize() {
+    String validInstanceName = _participants[0].getInstanceName();
+    _taskDriver.setTargetTaskThreadPoolSize(validInstanceName, TEST_THREAD_POOL_SIZE);
+    InstanceConfig instanceConfig =
+        _configAccessor.getInstanceConfig(CLUSTER_NAME, validInstanceName);
+
+    Assert.assertEquals(instanceConfig.getTargetTaskThreadPoolSize(), TEST_THREAD_POOL_SIZE);
+  }
+
+  @Test(dependsOnMethods = "testSetTargetTaskThreadPoolSize", expectedExceptions = IllegalArgumentException.class)
+  public void testSetTargetTaskThreadPoolSizeWrongInstanceName() {
+    _taskDriver.setTargetTaskThreadPoolSize(NON_EXISTENT_INSTANCE_NAME, TEST_THREAD_POOL_SIZE);
+  }
+
+  @Test(dependsOnMethods = "testSetTargetTaskThreadPoolSizeWrongInstanceName")
+  public void testGetGlobalTargetTaskThreadPoolSize() {
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setGlobalTargetTaskThreadPoolSize(TEST_THREAD_POOL_SIZE);
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    Assert.assertEquals(_taskDriver.getGlobalTargetTaskThreadPoolSize(), TEST_THREAD_POOL_SIZE);
+  }
+
+  @Test(dependsOnMethods = "testGetGlobalTargetTaskThreadPoolSize")
+  public void testSetGlobalTargetTaskThreadPoolSize() {
+    _taskDriver.setGlobalTargetTaskThreadPoolSize(TEST_THREAD_POOL_SIZE);
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+
+    Assert.assertEquals(clusterConfig.getGlobalTargetTaskThreadPoolSize(), TEST_THREAD_POOL_SIZE);
+  }
+
+  @Test(dependsOnMethods = "testSetGlobalTargetTaskThreadPoolSize")
+  public void testGetCurrentTaskThreadPoolSize() {
+    String validInstanceName = _participants[0].getInstanceName();
+
+    Assert.assertEquals(_taskDriver.getCurrentTaskThreadPoolSize(validInstanceName),
+        TaskConstants.DEFAULT_TASK_THREAD_POOL_SIZE);
+  }
+
+  @Test(dependsOnMethods = "testGetCurrentTaskThreadPoolSize", expectedExceptions = IllegalArgumentException.class)
+  public void testGetCurrentTaskThreadPoolSizeWrongInstanceName() {
+    _taskDriver.getCurrentTaskThreadPoolSize(NON_EXISTENT_INSTANCE_NAME);
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1010

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

With the recent changes of configurable thread pool size, we need to allow users to modify the "target thread pool sizes" that will be used to construct task thread pools. We are adding CRUD endpoints to TaskDriver that support "setting target thread pool sizes", "getting target thread pool sizes", "setting global target thread pool sizes", "getting global target thread pool sizes", and "getting current thread pool sizes".

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:
```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:117 expected:<true> but was:<false>
[ERROR]   TestCrossClusterMessagingService.TestMessageSimpleSendReceiveAsync:143
[ERROR]   TestStateTransitionTimeout.testStateTransitionTimeOut:166 expected:<true> but was:<false>
[ERROR]   TestStateTransitionTimeoutWithResource.testStateTransitionTimeOut:171 expected:<true> but was:<false>
[ERROR]   TestStateTransitionTimeoutWithResource.testStateTransitionTimeoutByClusterLevel:196 expected:<true> but was:<false>
[ERROR]   TestZkCacheAsyncOpSingleThread.testHappyPathExtOpZkCacheBaseDataAccessor:214 zkCache doesn't match data on Zk expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1169, Failures: 6, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:15 h
[INFO] Finished at: 2020-05-14T16:18:58-07:00
[INFO] ------------------------------------------------------------------------
```
Rerun failed tests
```
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 81.366 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:26 min
[INFO] Finished at: 2020-05-14T16:23:04-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)