### PR TITLE
Fix ReadOnlyWagedRebalancer so that it computes mapping from scratch

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
@@ -48,15 +48,6 @@ public class ReadOnlyWagedRebalancer extends WagedRebalancer {
         ConstraintBasedAlgorithmFactory.getInstance(preferences), Optional.empty());
   }
 
-  @Override
-  protected Map<String, ResourceAssignment> computeBestPossibleAssignment(
-      ResourceControllerDataProvider clusterData, Map<String, Resource> resourceMap,
-      Set<String> activeNodes, CurrentStateOutput currentStateOutput, RebalanceAlgorithm algorithm)
-      throws HelixRebalanceException {
-    return getBestPossibleAssignment(getAssignmentMetadataStore(), currentStateOutput,
-        resourceMap.keySet());
-  }
-
   private static class ReadOnlyAssignmentMetadataStore extends AssignmentMetadataStore {
     ReadOnlyAssignmentMetadataStore(String metadataStoreAddress, String clusterName) {
       super(new ZkBucketDataAccessor(metadataStoreAddress), clusterName);


### PR DESCRIPTION

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1057

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Previously, ReadOnlyWagedRebalancer would only read from the previously computed best possible mapping and returns it. This commit changes it so that it computes things from scratch - it can read the previously computed best possible mapping but shouldn't just return it without doing any calculation.

### Tests

- [ ] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:116 Â» ThreadTimeout Method...
[ERROR]   TestAutoRebalanceWithDisabledInstance.testDisableEnableInstanceAutoRebalance:69 expected:<true> but was:<false>
[ERROR]   TestDeleteJobFromJobQueue.testForceDeleteJobFromJobQueue:75 Â» Helix Failed to ...
[INFO] 
[ERROR] Tests run: 1149, Failures: 3, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```

Other tests succeed when run individually.

### Commits

- [ ] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)