### PR TITLE
Fix ZkBucketDataAccessor failure due to concurrent modification.

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -19,24 +19,25 @@ package org.apache.helix.manager.zk;
  * under the License.
  */
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.BucketDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.TestHelper;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.common.ZkTestBase;
-import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
 import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.testng.Assert;
@@ -49,6 +50,7 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
   private static final String NAME_KEY = TestHelper.getTestClassName();
   private static final String LAST_SUCCESSFUL_WRITE_KEY = "LAST_SUCCESSFUL_WRITE";
   private static final String LAST_WRITE_KEY = "LAST_WRITE";
+  private static final long VERSION_TTL_MS = 1000L;
 
   // Populate list and map fields for content comparison
   private static final List<String> LIST_FIELD = ImmutableList.of("1", "2");
@@ -62,7 +64,7 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
   @BeforeClass
   public void beforeClass() {
     // Initialize ZK accessors for testing
-    _bucketDataAccessor = new ZkBucketDataAccessor(ZK_ADDR, 50 * 1024, 0L);
+    _bucketDataAccessor = new ZkBucketDataAccessor(ZK_ADDR, 50 * 1024, VERSION_TTL_MS);
     HelixZkClient zkClient = DedicatedZkClientFactory.getInstance()
         .buildZkClient(new HelixZkClient.ZkConnectionConfig(ZK_ADDR));
     zkClient.setZkSerializer(new ZkSerializer() {
@@ -103,8 +105,13 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
 
   @Test(dependsOnMethods = "testCompressedBucketWrite")
   public void testMultipleWrites() throws Exception {
-    int count = 50;
+    // Note to use a count number < 10 for testing.
+    // Otherwise the nodes named with version number will be ordered in a different alphabet order.
+    // This might hide some bugs in the GC code。
+    int count = 5;
 
+    Assert.assertTrue(VERSION_TTL_MS > 100,
+        "This test should be executed with the TTL more than 100ms.");
     // Write "count" times
     for (int i = 0; i < count; i++) {
       _bucketDataAccessor.compressedBucketWrite(PATH, new HelixProperty(record));
@@ -126,8 +133,17 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
     // Use Verifier because GC can take ZK delay
     Assert.assertTrue(TestHelper.verify(() -> {
       List<String> children = _zkBaseDataAccessor.getChildNames(PATH, AccessOption.PERSISTENT);
-      return children.size() == 3;
-    }, 60 * 1000L));
+      return children.size() == 3 && children.containsAll(ImmutableList
+          .of(LAST_SUCCESSFUL_WRITE_KEY, LAST_WRITE_KEY,
+              new Long(lastSuccessfulWriteVer).toString()));
+    }, VERSION_TTL_MS * 2));
+
+    // Wait one more TTL to ensure that the
+    Thread.sleep(VERSION_TTL_MS);
+    List<String> children = _zkBaseDataAccessor.getChildNames(PATH, AccessOption.PERSISTENT);
+    Assert.assertTrue(children.size() == 3 && children.containsAll(ImmutableList
+        .of(LAST_SUCCESSFUL_WRITE_KEY, LAST_WRITE_KEY,
+            new Long(lastSuccessfulWriteVer).toString())));
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -138,7 +138,7 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
               new Long(lastSuccessfulWriteVer).toString()));
     }, VERSION_TTL_MS * 2));
 
-    // Wait one more TTL to ensure that the
+    // Wait one more TTL to ensure that the GC has been done.
     Thread.sleep(VERSION_TTL_MS);
     List<String> children = _zkBaseDataAccessor.getChildNames(PATH, AccessOption.PERSISTENT);
     Assert.assertTrue(children.size() == 3 && children.containsAll(ImmutableList


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#767 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Concurrent modification causes two issues.
1. Regular GC task fails due to concurrent list modification and the stale versions are not removed at all.
2. If, by coincident, there is a newer version in the list other then the current version, then because of the modification of the list inside the loop, the final element (the newer version) won't be filtered but being left in the to-be-removed list. Then the GC task removes the most recent version. For example,
  a) Input, current version "2"
  b) Children = [1, 2, 3]
  c) The task avoids checking "2", so the list for loop is: [1, 3]
  d) When checking "1", it is removed from the list. So the list becomes [3]. Then the loop ends, because the first item has already been looped from the for iteration perspective.
  e) The version to be removed is "3"!

This PR fixes the issue by avoiding concurrent modifications. Also, it simplifies the logic so as to reduce the pending GC tasks.
The test is also updated accordingly.

### Tests

- [X] The following tests are written for this issue:

TestZkBucketDataAccessor

- [X] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp:111 Sets differ: expected [testJobQueueAutoCleanUp_JOB8, testJobQueueAutoCleanUp_JOB7, testJobQueueAutoCleanUp_JOB6, testJobQueueAutoCleanUp_JOB5, testJobQueueAutoCleanUp_JOB9] but got [testJobQueueAutoCleanUp_JOB4, testJobQueueAutoCleanUp_JOB8, testJobQueueAutoCleanUp_JOB7, testJobQueueAutoCleanUp_JOB6, testJobQueueAutoCleanUp_JOB5, testJobQueueAutoCleanUp_JOB9]
[INFO]
[ERROR] Tests run: 1145, Failures: 1, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:19 h
[INFO] Finished at: 2020-06-19T19:27:46-07:00
[INFO] ------------------------------------------------------------------------

Rerun

[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.293 s - in org.apache.helix.integration.task.TestJobQueueCleanUp
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 21.621 s
[INFO] Finished at: 2020-06-19T21:53:23-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
