### PR TITLE
Remove previousAssignment from FixedTargetTaskAssignmentCalculator

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/AbstractTaskDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/AbstractTaskDispatcher.java
@@ -539,11 +539,10 @@ public abstract class AbstractTaskDispatcher {
   // Compute real assignment from theoretical calculation with applied throttling
   // This is the actual assigning part
   protected void handleAdditionalTaskAssignment(
-      Map<String, SortedSet<Integer>> currentInstanceToTaskAssignments, Set<String> excludedInstances,
-      String jobResource, CurrentStateOutput currStateOutput, JobContext jobCtx,
-      final JobConfig jobCfg, final WorkflowConfig workflowConfig, WorkflowContext workflowCtx,
-      final WorkflowControllerDataProvider cache,
-      ResourceAssignment prevTaskToInstanceStateAssignment,
+      Map<String, SortedSet<Integer>> currentInstanceToTaskAssignments,
+      Set<String> excludedInstances, String jobResource, CurrentStateOutput currStateOutput,
+      JobContext jobCtx, final JobConfig jobCfg, final WorkflowConfig workflowConfig,
+      WorkflowContext workflowCtx, final WorkflowControllerDataProvider cache,
       Map<String, Set<Integer>> assignedPartitions, Map<Integer, PartitionAssignment> paMap,
       Set<Integer> skippedPartitions, TaskAssignmentCalculator taskAssignmentCal,
       Set<Integer> allPartitions, final long currentTime, Collection<String> liveInstances) {
@@ -599,9 +598,9 @@ public abstract class AbstractTaskDispatcher {
 
     // The actual assignment is computed here
     // Get instance->[partition, ...] mappings for the target resource.
-    Map<String, SortedSet<Integer>> tgtPartitionAssignments = taskAssignmentCal.getTaskAssignment(
-        currStateOutput, prevTaskToInstanceStateAssignment, liveInstances, jobCfg, jobCtx,
-        workflowConfig, workflowCtx, filteredTaskPartitionNumbers, cache.getIdealStates());
+    Map<String, SortedSet<Integer>> tgtPartitionAssignments =
+        taskAssignmentCal.getTaskAssignment(currStateOutput, liveInstances, jobCfg, jobCtx,
+            workflowConfig, workflowCtx, filteredTaskPartitionNumbers, cache.getIdealStates());
 
     if (!TaskUtil.isGenericTaskJob(jobCfg) && jobCfg.isRebalanceRunningTask()) {
       // TODO: Revisit the logic for isRebalanceRunningTask() and valid use cases for it

--- a/helix-core/src/main/java/org/apache/helix/task/DeprecatedTaskRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/DeprecatedTaskRebalancer.java
@@ -99,7 +99,6 @@ public abstract class DeprecatedTaskRebalancer
   /**
    * Compute an assignment of tasks to instances
    * @param currStateOutput the current state of the instances
-   * @param prevAssignment the previous task partition assignment
    * @param instances the instances
    * @param jobCfg the task configuration
    * @param jobContext the task context
@@ -110,10 +109,9 @@ public abstract class DeprecatedTaskRebalancer
    * @return map of instances to set of partition numbers
    */
   public abstract Map<String, SortedSet<Integer>> getTaskAssignment(
-      CurrentStateOutput currStateOutput, ResourceAssignment prevAssignment,
-      Collection<String> instances, JobConfig jobCfg, JobContext jobContext,
-      WorkflowConfig workflowCfg, WorkflowContext workflowCtx, Set<Integer> partitionSet,
-      WorkflowControllerDataProvider cache);
+      CurrentStateOutput currStateOutput, Collection<String> instances, JobConfig jobCfg,
+      JobContext jobContext, WorkflowConfig workflowCfg, WorkflowContext workflowCtx,
+      Set<Integer> partitionSet, WorkflowControllerDataProvider cache);
 
   @Override
   public void init(HelixManager manager) {
@@ -529,7 +527,7 @@ public abstract class DeprecatedTaskRebalancer
       excludeSet.addAll(getNonReadyPartitions(jobCtx, currentTime));
       // Get instance->[partition, ...] mappings for the target resource.
       Map<String, SortedSet<Integer>> tgtPartitionAssignments =
-          getTaskAssignment(currStateOutput, prevAssignment, liveInstances, jobCfg, jobCtx,
+          getTaskAssignment(currStateOutput, liveInstances, jobCfg, jobCtx,
               workflowConfig, workflowCtx, allPartitions, cache);
       for (Map.Entry<String, SortedSet<Integer>> entry : taskAssignments.entrySet()) {
         String instance = entry.getKey();

--- a/helix-core/src/main/java/org/apache/helix/task/FixedTargetTaskAssignmentCalculator.java
+++ b/helix-core/src/main/java/org/apache/helix/task/FixedTargetTaskAssignmentCalculator.java
@@ -78,11 +78,11 @@ public class FixedTargetTaskAssignmentCalculator extends TaskAssignmentCalculato
 
   @Override
   public Map<String, SortedSet<Integer>> getTaskAssignment(CurrentStateOutput currStateOutput,
-      ResourceAssignment prevAssignment, Collection<String> instances, JobConfig jobCfg,
-      JobContext jobContext, WorkflowConfig workflowCfg, WorkflowContext workflowCtx,
-      Set<Integer> partitionSet, Map<String, IdealState> idealStateMap) {
-    return computeAssignmentAndChargeResource(currStateOutput, prevAssignment, instances,
-        workflowCfg, jobCfg, jobContext, partitionSet, idealStateMap);
+      Collection<String> instances, JobConfig jobCfg, JobContext jobContext,
+      WorkflowConfig workflowCfg, WorkflowContext workflowCtx, Set<Integer> partitionSet,
+      Map<String, IdealState> idealStateMap) {
+    return computeAssignmentAndChargeResource(currStateOutput, instances, workflowCfg, jobCfg,
+        jobContext, partitionSet, idealStateMap);
   }
 
   /**
@@ -175,7 +175,6 @@ public class FixedTargetTaskAssignmentCalculator extends TaskAssignmentCalculato
    * Calculate the assignment for given tasks. This assignment also charges resources for each task
    * and takes resource/quota availability into account while assigning.
    * @param currStateOutput
-   * @param prevAssignment
    * @param liveInstances
    * @param jobCfg
    * @param jobContext
@@ -184,9 +183,9 @@ public class FixedTargetTaskAssignmentCalculator extends TaskAssignmentCalculato
    * @return instance -> set of task partition numbers
    */
   private Map<String, SortedSet<Integer>> computeAssignmentAndChargeResource(
-      CurrentStateOutput currStateOutput, ResourceAssignment prevAssignment,
-      Collection<String> liveInstances, WorkflowConfig workflowCfg, JobConfig jobCfg,
-      JobContext jobContext, Set<Integer> taskPartitionSet, Map<String, IdealState> idealStateMap) {
+      CurrentStateOutput currStateOutput, Collection<String> liveInstances,
+      WorkflowConfig workflowCfg, JobConfig jobCfg, JobContext jobContext,
+      Set<Integer> taskPartitionSet, Map<String, IdealState> idealStateMap) {
 
     // Note: targeted jobs also take up capacity in quota-based scheduling
     // "Charge" resources for the tasks
@@ -250,23 +249,27 @@ public class FixedTargetTaskAssignmentCalculator extends TaskAssignmentCalculato
             // the new assignment differs from prevAssignment, release. If the assigned instances
             // from old and new assignments are the same, then do nothing and let it keep running
             // The following checks if two assignments (old and new) differ
-            Map<String, String> instanceMap = prevAssignment.getReplicaMap(new Partition(pName));
-            Iterator<String> itr = instanceMap.keySet().iterator();
+
             // First, check if this taskPartition has been ever assigned before by checking
-            // prevAssignment
-            if (itr.hasNext()) {
-              String prevInstance = itr.next();
-              if (!prevInstance.equals(instance)) {
-                // Old and new assignments are different. We need to release from prevInstance, and
-                // this task will be assigned to a different instance
+            // jobContext's AssignedParticipant field
+            String prevAssignedInstance = jobContext.getAssignedParticipant(targetPartitionId);
+            TaskPartitionState taskState = jobContext.getPartitionState(targetPartitionId);
+
+            if (prevAssignedInstance != null && (taskState != null)
+                && (taskState.equals(TaskPartitionState.INIT)
+                    || taskState.equals(TaskPartitionState.RUNNING))) {
+              // If the task is in active state and old and new assignments are different, we need
+              // to release from prevInstance, and this task will be assigned to a different
+              // instance
+              if (!prevAssignedInstance.equals(instance)) {
                 if (_assignableInstanceManager.getAssignableInstanceNames()
-                    .contains(prevInstance)) {
-                  _assignableInstanceManager.release(prevInstance, taskConfig, quotaType);
+                    .contains(prevAssignedInstance)) {
+                  _assignableInstanceManager.release(prevAssignedInstance, taskConfig, quotaType);
                 } else {
                   // This instance must be no longer live
                   LOG.warn(
                       "Task {} was reassigned from old instance: {} to new instance: {}. However, old instance: {} is not found in AssignableInstanceMap. The old instance is possibly no longer a LiveInstance. This task will not be released.",
-                      pName, prevAssignment, instance);
+                      pName, prevAssignedInstance, instance, prevAssignedInstance);
                 }
               } else {
                 // Old and new assignments are the same, so just skip assignment for this

--- a/helix-core/src/main/java/org/apache/helix/task/FixedTargetTaskRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/FixedTargetTaskRebalancer.java
@@ -48,13 +48,11 @@ public class FixedTargetTaskRebalancer extends DeprecatedTaskRebalancer {
   }
 
   @Override
-  public Map<String, SortedSet<Integer>> getTaskAssignment(
-      CurrentStateOutput currStateOutput, ResourceAssignment prevAssignment,
+  public Map<String, SortedSet<Integer>> getTaskAssignment(CurrentStateOutput currStateOutput,
       Collection<String> instances, JobConfig jobCfg, JobContext jobContext,
       WorkflowConfig workflowCfg, WorkflowContext workflowCtx, Set<Integer> partitionSet,
       WorkflowControllerDataProvider cache) {
-    return taskAssignmentCalculator
-        .getTaskAssignment(currStateOutput, prevAssignment, instances, jobCfg, jobContext,
-            workflowCfg, workflowCtx, partitionSet, cache.getIdealStates());
+    return taskAssignmentCalculator.getTaskAssignment(currStateOutput, instances, jobCfg,
+        jobContext, workflowCfg, workflowCtx, partitionSet, cache.getIdealStates());
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/task/GenericTaskAssignmentCalculator.java
+++ b/helix-core/src/main/java/org/apache/helix/task/GenericTaskAssignmentCalculator.java
@@ -65,9 +65,9 @@ public class GenericTaskAssignmentCalculator extends TaskAssignmentCalculator {
 
   @Override
   public Map<String, SortedSet<Integer>> getTaskAssignment(CurrentStateOutput currStateOutput,
-      ResourceAssignment prevAssignment, Collection<String> instances, JobConfig jobCfg,
-      final JobContext jobContext, WorkflowConfig workflowCfg, WorkflowContext workflowCtx,
-      Set<Integer> partitionSet, Map<String, IdealState> idealStateMap) {
+      Collection<String> instances, JobConfig jobCfg, final JobContext jobContext,
+      WorkflowConfig workflowCfg, WorkflowContext workflowCtx, Set<Integer> partitionSet,
+      Map<String, IdealState> idealStateMap) {
 
     if (jobCfg.getTargetResource() != null) {
       LOG.error(

--- a/helix-core/src/main/java/org/apache/helix/task/GenericTaskRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/task/GenericTaskRebalancer.java
@@ -40,18 +40,18 @@ public class GenericTaskRebalancer extends DeprecatedTaskRebalancer {
 
   @Override
   public Set<Integer> getAllTaskPartitions(JobConfig jobCfg, JobContext jobCtx,
-      WorkflowConfig workflowCfg, WorkflowContext workflowCtx, WorkflowControllerDataProvider cache) {
-    return taskAssignmentCalculator
-        .getAllTaskPartitions(jobCfg, jobCtx, workflowCfg, workflowCtx, cache.getIdealStates());
+      WorkflowConfig workflowCfg, WorkflowContext workflowCtx,
+      WorkflowControllerDataProvider cache) {
+    return taskAssignmentCalculator.getAllTaskPartitions(jobCfg, jobCtx, workflowCfg, workflowCtx,
+        cache.getIdealStates());
   }
 
   @Override
   public Map<String, SortedSet<Integer>> getTaskAssignment(CurrentStateOutput currStateOutput,
-      ResourceAssignment prevAssignment, Collection<String> instances, JobConfig jobCfg,
-      final JobContext jobContext, WorkflowConfig workflowCfg, WorkflowContext workflowCtx,
-      Set<Integer> partitionSet, WorkflowControllerDataProvider cache) {
-    return taskAssignmentCalculator
-        .getTaskAssignment(currStateOutput, prevAssignment, instances, jobCfg, jobContext,
-            workflowCfg, workflowCtx, partitionSet, cache.getIdealStates());
+      Collection<String> instances, JobConfig jobCfg, final JobContext jobContext,
+      WorkflowConfig workflowCfg, WorkflowContext workflowCtx, Set<Integer> partitionSet,
+      WorkflowControllerDataProvider cache) {
+    return taskAssignmentCalculator.getTaskAssignment(currStateOutput, instances, jobCfg,
+        jobContext, workflowCfg, workflowCtx, partitionSet, cache.getIdealStates());
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/task/JobDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobDispatcher.java
@@ -185,8 +185,8 @@ public class JobDispatcher extends AbstractTaskDispatcher {
 
     Set<Integer> partitionsToDrop = new TreeSet<>();
     ResourceAssignment newAssignment =
-        computeResourceMapping(jobName, workflowCfg, jobCfg, jobState, jobTgtState, prevAssignment,
-            liveInstances, currStateOutput, workflowCtx, jobCtx, partitionsToDrop, _dataProvider);
+        computeResourceMapping(jobName, workflowCfg, jobCfg, jobState, jobTgtState, liveInstances,
+            currStateOutput, workflowCtx, jobCtx, partitionsToDrop, _dataProvider);
 
     // Update Workflow and Job context in data cache and ZK.
     _dataProvider.updateJobContext(jobName, jobCtx);
@@ -200,9 +200,9 @@ public class JobDispatcher extends AbstractTaskDispatcher {
 
   private ResourceAssignment computeResourceMapping(String jobResource,
       WorkflowConfig workflowConfig, JobConfig jobCfg, TaskState jobState, TargetState jobTgtState,
-      ResourceAssignment prevTaskToInstanceStateAssignment, Collection<String> liveInstances,
-      CurrentStateOutput currStateOutput, WorkflowContext workflowCtx, JobContext jobCtx,
-      Set<Integer> partitionsToDropFromIs, WorkflowControllerDataProvider cache) {
+      Collection<String> liveInstances, CurrentStateOutput currStateOutput,
+      WorkflowContext workflowCtx, JobContext jobCtx, Set<Integer> partitionsToDropFromIs,
+      WorkflowControllerDataProvider cache) {
 
     // Used to keep track of tasks that have already been assigned to instances.
     // InstanceName -> Set of task partitions assigned to that instance in this iteration
@@ -316,10 +316,10 @@ public class JobDispatcher extends AbstractTaskDispatcher {
     // Make additional task assignments if needed.
     if (jobState != TaskState.TIMING_OUT && jobState != TaskState.TIMED_OUT
         && jobTgtState == TargetState.START) {
-      handleAdditionalTaskAssignment(currentInstanceToTaskAssignments, excludedInstances, jobResource,
-          currStateOutput, jobCtx, jobCfg, workflowConfig, workflowCtx, cache,
-          prevTaskToInstanceStateAssignment, assignedPartitions, paMap, skippedPartitions,
-          taskAssignmentCal, allPartitions, currentTime, liveInstances);
+      handleAdditionalTaskAssignment(currentInstanceToTaskAssignments, excludedInstances,
+          jobResource, currStateOutput, jobCtx, jobCfg, workflowConfig, workflowCtx, cache,
+          assignedPartitions, paMap, skippedPartitions, taskAssignmentCal, allPartitions,
+          currentTime, liveInstances);
     }
 
     return toResourceAssignment(jobResource, paMap);

--- a/helix-core/src/main/java/org/apache/helix/task/TaskAssignmentCalculator.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskAssignmentCalculator.java
@@ -27,7 +27,6 @@ public abstract class TaskAssignmentCalculator {
   /**
    * Compute an assignment of tasks to instances
    * @param currStateOutput the current state of the instances
-   * @param prevAssignment the previous task partition assignment
    * @param instances the instances
    * @param jobCfg the task configuration
    * @param jobContext the task context
@@ -38,10 +37,9 @@ public abstract class TaskAssignmentCalculator {
    * @return map of instances to set of partition numbers
    */
   public abstract Map<String, SortedSet<Integer>> getTaskAssignment(
-      CurrentStateOutput currStateOutput, ResourceAssignment prevAssignment,
-      Collection<String> instances, JobConfig jobCfg, JobContext jobContext,
-      WorkflowConfig workflowCfg, WorkflowContext workflowCtx, Set<Integer> partitionSet,
-      Map<String, IdealState> idealStateMap);
+      CurrentStateOutput currStateOutput, Collection<String> instances, JobConfig jobCfg,
+      JobContext jobContext, WorkflowConfig workflowCfg, WorkflowContext workflowCtx,
+      Set<Integer> partitionSet, Map<String, IdealState> idealStateMap);
 
   /**
    * Returns the correct type for this job. Note that if the parent workflow has a type, then all of

--- a/helix-core/src/main/java/org/apache/helix/task/ThreadCountBasedTaskAssignmentCalculator.java
+++ b/helix-core/src/main/java/org/apache/helix/task/ThreadCountBasedTaskAssignmentCalculator.java
@@ -76,9 +76,9 @@ public class ThreadCountBasedTaskAssignmentCalculator extends TaskAssignmentCalc
 
   @Override
   public Map<String, SortedSet<Integer>> getTaskAssignment(CurrentStateOutput currStateOutput,
-      ResourceAssignment prevAssignment, Collection<String> instances, JobConfig jobCfg,
-      JobContext jobContext, WorkflowConfig workflowCfg, WorkflowContext workflowCtx,
-      Set<Integer> partitionSet, Map<String, IdealState> idealStateMap) {
+      Collection<String> instances, JobConfig jobCfg, JobContext jobContext,
+      WorkflowConfig workflowCfg, WorkflowContext workflowCtx, Set<Integer> partitionSet,
+      Map<String, IdealState> idealStateMap) {
 
     if (jobCfg.getTargetResource() != null) {
       LOG.error(

--- a/helix-core/src/test/java/org/apache/helix/task/TestFixedTargetedTaskAssignmentCalculator.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestFixedTargetedTaskAssignmentCalculator.java
@@ -1,0 +1,288 @@
+package org.apache.helix.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import java.util.SortedSet;
+import org.apache.helix.common.caches.TaskDataCache;
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.Partition;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * This unit test check whether FixedTargetedTaskAssignmentCalculator makes correct decision for
+ * targeted jobs
+ */
+public class TestFixedTargetedTaskAssignmentCalculator {
+  private static final String CLUSTER_NAME = "TestCluster";
+  private static final String INSTANCE_PREFIX = "Instance_";
+  private static final int NUM_PARTICIPANTS = 3;
+
+  private static final String WORKFLOW_NAME = "TestWorkflow";
+  private static final String JOB_NAME = "TestJob";
+  private static final String PARTITION_NAME = "0";
+  private static final String TARGET_PARTITION_NAME = "0";
+  private static final int PARTITION_ID = 0;
+  private static final String TARGET_RESOURCES = "TestDB";
+
+  private Map<String, LiveInstance> _liveInstances;
+  private Map<String, InstanceConfig> _instanceConfigs;
+  private ClusterConfig _clusterConfig;
+  private AssignableInstanceManager _assignableInstanceManager;
+
+  @BeforeClass
+  public void beforeClass() {
+    // Populate live instances and their corresponding instance configs
+    _liveInstances = new HashMap<>();
+    _instanceConfigs = new HashMap<>();
+    _clusterConfig = new ClusterConfig(CLUSTER_NAME);
+
+    for (int i = 0; i < NUM_PARTICIPANTS; i++) {
+      String instanceName = INSTANCE_PREFIX + i;
+      LiveInstance liveInstance = new LiveInstance(instanceName);
+      InstanceConfig instanceConfig = new InstanceConfig(instanceName);
+      _liveInstances.put(instanceName, liveInstance);
+      _instanceConfigs.put(instanceName, instanceConfig);
+    }
+  }
+
+  /**
+   * Test FixedTargetTaskAssignmentCalculator and make sure that if a job has been assigned
+   * before and target partition is still on the same instance and in RUNNING state,
+   * we do not make new assignment for that task.
+   */
+  @Test
+  public void testFixedTargetTaskAssignmentCalculatorSameInstanceRunningTask() {
+    _assignableInstanceManager = new AssignableInstanceManager();
+    _assignableInstanceManager.buildAssignableInstances(_clusterConfig,
+        new TaskDataCache("CLUSTER_NAME"), _liveInstances, _instanceConfigs);
+    // Preparing the inputs
+    String masterInstance = INSTANCE_PREFIX + 1;
+    String slaveInstance1 = INSTANCE_PREFIX + 2;
+    String slaveInstance2 = INSTANCE_PREFIX + 3;
+    CurrentStateOutput currentStateOutput = prepareCurrentState(TaskPartitionState.RUNNING,
+        masterInstance, slaveInstance1, slaveInstance2);
+    List<String> instances =
+        new ArrayList<String>(Arrays.asList(masterInstance, slaveInstance1, slaveInstance2));
+    JobConfig jobConfig = prepareJobConfig();
+    JobContext jobContext = prepareJobContext(TaskPartitionState.RUNNING, masterInstance);
+    WorkflowConfig workflowConfig = prepareWorkflowConfig();
+    WorkflowContext workflowContext = prepareWorkflowContext();
+    Set<Integer> partitionSet = new HashSet<>(Collections.singletonList(PARTITION_ID));
+    Map<String, IdealState> idealStates =
+        prepareIdealStates(masterInstance, slaveInstance1, slaveInstance2);
+    TaskAssignmentCalculator taskAssignmentCal =
+        new FixedTargetTaskAssignmentCalculator(_assignableInstanceManager);
+    Map<String, SortedSet<Integer>> result =
+        taskAssignmentCal.getTaskAssignment(currentStateOutput, instances, jobConfig, jobContext,
+            workflowConfig, workflowContext, partitionSet, idealStates);
+    Assert.assertEquals(result.get(masterInstance).size(),0);
+    Assert.assertEquals(result.get(slaveInstance1).size(),0);
+    Assert.assertEquals(result.get(slaveInstance2).size(),0);
+  }
+
+  /**
+   * Test FixedTargetTaskAssignmentCalculator and make sure that if a job has been assigned
+   * before and target partition is still on the same instance and in INIT state,
+   * we do not make new assignment for that task.
+   */
+  @Test
+  public void testFixedTargetTaskAssignmentCalculatorSameInstanceInitTask() {
+    _assignableInstanceManager = new AssignableInstanceManager();
+    _assignableInstanceManager.buildAssignableInstances(_clusterConfig,
+        new TaskDataCache("CLUSTER_NAME"), _liveInstances, _instanceConfigs);
+    // Preparing the inputs
+    String masterInstance = INSTANCE_PREFIX + 1;
+    String slaveInstance1 = INSTANCE_PREFIX + 2;
+    String slaveInstance2 = INSTANCE_PREFIX + 3;
+    // Preparing the inputs
+    CurrentStateOutput currentStateOutput = prepareCurrentState(TaskPartitionState.INIT,
+        masterInstance, slaveInstance1, slaveInstance2);
+    List<String> instances =
+        new ArrayList<String>(Arrays.asList(masterInstance, slaveInstance1, slaveInstance2));
+    JobConfig jobConfig = prepareJobConfig();
+    JobContext jobContext = prepareJobContext(TaskPartitionState.INIT, masterInstance);
+    WorkflowConfig workflowConfig = prepareWorkflowConfig();
+    WorkflowContext workflowContext = prepareWorkflowContext();
+    Set<Integer> partitionSet = new HashSet<>(Collections.singletonList(PARTITION_ID));
+    Map<String, IdealState> idealStates =
+        prepareIdealStates(masterInstance, slaveInstance1, slaveInstance2);
+    TaskAssignmentCalculator taskAssignmentCal =
+        new FixedTargetTaskAssignmentCalculator(_assignableInstanceManager);
+    Map<String, SortedSet<Integer>> result =
+        taskAssignmentCal.getTaskAssignment(currentStateOutput, instances, jobConfig, jobContext,
+            workflowConfig, workflowContext, partitionSet, idealStates);
+    Assert.assertEquals(result.get(masterInstance).size(),0);
+    Assert.assertEquals(result.get(slaveInstance1).size(),0);
+    Assert.assertEquals(result.get(slaveInstance2).size(),0);
+  }
+
+  /**
+   * Test FixedTargetTaskAssignmentCalculator and make sure that if a job has been assigned
+   * before and target partition has moved to another instance, controller assign the task to
+   * new/correct instance.
+   */
+  @Test
+  public void testFixedTargetTaskAssignmentCalculatorDifferentInstance() {
+    _assignableInstanceManager = new AssignableInstanceManager();
+    _assignableInstanceManager.buildAssignableInstances(_clusterConfig,
+        new TaskDataCache("CLUSTER_NAME"), _liveInstances, _instanceConfigs);
+    // Preparing the inputs
+    String masterInstance = INSTANCE_PREFIX + 2;
+    String slaveInstance1 = INSTANCE_PREFIX + 1;
+    String slaveInstance2 = INSTANCE_PREFIX + 3;
+    // Preparing the inputs
+    CurrentStateOutput currentStateOutput = prepareCurrentState(TaskPartitionState.RUNNING,
+        masterInstance, slaveInstance1, slaveInstance2);
+    List<String> instances =
+        new ArrayList<String>(Arrays.asList(masterInstance, slaveInstance1, slaveInstance2));
+    JobConfig jobConfig = prepareJobConfig();
+    JobContext jobContext = prepareJobContext(TaskPartitionState.RUNNING, slaveInstance1);
+    WorkflowConfig workflowConfig = prepareWorkflowConfig();
+    WorkflowContext workflowContext = prepareWorkflowContext();
+    Set<Integer> partitionSet = new HashSet<>(Collections.singletonList(PARTITION_ID));
+    Map<String, IdealState> idealStates =
+        prepareIdealStates(masterInstance, slaveInstance1, slaveInstance2);
+    TaskAssignmentCalculator taskAssignmentCal =
+        new FixedTargetTaskAssignmentCalculator(_assignableInstanceManager);
+    Map<String, SortedSet<Integer>> result =
+        taskAssignmentCal.getTaskAssignment(currentStateOutput, instances, jobConfig, jobContext,
+            workflowConfig, workflowContext, partitionSet, idealStates);
+    Assert.assertEquals(result.get(slaveInstance1).size(),0);
+    Assert.assertEquals(result.get(masterInstance).size(),1);
+    Assert.assertEquals(result.get(slaveInstance2).size(),0);
+  }
+
+  private JobConfig prepareJobConfig() {
+    JobConfig.Builder jobConfigBuilder = new JobConfig.Builder();
+    jobConfigBuilder.setWorkflow(WORKFLOW_NAME);
+    jobConfigBuilder.setCommand("TestCommand");
+    jobConfigBuilder.setJobId(JOB_NAME);
+    jobConfigBuilder.setTargetResource(TARGET_RESOURCES);
+    List<String> targetPartition = new ArrayList<>();
+    jobConfigBuilder.setTargetPartitions(targetPartition);
+    Set<String> targetPartitionStates = new HashSet<>(Collections.singletonList("MASTER"));
+    jobConfigBuilder.setTargetPartitions(targetPartition);
+    jobConfigBuilder.setTargetPartitionStates(targetPartitionStates);
+    List<TaskConfig> taskConfigs = new ArrayList<>();
+    TaskConfig.Builder taskConfigBuilder = new TaskConfig.Builder();
+    taskConfigBuilder.setTaskId("0");
+    taskConfigs.add(taskConfigBuilder.build());
+    jobConfigBuilder.addTaskConfigs(taskConfigs);
+    return jobConfigBuilder.build();
+  }
+
+  private JobContext prepareJobContext(TaskPartitionState taskPartitionState, String instance) {
+    ZNRecord record = new ZNRecord(JOB_NAME);
+    JobContext jobContext = new JobContext(record);
+    jobContext.setStartTime(0L);
+    jobContext.setName(JOB_NAME);
+    jobContext.setStartTime(0L);
+    jobContext.setPartitionState(PARTITION_ID, taskPartitionState);
+    jobContext.setPartitionTarget(PARTITION_ID, TARGET_RESOURCES + "_" + TARGET_PARTITION_NAME);
+    jobContext.setAssignedParticipant(PARTITION_ID, instance);
+    return jobContext;
+  }
+
+  private CurrentStateOutput prepareCurrentState(TaskPartitionState taskCurrentState,
+      String masterInstance, String slaveInstance1, String slaveInstance2) {
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    currentStateOutput.setResourceStateModelDef(JOB_NAME, "TASK");
+    Partition taskPartition = new Partition(JOB_NAME + "_" + PARTITION_NAME);
+    currentStateOutput.setCurrentState(JOB_NAME, taskPartition, masterInstance,
+        taskCurrentState.name());
+    Partition dbPartition = new Partition(TARGET_RESOURCES + "_0");
+    currentStateOutput.setEndTime(TARGET_RESOURCES, dbPartition, masterInstance, 0L);
+    currentStateOutput.setCurrentState(TARGET_RESOURCES, dbPartition, masterInstance, "MASTER");
+    currentStateOutput.setCurrentState(TARGET_RESOURCES, dbPartition, slaveInstance1, "SLAVE");
+    currentStateOutput.setCurrentState(TARGET_RESOURCES, dbPartition, slaveInstance2, "SLAVE");
+    currentStateOutput.setInfo(TARGET_RESOURCES, dbPartition, masterInstance, "");
+    return currentStateOutput;
+  }
+
+  private WorkflowConfig prepareWorkflowConfig() {
+    WorkflowConfig.Builder workflowConfigBuilder = new WorkflowConfig.Builder();
+    workflowConfigBuilder.setWorkflowId(WORKFLOW_NAME);
+    workflowConfigBuilder.setTerminable(false);
+    workflowConfigBuilder.setTargetState(TargetState.START);
+    workflowConfigBuilder.setJobQueue(true);
+    JobDag jobDag = new JobDag();
+    jobDag.addNode(JOB_NAME);
+    workflowConfigBuilder.setJobDag(jobDag);
+    return workflowConfigBuilder.build();
+  }
+
+  private WorkflowContext prepareWorkflowContext() {
+    ZNRecord record = new ZNRecord(WORKFLOW_NAME);
+    record.setSimpleField(WorkflowContext.WorkflowContextProperties.StartTime.name(), "0");
+    record.setSimpleField(WorkflowContext.WorkflowContextProperties.NAME.name(), WORKFLOW_NAME);
+    record.setSimpleField(WorkflowContext.WorkflowContextProperties.STATE.name(),
+        TaskState.IN_PROGRESS.name());
+    Map<String, String> jobState = new HashMap<>();
+    jobState.put(JOB_NAME, TaskState.IN_PROGRESS.name());
+    record.setMapField(WorkflowContext.WorkflowContextProperties.JOB_STATES.name(), jobState);
+    return new WorkflowContext(record);
+  }
+
+  private Map<String, IdealState> prepareIdealStates(String instance1, String instance2,
+      String instance3) {
+    Map<String, IdealState> idealStates = new HashMap<>();
+
+    ZNRecord recordDB = new ZNRecord(TARGET_RESOURCES);
+    recordDB.setSimpleField(IdealState.IdealStateProperty.REPLICAS.name(), "3");
+    recordDB.setSimpleField(IdealState.IdealStateProperty.REBALANCE_MODE.name(), "FULL_AUTO");
+    recordDB.setSimpleField(IdealState.IdealStateProperty.IDEAL_STATE_MODE.name(),
+        "AUTO_REBALANCE");
+    recordDB.setSimpleField(IdealState.IdealStateProperty.STATE_MODEL_DEF_REF.name(),
+        "MasterSlave");
+    recordDB.setSimpleField(IdealState.IdealStateProperty.STATE_MODEL_DEF_REF.name(),
+        "org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy");
+    recordDB.setSimpleField(IdealState.IdealStateProperty.REBALANCER_CLASS_NAME.name(),
+        "org.apache.helix.controller.rebalancer.DelayedAutoRebalancer");
+    Map<String, String> mapping = new HashMap<>();
+    mapping.put(instance1, "MASTER");
+    mapping.put(instance2, "SLAVE");
+    mapping.put(instance3, "SLAVE");
+    recordDB.setMapField(TARGET_RESOURCES + "_0", mapping);
+    List<String> listField = new ArrayList<>();
+    listField.add(instance1);
+    listField.add(instance2);
+    listField.add(instance3);
+    recordDB.setListField(TARGET_RESOURCES + "_0", listField);
+    idealStates.put(TARGET_RESOURCES, new IdealState(recordDB));
+
+    return idealStates;
+  }
+}


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #1060 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
The FixedTargetTaskAssignmentCalculator class is relying on the previousAssignment.
In this commit, this class has been modified and previousAssignment has been
replaced with the context information.

### Tests
- [x] The following tests are written for this issue:
TestFixedTargetedTaskAssignmentCalculator

- [x] The following is the result of the "mvn test" command on the appropriate module:

Helix-Core:
```
```

Helix-rest:
```
```


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml