### PR TITLE
Validate data write size limit in ZkClient

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
@@ -60,4 +60,7 @@ public class ZkSystemPropertyKeys {
    */
   public static final String ZK_AUTOSYNC_ENABLED =
       "zk.zkclient.autosync.enabled";
+
+  /** System property key for jute.maxbuffer */
+  public static final String JUTE_MAXBUFFER = "jute.maxbuffer";
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/ZNRecordUtil.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/ZNRecordUtil.java
@@ -50,7 +50,7 @@ public class ZNRecordUtil {
 
   /**
    * Returns ZNRecord serializer write size limit in bytes. If size limit is configured to be less
-   * than or equal to 0, the default value will be used instead.
+   * than or equal to 0, the default value {@link ZNRecord#SIZE_LIMIT} will be used instead.
    */
   public static int getSerializerWriteSizeLimit() {
     Integer writeSizeLimit =

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -101,6 +101,7 @@ public class ZkClient implements Watcher {
   public final long _uid;
 
   // ZNode write size limit in bytes.
+  // TODO: use ZKConfig#JUTE_MAXBUFFER once bumping up ZK to 3.5.2+
   private static final int WRITE_SIZE_LIMIT =
       Integer.getInteger(ZkSystemPropertyKeys.JUTE_MAXBUFFER, ZNRecord.SIZE_LIMIT);
 
@@ -2505,7 +2506,6 @@ public class ZkClient implements Watcher {
     int serializerSize = ZNRecordUtil.getSerializerWriteSizeLimit();
     LOG.info("ZNRecord serializer write size limit: {}; ZkClient write size limit: {}",
         serializerSize, WRITE_SIZE_LIMIT);
-    // ZNRecord serializer write size limit should not be set greater than size limit in ZkClient
     if (serializerSize > WRITE_SIZE_LIMIT) {
       throw new IllegalStateException("ZNRecord serializer write size limit " + serializerSize
           + " is greater than ZkClient size limit " + WRITE_SIZE_LIMIT);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -35,10 +35,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.management.JMException;
 
 import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
-import org.apache.helix.zookeeper.datamodel.SessionAwareZNRecord;
 import org.apache.helix.zookeeper.constant.ZkSystemPropertyKeys;
+import org.apache.helix.zookeeper.datamodel.SessionAwareZNRecord;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.exception.ZkClientException;
+import org.apache.helix.zookeeper.util.ZNRecordUtil;
 import org.apache.helix.zookeeper.zkclient.annotation.PreFetchChangedData;
 import org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallMonitorContext;
 import org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks;
@@ -98,6 +99,10 @@ public class ZkClient implements Watcher {
 
   private static AtomicLong UID = new AtomicLong(0);
   public final long _uid;
+
+  // ZNode write size limit in bytes.
+  private static final int WRITE_SIZE_LIMIT =
+      Integer.getInteger(ZkSystemPropertyKeys.JUTE_MAXBUFFER, ZNRecord.SIZE_LIMIT);
 
   private final IZkConnection _connection;
   private final long _operationRetryTimeoutInMillis;
@@ -213,6 +218,7 @@ public class ZkClient implements Watcher {
     }
 
     _uid = UID.getAndIncrement();
+    validateWriteSizeLimitConfig();
 
     _connection = zkConnection;
     _pathBasedZkSerializer = zkSerializer;
@@ -718,7 +724,7 @@ public class ZkClient implements Watcher {
     long startT = System.currentTimeMillis();
     try {
       final byte[] dataBytes = dataObject == null ? null : serialize(dataObject, path);
-      checkDataSizeLimit(dataBytes);
+      checkDataSizeLimit(path, dataBytes);
 
       final String actualPath = retryUntilConnected(
           () -> getExpectedZookeeper(expectedSessionId).create(path, dataBytes, acl, mode));
@@ -1878,7 +1884,7 @@ public class ZkClient implements Watcher {
     long startT = System.currentTimeMillis();
     try {
       final byte[] data = serialize(datat, path);
-      checkDataSizeLimit(data);
+      checkDataSizeLimit(path, data);
       final Stat stat = (Stat) retryUntilConnected(new Callable<Object>() {
         @Override
         public Object call() throws Exception {
@@ -2006,12 +2012,15 @@ public class ZkClient implements Watcher {
     });
   }
 
-  private void checkDataSizeLimit(byte[] data) {
-    if (data != null && data.length > ZNRecord.SIZE_LIMIT) {
-      LOG.error(
-          "Data size larger than 1M, will not write to zk. Data (first 1k): " + new String(data)
-              .substring(0, 1024));
-      throw new ZkClientException("Data size larger than 1M");
+  private void checkDataSizeLimit(String path, byte[] data) {
+    if (data == null) {
+      return;
+    }
+
+    if (data.length > WRITE_SIZE_LIMIT) {
+      throw new ZkClientException("Data size of path " + path
+          + " is greater than write size limit "
+          + WRITE_SIZE_LIMIT + " bytes");
     }
   }
 
@@ -2480,8 +2489,7 @@ public class ZkClient implements Watcher {
 
     if (stat.getNumChildren() > NUM_CHILDREN_LIMIT) {
       LOG.error("Failed to get children for path {} because of connection loss. "
-              + "Number of children {} exceeds limit {}, aborting retry.", path,
-          stat.getNumChildren(),
+              + "Number of children {} exceeds limit {}, aborting retry.", path, stat.getNumChildren(),
           NUM_CHILDREN_LIMIT);
       // MarshallingErrorException could represent transport error: exceeding the
       // Jute buffer size. So use it to exit retry loop and tell that zk is not able to
@@ -2490,6 +2498,17 @@ public class ZkClient implements Watcher {
     } else {
       LOG.debug("Number of children {} is less than limit {}, not exiting retry.",
           stat.getNumChildren(), NUM_CHILDREN_LIMIT);
+    }
+  }
+
+  private void validateWriteSizeLimitConfig() {
+    int serializerSize = ZNRecordUtil.getSerializerWriteSizeLimit();
+    LOG.info("ZNRecord serializer write size limit: {}; ZkClient write size limit: {}",
+        serializerSize, WRITE_SIZE_LIMIT);
+    // ZNRecord serializer write size limit should not be set greater than size limit in ZkClient
+    if (serializerSize > WRITE_SIZE_LIMIT) {
+      throw new IllegalStateException("ZNRecord serializer write size limit " + serializerSize
+          + " is greater than ZkClient size limit " + WRITE_SIZE_LIMIT);
     }
   }
 }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/TestHelper.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/TestHelper.java
@@ -114,6 +114,14 @@ public class TestHelper {
     return fullClassName.substring(fullClassName.lastIndexOf('.') + 1);
   }
 
+  public static void resetSystemProperty(String key, String originValue) {
+    if (originValue == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, originValue);
+    }
+  }
+
   public interface Verifier {
     boolean verify()
         throws Exception;


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1071 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

If configurable write size limit for znrecord serializer is different from the default size 1 MB, especially it is set to larger than 1 MB, writing won't work because it would be blocked by this default size check in zkclient.

This PR also reads both `jute.maxbuffer` config and znrecord serializer write size limit, and validates the correctness of data size limit.

### Tests

- [x] The following tests are written for this issue:

- testDataSizeGreaterThanLimit
- testDataSizeLessThanLimit
- testInvalidWriteSizeLimitConfig

- [x] The following is the result of the "mvn test" command on the appropriate module:


In zookeeper-api module.
```
[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 64.326 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:08 min
[INFO] Finished at: 2020-10-22T17:17:17-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)