### PR TITLE
Fix test testDropInstance

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/GenericBaseDataAccessorBuilder.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/GenericBaseDataAccessorBuilder.java
@@ -99,8 +99,6 @@ public class GenericBaseDataAccessorBuilder<B extends GenericBaseDataAccessorBui
         break;
 
       case SINGLE_REALM:
-        // Create a HelixZkClient: Use a SharedZkClient because ZkBaseDataAccessor does not need to
-        // do ephemeral operations.
         if (_zkClientType == ZkClientType.DEDICATED) {
           // If DEDICATED, then we use a dedicated HelixZkClient because we must support ephemeral
           // operations
@@ -108,6 +106,8 @@ public class GenericBaseDataAccessorBuilder<B extends GenericBaseDataAccessorBui
               .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
                   clientConfig.createHelixZkClientConfig());
         } else {
+          // if SHARED: Use a SharedZkClient because ZkBaseDataAccessor does not need to
+          // do ephemeral operations.
           zkClient = SharedZkClientFactory.getInstance()
               .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
                   clientConfig.createHelixZkClientConfig());

--- a/helix-core/src/test/java/org/apache/helix/tools/TestClusterSetup.java
+++ b/helix-core/src/test/java/org/apache/helix/tools/TestClusterSetup.java
@@ -32,6 +32,7 @@ import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyKey.Builder;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.TestHelper;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.ZkUnitTestBase;
 import org.apache.helix.cloud.azure.AzureConstants;
@@ -51,6 +52,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
 
 public class TestClusterSetup extends ZkUnitTestBase {
   protected static final String CLUSTER_NAME = "TestClusterSetup";
@@ -343,6 +345,8 @@ public class TestClusterSetup extends ZkUnitTestBase {
     String className = TestHelper.getTestClassName();
     String methodName = TestHelper.getTestMethodName();
     String clusterName = className + "_" + methodName;
+    String instanceAddress = "localhost:12918";
+    String instanceName = "localhost_12918";
 
     System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
 
@@ -356,51 +360,57 @@ public class TestClusterSetup extends ZkUnitTestBase {
         "MasterSlave", true); // do rebalance
 
     // add fake liveInstance
-    ZKHelixDataAccessor accessor =
-        new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<ZNRecord>(ZK_ADDR));
-    Builder keyBuilder = new Builder(clusterName);
-    LiveInstance liveInstance = new LiveInstance("localhost_12918");
-    liveInstance.setSessionId("session_0");
-    liveInstance.setHelixVersion("version_0");
-    accessor.setProperty(keyBuilder.liveInstance("localhost_12918"), liveInstance);
+    HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName,
+        new ZkBaseDataAccessor.Builder<ZNRecord>()
+            .setRealmMode(RealmAwareZkClient.RealmMode.SINGLE_REALM)
+            .setZkClientType(ZkBaseDataAccessor.ZkClientType.DEDICATED)
+            .setZkAddress(ZK_ADDR)
+            .build());
 
-    // drop without stop the process, should throw exception
     try {
-      ClusterSetup.processCommandLineArgs(new String[] {
-          "--zkSvr", ZK_ADDR, "--dropNode", clusterName, "localhost:12918"
-      });
-      Assert.fail("Should throw exception since localhost_12918 is still in LIVEINSTANCES/");
-    } catch (Exception e) {
-      // OK
+      Builder keyBuilder = new Builder(clusterName);
+      LiveInstance liveInstance = new LiveInstance(instanceName);
+      liveInstance.setSessionId("session_0");
+      liveInstance.setHelixVersion("version_0");
+      accessor.setProperty(keyBuilder.liveInstance(instanceName), liveInstance);
+
+      // Drop instance without stopping the live instance, should throw HelixException
+      try {
+        ClusterSetup.processCommandLineArgs(
+            new String[]{"--zkSvr", ZK_ADDR, "--dropNode", clusterName, instanceAddress});
+        Assert.fail("Should throw exception since localhost_12918 is still in LIVEINSTANCES/");
+      } catch (HelixException expected) {
+        Assert.assertEquals(expected.getMessage(),
+            "Cannot drop instance " + instanceName + " as it is still live. Please stop it first");
+      }
+      accessor.removeProperty(keyBuilder.liveInstance(instanceName));
+
+      // drop without disable, should throw exception
+      try {
+        ClusterSetup.processCommandLineArgs(
+            new String[]{"--zkSvr", ZK_ADDR, "--dropNode", clusterName, instanceAddress});
+        Assert.fail("Should throw exception since " + instanceName + " is enabled");
+      } catch (HelixException expected) {
+        Assert.assertEquals(expected.getMessage(),
+            "Node " + instanceName + " is enabled, cannot drop");
+      }
+
+      // Disable the instance
+      ClusterSetup.processCommandLineArgs(
+          new String[]{"--zkSvr", ZK_ADDR, "--enableInstance", clusterName, instanceName, "false"});
+      // Drop the instance
+      ClusterSetup.processCommandLineArgs(
+          new String[]{"--zkSvr", ZK_ADDR, "--dropNode", clusterName, instanceAddress});
+
+      Assert.assertNull(accessor.getProperty(keyBuilder.instanceConfig(instanceName)),
+          "Instance config should be dropped");
+      Assert.assertFalse(_gZkClient.exists(PropertyPathBuilder.instance(clusterName, instanceName)),
+          "Instance/host should be dropped");
+    } finally {
+      // Have to close the dedicated zkclient in accessor to avoid zkclient leakage.
+      accessor.getBaseDataAccessor().close();
+      TestHelper.dropCluster(clusterName, _gZkClient);
     }
