### PR TITLE
Add configurable thread pool size endpoints to Helix REST

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
+import org.apache.helix.task.TaskConstants;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.api.config.HelixConfigProperty;
 import org.apache.helix.api.config.StateTransitionThrottleConfig;
@@ -144,7 +145,6 @@ public class ClusterConfig extends HelixProperty {
   private final static int MAX_REBALANCE_PREFERENCE = 10;
   private final static int MIN_REBALANCE_PREFERENCE = 0;
   public final static boolean DEFAULT_GLOBAL_REBALANCE_ASYNC_MODE_ENABLED = true;
-  private static final int GLOBAL_TARGET_TASK_THREAD_POOL_SIZE_NOT_SET = -1;
 
   /**
    * Instantiate for a specific cluster
@@ -727,7 +727,7 @@ public class ClusterConfig extends HelixProperty {
   public int getGlobalTargetTaskThreadPoolSize() {
     return _record
         .getIntField(ClusterConfig.ClusterConfigProperty.GLOBAL_TARGET_TASK_THREAD_POOL_SIZE.name(),
-            GLOBAL_TARGET_TASK_THREAD_POOL_SIZE_NOT_SET);
+            TaskConstants.TARGET_TASK_THREAD_POOL_SIZE_NOT_SET);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import com.google.common.base.Splitter;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
+import org.apache.helix.task.TaskConstants;
 import org.apache.helix.util.HelixUtil;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
@@ -62,7 +63,6 @@ public class InstanceConfig extends HelixProperty {
 
   public static final int WEIGHT_NOT_SET = -1;
   public static final int MAX_CONCURRENT_TASK_NOT_SET = -1;
-  private static final int TARGET_TASK_THREAD_POOL_SIZE_NOT_SET = -1;
 
   private static final Logger _logger = LoggerFactory.getLogger(InstanceConfig.class.getName());
 
@@ -515,7 +515,7 @@ public class InstanceConfig extends HelixProperty {
   public int getTargetTaskThreadPoolSize() {
     return _record
         .getIntField(InstanceConfig.InstanceConfigProperty.TARGET_TASK_THREAD_POOL_SIZE.name(),
-            TARGET_TASK_THREAD_POOL_SIZE_NOT_SET);
+            TaskConstants.TARGET_TASK_THREAD_POOL_SIZE_NOT_SET);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/task/TaskConstants.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskConstants.java
@@ -56,4 +56,11 @@ public class TaskConstants {
    * pool size default value if the current thread pool size is not defined in LiveInstance
    */
   public final static int DEFAULT_TASK_THREAD_POOL_SIZE = 40;
+
+  /**
+   * This value is used in InstanceConfig and ClusterConfig. When target task thread pool sizes are
+   * not defined, this value is returned. Due to the non-negative check in
+   * TaskUtil.getTargetThreadPoolSize(), this value must be negative.
+   */
+  public final static int TARGET_TASK_THREAD_POOL_SIZE_NOT_SET = -1;
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -927,9 +927,9 @@ public class ClusterAccessor extends AbstractHelixResource {
    * @param threadPoolSize - the thread pool size to be set
    */
   @POST
-  @Path("{clusterId}/global-target-task-thread-pool-size/{threadPoolSize}")
+  @Path("{clusterId}/global-target-task-thread-pool-size")
   public Response updateGlobalTargetTaskThreadPoolSize(@PathParam("clusterId") String clusterId,
-      @PathParam("threadPoolSize") int threadPoolSize) {
+      @QueryParam("threadPoolSize") int threadPoolSize) {
     ConfigAccessor accessor = getConfigAccessor();
     ClusterConfig config;
     try {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -589,10 +589,10 @@ public class PerInstanceAccessor extends AbstractHelixResource {
    * @param threadPoolSize - the thread pool size to be set
    */
   @POST
-  @Path("target-task-thread-pool-size/{threadPoolSize}")
+  @Path("target-task-thread-pool-size")
   public Response updateTargetTaskThreadPoolSize(@PathParam("clusterId") String clusterId,
       @PathParam("instanceName") String instanceName,
-      @PathParam("threadPoolSize") int threadPoolSize) {
+      @QueryParam("threadPoolSize") int threadPoolSize) {
     ConfigAccessor accessor = getConfigAccessor();
     InstanceConfig config;
     try {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -1193,8 +1193,9 @@ public class TestClusterAccessor extends AbstractTestClass {
     int testThreadPoolSize = 101;
 
     String cluster = _clusters.iterator().next();
-    post("clusters/" + cluster + "/global-target-task-thread-pool-size/" + testThreadPoolSize, null,
-        null, Response.Status.OK.getStatusCode());
+    post("clusters/" + cluster + "/global-target-task-thread-pool-size",
+        ImmutableMap.of("threadPoolSize", Integer.toString(testThreadPoolSize)), null,
+        Response.Status.OK.getStatusCode());
     ClusterConfig clusterConfigZk = _configAccessor.getClusterConfig(cluster);
 
     Assert.assertEquals(clusterConfigZk.getGlobalTargetTaskThreadPoolSize(), testThreadPoolSize);
@@ -1204,8 +1205,8 @@ public class TestClusterAccessor extends AbstractTestClass {
   @Test(dependsOnMethods = "testUpdateGlobalTaskThreadPoolSize")
   public void testUpdateGlobalTaskThreadPoolSizeNoCluster() {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
-    post("clusters/NON_EXISTENT_CLUSTER/global-target-task-thread-pool-size/100", null, null,
-        Response.Status.NOT_FOUND.getStatusCode());
+    post("clusters/NON_EXISTENT_CLUSTER/global-target-task-thread-pool-size",
+        ImmutableMap.of("threadPoolSize", "100"), null, Response.Status.NOT_FOUND.getStatusCode());
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
@@ -1213,8 +1214,8 @@ public class TestClusterAccessor extends AbstractTestClass {
   public void testUpdateGlobalTaskThreadPoolSizeBadRequest() {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String cluster = _clusters.iterator().next();
-    post("clusters/" + cluster + "/global-target-task-thread-pool-size/-1", null,
-        null, Response.Status.BAD_REQUEST.getStatusCode());
+    post("clusters/" + cluster + "/global-target-task-thread-pool-size",
+        ImmutableMap.of("threadPoolSize", "-1"), null, Response.Status.BAD_REQUEST.getStatusCode());
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -1149,6 +1149,75 @@ public class TestClusterAccessor extends AbstractTestClass {
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
+  @Test(dependsOnMethods = "testDeleteCustomizedConfig")
+  public void testGetGlobalTaskThreadPoolSizeNotDefined() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String cluster = _clusters.iterator().next();
+    get("clusters/" + cluster + "/global-target-task-thread-pool-size", null,
+        Response.Status.NOT_FOUND.getStatusCode(), true);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testGetGlobalTaskThreadPoolSizeNotDefined")
+  public void testGetGlobalTaskThreadPoolSize() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    int testThreadPoolSize = 100;
+
+    String cluster = _clusters.iterator().next();
+    ClusterConfig clusterConfigZk = _configAccessor.getClusterConfig(cluster);
+    clusterConfigZk.setGlobalTargetTaskThreadPoolSize(testThreadPoolSize);
+    _configAccessor.setClusterConfig(cluster, clusterConfigZk);
+
+    String body = get("clusters/" + cluster + "/global-target-task-thread-pool-size", null,
+        Response.Status.OK.getStatusCode(), true);
+    @SuppressWarnings("unchecked")
+    Map<String, Integer> resultMap = OBJECT_MAPPER.readValue(body, Map.class);
+
+    Assert.assertEquals((int) resultMap
+            .get(ClusterAccessor.ClusterProperties.globalTargetTaskThreadPoolSize.name()),
+        testThreadPoolSize);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testGetGlobalTaskThreadPoolSize")
+  public void testGetGlobalTaskThreadPoolSizeNoCluster() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    get("clusters/NON_EXISTENT_CLUSTER/global-target-task-thread-pool-size", null,
+        Response.Status.NOT_FOUND.getStatusCode(), true);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testGetGlobalTaskThreadPoolSizeNoCluster")
+  public void testUpdateGlobalTaskThreadPoolSize() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    int testThreadPoolSize = 101;
+
+    String cluster = _clusters.iterator().next();
+    post("clusters/" + cluster + "/global-target-task-thread-pool-size/" + testThreadPoolSize, null,
+        null, Response.Status.OK.getStatusCode());
+    ClusterConfig clusterConfigZk = _configAccessor.getClusterConfig(cluster);
+
+    Assert.assertEquals(clusterConfigZk.getGlobalTargetTaskThreadPoolSize(), testThreadPoolSize);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testUpdateGlobalTaskThreadPoolSize")
+  public void testUpdateGlobalTaskThreadPoolSizeNoCluster() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    post("clusters/NON_EXISTENT_CLUSTER/global-target-task-thread-pool-size/100", null, null,
+        Response.Status.NOT_FOUND.getStatusCode());
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testUpdateGlobalTaskThreadPoolSizeNoCluster")
+  public void testUpdateGlobalTaskThreadPoolSizeBadRequest() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String cluster = _clusters.iterator().next();
+    post("clusters/" + cluster + "/global-target-task-thread-pool-size/-1", null,
+        null, Response.Status.BAD_REQUEST.getStatusCode());
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
   private ClusterConfig getClusterConfigFromRest(String cluster) throws IOException {
     String body = get("clusters/" + cluster + "/configs", null, Response.Status.OK.getStatusCode(), true);
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -497,7 +497,8 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     int testTargetTaskThreadPoolSize = 101;
     post("clusters/" + CLUSTER_NAME + "/instances/" + INSTANCE_NAME
-            + "/target-task-thread-pool-size/" + testTargetTaskThreadPoolSize, null, null,
+            + "/target-task-thread-pool-size",
+        ImmutableMap.of("threadPoolSize", Integer.toString(testTargetTaskThreadPoolSize)), null,
         Response.Status.OK.getStatusCode());
     Assert.assertEquals(_configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME)
         .getTargetTaskThreadPoolSize(), testTargetTaskThreadPoolSize);
@@ -507,9 +508,9 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
   @Test(dependsOnMethods = "testUpdateTargetTaskThreadPoolSize")
   public void testUpdateTargetTaskThreadPoolSizeNotFound() {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
-    post("clusters/" + CLUSTER_NAME
-            + "/instances/NON_EXISTENT_INSTACE/target-task-thread-pool-size/100", null, null,
-        Response.Status.NOT_FOUND.getStatusCode());
+    post(
+        "clusters/" + CLUSTER_NAME + "/instances/NON_EXISTENT_INSTACE/target-task-thread-pool-size",
+        ImmutableMap.of("threadPoolSize", "100"), null, Response.Status.NOT_FOUND.getStatusCode());
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
@@ -517,7 +518,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
   public void testUpdateTargetTaskThreadPoolSizeBadRequest() {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     post("clusters/" + CLUSTER_NAME + "/instances/" + INSTANCE_NAME
-            + "/target-task-thread-pool-size/-1", null, null,
+            + "/target-task-thread-pool-size", ImmutableMap.of("threadPoolSize", "-1"), null,
         Response.Status.BAD_REQUEST.getStatusCode());
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1020 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In order to support configurable task thread pool size, we are adding endpoints to Helix REST to support relevant operations. The endpoints will be added to ClusterAccessor and PerInstanceAccessor as the operations are performed on ClusterConfig, InstanceConfig and LiveInstance.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:
```
[INFO] Tests run: 172, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 182.418 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 172, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:05 min
[INFO] Finished at: 2020-05-20T10:14:05-07:00
[INFO] ------------------------------------------------------------------------

```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)