### PR TITLE
Enhance flaky test TestRemoveUserCbHandlerOnPathRemoval

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/TestZkCallbackHandlerLeak.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestZkCallbackHandlerLeak.java
@@ -605,6 +605,17 @@ public class TestZkCallbackHandlerLeak extends ZkUnitTestBase {
         "Should have 1 data-watches: MESSAGES");
     Assert.assertEquals(watchPaths.get("childWatches").size(), 1,
         "Should have 1 child-watches: MESSAGES");
+
+    // In this test participant0 also register to its own cocurrent state with a callbackhandler
+    // When session expiration happens, the current state parent path would also changes. However,
+    // an exists watch would still be installed by event pushed to ZkCLient event thread by
+    // fireAllEvent() children even path on behalf of old session callbackhandler. By the time this
+    // event gets invoked, the old session callbackhandler was removed, but the event would still
+    // install a exist watch for old session.
+    // The closest similar case in production is that router/controller has an session expiration at
+    // the same time as participant.
+    // Currently there are many places to register watch in Zookeeper over the evolution of Helix
+    // and ZkClient. We plan for further simplify the logic of watch installation next.
     result = TestHelper.verify(()-> {
       Map<String, List<String>> wPaths = ZkTestHelper.getZkWatch(participantToExpire.getZkClient());
       return wPaths.get("existWatches").size() == 1;

--- a/helix-core/src/test/java/org/apache/helix/integration/TestZkCallbackHandlerLeak.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestZkCallbackHandlerLeak.java
@@ -605,9 +605,12 @@ public class TestZkCallbackHandlerLeak extends ZkUnitTestBase {
         "Should have 1 data-watches: MESSAGES");
     Assert.assertEquals(watchPaths.get("childWatches").size(), 1,
         "Should have 1 child-watches: MESSAGES");
-    Assert
-        .assertEquals(watchPaths.get("existWatches").size(), 2,
-            "Should have 2 exist-watches: CURRENTSTATE/{oldSessionId} and CURRENTSTATE/{oldSessionId}/TestDB0");
+    result = TestHelper.verify(()-> {
+      Map<String, List<String>> wPaths = ZkTestHelper.getZkWatch(participantToExpire.getZkClient());
+      return wPaths.get("existWatches").size() == 1;
+    }, 10000);
+    Assert.assertTrue(result,
+        "Should have 1 exist-watches: CURRENTSTATE/{oldSessionId}");
 
     // another session expiry on localhost_12918 should clear the two exist-watches on
     // CURRENTSTATE/{oldSessionId}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1102 
TestRemoveUserCbHandlerOnPathRemoval has a flaky test

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

`Assert
.assertEquals(watchPaths.get("existWatches").size(), 2,
"Should have 2 exist-watches: CURRENTSTATE/{oldSessionId} and CURRENTSTATE/{oldSessionId}/TestDB0");`
is flaky. 

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

This test case pass. This pull only touch test case logic.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)