### PR TITLE
Enhance flaky test TestRemoveUserCbHandlerOnPathRemoval

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/api/rebalancer/constraint/AbnormalStateResolver.java
+++ b/helix-core/src/main/java/org/apache/helix/api/rebalancer/constraint/AbnormalStateResolver.java
@@ -31,24 +31,6 @@ import org.apache.helix.model.StateModelDefinition;
  */
 public interface AbnormalStateResolver {
   /**
-   * A placeholder which will be used when the resolver is not specified.
-   * This is a dummy class that does not really functional.
-   */
-  AbnormalStateResolver DUMMY_STATE_RESOLVER = new AbnormalStateResolver() {
-    public boolean checkCurrentStates(final CurrentStateOutput currentStateOutput,
-        final String resourceName, final Partition partition,
-        final StateModelDefinition stateModelDef) {
-      // By default, all current states are valid.
-      return true;
-    }
-    public Map<String, String> computeRecoveryAssignment(final CurrentStateOutput currentStateOutput,
-        final String resourceName, final Partition partition,
-        final StateModelDefinition stateModelDef, final List<String> preferenceList) {
-      throw new UnsupportedOperationException("This resolver won't recover abnormal states.");
-    }
-  };
-
-  /**
    * Check if the current states of the specified partition is valid.
    * @param currentStateOutput
    * @param resourceName

--- a/helix-core/src/main/java/org/apache/helix/api/rebalancer/constraint/AbnormalStateResolver.java
+++ b/helix-core/src/main/java/org/apache/helix/api/rebalancer/constraint/AbnormalStateResolver.java
@@ -1,0 +1,75 @@
+package org.apache.helix.api.rebalancer.constraint;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.Partition;
+import org.apache.helix.model.StateModelDefinition;
+
+/**
+ * A generic interface to find and recover if the partition has abnormal current states.
+ */
+public interface AbnormalStateResolver {
+  /**
+   * A placeholder which will be used when the resolver is not specified.
+   * This is a dummy class that does not really functional.
+   */
+  AbnormalStateResolver DUMMY_STATE_RESOLVER = new AbnormalStateResolver() {
+    public boolean isCurrentStatesValid(final CurrentStateOutput currentStateOutput,
+        final String resourceName, final Partition partition,
+        final StateModelDefinition stateModelDef) {
+      // By default, all current states are valid.
+      return true;
+    }
+    public Map<String, String> computeRecoveryAssignment(final CurrentStateOutput currentStateOutput,
+        final String resourceName, final Partition partition,
+        final StateModelDefinition stateModelDef, final List<String> preferenceList) {
+      throw new UnsupportedOperationException("This resolver won't recover abnormal states.");
+    }
+  };
+
+  /**
+   * Check if the current states of the specified partition is valid.
+   * @param currentStateOutput
+   * @param resourceName
+   * @param partition
+   * @param stateModelDef
+   * @return true if the current states of the specified partition is valid.
+   */
+  boolean isCurrentStatesValid(final CurrentStateOutput currentStateOutput,
+      final String resourceName, final Partition partition,
+      final StateModelDefinition stateModelDef);
+
+  /**
+   * Compute a transient partition state assignment to fix the abnormal.
+   * @param currentStateOutput
+   * @param resourceName
+   * @param partition
+   * @param stateModelDef
+   * @param preferenceList
+   * @return the transient partition state assignment which remove the abnormal states.
+   */
+  Map<String, String> computeRecoveryAssignment(final CurrentStateOutput currentStateOutput,
+      final String resourceName, final Partition partition,
+      final StateModelDefinition stateModelDef, final List<String> preferenceList);
+}

--- a/helix-core/src/main/java/org/apache/helix/api/rebalancer/constraint/AbnormalStateResolver.java
+++ b/helix-core/src/main/java/org/apache/helix/api/rebalancer/constraint/AbnormalStateResolver.java
@@ -35,7 +35,7 @@ public interface AbnormalStateResolver {
    * This is a dummy class that does not really functional.
    */
   AbnormalStateResolver DUMMY_STATE_RESOLVER = new AbnormalStateResolver() {
-    public boolean isCurrentStatesValid(final CurrentStateOutput currentStateOutput,
+    public boolean checkCurrentStates(final CurrentStateOutput currentStateOutput,
         final String resourceName, final Partition partition,
         final StateModelDefinition stateModelDef) {
       // By default, all current states are valid.
@@ -56,7 +56,7 @@ public interface AbnormalStateResolver {
    * @param stateModelDef
    * @return true if the current states of the specified partition is valid.
    */
-  boolean isCurrentStatesValid(final CurrentStateOutput currentStateOutput,
+  boolean checkCurrentStates(final CurrentStateOutput currentStateOutput,
       final String resourceName, final Partition partition,
       final StateModelDefinition stateModelDef);
 

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -34,8 +34,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.PropertyKey;
+import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
 import org.apache.helix.common.caches.AbstractDataCache;
 import org.apache.helix.common.caches.CurrentStateCache;
 import org.apache.helix.common.caches.InstanceMessagesCache;
@@ -53,6 +55,7 @@ import org.apache.helix.model.Message;
 import org.apache.helix.model.ParticipantHistory;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
+import org.apache.helix.util.HelixUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,6 +106,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
   private Map<String, Map<String, String>> _idealStateRuleMap;
   private Map<String, Map<String, Set<String>>> _disabledInstanceForPartitionMap = new HashMap<>();
   private Set<String> _disabledInstanceSet = new HashSet<>();
+  private final Map<String, AbnormalStateResolver> _abnormalStateResolverMap = new HashMap<>();
 
   public BaseControllerDataProvider() {
     this(AbstractDataCache.UNKNOWN_CLUSTER, AbstractDataCache.UNKNOWN_PIPELINE);
@@ -225,6 +229,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     if (_propertyDataChangedMap.get(HelixConstants.ChangeType.CLUSTER_CONFIG).getAndSet(false)) {
       _clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
       refreshedType.add(HelixConstants.ChangeType.CLUSTER_CONFIG);
+      refreshAbnormalStateResolverMap(_clusterConfig);
     } else {
       LogUtil.logInfo(logger, getClusterEventId(), String.format(
           "No ClusterConfig change for cluster %s, pipeline %s", _clusterName, getPipelineName()));
@@ -372,6 +377,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
 
   public void setClusterConfig(ClusterConfig clusterConfig) {
     _clusterConfig = clusterConfig;
+    refreshAbnormalStateResolverMap(_clusterConfig);
   }
 
   @Override
@@ -729,6 +735,43 @@ public class BaseControllerDataProvider implements ControlContextProvider {
    */
   public void setAsyncTasksThreadPool(ExecutorService asyncTasksThreadPool) {
     _asyncTasksThreadPool = asyncTasksThreadPool;
+  }
+
+
+  public AbnormalStateResolver getAbnormalStateResolver(String stateModel) {
+    return _abnormalStateResolverMap
+        .getOrDefault(stateModel, AbnormalStateResolver.DUMMY_STATE_RESOLVER);
+  }
+
+  private void refreshAbnormalStateResolverMap(ClusterConfig clusterConfig) {
+    if (clusterConfig == null) {
+      logger.debug("Skip refreshing abnormal state resolvers because the ClusterConfig is missing");
+      return;
+    }
+    Map<String, String> resolverMap = clusterConfig.getAbnormalStateResolverMap();
+    logger.info("Start loading the abnormal state resolvers with configuration {}", resolverMap);
+    // Remove any resolver configuration that does not exist anymore.
+    _abnormalStateResolverMap.keySet().retainAll(resolverMap.keySet());
+    // Reload the resolver classes into cache based on the configuration.
+    for (String stateModel : resolverMap.keySet()) {
+      String resolverClassName = resolverMap.get(stateModel);
+      if (resolverClassName == null || resolverClassName.isEmpty()) {
+        // skip the empty definition.
+        continue;
+      }
+      if (!resolverClassName.equals(getAbnormalStateResolver(stateModel).getClass().getName())) {
+        try {
+          AbnormalStateResolver resolver = AbnormalStateResolver.class
+              .cast(HelixUtil.loadClass(getClass(), resolverClassName).newInstance());
+          _abnormalStateResolverMap.put(stateModel, resolver);
+        } catch (Exception e) {
+          throw new HelixException(String
+              .format("Failed to instantiate the abnormal state resolver %s for state model %s",
+                  resolverClassName, stateModel));
+        }
+      } // else, nothing to update since the same resolver class has been loaded.
+    }
+    logger.info("Finish loading the abnormal state resolvers {}", _abnormalStateResolverMap);
   }
 
   public boolean isMaintenanceModeEnabled() {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
@@ -245,7 +245,7 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
     }
 
     // (3) If the current states are not valid, fix the invalid part first.
-    if (!resolver.isCurrentStatesValid(currentStateOutput, resourceName, partition, stateModelDef)) {
+    if (!resolver.checkCurrentStates(currentStateOutput, resourceName, partition, stateModelDef)) {
       Map<String, String> recoveryAssignment = resolver
           .computeRecoveryAssignment(currentStateOutput, resourceName, partition, stateModelDef,
               preferenceList);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -32,8 +32,8 @@ import java.util.Set;
 
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.api.config.StateTransitionThrottleConfig;
-import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.rebalancer.constraint.MonitoredAbnormalResolver;
 import org.apache.helix.controller.rebalancer.util.DelayedRebalanceUtil;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.ClusterConfig;
@@ -283,10 +283,10 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
       StateModelDefinition stateModelDef, List<String> preferenceList,
       CurrentStateOutput currentStateOutput, Set<String> disabledInstancesForPartition,
       IdealState idealState, ClusterConfig clusterConfig, Partition partition,
-      AbnormalStateResolver resolver) {
+      MonitoredAbnormalResolver monitoredResolver) {
     Optional<Map<String, String>> optionalOverwrittenStates =
         computeStatesOverwriteForPartition(stateModelDef, preferenceList, currentStateOutput,
-            idealState, partition, resolver);
+            idealState, partition, monitoredResolver);
     if (optionalOverwrittenStates.isPresent()) {
       return optionalOverwrittenStates.get();
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/constraint/ExcessiveTopStateResolver.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/constraint/ExcessiveTopStateResolver.java
@@ -1,0 +1,123 @@
+package org.apache.helix.controller.rebalancer.constraint;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.Partition;
+import org.apache.helix.model.StateModelDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The abnormal state resolver that gracefully fixes the abnormality of excessive top states for
+ * single-topstate state model. For example, two replcias of a MasterSlave partition are assigned
+ * with the Master state at the same time. This could be caused by a network partitioning or the
+ * other unexpected issues.
+ *
+ * The resolver checks for the abnormality and computes recovery assignment which triggers the
+ * rebalancer to eventually reset all the top state replias for once. After the resets, only one
+ * replica will be assigned the top state.
+ *
+ * Note that without using this resolver, the regular Helix rebalance pipeline also removes the
+ * excessive top state replicas. However, the default logic does not force resetting ALL the top
+ * state replicas. Since the multiple top states situation may break application data, the default
+ * resolution won't be enough to fix the potential problem.
+ */
+public class ExcessiveTopStateResolver implements AbnormalStateResolver {
+  private static final Logger LOG = LoggerFactory.getLogger(ExcessiveTopStateResolver.class);
+
+  /**
+   * The current states are not valid if there are more than one top state replicas for a single top
+   * state state model.
+   */
+  @Override
+  public boolean checkCurrentStates(final CurrentStateOutput currentStateOutput,
+      final String resourceName, final Partition partition, StateModelDefinition stateModelDef) {
+    if (!stateModelDef.isSingleTopStateModel()) {
+      return true;
+    }
+    // TODO: Cache top state count in the ResourceControllerDataProvider and avoid repeated counting
+    // TODO: here. It would be premature to do it now. But with more use case, we can improve the
+    // TODO: ResourceControllerDataProvider to calculate by default.
+    if (currentStateOutput.getCurrentStateMap(resourceName, partition).values().stream()
+        .filter(state -> state.equals(stateModelDef.getTopState())).count() > 1) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public Map<String, String> computeRecoveryAssignment(final CurrentStateOutput currentStateOutput,
+      final String resourceName, final Partition partition, StateModelDefinition stateModelDef,
+      List<String> preferenceList) {
+    Map<String, String> currentStateMap =
+        currentStateOutput.getCurrentStateMap(resourceName, partition);
+    if (checkCurrentStates(currentStateOutput, resourceName, partition, stateModelDef)) {
+      // This method should not be triggered when the mapping is valid.
+      // Log the warning for debug purposes.
+      LOG.warn("The input current state map {} is valid, return the original current state.",
+          currentStateMap);
+      return currentStateMap;
+    }
+
+    Map<String, String> recoverMap = new HashMap<>(currentStateMap);
+    String recoveryState = stateModelDef
+        .getNextStateForTransition(stateModelDef.getTopState(), stateModelDef.getInitialState());
+
+    // 1. We have to reset the expected top state replica host if it is hosting the top state
+    // replica. Otherwise, the old master replica with the possible stale data will never be reset
+    // there.
+    if (preferenceList != null && !preferenceList.isEmpty()) {
+      String expectedTopStateHost = preferenceList.get(0);
+      if (recoverMap.get(expectedTopStateHost).equals(stateModelDef.getTopState())) {
+        recoverMap.put(expectedTopStateHost, recoveryState);
+      }
+    }
+
+    // 2. To minimize the impact of the resolution, we want to reserve one top state replica even
+    // during the recovery process.
+    boolean hasReservedTopState = false;
+    for (String instance : recoverMap.keySet()) {
+      if (recoverMap.get(instance).equals(stateModelDef.getTopState())) {
+        if (hasReservedTopState) {
+          recoverMap.put(instance, recoveryState);
+        } else {
+          hasReservedTopState = true;
+        }
+      }
+    }
+    // Here's what we expect to happen next:
+    // 1. The ideal partition assignment is changed to the proposed recovery state. Then the current
+    // rebalance pipeline proceeds. State transition messages will be sent accordingly.
+    // 2. When the next rebalance pipeline starts, the new current state may still contain
+    // abnormality if the participants have not finished state transition yet. Then the resolver
+    // continues to fix the states with the same logic.
+    // 3. Otherwise, if the new current state contains only one top state replica, then we will hand
+    // it over to the regular rebalancer logic. The rebalancer will trigger the state transition to
+    // bring the top state back in the expected allocation.
+    // And the masters with potential stale data will be all reset by then.
+    return recoverMap;
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/constraint/MonitoredAbnormalResolver.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/constraint/MonitoredAbnormalResolver.java
@@ -1,0 +1,117 @@
+package org.apache.helix.controller.rebalancer.constraint;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.Partition;
+import org.apache.helix.model.StateModelDefinition;
+import org.apache.helix.monitoring.metrics.AbnormalStatesMetricCollector;
+import org.apache.helix.monitoring.metrics.model.CountMetric;
+
+/**
+ * A wrap class to add monitor functionality into an AbnormalStateResolver implementation.
+ */
+public class MonitoredAbnormalResolver implements AbnormalStateResolver {
+  private final AbnormalStateResolver _resolver;
+  private final AbnormalStatesMetricCollector _metricCollector;
+
+  /**
+   * A placeholder which will be used when the resolver is not specified.
+   * This is a dummy class that does not really functional.
+   */
+  public final static MonitoredAbnormalResolver DUMMY_STATE_RESOLVER =
+      new MonitoredAbnormalResolver(new AbnormalStateResolver() {
+        public boolean checkCurrentStates(final CurrentStateOutput currentStateOutput,
+            final String resourceName, final Partition partition,
+            final StateModelDefinition stateModelDef) {
+          // By default, all current states are valid.
+          return true;
+        }
+
+        public Map<String, String> computeRecoveryAssignment(
+            final CurrentStateOutput currentStateOutput, final String resourceName,
+            final Partition partition, final StateModelDefinition stateModelDef,
+            final List<String> preferenceList) {
+          throw new UnsupportedOperationException("This resolver won't recover abnormal states.");
+        }
+      }, null);
+
+  private MonitoredAbnormalResolver(AbnormalStateResolver resolver,
+      AbnormalStatesMetricCollector metricCollector) {
+    if (resolver instanceof MonitoredAbnormalResolver) {
+      throw new IllegalArgumentException(
+          "Cannot construct a MonitoredAbnormalResolver wrap object using another MonitoredAbnormalResolver object.");
+    }
+    _resolver = resolver;
+    _metricCollector = metricCollector;
+  }
+
+  public MonitoredAbnormalResolver(AbnormalStateResolver resolver, String clusterName,
+      String stateModelDef) {
+    this(resolver, new AbnormalStatesMetricCollector(clusterName, stateModelDef));
+  }
+
+  public void recordAbnormalState() {
+    _metricCollector.getMetric(
+        AbnormalStatesMetricCollector.AbnormalStatesMetricNames.AbnormalStatePartitionCounter.name(),
+        CountMetric.class).increment(1);
+  }
+
+  public void recordRecoveryAttempt() {
+    _metricCollector.getMetric(
+        AbnormalStatesMetricCollector.AbnormalStatesMetricNames.RecoveryAttemptCounter.name(),
+        CountMetric.class).increment(1);
+  }
+
+  public Class getResolverClass() {
+    return _resolver.getClass();
+  }
+
+  @Override
+  public boolean checkCurrentStates(CurrentStateOutput currentStateOutput, String resourceName,
+      Partition partition, StateModelDefinition stateModelDef) {
+    return _resolver
+        .checkCurrentStates(currentStateOutput, resourceName, partition, stateModelDef);
+  }
+
+  @Override
+  public Map<String, String> computeRecoveryAssignment(CurrentStateOutput currentStateOutput,
+      String resourceName, Partition partition, StateModelDefinition stateModelDef,
+      List<String> preferenceList) {
+    return _resolver
+        .computeRecoveryAssignment(currentStateOutput, resourceName, partition, stateModelDef,
+            preferenceList);
+  }
+
+  public void close() {
+    if (_metricCollector != null) {
+      _metricCollector.unregister();
+    }
+  }
+
+  @Override
+  public void finalize() {
+    close();
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -547,11 +547,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
       // CallbackHandler to install exists watch, namely watch for path not existing.
       // Note when path is removed, the CallbackHanler would remove itself from ZkHelixManager too
       // to avoid leaking a CallbackHandler.
-      if (callbackType == Type.INIT) {
-        _zkClient.subscribeChildChanges(path, this);
-      } else {
-        _zkClient.subscribeChildChanges(path, this, true);
-      }
+      _zkClient.subscribeChildChanges(path, this, callbackType != Type.INIT);
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info("{} unsubscribe child-change. path: {}, listener: {}", _manager.getInstanceName(),
           path, _listener);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -570,9 +570,9 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         logger.debug("{} subscribe data-change. path: {}, listener: {}", _manager.getInstanceName(),
             path, _listener);
       }
-      boolean rt = _zkClient.subscribeDataChanges(path, this, callbackType != Type.INIT);
-      logger.debug("CallbackHandler {} subscribe data path {} result {}", this, path, rt);
-      if (!rt) {
+      boolean subStatus = _zkClient.subscribeDataChanges(path, this, callbackType != Type.INIT);
+      logger.debug("CallbackHandler {} subscribe data path {} result {}", this, path, subStatus);
+      if (!subStatus) {
         logger.info("CallbackHandler {} subscribe data path {} failed!", this, path);
       }
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
@@ -777,7 +777,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         } else {
           if (!isReady()) {
             // avoid leaking CallbackHandler
-            logger.info("Callbackhandler {} with path {} end of life as not ready to avoid leak",
+            logger.info("Callbackhandler {} with path {} is in reset state. Stop subscription to ZK client to avoid leaking",
                 this, parentPath);
             return;
           }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -539,6 +539,14 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         logger.debug("{} subscribes child-change. path: {} , listener: {}",
             _manager.getInstanceName(), path, _listener );
       }
+      // In the lifecycle of CallbackHandler, INIT is the first stage of registration of watch.
+      // For some usage case such as current state, the path can be created later. Thus we would
+      // install watch anyway event the path is not yet created.
+      // Later, CALLBACK type, the CallbackHandler already registered the watch and knows the
+      // path was created. Here, to avoid leaking path in ZooKeeper server, we would not let
+      // CallbackHandler to install exists watch, namely watch for path not existing.
+      // Note when path is removed, the CallbackHanler would remove itself from ZkHelixManager too
+      // to avoid leaking a CallbackHandler.
       if (callbackType == Type.INIT) {
         _zkClient.subscribeChildChanges(path, this);
       } else {
@@ -760,14 +768,14 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
           // removeListener will call handler.reset(), which in turn call invoke() on FINALIZE type
           _manager.removeListener(_propertyKey, _listener);
         } else {
-          NotificationContext changeContext = new NotificationContext(_manager);
-          changeContext.setType(NotificationContext.Type.CALLBACK);
-          changeContext.setPathChanged(parentPath);
-          changeContext.setChangeType(_changeType);
           if (!isReady()) {
             // avoid leaking CallbackHandler
             return;
           }
+          NotificationContext changeContext = new NotificationContext(_manager);
+          changeContext.setType(NotificationContext.Type.CALLBACK);
+          changeContext.setPathChanged(parentPath);
+          changeContext.setChangeType(_changeType);
           subscribeForChanges(changeContext.getType(), _path, _watchChild);
           enqueueTask(changeContext);
         }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -539,7 +539,11 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         logger.debug("{} subscribes child-change. path: {} , listener: {}",
             _manager.getInstanceName(), path, _listener );
       }
-      _zkClient.subscribeChildChanges(path, this);
+      if (callbackType == Type.INIT) {
+        _zkClient.subscribeChildChanges(path, this);
+      } else {
+        _zkClient.subscribeChildChanges(path, this, true);
+      }
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info("{} unsubscribe child-change. path: {}, listener: {}", _manager.getInstanceName(),
           path, _listener);
@@ -555,7 +559,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         logger.debug("{} subscribe data-change. path: {}, listener: {}", _manager.getInstanceName(),
             path, _listener);
       }
-      _zkClient.subscribeDataChanges(path, this);
+      _zkClient.subscribeDataChanges(path, this, true);
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info("{} unsubscribe data-change. path: {}, listener: {}",
           _manager.getInstanceName(), path, _listener);
@@ -760,6 +764,10 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
           changeContext.setType(NotificationContext.Type.CALLBACK);
           changeContext.setPathChanged(parentPath);
           changeContext.setChangeType(_changeType);
+          if (!isReady()) {
+            // avoid leaking CallbackHandler
+            return;
+          }
           subscribeForChanges(changeContext.getType(), _path, _watchChild);
           enqueueTask(changeContext);
         }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -563,7 +563,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         logger.debug("{} subscribe data-change. path: {}, listener: {}", _manager.getInstanceName(),
             path, _listener);
       }
-      _zkClient.subscribeDataChanges(path, this, true);
+      _zkClient.subscribeDataChanges(path, this, callbackType != Type.INIT);
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info("{} unsubscribe data-change. path: {}, listener: {}",
           _manager.getInstanceName(), path, _listener);

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -30,10 +30,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.api.config.HelixConfigProperty;
 import org.apache.helix.api.config.StateTransitionThrottleConfig;
 import org.apache.helix.api.config.StateTransitionTimeoutConfig;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
 /**
  * Cluster configurations
@@ -109,7 +109,13 @@ public class ClusterConfig extends HelixProperty {
     // https://github.com/apache/helix/wiki/Weight-aware-Globally-Evenly-distributed-Rebalancer#rebalance-coordinator
     //
     // Default to be true.
-    GLOBAL_REBALANCE_ASYNC_MODE
+    GLOBAL_REBALANCE_ASYNC_MODE,
+
+    /**
+     * Configure the abnormal partition states resolver classes for the corresponding state model.
+     * <State Model Def Name, Full Path of the Resolver Class Name>
+     */
+    ABNORMAL_STATES_RESOLVER_MAP
   }
 
   public enum GlobalRebalancePreferenceKey {
@@ -849,6 +855,24 @@ public class ClusterConfig extends HelixProperty {
   public boolean isGlobalRebalanceAsyncModeEnabled() {
     return _record.getBooleanField(ClusterConfigProperty.GLOBAL_REBALANCE_ASYNC_MODE.name(),
         DEFAULT_GLOBAL_REBALANCE_ASYNC_MODE_ENABLED);
+  }
+
+  /**
+   * Set the abnormal state resolver class map.
+   */
+  public void setAbnormalStateResolverMap(Map<String, String> resolverMap) {
+    if (resolverMap.values().stream()
+        .anyMatch(className -> className == null || className.isEmpty())) {
+      throw new IllegalArgumentException(
+          "Invalid Abnormal State Resolver Map definition. Class name cannot be empty.");
+    }
+    _record.setMapField(ClusterConfigProperty.ABNORMAL_STATES_RESOLVER_MAP.name(), resolverMap);
+  }
+
+  public Map<String, String> getAbnormalStateResolverMap() {
+    Map<String, String> resolverMap =
+        _record.getMapField(ClusterConfigProperty.ABNORMAL_STATES_RESOLVER_MAP.name());
+    return resolverMap == null ? Collections.EMPTY_MAP : resolverMap;
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/AbnormalStatesMetricCollector.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/AbnormalStatesMetricCollector.java
@@ -1,0 +1,67 @@
+package org.apache.helix.monitoring.metrics;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.management.JMException;
+
+import org.apache.helix.HelixException;
+import org.apache.helix.monitoring.mbeans.MonitorDomainNames;
+import org.apache.helix.monitoring.metrics.implementation.RebalanceCounter;
+import org.apache.helix.monitoring.metrics.model.CountMetric;
+
+public class AbnormalStatesMetricCollector extends MetricCollector {
+  private static final String ABNORMAL_STATES_ENTITY_NAME = "AbnormalStates";
+
+  /**
+   * This enum class contains all metric names defined for AbnormalStateResolver.
+   * Note that all enums are in camel case for readability.
+   */
+  public enum AbnormalStatesMetricNames {
+    // The counter of the partitions that contains abnormal state.
+    AbnormalStatePartitionCounter,
+    // The counter of the attempts that the resolver tries to recover the abnormal state.
+    RecoveryAttemptCounter
+  }
+
+  public AbnormalStatesMetricCollector(String clusterName, String stateModelDef) {
+    super(MonitorDomainNames.Rebalancer.name(), clusterName,
+        String.format("%s.%s", ABNORMAL_STATES_ENTITY_NAME, stateModelDef));
+    createMetrics();
+    if (clusterName != null) {
+      try {
+        register();
+      } catch (JMException e) {
+        throw new HelixException(
+            "Failed to register MBean for the " + AbnormalStatesMetricCollector.class
+                .getSimpleName(), e);
+      }
+    }
+  }
+
+  private void createMetrics() {
+    // Define all metrics
+    CountMetric abnormalStateReplicasCounter =
+        new RebalanceCounter(AbnormalStatesMetricNames.AbnormalStatePartitionCounter.name());
+    CountMetric RecoveryAttemptCounter =
+        new RebalanceCounter(AbnormalStatesMetricNames.RecoveryAttemptCounter.name());
+    addMetric(abnormalStateReplicasCounter);
+    addMetric(RecoveryAttemptCounter);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestAbstractRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestAbstractRebalancer.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.ClusterConfig;
@@ -52,7 +53,8 @@ public class TestAbstractRebalancer {
         .computeBestPossibleStateForPartition(new HashSet<>(liveInstances),
             BuiltInStateModelDefinitions.valueOf(stateModelName).getStateModelDefinition(),
             preferenceList, currentStateOutput, new HashSet<>(disabledInstancesForPartition),
-            new IdealState("test"), new ClusterConfig("TestCluster"), partition);
+            new IdealState("test"), new ClusterConfig("TestCluster"), partition,
+            AbnormalStateResolver.DUMMY_STATE_RESOLVER);
 
     Assert.assertEquals(bestPossibleMap, expectedBestPossibleMap);
   }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestAbstractRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestAbstractRebalancer.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
+import org.apache.helix.controller.rebalancer.constraint.MonitoredAbnormalResolver;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.ClusterConfig;
@@ -54,7 +54,7 @@ public class TestAbstractRebalancer {
             BuiltInStateModelDefinitions.valueOf(stateModelName).getStateModelDefinition(),
             preferenceList, currentStateOutput, new HashSet<>(disabledInstancesForPartition),
             new IdealState("test"), new ClusterConfig("TestCluster"), partition,
-            AbnormalStateResolver.DUMMY_STATE_RESOLVER);
+            MonitoredAbnormalResolver.DUMMY_STATE_RESOLVER);
 
     Assert.assertEquals(bestPossibleMap, expectedBestPossibleMap);
   }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestAutoRebalanceStrategy.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestAutoRebalanceStrategy.java
@@ -41,7 +41,7 @@ import com.google.common.collect.Sets;
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.MockAccessor;
 import org.apache.helix.PropertyKey.Builder;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
@@ -52,6 +52,7 @@ import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.tools.StateModelConfigGenerator;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -243,7 +244,8 @@ public class TestAutoRebalanceStrategy {
         }
         Map<String, String> assignment = new AutoRebalancer()
             .computeBestPossibleStateForPartition(cache.getLiveInstances().keySet(), _stateModelDef,
-                preferenceList, currentStateOutput, disabled, is, clusterConfig, p);
+                preferenceList, currentStateOutput, disabled, is, clusterConfig, p,
+                AbnormalStateResolver.DUMMY_STATE_RESOLVER);
         mapResult.put(partition, assignment);
       }
       return mapResult;

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestAutoRebalanceStrategy.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestAutoRebalanceStrategy.java
@@ -41,8 +41,8 @@ import com.google.common.collect.Sets;
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.MockAccessor;
 import org.apache.helix.PropertyKey.Builder;
-import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.rebalancer.constraint.MonitoredAbnormalResolver;
 import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
 import org.apache.helix.controller.stages.CurrentStateOutput;
@@ -245,7 +245,7 @@ public class TestAutoRebalanceStrategy {
         Map<String, String> assignment = new AutoRebalancer()
             .computeBestPossibleStateForPartition(cache.getLiveInstances().keySet(), _stateModelDef,
                 preferenceList, currentStateOutput, disabled, is, clusterConfig, p,
-                AbnormalStateResolver.DUMMY_STATE_RESOLVER);
+                MonitoredAbnormalResolver.DUMMY_STATE_RESOLVER);
         mapResult.put(partition, assignment);
       }
       return mapResult;

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestZeroReplicaAvoidance.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestZeroReplicaAvoidance.java
@@ -32,7 +32,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
 import org.apache.helix.controller.stages.BaseStageTest;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
@@ -41,6 +41,7 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.StateModelDefinition;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.ObjectReader;
 import org.testng.Assert;
@@ -85,9 +86,10 @@ public class TestZeroReplicaAvoidance extends BaseStageTest {
         }
       }
     }
-    Map<String, String> bestPossibleMap = rebalancer.computeBestPossibleStateForPartition(
-        liveInstances, stateModelDef, instancePreferenceList, currentStateOutput,
-        Collections.emptySet(), is, new ClusterConfig("TestCluster"), partition);
+    Map<String, String> bestPossibleMap = rebalancer
+        .computeBestPossibleStateForPartition(liveInstances, stateModelDef, instancePreferenceList,
+            currentStateOutput, Collections.emptySet(), is, new ClusterConfig("TestCluster"),
+            partition, AbnormalStateResolver.DUMMY_STATE_RESOLVER);
     Assert.assertEquals(bestPossibleMap, expectedBestPossibleMap,
         "Differs, get " + bestPossibleMap + "\nexpected: " + expectedBestPossibleMap
             + "\ncurrentState: " + currentStateMap + "\npreferenceList: " + instancePreferenceList);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestZeroReplicaAvoidance.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestZeroReplicaAvoidance.java
@@ -32,7 +32,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
+import org.apache.helix.controller.rebalancer.constraint.MonitoredAbnormalResolver;
 import org.apache.helix.controller.stages.BaseStageTest;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
@@ -89,7 +89,7 @@ public class TestZeroReplicaAvoidance extends BaseStageTest {
     Map<String, String> bestPossibleMap = rebalancer
         .computeBestPossibleStateForPartition(liveInstances, stateModelDef, instancePreferenceList,
             currentStateOutput, Collections.emptySet(), is, new ClusterConfig("TestCluster"),
-            partition, AbnormalStateResolver.DUMMY_STATE_RESOLVER);
+            partition, MonitoredAbnormalResolver.DUMMY_STATE_RESOLVER);
     Assert.assertEquals(bestPossibleMap, expectedBestPossibleMap,
         "Differs, get " + bestPossibleMap + "\nexpected: " + expectedBestPossibleMap
             + "\ncurrentState: " + currentStateMap + "\npreferenceList: " + instancePreferenceList);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/constraint/MockAbnormalStateResolver.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/constraint/MockAbnormalStateResolver.java
@@ -33,7 +33,7 @@ import org.apache.helix.model.StateModelDefinition;
  */
 public class MockAbnormalStateResolver implements AbnormalStateResolver {
   @Override
-  public boolean isCurrentStatesValid(final CurrentStateOutput currentStateOutput,
+  public boolean checkCurrentStates(final CurrentStateOutput currentStateOutput,
       final String resourceName, final Partition partition,
       final StateModelDefinition stateModelDef) {
     // By default, all current states are valid.

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/constraint/MockAbnormalStateResolver.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/constraint/MockAbnormalStateResolver.java
@@ -1,0 +1,48 @@
+package org.apache.helix.controller.rebalancer.constraint;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.Partition;
+import org.apache.helix.model.StateModelDefinition;
+
+/**
+ * A mock abnormal state resolver for supporting tests.
+ * It always return dummy result.
+ */
+public class MockAbnormalStateResolver implements AbnormalStateResolver {
+  @Override
+  public boolean isCurrentStatesValid(final CurrentStateOutput currentStateOutput,
+      final String resourceName, final Partition partition,
+      final StateModelDefinition stateModelDef) {
+    // By default, all current states are valid.
+    return true;
+  }
+
+  public Map<String, String> computeRecoveryAssignment(final CurrentStateOutput currentStateOutput,
+      final String resourceName, final Partition partition,
+      final StateModelDefinition stateModelDef, final List<String> preferenceList) {
+    throw new UnsupportedOperationException("The mock resolver won't recover abnormal states.");
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/constraint/TestAbnormalStatesResolverMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/constraint/TestAbnormalStatesResolverMonitor.java
@@ -1,0 +1,88 @@
+package org.apache.helix.controller.rebalancer.constraint;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.lang.management.ManagementFactory;
+import java.util.Random;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+import org.apache.helix.model.MasterSlaveSMD;
+import org.apache.helix.monitoring.mbeans.MonitorDomainNames;
+import org.apache.helix.monitoring.metrics.AbnormalStatesMetricCollector;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestAbnormalStatesResolverMonitor {
+  private static final MBeanServer MBEAN_SERVER = ManagementFactory.getPlatformMBeanServer();
+  private final String CLUSTER_NAME = "TestCluster";
+
+  @Test
+  public void testMonitorResolver()
+      throws MalformedObjectNameException, AttributeNotFoundException, MBeanException,
+      ReflectionException, InstanceNotFoundException {
+    final String testResolverMonitorMbeanName = String
+        .format("%s:%s=%s, %s=%s.%s", MonitorDomainNames.Rebalancer, "ClusterName", CLUSTER_NAME,
+            "EntityName", "AbnormalStates", MasterSlaveSMD.name);
+    final ObjectName testResolverMonitorMbeanObjectName =
+        new ObjectName(testResolverMonitorMbeanName);
+
+    Assert.assertFalse(MBEAN_SERVER.isRegistered(testResolverMonitorMbeanObjectName));
+
+    // Update the resolver configuration for MasterSlave state model.
+    MonitoredAbnormalResolver monitoredAbnormalResolver =
+        new MonitoredAbnormalResolver(new MockAbnormalStateResolver(), CLUSTER_NAME,
+            MasterSlaveSMD.name);
+
+    // Validate if the MBean has been registered
+    Assert.assertTrue(MBEAN_SERVER.isRegistered(testResolverMonitorMbeanObjectName));
+    Assert.assertEquals(MBEAN_SERVER.getAttribute(testResolverMonitorMbeanObjectName,
+        AbnormalStatesMetricCollector.AbnormalStatesMetricNames.AbnormalStatePartitionCounter
+            .name()), 0L);
+    Assert.assertEquals(MBEAN_SERVER.getAttribute(testResolverMonitorMbeanObjectName,
+        AbnormalStatesMetricCollector.AbnormalStatesMetricNames.RecoveryAttemptCounter.name()), 0L);
+    // Validate if the metrics recording methods work as expected
+    Random ran = new Random(System.currentTimeMillis());
+    Long expectation = 1L + ran.nextInt(10);
+    for (int i = 0; i < expectation; i++) {
+      monitoredAbnormalResolver.recordAbnormalState();
+    }
+    Assert.assertEquals(MBEAN_SERVER.getAttribute(testResolverMonitorMbeanObjectName,
+        AbnormalStatesMetricCollector.AbnormalStatesMetricNames.AbnormalStatePartitionCounter
+            .name()), expectation);
+    expectation = 1L + ran.nextInt(10);
+    for (int i = 0; i < expectation; i++) {
+      monitoredAbnormalResolver.recordRecoveryAttempt();
+    }
+    Assert.assertEquals(MBEAN_SERVER.getAttribute(testResolverMonitorMbeanObjectName,
+        AbnormalStatesMetricCollector.AbnormalStatesMetricNames.RecoveryAttemptCounter.name()),
+        expectation);
+
+    // Reset the resolver map
+    monitoredAbnormalResolver.close();
+    // Validate if the MBean has been unregistered
+    Assert.assertFalse(MBEAN_SERVER.isRegistered(testResolverMonitorMbeanObjectName));
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
@@ -29,8 +29,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.rebalancer.constraint.MonitoredAbnormalResolver;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.CurrentState;
@@ -112,7 +112,7 @@ public abstract class AbstractTestClusterModel {
     testClusterConfig.setTopologyAwareEnabled(true);
     when(testCache.getClusterConfig()).thenReturn(testClusterConfig);
     when(testCache.getAbnormalStateResolver(any()))
-        .thenReturn(AbnormalStateResolver.DUMMY_STATE_RESOLVER);
+        .thenReturn(MonitoredAbnormalResolver.DUMMY_STATE_RESOLVER);
 
     // 3. Mock the live instance node for the default instance.
     LiveInstance testLiveInstance = createMockLiveInstance(_testInstanceId);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.ClusterConfig;
@@ -39,6 +40,7 @@ import org.apache.helix.model.ResourceConfig;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 public abstract class AbstractTestClusterModel {
@@ -109,6 +111,8 @@ public abstract class AbstractTestClusterModel {
         _capacityDataMap.keySet().stream().collect(Collectors.toMap(key -> key, key -> 0)));
     testClusterConfig.setTopologyAwareEnabled(true);
     when(testCache.getClusterConfig()).thenReturn(testClusterConfig);
+    when(testCache.getAbnormalStateResolver(any()))
+        .thenReturn(AbnormalStateResolver.DUMMY_STATE_RESOLVER);
 
     // 3. Mock the live instance node for the default instance.
     LiveInstance testLiveInstance = createMockLiveInstance(_testInstanceId);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestZkCallbackHandlerLeak.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestZkCallbackHandlerLeak.java
@@ -605,9 +605,12 @@ public class TestZkCallbackHandlerLeak extends ZkUnitTestBase {
         "Should have 1 data-watches: MESSAGES");
     Assert.assertEquals(watchPaths.get("childWatches").size(), 1,
         "Should have 1 child-watches: MESSAGES");
-    Assert
-        .assertEquals(watchPaths.get("existWatches").size(), 2,
-            "Should have 2 exist-watches: CURRENTSTATE/{oldSessionId} and CURRENTSTATE/{oldSessionId}/TestDB0");
+    result = TestHelper.verify(()-> {
+      Map<String, List<String>> wPaths = ZkTestHelper.getZkWatch(participantToExpire.getZkClient());
+      return wPaths.get("existWatches").size() == 1;
+    }, 10000);
+    Assert.assertTrue(result,
+        "Should have 2 exist-watches: CURRENTSTATE/{oldSessionId}");
 
     // another session expiry on localhost_12918 should clear the two exist-watches on
     // CURRENTSTATE/{oldSessionId}

--- a/helix-core/src/test/java/org/apache/helix/integration/TestZkCallbackHandlerLeak.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestZkCallbackHandlerLeak.java
@@ -324,6 +324,7 @@ public class TestZkCallbackHandlerLeak extends ZkUnitTestBase {
 
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
   }
+
   @Test
   public void testDanglingCallbackHanlderFix() throws Exception {
     String className = TestHelper.getTestClassName();

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterControllerManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterControllerManager.java
@@ -35,76 +35,15 @@ import org.slf4j.LoggerFactory;
 /**
  * The standalone cluster controller class
  */
-public class ClusterControllerManager extends ZKHelixManager implements Runnable, ZkTestManager {
+public class ClusterControllerManager extends ClusterManager {
   private static Logger LOG = LoggerFactory.getLogger(ClusterControllerManager.class);
-
-  private final CountDownLatch _startCountDown = new CountDownLatch(1);
-  private final CountDownLatch _stopCountDown = new CountDownLatch(1);
-  private final CountDownLatch _waitStopFinishCountDown = new CountDownLatch(1);
-
-  private boolean _started = false;
 
   public ClusterControllerManager(String zkAddr, String clusterName) {
     this(zkAddr, clusterName, "controller");
   }
 
   public ClusterControllerManager(String zkAddr, String clusterName, String controllerName) {
-    super(clusterName, controllerName, InstanceType.CONTROLLER, zkAddr);
+    super(zkAddr, clusterName, controllerName, InstanceType.CONTROLLER);
   }
 
-  public void syncStop() {
-    _stopCountDown.countDown();
-    try {
-      _waitStopFinishCountDown.await();
-      _started = false;
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted waiting for finish", e);
-    }
-  }
-
-  // This should not be called more than once because HelixManager.connect() should not be called more than once.
-  public void syncStart() {
-    if (_started) {
-      throw new RuntimeException(
-          "Helix Controller already started. Do not call syncStart() more than once.");
-    } else {
-      _started = true;
-    }
-
-    new Thread(this).start();
-    try {
-      _startCountDown.await();
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted waiting for start", e);
-    }
-  }
-
-  @Override
-  public void run() {
-    try {
-      connect();
-      _startCountDown.countDown();
-      _stopCountDown.await();
-    } catch (Exception e) {
-      LOG.error("exception running controller-manager", e);
-    } finally {
-      _startCountDown.countDown();
-      disconnect();
-      _waitStopFinishCountDown.countDown();
-    }
-  }
-
-  @Override
-  public RealmAwareZkClient getZkClient() {
-    return _zkclient;
-  }
-
-  @Override
-  public List<CallbackHandler> getHandlers() {
-    return _handlers;
-  }
-
-  public List<HelixTimerTask> getControllerTimerTasks() {
-    return _controllerTimerTasks;
-  }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterDistributedController.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterDistributedController.java
@@ -32,35 +32,11 @@ import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ClusterDistributedController extends ZKHelixManager implements Runnable,
-    ZkTestManager {
+public class ClusterDistributedController extends ClusterManager {
   private static Logger LOG = LoggerFactory.getLogger(ClusterDistributedController.class);
 
-  private final CountDownLatch _startCountDown = new CountDownLatch(1);
-  private final CountDownLatch _stopCountDown = new CountDownLatch(1);
-  private final CountDownLatch _waitStopFinishCountDown = new CountDownLatch(1);
-
   public ClusterDistributedController(String zkAddr, String clusterName, String controllerName) {
-    super(clusterName, controllerName, InstanceType.CONTROLLER_PARTICIPANT, zkAddr);
-  }
-
-  public void syncStop() {
-    _stopCountDown.countDown();
-    try {
-      _waitStopFinishCountDown.await();
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted waiting for finish", e);
-    }
-  }
-
-  public void syncStart() {
-    // TODO: prevent start multiple times
-    new Thread(this).start();
-    try {
-      _startCountDown.await();
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted waiting for start", e);
-    }
+    super(zkAddr, clusterName, controllerName, InstanceType.CONTROLLER_PARTICIPANT);
   }
 
   @Override
@@ -81,15 +57,5 @@ public class ClusterDistributedController extends ZKHelixManager implements Runn
       disconnect();
       _waitStopFinishCountDown.countDown();
     }
-  }
-
-  @Override
-  public RealmAwareZkClient getZkClient() {
-    return _zkclient;
-  }
-
-  @Override
-  public List<CallbackHandler> getHandlers() {
-    return _handlers;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterManager.java
@@ -1,5 +1,24 @@
 package org.apache.helix.integration.manager;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterManager.java
@@ -39,12 +39,8 @@ public class ClusterManager extends ZKHelixManager implements Runnable, ZkTestMa
 
   protected boolean _started = false;
 
-  public ClusterManager(String zkAddr, String clusterName, InstanceType type) {
-    this(zkAddr, clusterName, "role", type);
-  }
-
-  public ClusterManager(String zkAddr, String clusterName, String roleName, InstanceType type) {
-    super(clusterName, roleName, type, zkAddr);
+  protected ClusterManager(String zkAddr, String clusterName, String instanceName, InstanceType type) {
+    super(clusterName, instanceName, type, zkAddr);
   }
 
   public void syncStop() {

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterManager.java
@@ -1,0 +1,83 @@
+package org.apache.helix.integration.manager;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.helix.InstanceType;
+import org.apache.helix.manager.zk.CallbackHandler;
+import org.apache.helix.manager.zk.ZKHelixManager;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ClusterManager extends ZKHelixManager implements Runnable, ZkTestManager {
+  private static Logger LOG = LoggerFactory.getLogger(ClusterControllerManager.class);
+
+  protected CountDownLatch _startCountDown = new CountDownLatch(1);
+  protected CountDownLatch _stopCountDown = new CountDownLatch(1);
+  protected CountDownLatch _waitStopFinishCountDown = new CountDownLatch(1);
+
+  protected boolean _started = false;
+
+  public ClusterManager(String zkAddr, String clusterName, InstanceType type) {
+    this(zkAddr, clusterName, "role", type);
+  }
+
+  public ClusterManager(String zkAddr, String clusterName, String roleName, InstanceType type) {
+    super(clusterName, roleName, type, zkAddr);
+  }
+
+  public void syncStop() {
+    _stopCountDown.countDown();
+    try {
+      _waitStopFinishCountDown.await();
+      _started = false;
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted waiting for finish", e);
+    }
+  }
+
+  // This should not be called more than once because HelixManager.connect() should not be called more than once.
+  public void syncStart() {
+    if (_started) {
+      throw new RuntimeException(
+          "Helix Controller already started. Do not call syncStart() more than once.");
+    } else {
+      _started = true;
+    }
+
+    new Thread(this).start();
+    try {
+      _startCountDown.await();
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted waiting for start", e);
+    }
+  }
+
+  @Override
+  public void run() {
+    try {
+      connect();
+      _startCountDown.countDown();
+      _stopCountDown.await();
+    } catch (Exception e) {
+      LOG.error("exception running controller-manager", e);
+    } finally {
+      _startCountDown.countDown();
+      disconnect();
+      _waitStopFinishCountDown.countDown();
+    }
+  }
+
+  @Override
+  public RealmAwareZkClient getZkClient() {
+    return _zkclient;
+  }
+
+  @Override
+  public List<CallbackHandler> getHandlers() {
+    return _handlers;
+  }
+}
+

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterSpectatorManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterSpectatorManager.java
@@ -1,5 +1,24 @@
 package org.apache.helix.integration.manager;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterSpectatorManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterSpectatorManager.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class ClusterSpectatorManager extends ZKHelixManager implements Runnable, ZkTestManager {
+public class ClusterSpectatorManager extends ClusterManager{
   private static Logger LOG = LoggerFactory.getLogger(ClusterControllerManager.class);
 
   private final CountDownLatch _startCountDown = new CountDownLatch(1);
@@ -25,58 +25,6 @@ public class ClusterSpectatorManager extends ZKHelixManager implements Runnable,
   }
 
   public ClusterSpectatorManager(String zkAddr, String clusterName, String spectatorName) {
-    super(clusterName, spectatorName, InstanceType.SPECTATOR, zkAddr);
-  }
-
-  public void syncStop() {
-    _stopCountDown.countDown();
-    try {
-      _waitStopFinishCountDown.await();
-      _started = false;
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted waiting for finish", e);
-    }
-  }
-
-  // This should not be called more than once because HelixManager.connect() should not be called more than once.
-  public void syncStart() {
-    if (_started) {
-      throw new RuntimeException(
-          "Helix Controller already started. Do not call syncStart() more than once.");
-    } else {
-      _started = true;
-    }
-
-    new Thread(this).start();
-    try {
-      _startCountDown.await();
-    } catch (InterruptedException e) {
-      LOG.error("Interrupted waiting for start", e);
-    }
-  }
-
-  @Override
-  public void run() {
-    try {
-      connect();
-      _startCountDown.countDown();
-      _stopCountDown.await();
-    } catch (Exception e) {
-      LOG.error("exception running controller-manager", e);
-    } finally {
-      _startCountDown.countDown();
-      disconnect();
-      _waitStopFinishCountDown.countDown();
-    }
-  }
-
-  @Override
-  public RealmAwareZkClient getZkClient() {
-    return _zkclient;
-  }
-
-  @Override
-  public List<CallbackHandler> getHandlers() {
-    return _handlers;
+    super(zkAddr, clusterName, spectatorName, InstanceType.SPECTATOR);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterSpectatorManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/ClusterSpectatorManager.java
@@ -1,0 +1,82 @@
+package org.apache.helix.integration.manager;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.helix.InstanceType;
+import org.apache.helix.manager.zk.CallbackHandler;
+import org.apache.helix.manager.zk.ZKHelixManager;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ClusterSpectatorManager extends ZKHelixManager implements Runnable, ZkTestManager {
+  private static Logger LOG = LoggerFactory.getLogger(ClusterControllerManager.class);
+
+  private final CountDownLatch _startCountDown = new CountDownLatch(1);
+  private final CountDownLatch _stopCountDown = new CountDownLatch(1);
+  private final CountDownLatch _waitStopFinishCountDown = new CountDownLatch(1);
+
+  private boolean _started = false;
+
+  public ClusterSpectatorManager(String zkAddr, String clusterName) {
+    this(zkAddr, clusterName, "spectator");
+  }
+
+  public ClusterSpectatorManager(String zkAddr, String clusterName, String spectatorName) {
+    super(clusterName, spectatorName, InstanceType.SPECTATOR, zkAddr);
+  }
+
+  public void syncStop() {
+    _stopCountDown.countDown();
+    try {
+      _waitStopFinishCountDown.await();
+      _started = false;
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted waiting for finish", e);
+    }
+  }
+
+  // This should not be called more than once because HelixManager.connect() should not be called more than once.
+  public void syncStart() {
+    if (_started) {
+      throw new RuntimeException(
+          "Helix Controller already started. Do not call syncStart() more than once.");
+    } else {
+      _started = true;
+    }
+
+    new Thread(this).start();
+    try {
+      _startCountDown.await();
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted waiting for start", e);
+    }
+  }
+
+  @Override
+  public void run() {
+    try {
+      connect();
+      _startCountDown.countDown();
+      _stopCountDown.await();
+    } catch (Exception e) {
+      LOG.error("exception running controller-manager", e);
+    } finally {
+      _startCountDown.countDown();
+      disconnect();
+      _waitStopFinishCountDown.countDown();
+    }
+  }
+
+  @Override
+  public RealmAwareZkClient getZkClient() {
+    return _zkclient;
+  }
+
+  @Override
+  public List<CallbackHandler> getHandlers() {
+    return _handlers;
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/MockParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/MockParticipantManager.java
@@ -70,7 +70,7 @@ public class MockParticipantManager extends ClusterManager {
   public void setTransition(MockTransition transition) {
     _msModelFactory.setTrasition(transition);
   }
-  
+
   /**
    * This method should be called before syncStart() called after syncStop()
    */

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/MockParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/MockParticipantManager.java
@@ -38,12 +38,8 @@ import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MockParticipantManager extends ZKHelixManager implements Runnable, ZkTestManager {
+public class MockParticipantManager extends ClusterManager {
   private static Logger LOG = LoggerFactory.getLogger(MockParticipantManager.class);
-
-  protected CountDownLatch _startCountDown = new CountDownLatch(1);
-  protected CountDownLatch _stopCountDown = new CountDownLatch(1);
-  protected CountDownLatch _waitStopCompleteCountDown = new CountDownLatch(1);
 
   protected int _transDelay = 10;
 
@@ -63,7 +59,7 @@ public class MockParticipantManager extends ZKHelixManager implements Runnable, 
 
   public MockParticipantManager(String zkAddr, String clusterName, String instanceName,
       int transDelay, HelixCloudProperty helixCloudProperty) {
-    super(clusterName, instanceName, InstanceType.PARTICIPANT, zkAddr);
+    super(zkAddr, clusterName, instanceName, InstanceType.PARTICIPANT);
     _transDelay = transDelay;
     _msModelFactory = new MockMSModelFactory(null);
     _lsModelFactory = new DummyLeaderStandbyStateModelFactory(_transDelay);
@@ -74,25 +70,7 @@ public class MockParticipantManager extends ZKHelixManager implements Runnable, 
   public void setTransition(MockTransition transition) {
     _msModelFactory.setTrasition(transition);
   }
-
-  public void syncStop() {
-    _stopCountDown.countDown();
-    try {
-      _waitStopCompleteCountDown.await();
-    } catch (InterruptedException e) {
-      LOG.error("exception in syncStop participant-manager", e);
-    }
-  }
-
-  public void syncStart() {
-    try {
-      new Thread(this).start();
-      _startCountDown.await();
-    } catch (InterruptedException e) {
-      LOG.error("exception in syncStart participant-manager", e);
-    }
-  }
-
+  
   /**
    * This method should be called before syncStart() called after syncStop()
    */
@@ -100,7 +78,7 @@ public class MockParticipantManager extends ZKHelixManager implements Runnable, 
     syncStop();
     _startCountDown = new CountDownLatch(1);
     _stopCountDown = new CountDownLatch(1);
-    _waitStopCompleteCountDown = new CountDownLatch(1);
+    _waitStopFinishCountDown = new CountDownLatch(1);
   }
 
   @Override
@@ -132,7 +110,7 @@ public class MockParticipantManager extends ZKHelixManager implements Runnable, 
       _startCountDown.countDown();
 
       disconnect();
-      _waitStopCompleteCountDown.countDown();
+      _waitStopFinishCountDown.countDown();
     }
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAbnormalStatesResolver.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAbnormalStatesResolver.java
@@ -19,16 +19,33 @@ package org.apache.helix.integration.rebalancer;
  * under the License.
  */
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.ConfigAccessor;
+import org.apache.helix.Criteria;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.InstanceType;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.TestHelper;
 import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.rebalancer.constraint.ExcessiveTopStateResolver;
 import org.apache.helix.controller.rebalancer.constraint.MockAbnormalStateResolver;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.messaging.AsyncCallback;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.MasterSlaveSMD;
+import org.apache.helix.model.Message;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -63,5 +80,105 @@ public class TestAbnormalStatesResolver extends ZkStandAloneCMTestBase {
     clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
     clusterConfig.setAbnormalStateResolverMap(Collections.emptyMap());
     configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+  }
+
+  @Test(dependsOnMethods = "testConfigureResolver")
+  public void testExcessiveTopStateResolver() {
+    BestPossibleExternalViewVerifier verifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+    Assert.assertTrue(verifier.verify());
+
+    // 1. Find a partition with a MASTER replica and a SLAVE replica
+    HelixAdmin admin = new ZKHelixAdmin.Builder().setZkAddress(ZK_ADDR).build();
+    ExternalView ev = admin.getResourceExternalView(CLUSTER_NAME, TEST_DB);
+    String targetPartition = ev.getPartitionSet().iterator().next();
+    Map<String, String> partitionAssignment = ev.getStateMap(targetPartition);
+    String slaveHost =
+        partitionAssignment.entrySet().stream().filter(entry -> entry.getValue().equals("SLAVE"))
+            .findAny().get().getKey();
+    long previousMasterUpdateTime = getTopStateUpdateTime(ev, targetPartition, "MASTER");
+
+    // Build SLAVE to MASTER message
+    String msgId = new UUID(123, 456).toString();
+    Message msg =
+        createMessage(Message.MessageType.STATE_TRANSITION, msgId, "SLAVE", "MASTER", TEST_DB,
+            slaveHost);
+    msg.setStateModelDef(MasterSlaveSMD.name);
+
+    Criteria cr = new Criteria();
+    cr.setInstanceName(slaveHost);
+    cr.setRecipientInstanceType(InstanceType.PARTICIPANT);
+    cr.setSessionSpecific(true);
+    cr.setPartition(targetPartition);
+    cr.setResource(TEST_DB);
+    cr.setClusterName(CLUSTER_NAME);
+
+    AsyncCallback callback = new AsyncCallback() {
+      @Override
+      public void onTimeOut() {
+        Assert.fail("The test state transition timeout.");
+      }
+
+      @Override
+      public void onReplyMessage(Message message) {
+        Assert.assertEquals(message.getMsgState(), Message.MessageState.READ);
+      }
+    };
+
+    // 2. Send the SLAVE to MASTER message to the SLAVE host to make abnormal partition states.
+
+    // 2.A. Without resolver, the fixing is not completely done by the default rebalancer logic.
+    _controller.getMessagingService()
+        .sendAndWait(cr, msg, callback, (int) TestHelper.WAIT_DURATION);
+    // Wait until the partition status is fixed, verify if the result is as expected
+    verifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+    Assert.assertTrue(verifier.verify());
+    ev = admin.getResourceExternalView(CLUSTER_NAME, TEST_DB);
+    Assert.assertEquals(
+        ev.getStateMap(targetPartition).values().stream().filter(state -> state.equals("MASTER"))
+            .count(), 1);
+    // Since the resolver is not used in the auto default fix process, there is no update on the
+    // original master. So if there is any data issue, it was not fixed.
+    long currentMasterUpdateTime = getTopStateUpdateTime(ev, targetPartition, "MASTER");
+    Assert.assertFalse(currentMasterUpdateTime > previousMasterUpdateTime);
+
+    // 2.B. with resolver configured, the fixing is complete.
+    ConfigAccessor configAccessor = new ConfigAccessor.Builder().setZkAddress(ZK_ADDR).build();
+    ClusterConfig clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setAbnormalStateResolverMap(
+        ImmutableMap.of(MasterSlaveSMD.name, ExcessiveTopStateResolver.class.getName()));
+    configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+    _controller.getMessagingService()
+        .sendAndWait(cr, msg, callback, (int) TestHelper.WAIT_DURATION);
+    // Wait until the partition status is fixed, verify if the result is as expected
+    Assert.assertTrue(verifier.verify());
+    ev = admin.getResourceExternalView(CLUSTER_NAME, TEST_DB);
+    Assert.assertEquals(
+        ev.getStateMap(targetPartition).values().stream().filter(state -> state.equals("MASTER"))
+            .count(), 1);
+    // Now the resolver is used in the auto fix process, the original master has also been refreshed.
+    // The potential data issue has been fixed in this process.
+    currentMasterUpdateTime = getTopStateUpdateTime(ev, targetPartition, "MASTER");
+    Assert.assertTrue(currentMasterUpdateTime > previousMasterUpdateTime);
+
+    // Reset the resolver map
+    clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setAbnormalStateResolverMap(Collections.emptyMap());
+    configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+  }
+
+  private long getTopStateUpdateTime(ExternalView ev, String partition, String state) {
+    String topStateHost = ev.getStateMap(partition).entrySet().stream()
+        .filter(entry -> entry.getValue().equals(state)).findFirst().get().getKey();
+    MockParticipantManager participant = Arrays.stream(_participants)
+        .filter(instance -> instance.getInstanceName().equals(topStateHost)).findFirst().get();
+
+    HelixDataAccessor accessor = _controller.getHelixDataAccessor();
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    CurrentState currentState = accessor.getProperty(keyBuilder
+        .currentState(participant.getInstanceName(), participant.getSessionId(),
+            ev.getResourceName()));
+    return currentState.getEndTime(partition);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAbnormalStatesResolver.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAbnormalStatesResolver.java
@@ -1,0 +1,67 @@
+package org.apache.helix.integration.rebalancer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.api.rebalancer.constraint.AbnormalStateResolver;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.rebalancer.constraint.MockAbnormalStateResolver;
+import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.MasterSlaveSMD;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestAbnormalStatesResolver extends ZkStandAloneCMTestBase {
+  @Test
+  public void testConfigureResolver() {
+    ResourceControllerDataProvider cache = new ResourceControllerDataProvider(CLUSTER_NAME);
+    // Verify the initial setup.
+    cache.refresh(_controller.getHelixDataAccessor());
+    for (String stateModelDefName : cache.getStateModelDefMap().keySet()) {
+      Assert.assertEquals(cache.getAbnormalStateResolver(stateModelDefName).getClass(),
+          AbnormalStateResolver.DUMMY_STATE_RESOLVER.getClass());
+    }
+
+    // Update the resolver configuration for MasterSlave state model.
+    ConfigAccessor configAccessor = new ConfigAccessor.Builder().setZkAddress(ZK_ADDR).build();
+    ClusterConfig clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setAbnormalStateResolverMap(
+        ImmutableMap.of(MasterSlaveSMD.name, MockAbnormalStateResolver.class.getName()));
+    configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    cache.requireFullRefresh();
+    cache.refresh(_controller.getHelixDataAccessor());
+    for (String stateModelDefName : cache.getStateModelDefMap().keySet()) {
+      Assert.assertEquals(cache.getAbnormalStateResolver(stateModelDefName).getClass(),
+          stateModelDefName.equals(MasterSlaveSMD.name) ?
+              MockAbnormalStateResolver.class :
+              AbnormalStateResolver.DUMMY_STATE_RESOLVER.getClass());
+    }
+
+    // Reset the resolver map
+    clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setAbnormalStateResolverMap(Collections.emptyMap());
+    configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskThrottling.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskThrottling.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.helix.TestHelper;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.InstanceConfig;
@@ -55,7 +56,7 @@ public class TestTaskThrottling extends TaskTestBase {
    * @throws InterruptedException
    */
   @Test
-  public void testTaskThrottle() throws InterruptedException {
+  public void testTaskThrottle() throws Exception {
     int numTasks = 30 * _numNodes; // 60 tasks
     int perNodeTaskLimitation = 5;
 
@@ -63,17 +64,16 @@ public class TestTaskThrottling extends TaskTestBase {
 
     // 1. Job executed in the participants with no limitation
     String jobName1 = "Job1";
-    Workflow flow = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName1, jobConfig).build();
-    _driver.start(flow);
-    _driver.pollForJobState(flow.getName(), TaskUtil.getNamespacedJobName(flow.getName(), jobName1),
+    Workflow flow1 = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName1, jobConfig).build();
+    _driver.start(flow1);
+    _driver.pollForJobState(flow1.getName(), TaskUtil.getNamespacedJobName(flow1.getName(), jobName1),
         TaskState.IN_PROGRESS);
-    // Wait for tasks to be picked up
-    Thread.sleep(1000L);
 
-    Assert.assertEquals(countRunningPartition(flow, jobName1), numTasks);
+    Assert.assertTrue(TestHelper.verify(() -> (countRunningPartition(flow1, jobName1) == numTasks),
+        TestHelper.WAIT_DURATION));
 
-    _driver.stop(flow.getName());
-    _driver.pollForWorkflowState(flow.getName(), TaskState.STOPPED);
+    _driver.stop(flow1.getName());
+    _driver.pollForWorkflowState(flow1.getName(), TaskState.STOPPED);
 
     // 2. Job executed in the participants with max task limitation
 
@@ -87,25 +87,25 @@ public class TestTaskThrottling extends TaskTestBase {
     _gSetupTool.getClusterManagementTool().setConfig(scope, properties);
 
     String jobName2 = "Job2";
-    flow = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName2, jobConfig).build();
-    _driver.start(flow);
-    _driver.pollForJobState(flow.getName(), TaskUtil.getNamespacedJobName(flow.getName(), jobName2),
+    Workflow flow2 = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName2, jobConfig).build();
+    _driver.start(flow2);
+    _driver.pollForJobState(flow2.getName(), TaskUtil.getNamespacedJobName(flow2.getName(), jobName2),
         TaskState.IN_PROGRESS);
-    // Wait for tasks to be picked up
-    Thread.sleep(1000L);
 
     // Expect 10 tasks
-    Assert.assertEquals(countRunningPartition(flow, jobName2), _numNodes * perNodeTaskLimitation);
+    Assert.assertTrue(TestHelper.verify(
+        () -> (countRunningPartition(flow2, jobName2) == (_numNodes * perNodeTaskLimitation)),
+        TestHelper.WAIT_DURATION));
 
-    _driver.stop(flow.getName());
-    _driver.pollForWorkflowState(flow.getName(), TaskState.STOPPED);
+    _driver.stop(flow2.getName());
+    _driver.pollForWorkflowState(flow2.getName(), TaskState.STOPPED);
 
     // 3. Ensure job can finish normally
     jobConfig.setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10"));
     String jobName3 = "Job3";
-    flow = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName3, jobConfig).build();
-    _driver.start(flow);
-    _driver.pollForJobState(flow.getName(), TaskUtil.getNamespacedJobName(flow.getName(), jobName3),
+    Workflow flow3 = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName3, jobConfig).build();
+    _driver.start(flow3);
+    _driver.pollForJobState(flow3.getName(), TaskUtil.getNamespacedJobName(flow3.getName(), jobName3),
         TaskState.COMPLETED);
   }
 
@@ -113,7 +113,7 @@ public class TestTaskThrottling extends TaskTestBase {
   @Test(dependsOnMethods = {
       "testTaskThrottle"
   }, enabled = false)
-  public void testJobPriority() throws InterruptedException {
+  public void testJobPriority() throws Exception {
     int numTasks = 30 * _numNodes;
     int perNodeTaskLimitation = 5;
 
@@ -129,9 +129,10 @@ public class TestTaskThrottling extends TaskTestBase {
     _driver.start(flow1);
     _driver.pollForJobState(flow1.getName(),
         TaskUtil.getNamespacedJobName(flow1.getName(), jobName1), TaskState.IN_PROGRESS);
-    // Wait for tasks to be picked up
-    Thread.sleep(1000L);
-    Assert.assertEquals(countRunningPartition(flow1, jobName1), _numNodes * perNodeTaskLimitation);
+
+    Assert.assertTrue(TestHelper.verify(
+        () -> (countRunningPartition(flow1, jobName1) == (_numNodes * perNodeTaskLimitation)),
+        TestHelper.WAIT_DURATION));
 
     // schedule job2
     String jobName2 = "PriorityJob2";
@@ -140,18 +141,20 @@ public class TestTaskThrottling extends TaskTestBase {
     _driver.start(flow2);
     _driver.pollForJobState(flow2.getName(),
         TaskUtil.getNamespacedJobName(flow2.getName(), jobName2), TaskState.IN_PROGRESS);
-    // Wait for tasks to be picked up
-    Thread.sleep(1500);
-    Assert.assertEquals(countRunningPartition(flow2, jobName2), 0);
+
+    Assert.assertTrue(TestHelper.verify(() -> (countRunningPartition(flow2, jobName2) == 0),
+        TestHelper.WAIT_DURATION));
 
     // Increasing participants capacity
-    perNodeTaskLimitation = 2 * perNodeTaskLimitation;
-    setParticipantsCapacity(perNodeTaskLimitation);
+    setParticipantsCapacity(2 * perNodeTaskLimitation);
 
-    Thread.sleep(1500);
     // Additional capacity should all be used by job1
-    Assert.assertEquals(countRunningPartition(flow1, jobName1), _numNodes * perNodeTaskLimitation);
-    Assert.assertEquals(countRunningPartition(flow2, jobName2), 0);
+    Assert.assertTrue(TestHelper.verify(
+        () -> (countRunningPartition(flow1, jobName1) == (_numNodes * 2 * perNodeTaskLimitation)),
+        TestHelper.WAIT_DURATION));
+
+    Assert.assertTrue(TestHelper.verify(() -> (countRunningPartition(flow2, jobName2) == 0),
+        TestHelper.WAIT_DURATION));
 
     _driver.stop(flow1.getName());
     _driver.pollForWorkflowState(flow1.getName(), TaskState.STOPPED);

--- a/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.helix.controller.rebalancer.constraint.MockAbnormalStateResolver;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -255,5 +256,20 @@ public class TestClusterConfig {
     Assert.assertEquals(testConfig.getRecord()
         .getBooleanField(ClusterConfig.ClusterConfigProperty.GLOBAL_REBALANCE_ASYNC_MODE.name(),
             false), true);
+  }
+
+  @Test
+  public void testAbnormalStatesResolverConfig() {
+    ClusterConfig testConfig = new ClusterConfig("testConfig");
+    // Default value is empty
+    Assert.assertEquals(testConfig.getAbnormalStateResolverMap(), Collections.EMPTY_MAP);
+    // Test set
+    Map<String, String> resolverMap = ImmutableMap.of(MasterSlaveSMD.name,
+        MockAbnormalStateResolver.class.getName());
+    testConfig.setAbnormalStateResolverMap(resolverMap);
+    Assert.assertEquals(testConfig.getAbnormalStateResolverMap(), resolverMap);
+    // Test empty the map
+    testConfig.setAbnormalStateResolverMap(Collections.emptyMap());
+    Assert.assertEquals(testConfig.getAbnormalStateResolverMap(), Collections.EMPTY_MAP);
   }
 }

--- a/helix-core/src/test/resources/log4j.properties
+++ b/helix-core/src/test/resources/log4j.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 # Set root logger level to DEBUG and its only appender to R.
-log4j.rootLogger=ERROR, C
+log4j.rootLogger=INFO, R
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.C=org.apache.log4j.ConsoleAppender
@@ -26,16 +26,17 @@ log4j.appender.C.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
 
 log4j.appender.R=org.apache.log4j.RollingFileAppender
 log4j.appender.R.layout=org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern=%5p [%C:%M] (%F:%L) - %m%n
+#log4j.appender.R.layout.ConversionPattern=%5p [%C:%M] (%F:%L) - %m%n
+log4j.appender.R.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss.SSS} %-5p [%C{1}][%t][%c{1}] %x - %m%n
 log4j.appender.R.File=target/ClusterManagerLogs/log.txt
 
 log4j.appender.STATUSDUMP=org.apache.log4j.RollingFileAppender
 log4j.appender.STATUSDUMP.layout=org.apache.log4j.SimpleLayout
 log4j.appender.STATUSDUMP.File=target/ClusterManagerLogs/statusUpdates.log
 
-log4j.logger.org.I0Itec=ERROR
-log4j.logger.org.apache=ERROR
-log4j.logger.com.noelios=ERROR
-log4j.logger.org.restlet=ERROR
+log4j.logger.org.I0Itec=INFO
+log4j.logger.org.apache=INFO
+log4j.logger.com.noelios=INFO
+log4j.logger.org.restlet=INFO
 
 log4j.logger.org.apache.helix.monitoring.ZKPathDataDumpTask=ERROR,STATUSDUMP

--- a/helix-core/src/test/resources/log4j.properties
+++ b/helix-core/src/test/resources/log4j.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 # Set root logger level to DEBUG and its only appender to R.
-log4j.rootLogger=INFO, R
+log4j.rootLogger=ERROR, C
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.C=org.apache.log4j.ConsoleAppender
@@ -26,17 +26,16 @@ log4j.appender.C.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
 
 log4j.appender.R=org.apache.log4j.RollingFileAppender
 log4j.appender.R.layout=org.apache.log4j.PatternLayout
-#log4j.appender.R.layout.ConversionPattern=%5p [%C:%M] (%F:%L) - %m%n
-log4j.appender.R.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss.SSS} %-5p [%C{1}][%t][%c{1}] %x - %m%n
+log4j.appender.R.layout.ConversionPattern=%5p [%C:%M] (%F:%L) - %m%n
 log4j.appender.R.File=target/ClusterManagerLogs/log.txt
 
 log4j.appender.STATUSDUMP=org.apache.log4j.RollingFileAppender
 log4j.appender.STATUSDUMP.layout=org.apache.log4j.SimpleLayout
 log4j.appender.STATUSDUMP.File=target/ClusterManagerLogs/statusUpdates.log
 
-log4j.logger.org.I0Itec=INFO
-log4j.logger.org.apache=INFO
-log4j.logger.com.noelios=INFO
-log4j.logger.org.restlet=INFO
+log4j.logger.org.I0Itec=ERROR
+log4j.logger.org.apache=ERROR
+log4j.logger.com.noelios=ERROR
+log4j.logger.org.restlet=ERROR
 
 log4j.logger.org.apache.helix.monitoring.ZKPathDataDumpTask=ERROR,STATUSDUMP

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
@@ -21,10 +21,19 @@ package org.apache.helix.zookeeper.api.client;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+
+
+/** Represents return type of {@link org.apache.helix.zookeeper.api.client.RealmAwareZkClient#subscribeChildChanges(String, IZkChildListener, boolean)}
+ *  The returned value would signal if watch installation to ZooKeeper server succeeded
+ *  or not using field _isInstalled. The _children field would contains the list of child names
+ *  of the watched path. It would be null if the parent path does not exist at the time of watch
+ *  installation.
+ */
 
 public class ChildrenSubscribeResult {
-  private List<String> _children;
-  private boolean _isInstalled;
+  private final List<String> _children;
+  private final boolean _isInstalled;
 
   public ChildrenSubscribeResult(List<String> children, boolean isInstalled) {
     if (children != null) {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
@@ -9,7 +9,11 @@ public class ChildrenSubscribeResult {
   private boolean _isInstalled;
 
   public ChildrenSubscribeResult(List<String> children, boolean isInstalled) {
-    _children = Collections.unmodifiableList(children);
+    if (children != null) {
+      _children = Collections.unmodifiableList(children);
+    } else {
+      _children = null;
+    }
     _isInstalled = isInstalled;
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
@@ -1,4 +1,22 @@
 package org.apache.helix.zookeeper.api.client;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 import java.util.Collections;
 import java.util.List;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
@@ -1,0 +1,23 @@
+package org.apache.helix.zookeeper.api.client;
+
+import java.util.Collections;
+import java.util.List;
+
+
+public class ChildrenSubscribeResult {
+  private List<String> _children;
+  private boolean _isInstalled;
+
+  public ChildrenSubscribeResult(List<String> children, boolean isInstalled) {
+    _children = Collections.unmodifiableList(children);
+    _isInstalled = isInstalled;
+  }
+
+  public List<String> getChildren() {
+    return _children;
+  }
+
+  public boolean isInstalled() {
+    return _isInstalled;
+  }
+}

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ChildrenSubscribeResult.java
@@ -30,7 +30,6 @@ import org.apache.helix.zookeeper.zkclient.IZkChildListener;
  *  of the watched path. It would be null if the parent path does not exist at the time of watch
  *  installation.
  */
-
 public class ChildrenSubscribeResult {
   private final List<String> _children;
   private final boolean _isInstalled;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -109,10 +109,10 @@ public interface RealmAwareZkClient {
    * WARNING: if the path is created after deletion, users need to re-subscribe the path
    * @param path The zookeeper path
    * @param listener Instance of {@link IZkDataListener}
-   * @param skipWatchingNodeNotExist True means not installing any watch if path does not exist.
+   * @param skipWatchingNonExistNode True means not installing any watch if path does not exist.
    * return True if installation of watch succeed. Otherwise, return false.
    */
-  boolean subscribeDataChanges(String path, IZkDataListener listener, boolean skipWatchingNodeNotExist);
+  boolean subscribeDataChanges(String path, IZkDataListener listener, boolean skipWatchingNonExistNode);
 
   void unsubscribeDataChanges(String path, IZkDataListener listener);
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -68,6 +68,11 @@ public interface RealmAwareZkClient {
   int DEFAULT_CONNECTION_TIMEOUT = 60 * 1000;
   int DEFAULT_SESSION_TIMEOUT = 30 * 1000;
 
+  class ChildrenSubscribeResult {
+    public List<String> children;
+    public boolean isInstalled;
+  }
+
   // listener subscription
   /**
    * Subscribe the path and the listener will handle child events of the path.
@@ -75,6 +80,8 @@ public interface RealmAwareZkClient {
    * WARNING: if the path is created after deletion, users need to re-subscribe the path
    * @param path The zookeeper path
    * @param listener Instance of {@link IZkDataListener}
+   * The method return null if the path does not exists. Otherwise, return a list of children
+   * under the path. The list can be empty if there is no children.
    */
   List<String> subscribeChildChanges(String path, IZkChildListener listener);
 
@@ -83,9 +90,11 @@ public interface RealmAwareZkClient {
    * WARNING: if the path is created after deletion, users need to re-subscribe the path
    * @param path The zookeeper path
    * @param listener Instance of {@link IZkDataListener}
-   * @param skipWatchingNodeNotExist Ture means not installing any watch if path does not exist.
+   * @param skipWatchingNodeNotExist True means not installing any watch if path does not exist.
+   * The method return ChildrentSubsribeResult. If the path does not exists, the isInstalled field
+   * is false. Otherwise, it is true and list of children are returned.
    */
-  List<String> subscribeChildChanges(String path, IZkChildListener listener, boolean skipWatchingNodeNotExist);
+  ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener, boolean skipWatchingNodeNotExist);
 
   void unsubscribeChildChanges(String path, IZkChildListener listener);
 
@@ -103,9 +112,10 @@ public interface RealmAwareZkClient {
    * WARNING: if the path is created after deletion, users need to re-subscribe the path
    * @param path The zookeeper path
    * @param listener Instance of {@link IZkDataListener}
-   * @param skipWatchingNodeNotExist Ture means not installing any watch if path does not exist.
+   * @param skipWatchingNodeNotExist True means not installing any watch if path does not exist.
+   * return True if installation of watch succeed. Otherwise, return false.
    */
-  void subscribeDataChanges(String path, IZkDataListener listener, boolean skipWatchingNodeNotExist);
+  boolean subscribeDataChanges(String path, IZkDataListener listener, boolean skipWatchingNodeNotExist);
 
   void unsubscribeDataChanges(String path, IZkDataListener listener);
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -68,11 +68,6 @@ public interface RealmAwareZkClient {
   int DEFAULT_CONNECTION_TIMEOUT = 60 * 1000;
   int DEFAULT_SESSION_TIMEOUT = 30 * 1000;
 
-  class ChildrenSubscribeResult {
-    public List<String> children;
-    public boolean isInstalled;
-  }
-
   // listener subscription
   /**
    * Subscribe the path and the listener will handle child events of the path.

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -71,9 +71,13 @@ public interface RealmAwareZkClient {
   // listener subscription
   List<String> subscribeChildChanges(String path, IZkChildListener listener);
 
+  List<String> subscribeChildChanges(String path, IZkChildListener listener, boolean skipWatchingNodeNotExist);
+
   void unsubscribeChildChanges(String path, IZkChildListener listener);
 
   void subscribeDataChanges(String path, IZkDataListener listener);
+
+  void subscribeDataChanges(String path, IZkDataListener listener, boolean skipWatchingNodeNotExist);
 
   void unsubscribeDataChanges(String path, IZkDataListener listener);
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -69,14 +69,42 @@ public interface RealmAwareZkClient {
   int DEFAULT_SESSION_TIMEOUT = 30 * 1000;
 
   // listener subscription
+  /**
+   * Subscribe the path and the listener will handle child events of the path.
+   * Add exists watch to path if the path does not exist in ZooKeeper server.
+   * WARNING: if the path is created after deletion, users need to re-subscribe the path
+   * @param path The zookeeper path
+   * @param listener Instance of {@link IZkDataListener}
+   */
   List<String> subscribeChildChanges(String path, IZkChildListener listener);
 
+  /**
+   * Subscribe the path and the listener will handle child events of the path
+   * WARNING: if the path is created after deletion, users need to re-subscribe the path
+   * @param path The zookeeper path
+   * @param listener Instance of {@link IZkDataListener}
+   * @param skipWatchingNodeNotExist Ture means not installing any watch if path does not exist.
+   */
   List<String> subscribeChildChanges(String path, IZkChildListener listener, boolean skipWatchingNodeNotExist);
 
   void unsubscribeChildChanges(String path, IZkChildListener listener);
 
+  /**
+   * Subscribe the path and the listener will handle data events of the path
+   * Add the exists watch to Zookeeper server even if the path does not exists in zookeeper server
+   * WARNING: if the path is created after deletion, users need to re-subscribe the path
+   * @param path The zookeeper path
+   * @param listener Instance of {@link IZkDataListener}
+   */
   void subscribeDataChanges(String path, IZkDataListener listener);
 
+  /**
+   * Subscribe the path and the listener will handle data events of the path
+   * WARNING: if the path is created after deletion, users need to re-subscribe the path
+   * @param path The zookeeper path
+   * @param listener Instance of {@link IZkDataListener}
+   * @param skipWatchingNodeNotExist Ture means not installing any watch if path does not exist.
+   */
   void subscribeDataChanges(String path, IZkDataListener listener, boolean skipWatchingNodeNotExist);
 
   void unsubscribeDataChanges(String path, IZkDataListener listener);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -78,6 +78,7 @@ public interface RealmAwareZkClient {
    * The method return null if the path does not exists. Otherwise, return a list of children
    * under the path. The list can be empty if there is no children.
    */
+  @Deprecated
   List<String> subscribeChildChanges(String path, IZkChildListener listener);
 
   /**
@@ -85,11 +86,11 @@ public interface RealmAwareZkClient {
    * WARNING: if the path is created after deletion, users need to re-subscribe the path
    * @param path The zookeeper path
    * @param listener Instance of {@link IZkDataListener}
-   * @param skipWatchingNodeNotExist True means not installing any watch if path does not exist.
-   * The method return ChildrentSubsribeResult. If the path does not exists, the isInstalled field
+   * @param skipWatchingNonExistNode True means not installing any watch if path does not exist.
+   * @return ChildrentSubsribeResult. If the path does not exists, the isInstalled field
    * is false. Otherwise, it is true and list of children are returned.
    */
-  ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener, boolean skipWatchingNodeNotExist);
+  ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener, boolean skipWatchingNonExistNode);
 
   void unsubscribeChildChanges(String path, IZkChildListener listener);
 
@@ -100,6 +101,7 @@ public interface RealmAwareZkClient {
    * @param path The zookeeper path
    * @param listener Instance of {@link IZkDataListener}
    */
+  @Deprecated
   void subscribeDataChanges(String path, IZkDataListener listener);
 
   /**

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -122,6 +122,12 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public List<String> subscribeChildChanges(String path, IZkChildListener listener,
+      boolean skipWatchingNodeNotExist) {
+    return _rawZkClient.subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
+  }
+
+  @Override
   public void unsubscribeChildChanges(String path, IZkChildListener listener) {
     checkIfPathContainsShardingKey(path);
     _rawZkClient.unsubscribeChildChanges(path, listener);
@@ -131,6 +137,12 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   public void subscribeDataChanges(String path, IZkDataListener listener) {
     checkIfPathContainsShardingKey(path);
     _rawZkClient.subscribeDataChanges(path, listener);
+  }
+
+  @Override
+  public void subscribeDataChanges(String path, IZkDataListener listener,
+      boolean skipWatchingNodeNotExist) {
+    _rawZkClient.subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -122,7 +122,7 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public List<String> subscribeChildChanges(String path, IZkChildListener listener,
+  public ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener,
       boolean skipWatchingNodeNotExist) {
     return _rawZkClient.subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
   }
@@ -140,9 +140,9 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public void subscribeDataChanges(String path, IZkDataListener listener,
+  public boolean subscribeDataChanges(String path, IZkDataListener listener,
       boolean skipWatchingNodeNotExist) {
-    _rawZkClient.subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
+    return _rawZkClient.subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
+import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.util.HttpRoutingDataReader;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -115,7 +115,7 @@ public class FederatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public List<String> subscribeChildChanges(String path, IZkChildListener listener,
+  public ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener,
       boolean skipWatchingNodeNotExist) {
     return getZkClient(path).subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
   }
@@ -131,9 +131,9 @@ public class FederatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public void subscribeDataChanges(String path, IZkDataListener listener,
+  public boolean subscribeDataChanges(String path, IZkDataListener listener,
       boolean skipWatchingNodeNotExist) {
-    getZkClient(path).subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
+    return getZkClient(path).subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -115,6 +115,12 @@ public class FederatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public List<String> subscribeChildChanges(String path, IZkChildListener listener,
+      boolean skipWatchingNodeNotExist) {
+    return getZkClient(path).subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
+  }
+
+  @Override
   public void unsubscribeChildChanges(String path, IZkChildListener listener) {
     getZkClient(path).unsubscribeChildChanges(path, listener);
   }
@@ -122,6 +128,12 @@ public class FederatedZkClient implements RealmAwareZkClient {
   @Override
   public void subscribeDataChanges(String path, IZkDataListener listener) {
     getZkClient(path).subscribeDataChanges(path, listener);
+  }
+
+  @Override
+  public void subscribeDataChanges(String path, IZkDataListener listener,
+      boolean skipWatchingNodeNotExist) {
+    getZkClient(path).subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
+import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
 import org.apache.helix.zookeeper.util.HttpRoutingDataReader;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -125,7 +125,7 @@ public class SharedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public List<String> subscribeChildChanges(String path, IZkChildListener listener,
+  public ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener,
       boolean skipWatchingNodeNotExist) {
     return _innerSharedZkClient.subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
   }
@@ -143,9 +143,9 @@ public class SharedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public void subscribeDataChanges(String path, IZkDataListener listener,
+  public boolean subscribeDataChanges(String path, IZkDataListener listener,
       boolean skipWatchingNodeNotExist) {
-    _innerSharedZkClient.subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
+    return _innerSharedZkClient.subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -125,6 +125,12 @@ public class SharedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public List<String> subscribeChildChanges(String path, IZkChildListener listener,
+      boolean skipWatchingNodeNotExist) {
+    return _innerSharedZkClient.subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
+  }
+
+  @Override
   public void unsubscribeChildChanges(String path, IZkChildListener listener) {
     checkIfPathContainsShardingKey(path);
     _innerSharedZkClient.unsubscribeChildChanges(path, listener);
@@ -134,6 +140,12 @@ public class SharedZkClient implements RealmAwareZkClient {
   public void subscribeDataChanges(String path, IZkDataListener listener) {
     checkIfPathContainsShardingKey(path);
     _innerSharedZkClient.subscribeDataChanges(path, listener);
+  }
+
+  @Override
+  public void subscribeDataChanges(String path, IZkDataListener listener,
+      boolean skipWatchingNodeNotExist) {
+    _innerSharedZkClient.subscribeDataChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
+import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1098,7 +1098,7 @@ public class ZkClient implements Watcher {
    */
   private Stat getStat(final String path, final boolean watch, final boolean useGetData) {
     long startT = System.currentTimeMillis();
-    Stat stat = null;
+    final Stat stat;
     try {
       if (!useGetData) {
         stat = retryUntilConnected(
@@ -1106,11 +1106,10 @@ public class ZkClient implements Watcher {
       } else {
         stat = new Stat();
         try {
-          LOG.debug("getstat() invoked with useGetData() with path: " + path);
-          Stat finalStat = stat;
-          retryUntilConnected(() -> ((ZkConnection) getConnection()).getZookeeper().getData(path, true, finalStat));
+          LOG.debug("getstat() invoked with useGetData() with path: {} ", path);
+          retryUntilConnected(() -> ((ZkConnection) getConnection()).getZookeeper().getData(path, true, stat));
         } catch (ZkNoNodeException e) {
-          LOG.debug("getstat() invoked path: " + path + " null" + " useGetData:" + useGetData);
+          LOG.debug("getstat() invoked path: {}  null  useGetData: {}", path, useGetData);
           record(path, null, startT, ZkClientMonitor.AccessType.READ);
           // Note, exists() path with useGetData false would never throw ZkNoNodeException.
           // thus, only useGetData true, we may get here. In this case, we eat the exception, return
@@ -1331,7 +1330,7 @@ public class ZkClient implements Watcher {
     final String path = event.getPath();
     final boolean pathExists = event.getType() != EventType.NodeDeleted;
     if (EventType.NodeDeleted == event.getType()) {
-      LOG.debug("event delelete: {}", event.getPath());
+      LOG.debug("Event NodeDeleted: {}", event.getPath());
     }
 
     if (event.getType() == EventType.NodeChildrenChanged || event.getType() == EventType.NodeCreated

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1111,6 +1111,12 @@ public class ZkClient implements Watcher {
     } catch (ZkNoNodeException e) {
       LOG.debug("getstat() invoked path: " + path + " null" + " useGetData:" + useGetData);
       record(path, null, startT, ZkClientMonitor.AccessType.READ);
+      // Note, exists() path with useGetData false would never throw ZkNoNodeException.
+      // thus, only useGetData true, we may get here. In this case, we eat the exception, return
+      // null. This is what we wanted. In essence, we simulate exists() in term never throw
+      // ZkNoNodeException. But when node does not exists in ZooKeeper server, we would not install
+      // watch. The side effect is in the case that node exists, this would return payload of
+      // the node data that we don't need. This is the place for further improvement.
       return null;
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.READ);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1124,7 +1124,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("exists, path: " + path + ", time: " + (endT - startT) + " ms");
+        LOG.trace("getData (installWatchOnlyPathExist), path: " + path + ", time: " + (endT - startT) + " ms");
       }
     }
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1331,7 +1331,7 @@ public class ZkClient implements Watcher {
     final String path = event.getPath();
     final boolean pathExists = event.getType() != EventType.NodeDeleted;
     if (EventType.NodeDeleted == event.getType()) {
-      LOG.debug("event delelete:" + event.getPath());
+      LOG.debug("event delelete: {}", event.getPath());
     }
 
     if (event.getType() == EventType.NodeChildrenChanged || event.getType() == EventType.NodeCreated


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1102 
TestRemoveUserCbHandlerOnPathRemoval has a flaky test

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

`Assert
.assertEquals(watchPaths.get("existWatches").size(), 2,
"Should have 2 exist-watches: CURRENTSTATE/{oldSessionId} and CURRENTSTATE/{oldSessionId}/TestDB0");`
is flaky. 

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

Waiting result for now.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)