### PR TITLE
Fix leaking Zk path watch and Callbackhandler issue

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -547,11 +547,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
       // CallbackHandler to install exists watch, namely watch for path not existing.
       // Note when path is removed, the CallbackHanler would remove itself from ZkHelixManager too
       // to avoid leaking a CallbackHandler.
-      if (callbackType == Type.INIT) {
-        _zkClient.subscribeChildChanges(path, this);
-      } else {
-        _zkClient.subscribeChildChanges(path, this, true);
-      }
+      _zkClient.subscribeChildChanges(path, this, callbackType != Type.INIT);
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info(_manager.getInstanceName() + " unsubscribe child-change. path: " + path
           + ", listener: " + _listener);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -569,9 +569,9 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         logger.debug(_manager.getInstanceName() + " subscribe data-change. path: " + path
             + ", listener: " + _listener);
       }
-      boolean rt = _zkClient.subscribeDataChanges(path, this, callbackType != Type.INIT);
-      logger.debug("CallbackHandler {} subscribe data path {} result {}", this, path, rt);
-      if (!rt) {
+      boolean subStatus = _zkClient.subscribeDataChanges(path, this, callbackType != Type.INIT);
+      logger.debug("CallbackHandler {} subscribe data path {} result {}", this, path, subStatus);
+      if (!subStatus) {
         logger.info("CallbackHandler {} subscribe data path {} failed!", this, path);
       }
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
@@ -768,7 +768,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         } else {
           if (!isReady()) {
             // avoid leaking CallbackHandler
-            logger.info("Callbackhandler {} with path {} end of life as not ready to avoid leak",
+            logger.info("Callbackhandler {} with path {} is in reset state. Stop subscription to ZK client to avoid leaking",
                 this, parentPath);
             return;
           }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -73,6 +73,7 @@ import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.monitoring.mbeans.HelixCallbackMonitor;
+import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -547,7 +548,12 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
       // CallbackHandler to install exists watch, namely watch for path not existing.
       // Note when path is removed, the CallbackHanler would remove itself from ZkHelixManager too
       // to avoid leaking a CallbackHandler.
-      _zkClient.subscribeChildChanges(path, this, callbackType != Type.INIT);
+      ChildrenSubscribeResult childrenSubscribeResult = _zkClient.subscribeChildChanges(path, this, callbackType != Type.INIT);
+      logger.debug("CallbackHandler {} subscribe data path {} result {}", this, path,
+          childrenSubscribeResult.isInstalled());
+      if (!childrenSubscribeResult.isInstalled()) {
+        logger.info("CallbackHandler {} subscribe data path {} failed!", this, path);
+      }
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info(_manager.getInstanceName() + " unsubscribe child-change. path: " + path
           + ", listener: " + _listener);
@@ -563,7 +569,11 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         logger.debug(_manager.getInstanceName() + " subscribe data-change. path: " + path
             + ", listener: " + _listener);
       }
-      _zkClient.subscribeDataChanges(path, this, callbackType != Type.INIT);
+      boolean rt = _zkClient.subscribeDataChanges(path, this, callbackType != Type.INIT);
+      logger.debug("CallbackHandler {} subscribe data path {} result {}", this, path, rt);
+      if (!rt) {
+        logger.info("CallbackHandler {} subscribe data path {} failed!", this, path);
+      }
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info(_manager.getInstanceName() + " unsubscribe data-change. path: " + path
           + ", listener: " + _listener);
@@ -758,6 +768,8 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         } else {
           if (!isReady()) {
             // avoid leaking CallbackHandler
+            logger.info("Callbackhandler {} with path {} end of life as not ready to avoid leak",
+                this, parentPath);
             return;
           }
           NotificationContext changeContext = new NotificationContext(_manager);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -563,7 +563,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         logger.debug(_manager.getInstanceName() + " subscribe data-change. path: " + path
             + ", listener: " + _listener);
       }
-      _zkClient.subscribeDataChanges(path, this, true);
+      _zkClient.subscribeDataChanges(path, this, callbackType != Type.INIT);
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info(_manager.getInstanceName() + " unsubscribe data-change. path: " + path
           + ", listener: " + _listener);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -539,7 +539,11 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         logger.debug(_manager.getInstanceName() + " subscribes child-change. path: " + path
             + ", listener: " + _listener);
       }
-      _zkClient.subscribeChildChanges(path, this);
+      if (callbackType == Type.INIT) {
+        _zkClient.subscribeChildChanges(path, this);
+      } else {
+        _zkClient.subscribeChildChanges(path, this, true);
+      }
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info(_manager.getInstanceName() + " unsubscribe child-change. path: " + path
           + ", listener: " + _listener);
@@ -555,7 +559,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         logger.debug(_manager.getInstanceName() + " subscribe data-change. path: " + path
             + ", listener: " + _listener);
       }
-      _zkClient.subscribeDataChanges(path, this);
+      _zkClient.subscribeDataChanges(path, this, true);
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info(_manager.getInstanceName() + " unsubscribe data-change. path: " + path
           + ", listener: " + _listener);
@@ -752,6 +756,10 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
           changeContext.setType(NotificationContext.Type.CALLBACK);
           changeContext.setPathChanged(parentPath);
           changeContext.setChangeType(_changeType);
+          if (!isReady()) {
+            // avoid leaking CallbackHandler
+            return;
+          }
           subscribeForChanges(changeContext.getType(), _path, _watchChild);
           enqueueTask(changeContext);
         }

--- a/helix-core/src/test/java/org/apache/helix/integration/TestZkCallbackHandlerLeak.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestZkCallbackHandlerLeak.java
@@ -324,6 +324,7 @@ public class TestZkCallbackHandlerLeak extends ZkUnitTestBase {
 
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
   }
