### PR TITLE
Do not ignore the baseline assignment when evaluating in PartitionMovementConstraint.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/PartitionMovementConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/PartitionMovementConstraint.java
@@ -103,10 +103,9 @@ class PartitionMovementConstraint extends SoftConstraint {
       Map<String, String> instanceToStateMap) {
     if (instanceToStateMap.containsKey(nodeName)) {
       return state.equals(instanceToStateMap.get(nodeName)) ?
-          // if state matches, no state transition required for the proposed assignment
-          1 :
-          // if state does not match, then the proposed assignment requires state transition
-          STATE_TRANSITION_COST_FACTOR;
+          1 : // if state matches, no state transition required for the proposed assignment
+          STATE_TRANSITION_COST_FACTOR; // if state does not match,
+                                        // then the proposed assignment requires state transition.
     }
     return 0;
   }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#931

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

The current implementation of the PartitionMovementConstraint will ignore the baseline assignment completely when the previous best possible assignment has the corresponding record.
Note that since the previous best possible assignment might become invalid, the constraint should refer to the baseline assignment as a secondary option.

This change fixes this issue by prioritizing the baseline and the best possible assignments instead of just ignoring.
This reduces the chance of divergences between the baseline and the best possible assignments. Also, it reduces the possibility of bouncing partition assignments.

### Tests

- [X] The following tests are written for this issue:

TestPartitionMovementConstraint.java

I also profiled the rebalancer performance with the change.
Simulate a cluster with 15 nodes. Then execute the following operations,
1. add 20 resources (128 partitions/3 replicas).
2. remove 10 resources that are added first.
3. rolling disable/reset/enable instances by zones (not delayed rebalance is not enabled or there won't be any change after all operations)

The final results,
- Before change,
Partition distribution:	Max	271.000000	Min	209.000000	STDEV	23.880656
MASTER distribution:	Max	87.000000	Min	79.000000	STDEV	2.870208
SLAVE distribution:	Max	184.000000	Min	128.000000	STDEV	21.137869
Capacity Usage Partition distribution:	Max	271.000000	Min	209.000000	STDEV	23.880656
- After change,
Partition distribution:	Max	259.000000	Min	252.000000	STDEV	2.236068
MASTER distribution:	Max	87.000000	Min	84.000000	STDEV	0.899735
SLAVE distribution:	Max	174.000000	Min	166.000000	STDEV	2.716791
Capacity Usage Partition distribution:	Max	259.000000	Min	252.000000	STDEV	2.236068
There is an obvious enhancement.

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures:
[ERROR]   TestNoThrottleDisabledPartitions.testDisablingTopStateReplicaByDisablingInstance:98 expected:<false> but was:<true>
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[ERROR]   TestTaskRebalancerStopResume.testStopWorkflowInStoppingState:513 expected:<STOPPING> but was:<STOPPED>
[ERROR]   TestWorkflowTimeout.testWorkflowTimeoutWhenWorkflowCompleted:116 expected:<true> but was:<false>
[ERROR]   TestClusterVerifier.testResourceSubset:225 expected:<false> but was:<true>
[INFO]
[ERROR] Tests run: 1139, Failures: 5, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:23 h
[INFO] Finished at: 2020-06-11T18:50:17-07:00
[INFO] ------------------------------------------------------------------------

Rerun

[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 136.49 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:23 min
[INFO] Finished at: 2020-06-12T11:16:55-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)