-    accessor.removeProperty(keyBuilder.liveInstance("localhost_12918"));
-
-    // drop without disable, should throw exception
-    try {
-      ClusterSetup.processCommandLineArgs(new String[] {
-          "--zkSvr", ZK_ADDR, "--dropNode", clusterName, "localhost:12918"
-      });
-      Assert.fail("Should throw exception since localhost_12918 is enabled");
-    } catch (Exception e) {
-      // e.printStackTrace();
-      // OK
-    }
-
-    // drop it
-    ClusterSetup.processCommandLineArgs(new String[] {
-        "--zkSvr", ZK_ADDR, "--enableInstance", clusterName, "localhost_12918", "false"
-    });
-    ClusterSetup.processCommandLineArgs(new String[] {
-        "--zkSvr", ZK_ADDR, "--dropNode", clusterName, "localhost:12918"
-    });
-
-    Assert.assertNull(accessor.getProperty(keyBuilder.instanceConfig("localhost_12918")),
-        "Instance config should be dropped");
-    Assert.assertFalse(
-        _gZkClient.exists(PropertyPathBuilder.instance(clusterName, "localhost_12918")),
-        "Instance/host should be dropped");
-
-    TestHelper.dropCluster(clusterName, _gZkClient);
 
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
   }
@@ -439,7 +449,6 @@ public class TestClusterSetup extends ZkUnitTestBase {
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
   }
 
-
   @Test(expectedExceptions = HelixException.class)
   public void testAddClusterWithInvalidCloudConfig() throws Exception {
     String className = TestHelper.getTestClassName();
@@ -454,7 +463,6 @@ public class TestClusterSetup extends ZkUnitTestBase {
     cloudConfigInitBuilder.setCloudProvider(CloudProvider.CUSTOMIZED);
 
     CloudConfig cloudConfigInit = cloudConfigInitBuilder.build();
-
 
     // Since setCloudInfoProcessorName is missing, this add cluster call will throw an exception
     _clusterSetup.addCluster(clusterName, false, cloudConfigInit);
@@ -489,7 +497,6 @@ public class TestClusterSetup extends ZkUnitTestBase {
     Assert.assertEquals(cloudConfigFromZk.getCloudInfoProcessorName(), "TestProcessorName");
     Assert.assertEquals(cloudConfigFromZk.getCloudProvider(), CloudProvider.CUSTOMIZED.name());
   }
-
 
   @Test(dependsOnMethods = "testAddClusterWithValidCloudConfig")
   public void testAddClusterAzureProvider() throws Exception {

--- a/helix-core/src/test/java/org/apache/helix/tools/TestClusterSetup.java
+++ b/helix-core/src/test/java/org/apache/helix/tools/TestClusterSetup.java
@@ -372,7 +372,7 @@ public class TestClusterSetup extends ZkUnitTestBase {
       LiveInstance liveInstance = new LiveInstance(instanceName);
       liveInstance.setSessionId("session_0");
       liveInstance.setHelixVersion("version_0");
-      accessor.setProperty(keyBuilder.liveInstance(instanceName), liveInstance);
+      Assert.assertTrue(accessor.setProperty(keyBuilder.liveInstance(instanceName), liveInstance));
 
       // Drop instance without stopping the live instance, should throw HelixException
       try {

--- a/helix-core/src/test/java/org/apache/helix/tools/TestClusterSetup.java
+++ b/helix-core/src/test/java/org/apache/helix/tools/TestClusterSetup.java
@@ -410,6 +410,14 @@ public class TestClusterSetup extends ZkUnitTestBase {
       // Have to close the dedicated zkclient in accessor to avoid zkclient leakage.
       accessor.getBaseDataAccessor().close();
       TestHelper.dropCluster(clusterName, _gZkClient);
+
+      // Verify the cluster has been dropped.
+      Assert.assertTrue(TestHelper.verify(() -> {
+        if (_gZkClient.exists("/" + clusterName)) {
+          TestHelper.dropCluster(clusterName, _gZkClient);
+        }
+        return true;
+      }, TestHelper.WAIT_DURATION));
     }
 
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1051 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Test testDropInstance doesn't assert expected exception and ignores the unexpected behavior. ZkBaseDataAccessor is created using a shared zkclient to create a live instance. The creation fails because shared zkclient doesn't support creating a live instance.

This PR addresses this problem by creating a dedicated zkclient in ZkBaseDataAccessor to create a live instance.

### Tests

- [ ] The following tests are written for this issue:

N/A

- [x] The following is the result of the "mvn test" command on the appropriate module:

There is no main code change, so just run this test class including testDropInstance. No more error message.

```
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 41.596 s - in org.apache.helix.tools.TestClusterSetup
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  47.458 s
[INFO] Finished at: 2020-06-02T19:54:34-07:00
[INFO] ------------------------------------------------------------------------
```



### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)