### PR TITLE
Add PropertyStore write endpoint to Helix REST

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
@@ -31,6 +31,7 @@ import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.InstanceType;
 import org.apache.helix.SystemPropertyKeys;
+import org.apache.helix.manager.zk.ByteArraySerializer;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
@@ -231,19 +232,8 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
     if (_byteArrayZkBaseDataAccessor == null) {
       synchronized (this) {
         if (_byteArrayZkBaseDataAccessor == null) {
-
-          _byteArrayZkBaseDataAccessor = new ZkBaseDataAccessor<>(_zkAddr, new ZkSerializer() {
-            @Override
-            public byte[] serialize(Object o) throws ZkMarshallingError {
-              // TODO: Support serialize for write methods if necessary
-              throw new UnsupportedOperationException("serialize() is not supported.");
-            }
-
-            @Override
-            public Object deserialize(byte[] bytes) throws ZkMarshallingError {
-              return bytes;
-            }
-          });
+          _byteArrayZkBaseDataAccessor =
+              new ZkBaseDataAccessor<>(_zkAddr, new ByteArraySerializer());
         }
       }
     }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -98,6 +98,11 @@ public class AbstractResource {
     return Response.serverError().build();
   }
 
+  protected Response serverError(String errorMsg) {
+    return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(errorMsgToJson(errorMsg))
+        .build();
+  }
+
   protected Response serverError(Exception ex) {
     addExceptionToAuditLog(ex);
     return Response.serverError().entity(errorMsgToJson(ex.getMessage())).build();

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
@@ -31,11 +31,10 @@ import javax.ws.rs.core.Response;
 
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
-import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.msdcommon.util.ZkValidationUtil;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.codehaus.jackson.node.ObjectNode;
 import org.slf4j.Logger;
@@ -107,7 +106,6 @@ public class PropertyStoreAccessor extends AbstractHelixResource {
           "Invalid path string. Valid path strings use slash as the directory separator and names the location of ZNode");
     }
     final String recordPath = PropertyPathBuilder.propertyStore(clusterId) + path;
-
     try {
       if (Boolean.parseBoolean(isZNRecord)) {
         try {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
@@ -19,18 +19,24 @@ package org.apache.helix.rest.server.resources.helix;
  * under the License.
  */
 
+import java.io.IOException;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 import org.apache.helix.AccessOption;
+import org.apache.helix.BaseDataAccessor;
+import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyPathBuilder;
-import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.msdcommon.util.ZkValidationUtil;
+import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.codehaus.jackson.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +82,58 @@ public class PropertyStoreAccessor extends AbstractHelixResource {
     } else {
       throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
           .entity(String.format("The property store path %s doesn't exist", recordPath)).build());
+    }
+  }
+
+  /**
+   * Sample HTTP URLs:
+   *  http://<HOST>/clusters/{clusterId}/propertyStore/<PATH>
+   * It refers to the /PROPERTYSTORE/<PATH> in Helix metadata store
+   * @param clusterId The cluster Id
+   * @param path path parameter is like "abc/abc/abc" in the URL
+   * @param isZNRecord true if the content represents a ZNRecord. false means byte array.
+   * @param content
+   * @return Response
+   */
+  @PUT
+  @Path("{path: .+}")
+  public Response putPropertyByPath(@PathParam("clusterId") String clusterId,
+      @PathParam("path") String path,
+      @QueryParam("isZNRecord") @DefaultValue("true") String isZNRecord, String content) {
+    path = "/" + path;
+    if (!ZkValidationUtil.isPathValid(path)) {
+      LOG.info("The propertyStore path {} is invalid for cluster {}", path, clusterId);
+      return badRequest(
+          "Invalid path string. Valid path strings use slash as the directory separator and names the location of ZNode");
+    }
+    final String recordPath = PropertyPathBuilder.propertyStore(clusterId) + path;
+
+    try {
+      if (Boolean.parseBoolean(isZNRecord)) {
+        try {
+          ZNRecord record = toZNRecord(content);
+          BaseDataAccessor<ZNRecord> propertyStoreDataAccessor =
+              getDataAccssor(clusterId).getBaseDataAccessor();
+          if (!propertyStoreDataAccessor.set(recordPath, record, AccessOption.PERSISTENT)) {
+            return serverError(
+                "Failed to set content: " + content + " in PropertyStore path: " + path);
+          }
+        } catch (IOException e) {
+          LOG.error("Failed to deserialize content " + content + " into a ZNRecord!", e);
+          return badRequest(
+              "Failed to write to path: " + recordPath + "! Content is not a valid ZNRecord!");
+        }
+      } else {
+        ZkBaseDataAccessor<byte[]> propertyStoreDataAccessor = getByteArrayDataAccessor();
+        if (!propertyStoreDataAccessor
+            .set(recordPath, content.getBytes(), AccessOption.PERSISTENT)) {
+          return serverError(
+              "Failed to set content: " + content + " in PropertyStore path: " + path);
+        }
+      }
+      return OK();
+    } catch (Exception e) {
+      return serverError(e);
     }
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1048

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Helix REST now supports a write endpoint that allows you to either write byte array or a ZNRecord to any path under PropertyStore, which is a directory in cluster metadata in ZK where applications can write custom data.

### Tests

- [x] The following tests are written for this issue:

testPutPropertyStore

- [x] The following is the result of the "mvn test" command on the appropriate module:

Helix REST module:
```
[INFO] Tests run: 161, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.495 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 161, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  43.454 s
[INFO] Finished at: 2020-06-01T21:44:18-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)