### PR TITLE
Remove waiting on message deletion if current state is already updated

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -220,7 +220,8 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
                 generateCancellationMessageForPendingMessage(desiredState, currentState, nextState, pendingMessage,
                     manager, resource, partition, sessionIdMap, instanceName, stateModelDef,
                     cancellationMessage, isCancellationEnabled);
-          } else {
+          }
+          if (pendingMessage == null || currentState.equalsIgnoreCase(pendingMessage.getToState())) {
             // Create new state transition message
             message = createStateTransitionMessage(manager, resource, partition.getPartitionName(),
                 instanceName, currentState, nextState, sessionIdMap.get(instanceName),

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -221,7 +221,10 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
                     manager, resource, partition, sessionIdMap, instanceName, stateModelDef,
                     cancellationMessage, isCancellationEnabled);
           }
-          if (pendingMessage == null || currentState.equalsIgnoreCase(pendingMessage.getToState())) {
+          // We will generate new message if pending message is null or current state equals
+          // pending message's toState (no cancellation message should be generated in this case)
+          if (pendingMessage == null || (message == null &&
+              currentState.equalsIgnoreCase(pendingMessage.getToState()))) {
             // Create new state transition message
             message = createStateTransitionMessage(manager, resource, partition.getPartitionName(),
                 instanceName, currentState, nextState, sessionIdMap.get(instanceName),

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -225,6 +225,13 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
           // pending message's toState (no cancellation message should be generated in this case)
           if (pendingMessage == null || (message == null &&
               currentState.equalsIgnoreCase(pendingMessage.getToState()))) {
+            if (pendingMessage != null && message == null && currentState
+                .equalsIgnoreCase(pendingMessage.getToState())) {
+              logger.info("Ignore the pending message for resource %s partition %s instance "
+                      + "%s since the current state %s equals toState of pending message.",
+                  resource.getResourceName(), partition.getPartitionName(), instanceName,
+                  currentState);
+            }
             // Create new state transition message
             message = createStateTransitionMessage(manager, resource, partition.getPartitionName(),
                 instanceName, currentState, nextState, sessionIdMap.get(instanceName),

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -225,8 +225,7 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
           // pending message's toState (no cancellation message should be generated in this case)
           if (pendingMessage == null || (message == null &&
               currentState.equalsIgnoreCase(pendingMessage.getToState()))) {
-            if (pendingMessage != null && message == null && currentState
-                .equalsIgnoreCase(pendingMessage.getToState())) {
+            if (pendingMessage != null) {
               logger.info("Ignore the pending message for resource %s partition %s instance "
                       + "%s since the current state %s equals toState of pending message.",
                   resource.getResourceName(), partition.getPartitionName(), instanceName,

--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PNoDuplicatedMessage.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PNoDuplicatedMessage.java
@@ -171,11 +171,7 @@ public class TestP2PNoDuplicatedMessage extends ZkTestBase {
       verifyP2PEnabled(startTime);
     }
 
-    double ratio = ((double) p2pTrigged) / ((double) total);
-    Assert.assertTrue(ratio == 1, String
-       .format("Only %d out of %d percent transitions to Master were triggered by expected host!",
-           p2pTrigged, total));
-
+    Assert.assertEquals(p2pTrigged, total);
     Assert.assertEquals(MockHelixTaskExecutor.duplicatedMessagesInProgress, 0,
         "There are duplicated transition messages sent while participant is handling the state-transition!");
     Assert.assertEquals(MockHelixTaskExecutor.duplicatedMessages, 0,

--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PNoDuplicatedMessage.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PNoDuplicatedMessage.java
@@ -62,12 +62,12 @@ public class TestP2PNoDuplicatedMessage extends ZkTestBase {
   final String CLASS_NAME = getShortClassName();
   final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + CLASS_NAME;
 
-  static final int PARTICIPANT_NUMBER = 6;
+  static final int PARTICIPANT_NUMBER = 10;
   static final int PARTICIPANT_START_PORT = 12918;
 
   static final int DB_COUNT = 2;
 
-  static final int PARTITION_NUMBER = 50;
+  static final int PARTITION_NUMBER = 100;
   static final int REPLICA_NUMBER = 3;
 
   final String _controllerName = CONTROLLER_PREFIX + "_0";
@@ -172,7 +172,7 @@ public class TestP2PNoDuplicatedMessage extends ZkTestBase {
     }
 
     double ratio = ((double) p2pTrigged) / ((double) total);
-    Assert.assertTrue(ratio > 0.6, String
+    Assert.assertTrue(ratio == 1, String
        .format("Only %d out of %d percent transitions to Master were triggered by expected host!",
            p2pTrigged, total));
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

(#1067 )

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
This PR remove the waiting on existing pending message if the message is already processed and current state has already been updated. This would help generate message earlier and increase the rate of P2P message.

### Tests

- [X] The following tests are written for this issue:
Two tests are heavily modified:
TestP2PMessagesAvoidDuplicatedMessage
TestP2PStateTransitionMessages

- [X] The following is the result of the "mvn test" command on the appropriate module:
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestRebalancePipeline.testMsgTriggeredRebalance:203 expected:<true> but was:<false>
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[ERROR]   TestTaskNumAttempts.testTaskNumAttemptsWithDelay:76 expected:<2> but was:<1>
[ERROR]   TestTaskRebalancer.timeouts » ThreadTimeout Method org.testng.internal.TestNGM...
[INFO] 
[ERROR] Tests run: 1145, Failures: 4, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:27 h
[INFO] Finished at: 2020-06-22T12:14:24-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 

helix-rest
[INFO] Tests run: 162, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 36.34 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 162, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  40.589 s
[INFO] Finished at: 2020-06-09T19:12:40-07:00

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)