### PR TITLE
Fix incorrect name in exception of SharedZkClient

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -518,13 +518,12 @@ public class SharedZkClient implements RealmAwareZkClient {
   }
 
   private void checkIfPathContainsShardingKey(String path) {
-    // TODO: replace with the singleton MetadataStoreRoutingData
     try {
       String zkRealmForPath = _metadataStoreRoutingData.getMetadataStoreRealm(path);
       if (!_zkRealmAddress.equals(zkRealmForPath)) {
         throw new IllegalArgumentException("Given path: " + path + "'s ZK realm: " + zkRealmForPath
             + " does not match the ZK realm: " + _zkRealmAddress + " and sharding key: "
-            + _zkRealmShardingKey + " for this DedicatedZkClient!");
+            + _zkRealmShardingKey + " for this SharedZkClient!");
       }
     } catch (NoSuchElementException e) {
       throw new IllegalArgumentException(


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1004 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

There is a typo in the IllegalArgumentException of SharedZkClient which is confusing. `DedicatedZkClient` should change to `SharedZkClient`.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

Run tests in zookeeper-api
```
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.851 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.155 s
[INFO] Finished at: 2020-05-25T22:13:43-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)