### PR TITLE
Add delete for PropertyStore in Helix REST

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
@@ -51,8 +52,6 @@ import org.apache.helix.zookeeper.util.HttpRoutingDataReader;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.helix.zookeeper.zkclient.IZkStateListener;
-import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
-import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.apache.zookeeper.Watcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -228,7 +227,7 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
    * Returns a lazily-instantiated ZkBaseDataAccessor for the byte array type.
    * @return
    */
-  public ZkBaseDataAccessor<byte[]> getByteArrayZkBaseDataAccessor() {
+  public BaseDataAccessor<byte[]> getByteArrayZkBaseDataAccessor() {
     if (_byteArrayZkBaseDataAccessor == null) {
       synchronized (this) {
         if (_byteArrayZkBaseDataAccessor == null) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/AbstractHelixResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/AbstractHelixResource.java
@@ -21,10 +21,10 @@ package org.apache.helix.rest.server.resources.helix;
 
 import java.io.IOException;
 
+import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.rest.common.ContextPropertyKeys;
 import org.apache.helix.rest.server.ServerContext;
 import org.apache.helix.rest.server.resources.AbstractResource;
@@ -77,7 +77,7 @@ public class AbstractHelixResource extends AbstractResource {
     return serverContext.getDataAccessor(clusterName);
   }
 
-  protected ZkBaseDataAccessor<byte[]> getByteArrayDataAccessor() {
+  protected BaseDataAccessor<byte[]> getByteArrayDataAccessor() {
     return getServerContext().getByteArrayZkBaseDataAccessor();
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.Response;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.PropertyPathBuilder;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.msdcommon.util.ZkValidationUtil;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
@@ -68,7 +67,7 @@ public class PropertyStoreAccessor extends AbstractHelixResource {
           "Invalid path string. Valid path strings use slash as the directory separator and names the location of ZNode");
     }
     final String recordPath = PropertyPathBuilder.propertyStore(clusterId) + path;
-    ZkBaseDataAccessor<byte[]> propertyStoreDataAccessor = getByteArrayDataAccessor();
+    BaseDataAccessor<byte[]> propertyStoreDataAccessor = getByteArrayDataAccessor();
     if (propertyStoreDataAccessor.exists(recordPath, AccessOption.PERSISTENT)) {
       byte[] bytes = propertyStoreDataAccessor.get(recordPath, null, AccessOption.PERSISTENT);
       ZNRecord znRecord = (ZNRecord) ZN_RECORD_SERIALIZER.deserialize(bytes);
@@ -123,7 +122,7 @@ public class PropertyStoreAccessor extends AbstractHelixResource {
               "Failed to write to path: " + recordPath + "! Content is not a valid ZNRecord!");
         }
       } else {
-        ZkBaseDataAccessor<byte[]> propertyStoreDataAccessor = getByteArrayDataAccessor();
+        BaseDataAccessor<byte[]> propertyStoreDataAccessor = getByteArrayDataAccessor();
         if (!propertyStoreDataAccessor
             .set(recordPath, content.getBytes(), AccessOption.PERSISTENT)) {
           return serverError(
@@ -153,7 +152,7 @@ public class PropertyStoreAccessor extends AbstractHelixResource {
           "Invalid path string. Valid path strings use slash as the directory separator and names the location of ZNode");
     }
     final String recordPath = PropertyPathBuilder.propertyStore(clusterId) + path;
-    ZkBaseDataAccessor<byte[]> propertyStoreDataAccessor = getByteArrayDataAccessor();
+    BaseDataAccessor<byte[]> propertyStoreDataAccessor = getByteArrayDataAccessor();
     if (!propertyStoreDataAccessor.remove(recordPath, AccessOption.PERSISTENT)) {
       return serverError("Failed to delete PropertyStore record in path: " + path);
     }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
@@ -31,11 +31,11 @@ import javax.ws.rs.core.Response;
 import com.google.common.base.Enums;
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.AccessOption;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.BaseDataAccessor;
+import org.apache.helix.msdcommon.util.ZkValidationUtil;
 import org.apache.helix.rest.common.ContextPropertyKeys;
 import org.apache.helix.rest.server.ServerContext;
 import org.apache.helix.rest.server.resources.AbstractResource;
-import org.apache.helix.msdcommon.util.ZkValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,13 +47,10 @@ import org.slf4j.LoggerFactory;
 @Path("/zookeeper")
 public class ZooKeeperAccessor extends AbstractResource {
   private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperAccessor.class.getName());
-  private ZkBaseDataAccessor<byte[]> _zkBaseDataAccessor;
+  private BaseDataAccessor<byte[]> _zkBaseDataAccessor;
 
   public enum ZooKeeperCommand {
-    exists,
-    getBinaryData,
-    getStringData,
-    getChildren
+    exists, getBinaryData, getStringData, getChildren
   }
 
   @GET
@@ -101,7 +98,7 @@ public class ZooKeeperAccessor extends AbstractResource {
    * @param path
    * @return true if a ZNode exists, false otherwise
    */
-  private Response exists(ZkBaseDataAccessor<byte[]> zkBaseDataAccessor, String path) {
+  private Response exists(BaseDataAccessor<byte[]> zkBaseDataAccessor, String path) {
     Map<String, Boolean> result = ImmutableMap.of(ZooKeeperCommand.exists.name(),
         zkBaseDataAccessor.exists(path, AccessOption.PERSISTENT));
     return JSONRepresentation(result);
@@ -113,7 +110,7 @@ public class ZooKeeperAccessor extends AbstractResource {
    * @param path
    * @return
    */
-  private Response getBinaryData(ZkBaseDataAccessor<byte[]> zkBaseDataAccessor, String path) {
+  private Response getBinaryData(BaseDataAccessor<byte[]> zkBaseDataAccessor, String path) {
     byte[] bytes = readBinaryDataFromZK(zkBaseDataAccessor, path);
     Map<String, byte[]> binaryResult =
         ImmutableMap.of(ZooKeeperCommand.getBinaryData.name(), bytes);
@@ -129,7 +126,7 @@ public class ZooKeeperAccessor extends AbstractResource {
    * @param path
    * @return
    */
-  private Response getStringData(ZkBaseDataAccessor<byte[]> zkBaseDataAccessor, String path) {
+  private Response getStringData(BaseDataAccessor<byte[]> zkBaseDataAccessor, String path) {
     byte[] bytes = readBinaryDataFromZK(zkBaseDataAccessor, path);
     Map<String, String> stringResult =
         ImmutableMap.of(ZooKeeperCommand.getStringData.name(), new String(bytes));
@@ -142,7 +139,7 @@ public class ZooKeeperAccessor extends AbstractResource {
    * @param path
    * @return
    */
-  private byte[] readBinaryDataFromZK(ZkBaseDataAccessor<byte[]> zkBaseDataAccessor, String path) {
+  private byte[] readBinaryDataFromZK(BaseDataAccessor<byte[]> zkBaseDataAccessor, String path) {
     if (zkBaseDataAccessor.exists(path, AccessOption.PERSISTENT)) {
       return zkBaseDataAccessor.get(path, null, AccessOption.PERSISTENT);
     } else {
@@ -157,7 +154,7 @@ public class ZooKeeperAccessor extends AbstractResource {
    * @param path
    * @return list of child ZNodes
    */
-  private Response getChildren(ZkBaseDataAccessor<byte[]> zkBaseDataAccessor, String path) {
+  private Response getChildren(BaseDataAccessor<byte[]> zkBaseDataAccessor, String path) {
     if (zkBaseDataAccessor.exists(path, AccessOption.PERSISTENT)) {
       Map<String, List<String>> result = ImmutableMap.of(ZooKeeperCommand.getChildren.name(),
           zkBaseDataAccessor.getChildNames(path, AccessOption.PERSISTENT));

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPropertyStoreAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPropertyStoreAccessor.java
@@ -130,7 +130,7 @@ public class TestPropertyStoreAccessor extends AbstractTestClass {
 
     // Verify
     ZkBaseDataAccessor<byte[]> byteAccessor =
-        new ZkBaseDataAccessor(ZK_ADDR, new ByteArraySerializer());
+        new ZkBaseDataAccessor<>(ZK_ADDR, new ByteArraySerializer());
     byte[] data = byteAccessor
         .get(PropertyPathBuilder.propertyStore(TEST_CLUSTER) + path, null, AccessOption.PERSISTENT);
     byteAccessor.close();
@@ -147,5 +147,15 @@ public class TestPropertyStoreAccessor extends AbstractTestClass {
     ZNRecord record = _baseAccessor
         .get(PropertyPathBuilder.propertyStore(TEST_CLUSTER) + path, null, AccessOption.PERSISTENT);
     Assert.assertEquals(contentRecord, record);
+  }
+
+  @Test(dependsOnMethods = "testPutPropertyStore")
+  public void testDeletePropertyStore() {
+    String path = "/writePath/content";
+    delete("clusters/" + TEST_CLUSTER + "/propertyStore" + path,
+        Response.Status.OK.getStatusCode());
+
+    Assert.assertFalse(_baseAccessor
+        .exists(PropertyPathBuilder.propertyStore(TEST_CLUSTER) + path, AccessOption.PERSISTENT));
   }
 }


### PR DESCRIPTION


### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1048 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This commit adds the delete endpoint for PropertyStore in Helix REST.

### Tests

- [x] The following tests are written for this issue:

testDeletePropertyStore

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 162, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.947 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 162, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  45.025 s
[INFO] Finished at: 2020-06-09T15:21:42-07:00


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)