### PR TITLE
Remove commented out code in participant manager

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -201,18 +201,6 @@ public class ParticipantManager {
           String domain = cloudInstanceInformation
               .get(CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name()) + _instanceName;
 
-          // Disable the verification for now
-          /*String cloudIdInRemote = cloudInstanceInformation
-              .get(CloudInstanceInformation.CloudInstanceField.INSTANCE_SET_NAME.name());
-          String cloudIdInConfig = _configAccessor.getCloudConfig(_clusterName).getCloudID();
-
-          // validate that the instance is auto registering to the correct cluster
-          if (!cloudIdInRemote.equals(cloudIdInConfig)) {
-            throw new IllegalArgumentException(String.format(
-                "cloudId in config: %s is not consistent with cloudId from remote: %s. The instance is auto registering to a wrong cluster.",
-                cloudIdInConfig, cloudIdInRemote));
-          }*/
-
           InstanceConfig instanceConfig = HelixUtil.composeInstanceConfig(_instanceName);
           instanceConfig.setDomain(domain);
           _helixAdmin.addInstance(_clusterName, instanceConfig);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

(#1026 )

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Remove commented out code in Helix participant manager for clarity.

### Tests

- [X] The following is the result of the "mvn test" command on the appropriate module:
in helix-core:
[ERROR] Failures: 
[ERROR]   TestClusterInMaintenanceModeWhenReachingMaxPartition.testDisableCluster:119 expected:<true> but was:<false>
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp:107 » ThreadTimeout Method org.tes...
[ERROR]   TestRebalanceRunningTask.testFixedTargetTaskAndDisabledRebalanceAndNodeAdded:297 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1147, Failures: 3, Errors: 0, Skipped: 1

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)