### PR TITLE
Add compression and encode support for get propertyStore endpoint

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/ZLibCompressionUtil.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/ZLibCompressionUtil.java
@@ -1,0 +1,94 @@
+package org.apache.helix.zookeeper.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.DataFormatException;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This class provides support for general purpose compression using the popular ZLIB compression.
+ * It uses {@link Deflater} to compress.
+ */
+public class ZLibCompressionUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(ZLibCompressionUtil.class);
+
+  /**
+   * Compresses input byte array using {@link Deflater} compression.
+   *
+   * @param bytes byte array to be compressed
+   * @return compressed byte array
+   * @throws IOException if an I/O error occurs
+   */
+  public static byte[] compress(byte[] bytes) throws IOException {
+    Deflater df = new Deflater();
+    df.setInput(bytes);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(bytes.length);
+    df.finish();
+
+    byte[] buff = new byte[1024];
+    while (!df.finished())
+    {
+      int count = df.deflate(buff);
+      baos.write(buff, 0, count);
+    }
+    baos.close();
+    byte[] compressedBytes = baos.toByteArray();
+
+    LOG.debug("Compress: decompressed size: {}, compressed size: {}", bytes.length,
+        compressedBytes.length);
+
+    return compressedBytes;
+  }
+
+  /**
+   * Decompresses byte array using {@link Inflater} decompression.
+   *
+   * @param bytes compressed byte array to be decompressed
+   * @return decompressed byte array
+   * @throws IOException if an I/O error occurs
+   * @throws DataFormatException if the compressed data format is invalid
+   */
+  public static byte[] decompress(byte[] bytes) throws IOException, DataFormatException {
+    Inflater decompressor = new Inflater();
+    decompressor.setInput(bytes);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(bytes.length);
+
+    byte[] buff = new byte[1024];
+    while (!decompressor.finished()) {
+      int count = decompressor.inflate(buff);
+      baos.write(buff, 0, count);
+    }
+    baos.close();
+
+    byte[] decompressedBytes = baos.toByteArray();
+
+    LOG.debug("Decompress: decompressed size: {}, compressed size: {}", decompressedBytes.length,
+        bytes.length);
+
+    return decompressedBytes;
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixed #1105 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Get propertyStore endpoint creates a string response for zlib compressed bytes which causes client not able to decompress the data.

This PR adds compression and encode support to decompress/encode the compressed bytes properly.

For example: 

- "/propertyStore/path?compression=zlib"
- "/propertyStore/path?encode=base64"

### Tests

- [x] The following tests are written for this issue:

- testGetPropertyStoreWithZLibCompression
- testGetPropertyStoreWithGzipCompression
- testGetPropertyStoreWithEncode

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 166, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 65.177 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 166, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:11 min
[INFO] Finished at: 2020-06-19T23:01:49-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)