### PR TITLE
Avoid adding JobConfig if queue has reached its capacity limit

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -450,6 +450,13 @@ public class TaskDriver {
           .fromJson(currentData.getSimpleField(WorkflowConfig.WorkflowConfigProperty.Dag.name()));
       Set<String> allNodes = jobDag.getAllNodes();
       if (capacity > 0 && allNodes.size() + jobConfigs.size() >= capacity) {
+        // Remove previously added jobConfigs if adding new jobs will cause exceeding capacity
+        // limit. Removing the job configs is necessary to avoid multiple threads adding jobs at the
+        // same time and cause overcapacity queue
+        for (String job : jobs) {
+          String namespacedJobName = TaskUtil.getNamespacedJobName(queue, job);
+          TaskUtil.removeJobConfig(_accessor, namespacedJobName);
+        }
         throw new IllegalStateException(
             String.format("Queue %s already reaches its max capacity %d, failed to add %s", queue,
                 capacity, jobs.toString()));

--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -403,6 +403,14 @@ public class TaskDriver {
       }
     }
 
+    // Fail the operation if adding new jobs will cause the queue to reach its capacity limit
+    workflowConfig = TaskUtil.getWorkflowConfig(_accessor, queue);
+    if (workflowConfig.getJobDag().size() + jobs.size() >= capacity) {
+      throw new IllegalStateException(
+          String.format("Queue %s already reaches its max capacity %d, failed to add %s", queue,
+              capacity, jobs.toString()));
+    }
+
     validateZKNodeLimitation(1);
     final List<JobConfig> jobConfigs = new ArrayList<>();
     final List<String> namespacedJobNames = new ArrayList<>();


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #1062 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In this PR, the necessary check has been added in TaskDriver side
to fail creation of JobConfig if queue has reached its capacity limit.

### Tests
- [x] The following tests are written for this issue:
TestEnqueueJobs.testQueueJobsMaxCapacity

- [x] The following is the result of the "mvn test" command on the appropriate module:

helix-core:
```
[ERROR] Tests run: 1150, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 4,993.03 s <<< FAILURE! - in TestSuite
[ERROR] testWorkflowTimeoutWhenWorkflowCompleted(org.apache.helix.integration.task.TestWorkflowTimeout)  Time elapsed: 2.793 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.integration.task.TestWorkflowTimeout.testWorkflowTimeoutWhenWorkflowCompleted(TestWorkflowTimeout.java:116)

[ERROR] testDeletingRecurrentQueueWithHistory(org.apache.helix.integration.task.TestRecurringJobQueue)  Time elapsed: 122.517 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.integration.task.TestRecurringJobQueue.testDeletingRecurrentQueueWithHistory(TestRecurringJobQueue.java:296)

[ERROR] testWorkflowJobFail(org.apache.helix.integration.task.TestWorkflowTermination)  Time elapsed: 10.693 s  <<< FAILURE!
org.apache.helix.HelixException: Workflow "testWorkflowJobFail" context is empty or not in states: "[FAILED]", current state: "IN_PROGRESS"
	at org.apache.helix.integration.task.TestWorkflowTermination.testWorkflowJobFail(TestWorkflowTermination.java:223)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestRecurringJobQueue.testDeletingRecurrentQueueWithHistory:296 expected:<true> but was:<false>
[ERROR]   TestWorkflowTermination.testWorkflowJobFail:223 » Helix Workflow "testWorkflow...
[ERROR]   TestWorkflowTimeout.testWorkflowTimeoutWhenWorkflowCompleted:116 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1150, Failures: 3, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:23 h
[INFO] Finished at: 2020-06-04T17:24:00-07:00
[INFO] ------------------------------------------------------------------------
```
The failed tests succeed when run individually.
mvn test -Dtest="TestRecurringJobQueue,TestWorkflowTermination,TestWorkflowTimeout"
```
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 154.027 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:39 min
[INFO] Finished at: 2020-06-04T17:27:08-07:00
[INFO] ------------------------------------------------------------------------
```

helix-rest:
```
[INFO] Tests run: 161, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 41.995 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 161, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  47.407 s
[INFO] Finished at: 2020-06-05T13:47:39-07:00
[INFO] ------------------------------------------------------------------------
```
### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml
