### PR TITLE
Add getIdealAssignmentForWagedFullAuto in HelixUtil for WAGED rebalancer

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -601,6 +601,14 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     return _resourceConfigCache.getPropertyMap();
   }
 
+  /**
+   * Sets the resource config map
+   * @param resourceConfigMap
+   */
+  public void setResourceConfigMap(Map<String, ResourceConfig> resourceConfigMap) {
+    _resourceConfigCache.setPropertyMap(resourceConfigMap);
+  }
+
   public ResourceConfig getResourceConfig(String resource) {
     return _resourceConfigCache.getPropertyByName(resource);
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
@@ -1,0 +1,88 @@
+package org.apache.helix.controller.rebalancer.waged;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.helix.HelixRebalanceException;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.rebalancer.waged.constraints.ConstraintBasedAlgorithmFactory;
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.manager.zk.ZkBucketDataAccessor;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.Resource;
+import org.apache.helix.model.ResourceAssignment;
+
+
+/**
+ * This rebalancer is a version of WagedRebalancer that only reads the existing assignment metadata
+ * to compute the best possible assignment but never writes back the resulting assignment metadata
+ * from global or partial rebalance. It does so by using a modified version of
+ * AssignmentMetadataStore, ReadOnlyAssignmentMetadataStore.
+ *
+ * This class is to be used in the cluster verifiers, tests, or util methods.
+ */
+public class ReadOnlyWagedRebalancer extends WagedRebalancer {
+  public ReadOnlyWagedRebalancer(String metadataStoreAddress, String clusterName,
+      Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> preferences) {
+    super(new ReadOnlyAssignmentMetadataStore(metadataStoreAddress, clusterName),
+        ConstraintBasedAlgorithmFactory.getInstance(preferences), Optional.empty());
+  }
+
+  @Override
+  protected Map<String, ResourceAssignment> computeBestPossibleAssignment(
+      ResourceControllerDataProvider clusterData, Map<String, Resource> resourceMap,
+      Set<String> activeNodes, CurrentStateOutput currentStateOutput, RebalanceAlgorithm algorithm)
+      throws HelixRebalanceException {
+    return getBestPossibleAssignment(getAssignmentMetadataStore(), currentStateOutput,
+        resourceMap.keySet());
+  }
+
+  private static class ReadOnlyAssignmentMetadataStore extends AssignmentMetadataStore {
+    ReadOnlyAssignmentMetadataStore(String metadataStoreAddress, String clusterName) {
+      super(new ZkBucketDataAccessor(metadataStoreAddress), clusterName);
+    }
+
+    @Override
+    public boolean persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
+      // If baseline hasn't changed, skip updating the metadata store
+      if (compareAssignments(_globalBaseline, globalBaseline)) {
+        return false;
+      }
+      // Update the in-memory reference only
+      _globalBaseline = globalBaseline;
+      return true;
+    }
+
+    @Override
+    public boolean persistBestPossibleAssignment(
+        Map<String, ResourceAssignment> bestPossibleAssignment) {
+      // If bestPossibleAssignment hasn't changed, skip updating the metadata store
+      if (compareAssignments(_bestPossibleAssignment, bestPossibleAssignment)) {
+        return false;
+      }
+      // Update the in-memory reference only
+      _bestPossibleAssignment = bestPossibleAssignment;
+      return true;
+    }
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
@@ -19,7 +19,6 @@ package org.apache.helix.manager.zk;
  * under the License.
  */
 
-import com.google.common.collect.ImmutableMap;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,18 +29,20 @@ import java.util.TimerTask;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.ImmutableMap;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BucketDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
-import org.apache.helix.zookeeper.util.GZipCompressionUtil;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.impl.client.FederatedZkClient;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
+import org.apache.helix.zookeeper.util.GZipCompressionUtil;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
 import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -167,14 +167,14 @@ public final class HelixUtil {
    * @param clusterConfig
    * @param instanceConfigs
    * @param liveInstances
-   * @param newIdealStates
-   * @param newResourceConfigs
+   * @param idealStates
+   * @param resourceConfigs
    * @return
    */
   public static Map<String, ResourceAssignment> getIdealAssignmentForWagedFullAuto(
       String metadataStoreAddress, ClusterConfig clusterConfig,
       List<InstanceConfig> instanceConfigs, List<String> liveInstances,
-      List<IdealState> newIdealStates, List<ResourceConfig> newResourceConfigs) {
+      List<IdealState> idealStates, List<ResourceConfig> resourceConfigs) {
     // Prepare a data accessor for a dataProvider (cache) refresh
     BaseDataAccessor<ZNRecord> baseDataAccessor = new ZkBaseDataAccessor<>(metadataStoreAddress);
     HelixDataAccessor helixDataAccessor =
@@ -200,8 +200,8 @@ public final class HelixUtil {
           .collect(Collectors.toMap(InstanceConfig::getInstanceName, Function.identity())));
       dataProvider.setLiveInstances(
           liveInstances.stream().map(LiveInstance::new).collect(Collectors.toList()));
-      dataProvider.setIdealStates(newIdealStates);
-      dataProvider.setResourceConfigMap(newResourceConfigs.stream()
+      dataProvider.setIdealStates(idealStates);
+      dataProvider.setResourceConfigMap(resourceConfigs.stream()
           .collect(Collectors.toMap(ResourceConfig::getResourceName, Function.identity())));
 
       event.addAttribute(AttributeName.ControllerDataProvider.name(), dataProvider);

--- a/helix-core/src/main/java/org/apache/helix/util/RebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/RebalanceUtil.java
@@ -28,6 +28,9 @@ import java.util.TreeMap;
 
 import org.apache.helix.HelixException;
 import org.apache.helix.controller.GenericHelixController;
+import org.apache.helix.controller.pipeline.Stage;
+import org.apache.helix.controller.pipeline.StageContext;
+import org.apache.helix.controller.stages.ClusterEvent;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.StateModelDefinition;
 import org.slf4j.Logger;
@@ -163,5 +166,26 @@ public class RebalanceUtil {
       LOG.error("Failed to issue a pipeline. Controller for cluster {} does not exist.",
           clusterName);
     }
+  }
+
+  /**
+   * runStage allows the run of individual stages. It can be used to mock a part of the Controller
+   * pipeline run.
+   *
+   * An example usage is as follows:
+   *       runStage(event, new ResourceComputationStage());
+   *       runStage(event, new CurrentStateComputationStage());
+   *       runStage(event, new BestPossibleStateCalcStage());
+   * By running these stages, we are able to obtain BestPossibleStateOutput in the event object.
+   * @param event
+   * @param stage
+   * @throws Exception
+   */
+  public static void runStage(ClusterEvent event, Stage stage) throws Exception {
+    StageContext context = new StageContext();
+    stage.init(context);
+    stage.preProcess();
+    stage.process(event);
+    stage.postProcess();
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/util/WeightAwareRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/WeightAwareRebalanceUtil.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.helix.HelixException;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.api.config.RebalanceConfig;
 import org.apache.helix.api.rebalancer.constraint.AbstractRebalanceHardConstraint;
 import org.apache.helix.api.rebalancer.constraint.AbstractRebalanceSoftConstraint;
@@ -22,6 +21,7 @@ import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
 /**
  * A rebalance tool that generate an resource partition assignment based on the input.

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
@@ -195,7 +195,7 @@ public class TestWagedRebalance extends ZkTestBase {
     }
   }
 
-  @Test(dependsOnMethods = "testRebalanceTool")
+  @Test(dependsOnMethods = "test")
   public void testWithInstanceTag() throws Exception {
     Set<String> tags = new HashSet<String>(_nodeToTagMap.values());
     int i = 3;
@@ -214,7 +214,7 @@ public class TestWagedRebalance extends ZkTestBase {
     validate(_replica);
   }
 
-  @Test(dependsOnMethods = "testRebalanceTool")
+  @Test(dependsOnMethods = "test")
   public void testChangeIdealState() throws InterruptedException {
     String dbName = "Test-DB-" + TestHelper.getTestMethodName();
     createResourceWithWagedRebalance(CLUSTER_NAME, dbName,
@@ -248,7 +248,7 @@ public class TestWagedRebalance extends ZkTestBase {
     Assert.assertEquals(ev.getPartitionSet().size(), PARTITIONS + 1);
   }
 
-  @Test(dependsOnMethods = "testRebalanceTool")
+  @Test(dependsOnMethods = "test")
   public void testDisableInstance() throws InterruptedException {
     String dbName = "Test-DB-" + TestHelper.getTestMethodName();
     createResourceWithWagedRebalance(CLUSTER_NAME, dbName,
@@ -372,7 +372,7 @@ public class TestWagedRebalance extends ZkTestBase {
     validate(_replica);
   }
 
-  @Test(dependsOnMethods = "testRebalanceTool")
+  @Test(dependsOnMethods = "test")
   public void testMixedRebalancerUsage() throws InterruptedException {
     int i = 0;
     for (String stateModel : _testModels) {
@@ -395,7 +395,7 @@ public class TestWagedRebalance extends ZkTestBase {
     validate(_replica);
   }
 
-  @Test(dependsOnMethods = "testRebalanceTool")
+  @Test(dependsOnMethods = "test")
   public void testMaxPartitionLimitation() throws Exception {
     ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
     ClusterConfig clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
@@ -462,7 +462,7 @@ public class TestWagedRebalance extends ZkTestBase {
     }
   }
 
-  @Test(dependsOnMethods = "testRebalanceTool")
+  @Test(dependsOnMethods = "test")
   public void testNewInstances() throws InterruptedException {
     ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
     ClusterConfig clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
@@ -529,7 +529,7 @@ public class TestWagedRebalance extends ZkTestBase {
    * This test is to verify if the reset has been done and the rebalancer has forgotten any previous
    * status after leadership switched.
    */
-  @Test(dependsOnMethods = "testRebalanceTool")
+  @Test(dependsOnMethods = "test")
   public void testRebalancerReset() throws Exception {
     // Configure the rebalance preference so as to trigger more partition movements for evenness.
     // This is to ensure the controller will try to move something if the rebalancer has been reset.

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TaskTestUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TaskTestUtil.java
@@ -33,6 +33,7 @@ import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.TestHelper;
+import org.apache.helix.util.RebalanceUtil;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.common.DedupEventProcessor;
 import org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider;
@@ -292,14 +293,6 @@ public class TaskTestUtil {
     return cache;
   }
 
-  static void runStage(ClusterEvent event, Stage stage) throws Exception {
-    StageContext context = new StageContext();
-    stage.init(context);
-    stage.preProcess();
-    stage.process(event);
-    stage.postProcess();
-  }
-
   public static BestPossibleStateOutput calculateTaskSchedulingStage(WorkflowControllerDataProvider cache,
       HelixManager manager) throws Exception {
     ClusterEvent event = new ClusterEvent(ClusterEventType.Unknown);
@@ -331,7 +324,7 @@ public class TaskTestUtil {
     stages.add(new TaskGarbageCollectionStage());
 
     for (Stage stage : stages) {
-      runStage(event, stage);
+      RebalanceUtil.runStage(event, stage);
     }
 
     return event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.name());


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1030 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This commit adds a method, getIdealAssignmentForWagedFullAuto() in HelixUtil that returns to the user the cluster-wide assignment result obtained from running a rebalance using WAGED. The user will be able to use this method to predict how Helix will be rebalancing resources using the WAGED rebalancer.

### Tests

- [x] The following tests are written for this issue:

testRebalanceTool

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:116 Â» ThreadTimeout Method...
[ERROR]   TestControllerLeadershipChange.testMissingTopStateDurationMonitoring:262 expected:<true> but was:<false>
[ERROR]   TestDeleteJobFromJobQueue.testForceDeleteJobFromJobQueue:75 Â» Helix Failed to ...
[INFO] 
[ERROR] Tests run: 1148, Failures: 3, Errors: 0, Skipped: 0


Individual runs of failed tests pass.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)

