### PR TITLE
Implement getStat in ZookeeperAccessor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -22,7 +22,9 @@ package org.apache.helix.manager.zk;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.helix.HelixException;
 import org.apache.helix.InstanceType;
@@ -631,5 +633,40 @@ public final class ZKUtil {
     clientConfig.setZkSerializer(new ZNRecordSerializer());
     return DedicatedZkClientFactory.getInstance()
         .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddr), clientConfig);
+  }
+
+  /**
+   * Convert Stat fields into a Map.
+   *     private long czxid;
+   *     private long mzxid;
+   *     private long ctime;
+   *     private long mtime;
+   *     private int version;
+   *     private int cversion;
+   *     private int aversion;
+   *     private long ephemeralOwner;
+   *     private int dataLength;
+   *     private int numChildren;
+   *     private long pzxid;
+   * @param stat
+   * @return
+   */
+  public static Map<String, String> fromStatToMap(Stat stat) {
+    if (stat == null) {
+      throw new HelixException("Stat cannot be null!");
+    }
+    Map<String, String> statMap = new HashMap<>();
+    statMap.put("czxid", Long.toString(stat.getCzxid()));
+    statMap.put("mzxid", Long.toString(stat.getMzxid()));
+    statMap.put("ctime", Long.toString(stat.getCtime()));
+    statMap.put("mtime", Long.toString(stat.getMtime()));
+    statMap.put("version", Integer.toString(stat.getVersion()));
+    statMap.put("cversion", Integer.toString(stat.getCversion()));
+    statMap.put("aversion", Integer.toString(stat.getAversion()));
+    statMap.put("ephemeralOwner", Long.toString(stat.getEphemeralOwner()));
+    statMap.put("dataLength", Integer.toString(stat.getDataLength()));
+    statMap.put("numChildren", Integer.toString(stat.getNumChildren()));
+    statMap.put("pzxid", Long.toString(stat.getPzxid()));
+    return statMap;
   }
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
@@ -186,15 +186,14 @@ public class ZooKeeperAccessor extends AbstractResource {
    * @return
    */
   private Response getStat(BaseDataAccessor<byte[]> zkBaseDataAccessor, String path) {
-    if (zkBaseDataAccessor.exists(path, AccessOption.PERSISTENT)) {
-      Stat stat = zkBaseDataAccessor.getStat(path, AccessOption.PERSISTENT);
-      Map<String, String> result = ZKUtil.fromStatToMap(stat);
-      result.put("path", path);
-      return JSONRepresentation(result);
-    } else {
+    Stat stat = zkBaseDataAccessor.getStat(path, AccessOption.PERSISTENT);
+    if (stat == null) {
       throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
           .entity(String.format("The ZNode at path %s does not exist!", path)).build());
     }
+    Map<String, String> result = ZKUtil.fromStatToMap(stat);
+    result.put("path", path);
+    return JSONRepresentation(result);
   }
 
   private ZooKeeperCommand getZooKeeperCommandIfPresent(String command) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
@@ -52,7 +52,11 @@ public class ZooKeeperAccessor extends AbstractResource {
   private BaseDataAccessor<byte[]> _zkBaseDataAccessor;
 
   public enum ZooKeeperCommand {
-    exists, getBinaryData, getStringData, getChildren, getStat
+    exists,
+    getBinaryData,
+    getStringData,
+    getChildren,
+    getStat
   }
 
   @GET

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
@@ -171,6 +171,11 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
   public void testGetStat() throws IOException {
     String path = "/path/getStat";
 
+    // Make sure it returns a NOT FOUND if there is no ZNode
+    String data = new JerseyUriRequestBuilder("zookeeper{}?command=getStat").format(path)
+        .isBodyReturnExpected(false)
+        .expectedReturnStatusCode(Response.Status.NOT_FOUND.getStatusCode()).get(this);
+
     // Create a test ZNode (ephemeral)
     _testBaseDataAccessor.create(path, null, AccessOption.PERSISTENT);
     Stat stat = _testBaseDataAccessor.getStat(path, AccessOption.PERSISTENT);
@@ -178,7 +183,7 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
     expectedFields.put("path", path);
 
     // Verify with the REST endpoint
-    String data = new JerseyUriRequestBuilder("zookeeper{}?command=getStat").format(path)
+    data = new JerseyUriRequestBuilder("zookeeper{}?command=getStat").format(path)
         .isBodyReturnExpected(true).get(this);
     Map<String, String> result = OBJECT_MAPPER.readValue(data, HashMap.class);
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
@@ -176,5 +176,8 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
     Map<String, String> result = OBJECT_MAPPER.readValue(data, HashMap.class);
 
     Assert.assertEquals(result, expectedFields);
+
+    // Clean up
+    _testBaseDataAccessor.remove(path, AccessOption.PERSISTENT);
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1088

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Helix REST doesn't provide a way for users to get the Stat object for a ZNode. This commit enables this with a getStat command.

### Tests

- [x] The following tests are written for this issue:

ZookeeperAccessor::testGetStat

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 163, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.178 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 163, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)