### PR TITLE
Clean up lock module dependencies

### DIFF
--- a/helix-lock/helix-lock-1.0.1-SNAPSHOT.ivy
+++ b/helix-lock/helix-lock-1.0.1-SNAPSHOT.ivy
@@ -43,9 +43,6 @@ under the License.
     <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.7.14" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)">
         <artifact name="slf4j-log4j12" ext="jar"/>
     </dependency>
-    <dependency org="org.yaml" name="snakeyaml" rev="1.17">
-        <artifact name="snakeyaml" m:classifier="sources" ext="jar"/>
-    </dependency>
 		<dependency org="org.apache.helix" name="helix-core" rev="1.0.1-SNAPSHOT" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 	</dependencies>
 </ivy-module>

--- a/helix-lock/pom.xml
+++ b/helix-lock/pom.xml
@@ -40,28 +40,8 @@ under the License.
 
   <dependencies>
     <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <version>1.17</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.helix</groupId>
       <artifactId>helix-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.8.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.8</version>
-    </dependency>
-    <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <version>1.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>
@@ -72,11 +52,6 @@ under the License.
       <groupId>org.apache.helix</groupId>
       <artifactId>helix-core</artifactId>
       <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Current ivy file and pom.xml in helix-lock module contain some unnecessary dependencies. This PR cleans up these dependencies.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Removed snakeyaml from ivy file.
Removed snakeyaml, commons-lang3, httpclient,  xstream from pom.xml

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:
helix-lock module
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:23 min
[INFO] Finished at: 2020-05-29T11:50:59-07:00
[INFO] ------------------------------------------------------------------------


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)