+
   @Test
   public void testDanglingCallbackHanlderFix() throws Exception {
     String className = TestHelper.getTestClassName();

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterControllerManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterControllerManager.java
@@ -35,76 +35,15 @@ import org.slf4j.LoggerFactory;
 /**
  * The standalone cluster controller class
  */
-public class ClusterControllerManager extends ZKHelixManager implements Runnable, ZkTestManager {
+public class ClusterControllerManager extends ClusterManager {
   private static Logger LOG = LoggerFactory.getLogger(ClusterControllerManager.class);
-
-  private final CountDownLatch _startCountDown = new CountDownLatch(1);
-  private final CountDownLatch _stopCountDown = new CountDownLatch(1);
-  private final CountDownLatch _waitStopFinishCountDown = new CountDownLatch(1);
-
-  private boolean _started = false;
 
   public ClusterControllerManager(String zkAddr, String clusterName) {
     this(zkAddr, clusterName, "controller");
   }
 
   public ClusterControllerManager(String zkAddr, String clusterName, String controllerName) {
-    super(clusterName, controllerName, InstanceType.CONTROLLER, zkAddr);
+    super(zkAddr, clusterName, controllerName, InstanceType.CONTROLLER);
   }
 
-  public void syncStop() {
-    _stopCountDown.countDown();
-    try {
-      _waitStopFinishCountDown.await();
-      _started = false;
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted waiting for finish", e);
-    }
-  }
-
-  // This should not be called more than once because HelixManager.connect() should not be called more than once.
-  public void syncStart() {
-    if (_started) {
-      throw new RuntimeException(
-          "Helix Controller already started. Do not call syncStart() more than once.");
-    } else {
-      _started = true;
-    }
-
-    new Thread(this).start();
-    try {
-      _startCountDown.await();
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted waiting for start", e);
-    }
-  }
-
-  @Override
-  public void run() {
-    try {
-      connect();
-      _startCountDown.countDown();
-      _stopCountDown.await();
-    } catch (Exception e) {
-      LOG.error("exception running controller-manager", e);
-    } finally {
-      _startCountDown.countDown();
-      disconnect();
-      _waitStopFinishCountDown.countDown();
-    }
-  }
-
-  @Override
-  public RealmAwareZkClient getZkClient() {
-    return _zkclient;
-  }
-
-  @Override
-  public List<CallbackHandler> getHandlers() {
-    return _handlers;
-  }
-
-  public List<HelixTimerTask> getControllerTimerTasks() {
-    return _controllerTimerTasks;
-  }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterDistributedController.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterDistributedController.java
@@ -32,35 +32,11 @@ import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ClusterDistributedController extends ZKHelixManager implements Runnable,
-    ZkTestManager {
+public class ClusterDistributedController extends ClusterManager {
   private static Logger LOG = LoggerFactory.getLogger(ClusterDistributedController.class);
 
-  private final CountDownLatch _startCountDown = new CountDownLatch(1);
-  private final CountDownLatch _stopCountDown = new CountDownLatch(1);
-  private final CountDownLatch _waitStopFinishCountDown = new CountDownLatch(1);
-
   public ClusterDistributedController(String zkAddr, String clusterName, String controllerName) {
-    super(clusterName, controllerName, InstanceType.CONTROLLER_PARTICIPANT, zkAddr);
-  }
-
-  public void syncStop() {
-    _stopCountDown.countDown();
-    try {
-      _waitStopFinishCountDown.await();
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted waiting for finish", e);
-    }
-  }
-
-  public void syncStart() {
-    // TODO: prevent start multiple times
-    new Thread(this).start();
-    try {
-      _startCountDown.await();
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted waiting for start", e);
-    }
+    super(zkAddr, clusterName, controllerName, InstanceType.CONTROLLER_PARTICIPANT);
   }
 
   @Override
@@ -81,15 +57,5 @@ public class ClusterDistributedController extends ZKHelixManager implements Runn
       disconnect();
       _waitStopFinishCountDown.countDown();
     }
-  }
-
-  @Override
-  public RealmAwareZkClient getZkClient() {
-    return _zkclient;
-  }
-
-  @Override
-  public List<CallbackHandler> getHandlers() {
-    return _handlers;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterManager.java
@@ -1,5 +1,24 @@
 package org.apache.helix.integration.manager;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterManager.java
@@ -39,12 +39,8 @@ public class ClusterManager extends ZKHelixManager implements Runnable, ZkTestMa
 
   protected boolean _started = false;
 
-  public ClusterManager(String zkAddr, String clusterName, InstanceType type) {
-    this(zkAddr, clusterName, "role", type);
-  }
-
-  public ClusterManager(String zkAddr, String clusterName, String roleName, InstanceType type) {
-    super(clusterName, roleName, type, zkAddr);
+  protected ClusterManager(String zkAddr, String clusterName, String instanceName, InstanceType type) {
+    super(clusterName, instanceName, type, zkAddr);
   }
 
   public void syncStop() {

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterManager.java
@@ -1,0 +1,83 @@
+package org.apache.helix.integration.manager;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.helix.InstanceType;
+import org.apache.helix.manager.zk.CallbackHandler;
+import org.apache.helix.manager.zk.ZKHelixManager;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ClusterManager extends ZKHelixManager implements Runnable, ZkTestManager {
+  private static Logger LOG = LoggerFactory.getLogger(ClusterControllerManager.class);
+
+  protected CountDownLatch _startCountDown = new CountDownLatch(1);
+  protected CountDownLatch _stopCountDown = new CountDownLatch(1);
+  protected CountDownLatch _waitStopFinishCountDown = new CountDownLatch(1);
+
+  protected boolean _started = false;
+
+  public ClusterManager(String zkAddr, String clusterName, InstanceType type) {
+    this(zkAddr, clusterName, "role", type);
+  }
+
+  public ClusterManager(String zkAddr, String clusterName, String roleName, InstanceType type) {
+    super(clusterName, roleName, type, zkAddr);
+  }
+
+  public void syncStop() {
+    _stopCountDown.countDown();
+    try {
+      _waitStopFinishCountDown.await();
+      _started = false;
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted waiting for finish", e);
+    }
+  }
+
+  // This should not be called more than once because HelixManager.connect() should not be called more than once.
+  public void syncStart() {
+    if (_started) {
+      throw new RuntimeException(
+          "Helix Controller already started. Do not call syncStart() more than once.");
+    } else {
+      _started = true;
+    }
+
+    new Thread(this).start();
+    try {
+      _startCountDown.await();
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted waiting for start", e);
+    }
+  }
+
+  @Override
+  public void run() {
+    try {
+      connect();
+      _startCountDown.countDown();
+      _stopCountDown.await();
+    } catch (Exception e) {
+      LOG.error("exception running controller-manager", e);
+    } finally {
+      _startCountDown.countDown();
+      disconnect();
+      _waitStopFinishCountDown.countDown();
+    }
+  }
+
+  @Override
+  public RealmAwareZkClient getZkClient() {
+    return _zkclient;
+  }
+
+  @Override
+  public List<CallbackHandler> getHandlers() {
+    return _handlers;
+  }
+}
+

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterSpectatorManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterSpectatorManager.java
@@ -1,5 +1,24 @@
 package org.apache.helix.integration.manager;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterSpectatorManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterSpectatorManager.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class ClusterSpectatorManager extends ZKHelixManager implements Runnable, ZkTestManager {
+public class ClusterSpectatorManager extends ClusterManager{
   private static Logger LOG = LoggerFactory.getLogger(ClusterControllerManager.class);
 
   private final CountDownLatch _startCountDown = new CountDownLatch(1);
@@ -25,58 +25,6 @@ public class ClusterSpectatorManager extends ZKHelixManager implements Runnable,
   }
 
   public ClusterSpectatorManager(String zkAddr, String clusterName, String spectatorName) {
-    super(clusterName, spectatorName, InstanceType.SPECTATOR, zkAddr);
-  }
-
-  public void syncStop() {
-    _stopCountDown.countDown();
-    try {
-      _waitStopFinishCountDown.await();
-      _started = false;
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted waiting for finish", e);
-    }
-  }
-
-  // This should not be called more than once because HelixManager.connect() should not be called more than once.
-  public void syncStart() {
-    if (_started) {
-      throw new RuntimeException(
-          "Helix Controller already started. Do not call syncStart() more than once.");
-    } else {
-      _started = true;
-    }
-
-    new Thread(this).start();
-    try {
-      _startCountDown.await();
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted waiting for start", e);
-    }
-  }
-
-  @Override
-  public void run() {
-    try {
-      connect();
-      _startCountDown.countDown();
-      _stopCountDown.await();
-    } catch (Exception e) {
-      LOG.error("exception running controller-manager", e);
-    } finally {
-      _startCountDown.countDown();
-      disconnect();
-      _waitStopFinishCountDown.countDown();
-    }
-  }
-
-  @Override
-  public RealmAwareZkClient getZkClient() {
-    return _zkclient;
-  }
-
-  @Override
-  public List<CallbackHandler> getHandlers() {
-    return _handlers;
+    super(zkAddr, clusterName, spectatorName, InstanceType.SPECTATOR);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterSpectatorManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterSpectatorManager.java
@@ -1,0 +1,82 @@
+package org.apache.helix.integration.manager;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.helix.InstanceType;
+import org.apache.helix.manager.zk.CallbackHandler;
+import org.apache.helix.manager.zk.ZKHelixManager;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ClusterSpectatorManager extends ZKHelixManager implements Runnable, ZkTestManager {
+  private static Logger LOG = LoggerFactory.getLogger(ClusterControllerManager.class);
+
+  private final CountDownLatch _startCountDown = new CountDownLatch(1);
+  private final CountDownLatch _stopCountDown = new CountDownLatch(1);
+  private final CountDownLatch _waitStopFinishCountDown = new CountDownLatch(1);
+
+  private boolean _started = false;
+
+  public ClusterSpectatorManager(String zkAddr, String clusterName) {
+    this(zkAddr, clusterName, "spectator");
+  }
+
+  public ClusterSpectatorManager(String zkAddr, String clusterName, String spectatorName) {
+    super(clusterName, spectatorName, InstanceType.SPECTATOR, zkAddr);
+  }
+
+  public void syncStop() {
+    _stopCountDown.countDown();
+    try {
+      _waitStopFinishCountDown.await();
+      _started = false;
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted waiting for finish", e);
+    }
+  }
+
+  // This should not be called more than once because HelixManager.connect() should not be called more than once.
+  public void syncStart() {
+    if (_started) {
+      throw new RuntimeException(
+          "Helix Controller already started. Do not call syncStart() more than once.");
+    } else {
+      _started = true;
+    }
+
+    new Thread(this).start();
+    try {
+      _startCountDown.await();
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted waiting for start", e);
+    }
+  }
+
+  @Override
+  public void run() {
+    try {
+      connect();
+      _startCountDown.countDown();
+      _stopCountDown.await();
+    } catch (Exception e) {
+      LOG.error("exception running controller-manager", e);
+    } finally {
+      _startCountDown.countDown();
+      disconnect();
+      _waitStopFinishCountDown.countDown();
+    }
+  }
+
+  @Override
+  public RealmAwareZkClient getZkClient() {
+    return _zkclient;
+  }
+
+  @Override
+  public List<CallbackHandler> getHandlers() {
+    return _handlers;
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/MockParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/MockParticipantManager.java
@@ -70,7 +70,7 @@ public class MockParticipantManager extends ClusterManager {
   public void setTransition(MockTransition transition) {
     _msModelFactory.setTrasition(transition);
   }
-  
+
   /**
    * This method should be called before syncStart() called after syncStop()
    */

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/MockParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/MockParticipantManager.java
@@ -38,12 +38,8 @@ import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MockParticipantManager extends ZKHelixManager implements Runnable, ZkTestManager {
+public class MockParticipantManager extends ClusterManager {
   private static Logger LOG = LoggerFactory.getLogger(MockParticipantManager.class);
-
-  protected CountDownLatch _startCountDown = new CountDownLatch(1);
-  protected CountDownLatch _stopCountDown = new CountDownLatch(1);
-  protected CountDownLatch _waitStopCompleteCountDown = new CountDownLatch(1);
 
   protected int _transDelay = 10;
 
@@ -63,7 +59,7 @@ public class MockParticipantManager extends ZKHelixManager implements Runnable, 
 
   public MockParticipantManager(String zkAddr, String clusterName, String instanceName,
       int transDelay, HelixCloudProperty helixCloudProperty) {
-    super(clusterName, instanceName, InstanceType.PARTICIPANT, zkAddr);
+    super(zkAddr, clusterName, instanceName, InstanceType.PARTICIPANT);
     _transDelay = transDelay;
     _msModelFactory = new MockMSModelFactory(null);
     _lsModelFactory = new DummyLeaderStandbyStateModelFactory(_transDelay);
@@ -74,25 +70,7 @@ public class MockParticipantManager extends ZKHelixManager implements Runnable, 
   public void setTransition(MockTransition transition) {
     _msModelFactory.setTrasition(transition);
   }
-
-  public void syncStop() {
-    _stopCountDown.countDown();
-    try {
-      _waitStopCompleteCountDown.await();
-    } catch (InterruptedException e) {
-      LOG.error("exception in syncStop participant-manager", e);
-    }
-  }
-
-  public void syncStart() {
-    try {
-      new Thread(this).start();
-      _startCountDown.await();
-    } catch (InterruptedException e) {
-      LOG.error("exception in syncStart participant-manager", e);
-    }
-  }
-
+  
   /**
    * This method should be called before syncStart() called after syncStop()
    */
@@ -100,7 +78,7 @@ public class MockParticipantManager extends ZKHelixManager implements Runnable, 
     syncStop();
     _startCountDown = new CountDownLatch(1);
     _stopCountDown = new CountDownLatch(1);
-    _waitStopCompleteCountDown = new CountDownLatch(1);
+    _waitStopFinishCountDown = new CountDownLatch(1);
   }
 
   @Override
@@ -132,7 +110,7 @@ public class MockParticipantManager extends ZKHelixManager implements Runnable, 
       _startCountDown.countDown();
 
       disconnect();
-      _waitStopCompleteCountDown.countDown();
+      _waitStopFinishCountDown.countDown();
     }
   }
 

--- a/helix-core/src/test/resources/log4j.properties
+++ b/helix-core/src/test/resources/log4j.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 # Set root logger level to DEBUG and its only appender to R.
-log4j.rootLogger=ERROR, C
+log4j.rootLogger=INFO, R
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.C=org.apache.log4j.ConsoleAppender
@@ -26,16 +26,17 @@ log4j.appender.C.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
 
 log4j.appender.R=org.apache.log4j.RollingFileAppender
 log4j.appender.R.layout=org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern=%5p [%C:%M] (%F:%L) - %m%n
+#log4j.appender.R.layout.ConversionPattern=%5p [%C:%M] (%F:%L) - %m%n
+log4j.appender.R.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss.SSS} %-5p [%C{1}][%t][%c{1}] %x - %m%n
 log4j.appender.R.File=target/ClusterManagerLogs/log.txt
 
 log4j.appender.STATUSDUMP=org.apache.log4j.RollingFileAppender
 log4j.appender.STATUSDUMP.layout=org.apache.log4j.SimpleLayout
 log4j.appender.STATUSDUMP.File=target/ClusterManagerLogs/statusUpdates.log
 
-log4j.logger.org.I0Itec=ERROR
-log4j.logger.org.apache=ERROR
-log4j.logger.com.noelios=ERROR
-log4j.logger.org.restlet=ERROR
+log4j.logger.org.I0Itec=INFO
+log4j.logger.org.apache=INFO
+log4j.logger.com.noelios=INFO
+log4j.logger.org.restlet=INFO
 
 log4j.logger.org.apache.helix.monitoring.ZKPathDataDumpTask=ERROR,STATUSDUMP

--- a/helix-core/src/test/resources/log4j.properties
+++ b/helix-core/src/test/resources/log4j.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 # Set root logger level to DEBUG and its only appender to R.
-log4j.rootLogger=INFO, R
+log4j.rootLogger=ERROR, C
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.C=org.apache.log4j.ConsoleAppender
@@ -26,17 +26,16 @@ log4j.appender.C.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
 
 log4j.appender.R=org.apache.log4j.RollingFileAppender
 log4j.appender.R.layout=org.apache.log4j.PatternLayout
-#log4j.appender.R.layout.ConversionPattern=%5p [%C:%M] (%F:%L) - %m%n
-log4j.appender.R.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss.SSS} %-5p [%C{1}][%t][%c{1}] %x - %m%n
+log4j.appender.R.layout.ConversionPattern=%5p [%C:%M] (%F:%L) - %m%n
 log4j.appender.R.File=target/ClusterManagerLogs/log.txt
 
 log4j.appender.STATUSDUMP=org.apache.log4j.RollingFileAppender
 log4j.appender.STATUSDUMP.layout=org.apache.log4j.SimpleLayout
 log4j.appender.STATUSDUMP.File=target/ClusterManagerLogs/statusUpdates.log
 
-log4j.logger.org.I0Itec=INFO
-log4j.logger.org.apache=INFO
-log4j.logger.com.noelios=INFO
-log4j.logger.org.restlet=INFO
+log4j.logger.org.I0Itec=ERROR
+log4j.logger.org.apache=ERROR
+log4j.logger.com.noelios=ERROR
+log4j.logger.org.restlet=ERROR
 
 log4j.logger.org.apache.helix.monitoring.ZKPathDataDumpTask=ERROR,STATUSDUMP

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
@@ -21,10 +21,19 @@ package org.apache.helix.zookeeper.api.client;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+
+
+/** Represents return type of {@link org.apache.helix.zookeeper.api.client.RealmAwareZkClient#subscribeChildChanges(String, IZkChildListener, boolean)}
+ *  The returned value would signal if watch installation to ZooKeeper server succeeded
+ *  or not using field _isInstalled. The _children field would contains the list of child names
+ *  of the watched path. It would be null if the parent path does not exist at the time of watch
+ *  installation.
+ */
 
 public class ChildrenSubscribeResult {
-  private List<String> _children;
-  private boolean _isInstalled;
+  private final List<String> _children;
+  private final boolean _isInstalled;
 
   public ChildrenSubscribeResult(List<String> children, boolean isInstalled) {
     if (children != null) {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
@@ -9,7 +9,11 @@ public class ChildrenSubscribeResult {
   private boolean _isInstalled;
 
   public ChildrenSubscribeResult(List<String> children, boolean isInstalled) {
-    _children = Collections.unmodifiableList(children);
+    if (children != null) {
+      _children = Collections.unmodifiableList(children);
+    } else {
+      _children = null;
+    }
     _isInstalled = isInstalled;
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
@@ -1,4 +1,22 @@
 package org.apache.helix.zookeeper.api.client;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 import java.util.Collections;
 import java.util.List;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
@@ -1,0 +1,23 @@
+package org.apache.helix.zookeeper.api.client;
+
+import java.util.Collections;
+import java.util.List;
+
+
+public class ChildrenSubscribeResult {
+  private List<String> _children;
+  private boolean _isInstalled;
+
+  public ChildrenSubscribeResult(List<String> children, boolean isInstalled) {
+    _children = Collections.unmodifiableList(children);
+    _isInstalled = isInstalled;
+  }
+
+  public List<String> getChildren() {
+    return _children;
+  }
+
+  public boolean isInstalled() {
+    return _isInstalled;
+  }
+}

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
@@ -30,7 +30,6 @@ import org.apache.helix.zookeeper.zkclient.IZkChildListener;
  *  of the watched path. It would be null if the parent path does not exist at the time of watch
  *  installation.
  */
-
 public class ChildrenSubscribeResult {
   private final List<String> _children;
   private final boolean _isInstalled;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -109,10 +109,10 @@ public interface RealmAwareZkClient {
    * WARNING: if the path is created after deletion, users need to re-subscribe the path
    * @param path The zookeeper path
    * @param listener Instance of {@link IZkDataListener}
-   * @param skipWatchingNodeNotExist True means not installing any watch if path does not exist.
+   * @param skipWatchingNonExistNode True means not installing any watch if path does not exist.
    * return True if installation of watch succeed. Otherwise, return false.
    */
-  boolean subscribeDataChanges(String path, IZkDataListener listener, boolean skipWatchingNodeNotExist);
+  boolean subscribeDataChanges(String path, IZkDataListener listener, boolean skipWatchingNonExistNode);
 
   void unsubscribeDataChanges(String path, IZkDataListener listener);
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -68,6 +68,11 @@ public interface RealmAwareZkClient {
   int DEFAULT_CONNECTION_TIMEOUT = 60 * 1000;
   int DEFAULT_SESSION_TIMEOUT = 30 * 1000;
 
+  class ChildrenSubscribeResult {
+    public List<String> children;
+    public boolean isInstalled;
+  }
+
   // listener subscription
   /**
    * Subscribe the path and the listener will handle child events of the path.
@@ -75,6 +80,8 @@ public interface RealmAwareZkClient {
    * WARNING: if the path is created after deletion, users need to re-subscribe the path
    * @param path The zookeeper path
    * @param listener Instance of {@link IZkDataListener}
+   * The method return null if the path does not exists. Otherwise, return a list of children
+   * under the path. The list can be empty if there is no children.
    */
   List<String> subscribeChildChanges(String path, IZkChildListener listener);
 
@@ -83,9 +90,11 @@ public interface RealmAwareZkClient {
    * WARNING: if the path is created after deletion, users need to re-subscribe the path
    * @param path The zookeeper path
    * @param listener Instance of {@link IZkDataListener}
-   * @param skipWatchingNodeNotExist Ture means not installing any watch if path does not exist.
+   * @param skipWatchingNodeNotExist True means not installing any watch if path does not exist.
+   * The method return ChildrentSubsribeResult. If the path does not exists, the isInstalled field
+   * is false. Otherwise, it is true and list of children are returned.
    */
-  List<String> subscribeChildChanges(String path, IZkChildListener listener, boolean skipWatchingNodeNotExist);
+  ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener, boolean skipWatchingNodeNotExist);
 
   void unsubscribeChildChanges(String path, IZkChildListener listener);
 
@@ -103,9 +112,10 @@ public interface RealmAwareZkClient {
    * WARNING: if the path is created after deletion, users need to re-subscribe the path
    * @param path The zookeeper path
    * @param listener Instance of {@link IZkDataListener}
-   * @param skipWatchingNodeNotExist Ture means not installing any watch if path does not exist.
+   * @param skipWatchingNodeNotExist True means not installing any watch if path does not exist.
+   * return True if installation of watch succeed. Otherwise, return false.
    */
-  void subscribeDataChanges(String path, IZkDataListener listener, boolean skipWatchingNodeNotExist);
+  boolean subscribeDataChanges(String path, IZkDataListener listener, boolean skipWatchingNodeNotExist);
 
   void unsubscribeDataChanges(String path, IZkDataListener listener);
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -68,11 +68,6 @@ public interface RealmAwareZkClient {
   int DEFAULT_CONNECTION_TIMEOUT = 60 * 1000;
   int DEFAULT_SESSION_TIMEOUT = 30 * 1000;
 
-  class ChildrenSubscribeResult {
-    public List<String> children;
-    public boolean isInstalled;
-  }
-
   // listener subscription
   /**
    * Subscribe the path and the listener will handle child events of the path.

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -71,9 +71,13 @@ public interface RealmAwareZkClient {
   // listener subscription
   List<String> subscribeChildChanges(String path, IZkChildListener listener);
 
+  List<String> subscribeChildChanges(String path, IZkChildListener listener, boolean skipWatchingNodeNotExist);
+
   void unsubscribeChildChanges(String path, IZkChildListener listener);
 
   void subscribeDataChanges(String path, IZkDataListener listener);
+
+  void subscribeDataChanges(String path, IZkDataListener listener, boolean skipWatchingNodeNotExist);
 
   void unsubscribeDataChanges(String path, IZkDataListener listener);
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -69,14 +69,42 @@ public interface RealmAwareZkClient {
   int DEFAULT_SESSION_TIMEOUT = 30 * 1000;
 
   // listener subscription
+  /**
+   * Subscribe the path and the listener will handle child events of the path.
+   * Add exists watch to path if the path does not exist in ZooKeeper server.
+   * WARNING: if the path is created after deletion, users need to re-subscribe the path
+   * @param path The zookeeper path
+   * @param listener Instance of {@link IZkDataListener}
+   */
   List<String> subscribeChildChanges(String path, IZkChildListener listener);
 
+  /**
+   * Subscribe the path and the listener will handle child events of the path
+   * WARNING: if the path is created after deletion, users need to re-subscribe the path
+   * @param path The zookeeper path
+   * @param listener Instance of {@link IZkDataListener}
+   * @param skipWatchingNodeNotExist Ture means not installing any watch if path does not exist.
+   */
   List<String> subscribeChildChanges(String path, IZkChildListener listener, boolean skipWatchingNodeNotExist);
 
   void unsubscribeChildChanges(String path, IZkChildListener listener);
 
+  /**
+   * Subscribe the path and the listener will handle data events of the path
+   * Add the exists watch to Zookeeper server even if the path does not exists in zookeeper server
+   * WARNING: if the path is created after deletion, users need to re-subscribe the path
+   * @param path The zookeeper path
+   * @param listener Instance of {@link IZkDataListener}
+   */
   void subscribeDataChanges(String path, IZkDataListener listener);
 
+  /**
+   * Subscribe the path and the listener will handle data events of the path
+   * WARNING: if the path is created after deletion, users need to re-subscribe the path
+   * @param path The zookeeper path
+   * @param listener Instance of {@link IZkDataListener}
+   * @param skipWatchingNodeNotExist Ture means not installing any watch if path does not exist.
+   */
   void subscribeDataChanges(String path, IZkDataListener listener, boolean skipWatchingNodeNotExist);
 
   void unsubscribeDataChanges(String path, IZkDataListener listener);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -78,6 +78,7 @@ public interface RealmAwareZkClient {
    * The method return null if the path does not exists. Otherwise, return a list of children
    * under the path. The list can be empty if there is no children.
    */
+  @Deprecated
   List<String> subscribeChildChanges(String path, IZkChildListener listener);
 
   /**
@@ -85,11 +86,11 @@ public interface RealmAwareZkClient {
    * WARNING: if the path is created after deletion, users need to re-subscribe the path
    * @param path The zookeeper path
    * @param listener Instance of {@link IZkDataListener}
-   * @param skipWatchingNodeNotExist True means not installing any watch if path does not exist.
-   * The method return ChildrentSubsribeResult. If the path does not exists, the isInstalled field
+   * @param skipWatchingNonExistNode True means not installing any watch if path does not exist.
+   * @return ChildrentSubsribeResult. If the path does not exists, the isInstalled field
    * is false. Otherwise, it is true and list of children are returned.
    */
-  ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener, boolean skipWatchingNodeNotExist);
+  ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener, boolean skipWatchingNonExistNode);
 
   void unsubscribeChildChanges(String path, IZkChildListener listener);
 
@@ -100,6 +101,7 @@ public interface RealmAwareZkClient {
    * @param path The zookeeper path
    * @param listener Instance of {@link IZkDataListener}
    */
+  @Deprecated
   void subscribeDataChanges(String path, IZkDataListener listener);
 
   /**

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -122,6 +122,12 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public List<String> subscribeChildChanges(String path, IZkChildListener listener,
+      boolean skipWatchingNodeNotExist) {
+    return _rawZkClient.subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
+  }
+
+  @Override
   public void unsubscribeChildChanges(String path, IZkChildListener listener) {
     checkIfPathContainsShardingKey(path);
     _rawZkClient.unsubscribeChildChanges(path, listener);
@@ -131,6 +137,12 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   public void subscribeDataChanges(String path, IZkDataListener listener) {
     checkIfPathContainsShardingKey(path);
     _rawZkClient.subscribeDataChanges(path, listener);
+  }
+
+  @Override
+  public void subscribeDataChanges(String path, IZkDataListener listener,
+      boolean skipWatchingNodeNotExist) {
+    _rawZkClient.subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -122,7 +122,7 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public List<String> subscribeChildChanges(String path, IZkChildListener listener,
+  public ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener,
       boolean skipWatchingNodeNotExist) {
     return _rawZkClient.subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
   }
@@ -140,9 +140,9 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public void subscribeDataChanges(String path, IZkDataListener listener,
+  public boolean subscribeDataChanges(String path, IZkDataListener listener,
       boolean skipWatchingNodeNotExist) {
-    _rawZkClient.subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
+    return _rawZkClient.subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
+import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.util.HttpRoutingDataReader;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -115,7 +115,7 @@ public class FederatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public List<String> subscribeChildChanges(String path, IZkChildListener listener,
+  public ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener,
       boolean skipWatchingNodeNotExist) {
     return getZkClient(path).subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
   }
@@ -131,9 +131,9 @@ public class FederatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public void subscribeDataChanges(String path, IZkDataListener listener,
+  public boolean subscribeDataChanges(String path, IZkDataListener listener,
       boolean skipWatchingNodeNotExist) {
-    getZkClient(path).subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
+    return getZkClient(path).subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -115,6 +115,12 @@ public class FederatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public List<String> subscribeChildChanges(String path, IZkChildListener listener,
+      boolean skipWatchingNodeNotExist) {
+    return getZkClient(path).subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
+  }
+
+  @Override
   public void unsubscribeChildChanges(String path, IZkChildListener listener) {
     getZkClient(path).unsubscribeChildChanges(path, listener);
   }
@@ -122,6 +128,12 @@ public class FederatedZkClient implements RealmAwareZkClient {
   @Override
   public void subscribeDataChanges(String path, IZkDataListener listener) {
     getZkClient(path).subscribeDataChanges(path, listener);
+  }
+
+  @Override
+  public void subscribeDataChanges(String path, IZkDataListener listener,
+      boolean skipWatchingNodeNotExist) {
+    getZkClient(path).subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
+import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
 import org.apache.helix.zookeeper.util.HttpRoutingDataReader;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -125,7 +125,7 @@ public class SharedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public List<String> subscribeChildChanges(String path, IZkChildListener listener,
+  public ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener,
       boolean skipWatchingNodeNotExist) {
     return _innerSharedZkClient.subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
   }
@@ -143,9 +143,9 @@ public class SharedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public void subscribeDataChanges(String path, IZkDataListener listener,
+  public boolean subscribeDataChanges(String path, IZkDataListener listener,
       boolean skipWatchingNodeNotExist) {
-    _innerSharedZkClient.subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
+    return _innerSharedZkClient.subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -125,6 +125,12 @@ public class SharedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public List<String> subscribeChildChanges(String path, IZkChildListener listener,
+      boolean skipWatchingNodeNotExist) {
+    return _innerSharedZkClient.subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
+  }
+
+  @Override
   public void unsubscribeChildChanges(String path, IZkChildListener listener) {
     checkIfPathContainsShardingKey(path);
     _innerSharedZkClient.unsubscribeChildChanges(path, listener);
@@ -134,6 +140,12 @@ public class SharedZkClient implements RealmAwareZkClient {
   public void subscribeDataChanges(String path, IZkDataListener listener) {
     checkIfPathContainsShardingKey(path);
     _innerSharedZkClient.subscribeDataChanges(path, listener);
+  }
+
+  @Override
+  public void subscribeDataChanges(String path, IZkDataListener listener,
+      boolean skipWatchingNodeNotExist) {
+    _innerSharedZkClient.subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
+import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1098,7 +1098,7 @@ public class ZkClient implements Watcher {
    */
   private Stat getStat(final String path, final boolean watch, final boolean useGetData) {
     long startT = System.currentTimeMillis();
-    Stat stat = null;
+    final Stat stat;
     try {
       if (!useGetData) {
         stat = retryUntilConnected(
@@ -1106,11 +1106,10 @@ public class ZkClient implements Watcher {
       } else {
         stat = new Stat();
         try {
-          LOG.debug("getstat() invoked with useGetData() with path: " + path);
-          Stat finalStat = stat;
-          retryUntilConnected(() -> ((ZkConnection) getConnection()).getZookeeper().getData(path, true, finalStat));
+          LOG.debug("getstat() invoked with useGetData() with path: {} ", path);
+          retryUntilConnected(() -> ((ZkConnection) getConnection()).getZookeeper().getData(path, true, stat));
         } catch (ZkNoNodeException e) {
-          LOG.debug("getstat() invoked path: " + path + " null" + " useGetData:" + useGetData);
+          LOG.debug("getstat() invoked path: {}  null  useGetData: {}", path, useGetData);
           record(path, null, startT, ZkClientMonitor.AccessType.READ);
           // Note, exists() path with useGetData false would never throw ZkNoNodeException.
           // thus, only useGetData true, we may get here. In this case, we eat the exception, return
@@ -1331,7 +1330,7 @@ public class ZkClient implements Watcher {
     final String path = event.getPath();
     final boolean pathExists = event.getType() != EventType.NodeDeleted;
     if (EventType.NodeDeleted == event.getType()) {
-      LOG.debug("event delelete: {}", event.getPath());
+      LOG.debug("Event NodeDeleted: {}", event.getPath());
     }
 
     if (event.getType() == EventType.NodeChildrenChanged || event.getType() == EventType.NodeCreated

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1111,6 +1111,12 @@ public class ZkClient implements Watcher {
     } catch (ZkNoNodeException e) {
       LOG.debug("getstat() invoked path: " + path + " null" + " useGetData:" + useGetData);
       record(path, null, startT, ZkClientMonitor.AccessType.READ);
+      // Note, exists() path with useGetData false would never throw ZkNoNodeException.
+      // thus, only useGetData true, we may get here. In this case, we eat the exception, return
+      // null. This is what we wanted. In essence, we simulate exists() in term never throw
+      // ZkNoNodeException. But when node does not exists in ZooKeeper server, we would not install
+      // watch. The side effect is in the case that node exists, this would return payload of
+      // the node data that we don't need. This is the place for further improvement.
       return null;
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.READ);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1124,7 +1124,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("exists, path: " + path + ", time: " + (endT - startT) + " ms");
+        LOG.trace("getData (installWatchOnlyPathExist), path: " + path + ", time: " + (endT - startT) + " ms");
       }
     }
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1331,7 +1331,7 @@ public class ZkClient implements Watcher {
     final String path = event.getPath();
     final boolean pathExists = event.getType() != EventType.NodeDeleted;
     if (EventType.NodeDeleted == event.getType()) {
-      LOG.debug("event delelete:" + event.getPath());
+      LOG.debug("event delelete: {}", event.getPath());
     }
 
     if (event.getType() == EventType.NodeChildrenChanged || event.getType() == EventType.NodeCreated


### PR DESCRIPTION
Short term fix #1034. Get rid of dangling CallbackHandlers and its
related current state parent path in Zookeeper. Get rid of leaking
of current state znode path due to async nature of deletion of
current state znode path to installatio of watcher in various
thread in Helix.

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Short term fix #1034
 
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
. 
Get rid of dangling CallbackHandlers and its
related current state parent path in Zookeeper. Get rid of leaking
of current state znode path due to async nature of deletion of
current state znode path to installatio of watcher in various
thread in Helix.

### Tests

- [x] The following tests are written for this issue:

- TestZkCallbackHandlerLeak_testCurrentStatePathLeakingByAsycRemoval

- TestZkCallbackHandlerLeak_testDanglingCallbackHanlderFix

- [x] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:116 » ThreadTimeout Method...
[ERROR]   TestZkCallbackHandlerLeak.testRemoveUserCbHandlerOnPathRemoval:610 Should have 2 exist-watches: CURRENTSTATE/{oldSessionId} and CURRENTSTATE/{oldSessionId}/TestDB0 expected:<2> but was:<1>
[ERROR]   TestWagedRebalanceTopologyAware.testAddZone:112->TestWagedRebalanceFaultZone.testAddZone:269->TestWagedRebalanceFaultZone.validate:315->TestWagedRebalanceFaultZone.validateZoneAndTagIsolation:339 expected:<3> but was:<2>
[INFO] 
[ERROR] Tests run: 1149, Failures: 3, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Helix 1.0.1-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  0.644 s]
[INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  2.058 s]
[INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [  1.539 s]
[INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [  8.231 s]
[INFO] Apache Helix :: Helix Common ....................... SUCCESS [  1.319 s]
[INFO] Apache Helix :: Core ............................... FAILURE [  01:29 h]
[INFO] Apache Helix :: Admin Webapp ....................... SKIPPED
[INFO] Apache Helix :: Restful Interface .................. SKIPPED
[INFO] Apache Helix :: Distributed Lock ................... SKIPPED
[INFO] Apache Helix :: HelixAgent ......................... SKIPPED
[INFO] Apache Helix :: Recipes ............................ SKIPPED
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SKIPPED
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SKIPPED
[INFO] Apache Helix :: Recipes :: distributed lock manager  SKIPPED
[INFO] Apache Helix :: Recipes :: distributed task execution SKIPPED
[INFO] Apache Helix :: Recipes :: service discovery ....... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:29 h
[INFO] Finished at: 2020-06-03T15:29:36-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/ksun/helix_kaisun2000/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :helix-core
[ksun@ksun-ld1 helix]$ pwd
/home/ksun/helix_kaisun2000/helix
[ksun@ksun-ld1 helix]$ mvn test 


------------------------- 2nd time ----------
[ERROR] Tests run: 1149, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 5,396.812 s <<< FAILURE! - in TestSuite
[ERROR] testRemoveUserCbHandlerOnPathRemoval(org.apache.helix.integration.TestZkCallbackHandlerLeak)  Time elapsed: 3.75 s  <<< FAILURE!
java.lang.AssertionError: Should have 2 exist-watches: CURRENTSTATE/{oldSessionId} and CURRENTSTATE/{oldSessionId}/TestDB0 expected:<2> but was:<1>
        at org.apache.helix.integration.TestZkCallbackHandlerLeak.testRemoveUserCbHandlerOnPathRemoval(TestZkCallbackHandlerLeak.java:610)

[ERROR] testEnableCompressionResource(org.apache.helix.integration.TestEnableCompression)  Time elapsed: 300.777 s  <<< FAILURE!
org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testEnableCompressionResource() didn't finish within the time-out 300000
        at org.apache.helix.integration.TestEnableCompression.testEnableCompressionResource(TestEnableCompression.java:116)

[ERROR] testBasic(org.apache.helix.integration.TestDrop)  Time elapsed: 300.142 s  <<< FAILURE!
org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testBasic() didn't finish within the time-out 300000
        at org.apache.helix.integration.TestDrop.testBasic(TestDrop.java:103)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures: 
[ERROR]   TestDrop.testBasic:103 » ThreadTimeout Method org.testng.internal.TestNGMethod...
[ERROR]   TestEnableCompression.testEnableCompressionResource:116 » ThreadTimeout Method...
[ERROR]   TestZkCallbackHandlerLeak.testRemoveUserCbHandlerOnPathRemoval:610 Should have 2 exist-watches: CURRENTSTATE/{oldSessionId} and CURRENTSTATE/{oldSessionId}/TestDB0 expected:<2> but was:<1>
[INFO]
[ERROR] Tests run: 1149, Failures: 3, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:30 h
[INFO] Finished at: 2020-06-03T17:08:13-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR]
[ERROR] Please refer to /home/ksun/helix_kaisun2000/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ksun@ksun-ld1 helix-core]$ mvn test

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)