### PR TITLE
Add metrics for expired session count

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
@@ -110,6 +110,10 @@ public class TestZkClientMonitor {
     long stateChangeCount = (long) _beanServer.getAttribute(name, "StateChangeEventCounter");
     Assert.assertEquals(stateChangeCount, 1);
 
+    monitor.increasExpiredSessionCounter();
+    long expiredSessionCount = (long) _beanServer.getAttribute(name, "ExpiredSessionCounter");
+    Assert.assertEquals(expiredSessionCount, 1);
+
     monitor.increaseOutstandingRequestGauge();
     long requestGauge = (long) _beanServer.getAttribute(name, "OutstandingRequestGauge");
     Assert.assertEquals(requestGauge, 1);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -2144,12 +2144,12 @@ public class ZkClient implements Watcher {
     if (_monitor != null) {
       if (stateChanged) {
         _monitor.increaseStateChangeEventCounter();
-        if (sessionExpired) {
-          _monitor.increasExpiredSessionCounter();
-        }
       }
       if (dataChanged) {
         _monitor.increaseDataChangeEventCounter();
+      }
+      if (sessionExpired) {
+        _monitor.increasExpiredSessionCounter();
       }
     }
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/metric/ZkClientMonitor.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/metric/ZkClientMonitor.java
@@ -56,6 +56,7 @@ public class ZkClientMonitor extends DynamicMBeanProvider {
   private boolean _monitorRootOnly;
 
   private SimpleDynamicMetric<Long> _stateChangeEventCounter;
+  private SimpleDynamicMetric<Long> _expiredSessionCounter;
   private SimpleDynamicMetric<Long> _dataChangeEventCounter;
   private SimpleDynamicMetric<Long> _outstandingRequestGauge;
 
@@ -79,6 +80,7 @@ public class ZkClientMonitor extends DynamicMBeanProvider {
     _monitorRootOnly = monitorRootOnly;
 
     _stateChangeEventCounter = new SimpleDynamicMetric("StateChangeEventCounter", 0l);
+    _expiredSessionCounter = new SimpleDynamicMetric("ExpiredSessionCounter", 0l);
     _dataChangeEventCounter = new SimpleDynamicMetric("DataChangeEventCounter", 0l);
     _outstandingRequestGauge = new SimpleDynamicMetric("OutstandingRequestGauge", 0l);
     if (zkEventThread != null) {
@@ -100,6 +102,7 @@ public class ZkClientMonitor extends DynamicMBeanProvider {
     attributeList.add(_dataChangeEventCounter);
     attributeList.add(_outstandingRequestGauge);
     attributeList.add(_stateChangeEventCounter);
+    attributeList.add(_expiredSessionCounter);
     if (_zkEventThreadMetric != null) {
       attributeList.add(_zkEventThreadMetric);
     }
@@ -135,6 +138,12 @@ public class ZkClientMonitor extends DynamicMBeanProvider {
   public void increaseStateChangeEventCounter() {
     synchronized (_stateChangeEventCounter) {
       _stateChangeEventCounter.updateValue(_stateChangeEventCounter.getValue() + 1);
+    }
+  }
+
+  public void increasExpiredSessionCounter() {
+    synchronized (_expiredSessionCounter) {
+      _expiredSessionCounter.updateValue(_expiredSessionCounter.getValue() + 1);
     }
   }
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
#1100 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Having a metric for number of expired session in zk client side will help user debugging cases that has frequent session expiration.
This PR adds a "ExpiredSessionCounter" metrics in ZkClientMonitor.

### Tests

- [X] The following tests are written for this issue:

TestRawZkClient.testSessionExpireCount

- [X] The following is the result of the "mvn test" command on the appropriate module:
```

[ERROR] org.apache.helix.integration.TestDisablePartition.testDisableFullAuto(org.apache.helix.integration.TestDisablePartition)
[ERROR]   Run 1: TestDisablePartition.testDisableFullAuto:202 expected:<OFFLINE> but was:<STANDBY>
[INFO]   Run 2: PASS
[INFO]
[ERROR]   TestControllerLeadershipChange.testMissingTopStateDurationMonitoring:262 expected:<true> but was:<false>
[ERROR]   TestStateTransitionTimeout.testStateTransitionTimeOut:166 expected:<true> but was:<false>
[ERROR]   TestStateTransitionTimeoutWithResource.testStateTransitionTimeOut:171 expected:<true> but was:<false>
[ERROR]   TestJobFailureDependence.testWorkflowFailureJobThreshold » ThreadTimeout Metho...

Rerun：
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.536 s - in org.apache.helix.integration.controller.TestControllerLeadershipChange
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.018 s - in org.apache.helix.integration.paticipant.TestStateTransitionTimeout
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.774 s - in org.apache.helix.integration.paticipant.TestStateTransitionTimeoutWithResource
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 48.617 s - in org.apache.helix.integration.task.TestJobFailureDependence

```
### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [X] In case of new functionality, my PR adds documentation in the following wiki page:


### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)