### PR TITLE
Add null check in close() of ZkConnectionManager

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/ZkConnectionManager.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/ZkConnectionManager.java
@@ -118,7 +118,7 @@ public class ZkConnectionManager extends ZkClient {
 
   protected synchronized void close(boolean skipIfWatched) {
     cleanupInactiveWatchers();
-    if (_sharedWatchers.size() > 0) {
+    if (_sharedWatchers != null && _sharedWatchers.size() > 0) {
       if (skipIfWatched) {
         LOG.debug("Skip closing ZkConnection due to existing watchers. Watcher count {}.",
             _sharedWatchers.size());
@@ -134,12 +134,15 @@ public class ZkConnectionManager extends ZkClient {
 
   protected void cleanupInactiveWatchers() {
     Set<Watcher> closedWatchers = new HashSet<>();
-    for (Watcher watcher : _sharedWatchers) {
-      // TODO ideally, we shall have a ClosableWatcher interface so as to check accordingly. -- JJ
-      if (watcher instanceof SharedZkClient && ((SharedZkClient) watcher).isClosed()) {
-        closedWatchers.add(watcher);
+    // Null check needed because close() might get invoked before initialization
+    if (_sharedWatchers != null) {
+      for (Watcher watcher : _sharedWatchers) {
+        // TODO ideally, we shall have a ClosableWatcher interface so as to check accordingly. -- JJ
+        if (watcher instanceof SharedZkClient && ((SharedZkClient) watcher).isClosed()) {
+          closedWatchers.add(watcher);
+        }
       }
+      _sharedWatchers.removeAll(closedWatchers);
     }
-    _sharedWatchers.removeAll(closedWatchers);
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1015

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Java objects may not have been fully initialized when their callback/interface methods are called. This adds a null check to ensure that an NPE does not happen.

### Tests

- [x] The following tests are written for this issue:

Simple null check. No explicit test needed.

Build result:

```
[INFO] Reactor Summary for Apache Helix 1.0.1-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  1.461 s]
[INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  2.682 s]
[INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [  1.861 s]
[INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [  3.128 s]
[INFO] Apache Helix :: Helix Common ....................... SUCCESS [  1.780 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [ 20.650 s]
[INFO] Apache Helix :: Admin Webapp ....................... SUCCESS [  2.814 s]
[INFO] Apache Helix :: Restful Interface .................. SUCCESS [  5.717 s]
[INFO] Apache Helix :: Distributed Lock ................... SUCCESS [  1.011 s]
[INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  1.552 s]
[INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.035 s]
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  0.964 s]
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  1.051 s]
[INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  0.952 s]
[INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  0.885 s]
[INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  0.903 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  48.452 s
[INFO] Finished at: 2020-05-18T14:08:53-07:00
[INFO] ------------------------------------------------------------------------
```


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)