### PR TITLE
Fix waitToStop method in TaskDriver

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -652,7 +652,7 @@ public class TaskDriver {
       WorkflowContext workflowContext = getWorkflowContext(workflow);
 
       if (workflowContext == null
-          || TaskState.IN_PROGRESS.equals(workflowContext.getWorkflowState())) {
+          || !TaskState.STOPPED.equals(workflowContext.getWorkflowState())) {
         Thread.sleep(1000);
       } else {
         // Successfully stopped

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestStoppingQueueFailToStop.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestStoppingQueueFailToStop.java
@@ -21,8 +21,6 @@ package org.apache.helix.integration.task;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
@@ -41,10 +39,8 @@ import org.apache.helix.task.TaskUtil;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-
 
 /**
  * Test to check if waitToStop method correctly throws an Exception if Queue stuck in STOPPING
@@ -52,8 +48,7 @@ import com.google.common.collect.Sets;
  */
 public class TestStoppingQueueFailToStop extends TaskTestBase {
   private static final String DATABASE = WorkflowGenerator.DEFAULT_TGT_DB;
-  protected HelixDataAccessor _accessor;
-  private boolean TASK_STOPPABLE = false;
+  private boolean _taskStoppable = false;
 
   @BeforeClass
   public void beforeClass() throws Exception {
@@ -104,13 +99,13 @@ public class TestStoppingQueueFailToStop extends TaskTestBase {
         TaskState.IN_PROGRESS);
     boolean exceptionHappened = false;
     try {
-      _driver.waitToStop(jobQueueName, 5000);
+      _driver.waitToStop(jobQueueName, 5000L);
     } catch (HelixException e) {
       exceptionHappened = true;
     }
     _driver.pollForWorkflowState(jobQueueName, TaskState.STOPPING);
     Assert.assertTrue(exceptionHappened);
-    TASK_STOPPABLE = true;
+    _taskStoppable = true;
   }
 
   /**
@@ -124,7 +119,7 @@ public class TestStoppingQueueFailToStop extends TaskTestBase {
 
     @Override
     public void cancel() {
-      while (!TASK_STOPPABLE) {
+      while (!_taskStoppable) {
         try {
           Thread.sleep(1000L);
         } catch (Exception e) {

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestStoppingQueueFailToStop.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestStoppingQueueFailToStop.java
@@ -1,0 +1,137 @@
+package org.apache.helix.integration.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixException;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.MasterSlaveSMD;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.JobQueue;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.TaskUtil;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+
+
+/**
+ * Test to check if waitToStop method correctly throws an Exception if Queue stuck in STOPPING
+ * state.
+ */
+public class TestStoppingQueueFailToStop extends TaskTestBase {
+  private static final String DATABASE = WorkflowGenerator.DEFAULT_TGT_DB;
+  protected HelixDataAccessor _accessor;
+  private boolean TASK_STOPPABLE = false;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _numPartitions = 1;
+    _numNodes = 3;
+    super.beforeClass();
+    _manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "Admin",
+        InstanceType.ADMINISTRATOR, ZK_ADDR);
+
+    // Stop participants that have been started in super class
+    for (int i = 0; i < _numNodes; i++) {
+      super.stopParticipant(i);
+      Assert.assertFalse(_participants[i].isConnected());
+    }
+
+    // Start new participants that have new TaskStateModel (NewMockTask) information
+    _participants = new MockParticipantManager[_numNodes];
+    for (int i = 0; i < _numNodes; i++) {
+      Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
+      taskFactoryReg.put(NewMockTask.TASK_COMMAND, NewMockTask::new);
+      String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+
+      // Register a Task state model factory.
+      StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+      stateMachine.registerStateModelFactory("Task",
+          new TaskStateModelFactory(_participants[i], taskFactoryReg));
+      _participants[i].syncStart();
+    }
+
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+  }
+
+  @Test
+  public void testStoppingQueueFailToStop() throws Exception {
+    String jobQueueName = TestHelper.getTestMethodName();
+    JobConfig.Builder jobBuilder0 =
+        new JobConfig.Builder().setWorkflow(jobQueueName).setTargetResource(DATABASE)
+            .setTargetPartitionStates(Sets.newHashSet(MasterSlaveSMD.States.MASTER.name()))
+            .setCommand(MockTask.TASK_COMMAND)
+            .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "100000"));
+
+    JobQueue.Builder jobQueue = TaskTestUtil.buildJobQueue(jobQueueName);
+    jobQueue.enqueueJob("JOB0", jobBuilder0);
+    _driver.start(jobQueue.build());
+    _driver.pollForJobState(jobQueueName, TaskUtil.getNamespacedJobName(jobQueueName, "JOB0"),
+        TaskState.IN_PROGRESS);
+    boolean exceptionHappened = false;
+    try {
+      _driver.waitToStop(jobQueueName, 5000);
+    } catch (HelixException e) {
+      exceptionHappened = true;
+    }
+    _driver.pollForWorkflowState(jobQueueName, TaskState.STOPPING);
+    Assert.assertTrue(exceptionHappened);
+    TASK_STOPPABLE = true;
+  }
+
+  /**
+   * A mock task that extents MockTask class and stuck in running when cancel is called.
+   */
+  private class NewMockTask extends MockTask {
+
+    NewMockTask(TaskCallbackContext context) {
+      super(context);
+    }
+
+    @Override
+    public void cancel() {
+      while (!TASK_STOPPABLE) {
+        try {
+          Thread.sleep(1000L);
+        } catch (Exception e) {
+          // Pass
+        }
+      }
+      super.cancel();
+    }
+  }
+}


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #1082 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In this PR, waitToStop has been changed to make sure workflow/queue is in stopped state if waitToStop returns successfully without Exception. When the queue targetState is set to stop, the queue will go to STOPPING state. STOPPING state is a transient state which means some of the jobs has not ben completely stopped or in terminal state. In other words, some of that tasks within the jobs have not reached the terminal state yet.

