### PR TITLE
ConnectionTimeout change to ensure HelixManager initial connection

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/ZkClient.java
@@ -62,7 +62,10 @@ public class ZkClient extends org.apache.helix.zookeeper.zkclient.ZkClient imple
   private static Logger LOG = LoggerFactory.getLogger(ZkClient.class);
 
   public static final int DEFAULT_OPERATION_TIMEOUT = Integer.MAX_VALUE;
-  public static final int DEFAULT_CONNECTION_TIMEOUT = 60 * 1000;
+  // Four times of DEFAULT_SESSION_TIMEOUT would give less 1/125 chance of initial connection
+  // to Zookeeper failure assuming one observer in the 5 observer Zookeeper Quorum is down
+  // with one DNS name configured as connection string with 3.4.13+ Zookeeper client version
+  public static final int DEFAULT_CONNECTION_TIMEOUT = 120 * 1000;
   public static final int DEFAULT_SESSION_TIMEOUT = 30 * 1000;
 
   /**


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

(fix #1018 )

### Description

- [x] Here are some details about my PR:

ConnectionTimeout change to ensure HelixManager initial connection.

Ensure HelixManager initial session establishment to
ZooKeeper server would be highly like to succeed given one quorum
node unresponsive. This is done by make default connection timeout
value 4 times of default session timeout value.

### Tests

- [ ] The following tests are written for this issue:

- [ ] The following is the result of the "mvn test" command on the appropriate module:

running, will add later.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)