### PR TITLE
Code clean up Topology.java

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
@@ -258,25 +258,18 @@ public class Topology {
          * Return a ordered map representing the instance path. The topology order is defined in
          * ClusterConfig.topology.
          */
-        Map<String, String> domainAsMap = new HashMap<>();
-        String[] pathPairs = instanceConfig.getDomainAsString().trim().split(",");
-        for (String pair : pathPairs) {
-          String[] values = pair.trim().split("=");
-          if (values.length != 2 || values[0].isEmpty() || values[1].isEmpty()) {
-            throw new IllegalArgumentException(String.format(
-                "Domain-Value pair %s for instance %s is not valid, failed the topology-aware placement!",
-                pair, instanceName));
-          }
-          domainAsMap.put(values[0], values[1]);
+        Map<String, String> domainAsMap = instanceConfig.getDomainAsMap();
+        if (domainAsMap.isEmpty()) {
+          throw new IllegalArgumentException(String
+              .format("Domain for instance %s is not set, fail the topology-aware placement!",
+                  instanceName));
         }
-
         int numOfMatchedKeys = 0;
         for (String key : clusterTopologyKeys) {
           // if a key does not exist in the instance domain config, using the default domain value.
           String value = domainAsMap.get(key);
           if (value == null || value.length() == 0) {
             value = _defaultDomainPathValues.get(key);
-                //defaultDomainPathValuesCache.computeIfAbsent(key, k -> (DEFAULT_DOMAIN_PREFIX + key));
           } else {
             numOfMatchedKeys++;
           }

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -157,12 +157,12 @@ public class InstanceConfig extends HelixProperty {
 
     String[] pathPairs = domain.trim().split(",");
     for (String pair : pathPairs) {
-      String[] values = pair.trim().split("=");
+      String[] values = pair.split("=");
       if (values.length != 2 || values[0].isEmpty() || values[1].isEmpty()) {
         throw new IllegalArgumentException(
             String.format("Domain-Value pair %s is not valid.", pair));
       }
-      domainAsMap.put(values[0], values[1]);
+      domainAsMap.put(values[0].trim(), values[1].trim());
     }
 
     return domainAsMap;

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -150,12 +150,22 @@ public class InstanceConfig extends HelixProperty {
    */
   public Map<String, String> getDomainAsMap() {
     String domain = getDomainAsString();
+    Map<String, String> domainAsMap = new HashMap<>();
     if (domain == null || domain.isEmpty()) {
-      return Collections.emptyMap();
+      return domainAsMap;
     }
 
-    return Splitter.on(',').trimResults()
-        .withKeyValueSeparator(Splitter.on('=').limit(2).trimResults()).split(domain);
+    String[] pathPairs = domain.trim().split(",");
+    for (String pair : pathPairs) {
+      String[] values = pair.trim().split("=");
+      if (values.length != 2 || values[0].isEmpty() || values[1].isEmpty()) {
+        throw new IllegalArgumentException(
+            String.format("Domain-Value pair %s is not valid.", pair));
+      }
+      domainAsMap.put(values[0], values[1]);
+    }
+
+    return domainAsMap;
   }
 
   /**


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1042 Validate instance topology configuration before let it comes online 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

We need sanity check for topology definition in InstanceConfig in multiple places. Since we already have sanity check logic in controller/rebalancer/topology/Topology.java and controller/rebalancer/waged/model/AssignableNode.java, it's better to extract the logic into an single util function first and use the same logic to do sanity check in multiple places.

This PR is the first PR for issue #1042. It extracts the sanity check logic in multiple functions into one single function in Topology.java to align with the topology verification logic in AssignableNode.java. 

It also changes the implementation for InstanceConfig.getDomainAsMap since to resolve CPU usage hotspot showed in CPU profiler. 




### Tests

- [X] The following tests are written for this issue:

No new test is added since this PR is code clean up.

- [X] The following is the result of the "mvn test" command on the appropriate module:

```
[ERROR] Failures: 
[ERROR]   TestWagedRebalance.testChangeIdealState:271->validate:614 expected:<true> but was:<false>                                                      
[ERROR]   TestDeleteJobFromJobQueue.testForceDeleteJobFromJobQueue:75 » Helix Failed to ...                                                              
[ERROR]   TestWorkflowTermination.testWorkflowRunningTimeout:126 » Helix Workflow "testW...                                                              
[INFO]
[ERROR] Tests run: 1145, Failures: 3, Errors: 0, Skipped: 1


[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 40.747 s - in org.apache.helix.integration.rebalancer.WagedRebalancer.TestWagedRebalance
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.246 s - in org.apache.helix.integration.task.TestDeleteJobFromJobQueue
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 32.675 s - in org.apache.helix.integration.task.TestWorkflowTermination



```
### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [X] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)