### Tests
- [x] The following tests are written for this issue:
TestStoppingQueueFailToStop
- [x] The following is the result of the "mvn test" command on the appropriate module:

helix-core:
```
[ERROR] Tests run: 1140, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 5,244.233 s <<< FAILURE! - in TestSuite
[ERROR] testJobQueueAutoCleanUp(org.apache.helix.integration.task.TestJobQueueCleanUp)  Time elapsed: 300.016 s  <<< FAILURE!
org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testJobQueueAutoCleanUp() didn't finish within the time-out 300000

[ERROR] testControllerSwitch(org.apache.helix.task.TestAssignableInstanceManagerControllerSwitch)  Time elapsed: 1.352 s  <<< FAILURE!
java.lang.AssertionError: expected:<5> but was:<0>
	at org.apache.helix.task.TestAssignableInstanceManagerControllerSwitch.testControllerSwitch(TestAssignableInstanceManagerControllerSwitch.java:105)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[ERROR]   TestAssignableInstanceManagerControllerSwitch.testControllerSwitch:105 expected:<5> but was:<0>
[INFO] 
[ERROR] Tests run: 1140, Failures: 2, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:27 h
[INFO] Finished at: 2020-06-10T14:07:27-07:00
[INFO] ------------------------------------------------------------------------
```
The failed test succeed when run individually.
mvn test -Dtest="TestJobQueueCleanUp,TestAssignableInstanceManagerControllerSwitch"
```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.077 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  25.503 s
[INFO] Finished at: 2020-06-10T14:37:42-07:00
[INFO] ------------------------------------------------------------------------
```
helix-rest:
```
[INFO] Tests run: 162, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 46.785 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 162, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  52.195 s
[INFO] Finished at: 2020-06-10T14:36:25-07:00
[INFO] ------------------------------------------------------------------------
```


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml