### PR TITLE
ZkClient should not keep retrying getChildren() due to large number of children

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1017,7 +1017,7 @@ public class ZkClient implements Watcher {
             // TODO: remove this check once we have a better way to exit infinite retry
             ++connectionLossRetryCount;
             if (connectionLossRetryCount >= 3) {
-              checkNumChildren(path);
+              checkNumChildrenLimit(path);
               connectionLossRetryCount = 0;
             }
 
@@ -2254,8 +2254,8 @@ public class ZkClient implements Watcher {
     }
   }
 
-  private void checkNumChildren(String path) throws KeeperException, InterruptedException {
-    Stat stat = ((ZkConnection) getConnection()).getZookeeper().exists(path, false);
+  private void checkNumChildrenLimit(String path) throws KeeperException {
+    Stat stat = getStat(path);
     if (stat == null) {
       return;
     }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1007,23 +1007,22 @@ public class ZkClient implements Watcher {
           try {
             return getConnection().getChildren(path, watch);
           } catch (ConnectionLossException e) {
-            ++connectionLossRetryCount;
+            // Issue: https://github.com/apache/helix/issues/962
+            // Connection loss might be caused by an excessive number of children.
+            // Infinitely retrying connecting may cause high GC in ZK server and kill ZK server.
+            // This is a workaround to check numChildren to have a chance to exit retry loop.
             // Allow retrying 3 times before checking stat checking number of children,
             // because there is a higher possibility that connection loss is caused by other
-            // factors such as network connectivity, connected ZK node could not serve
-            // the request, session expired, etc.
+            // factors such as network connectivity, session expired, etc.
+            // TODO: remove this check once we have a better way to exit infinite retry
+            ++connectionLossRetryCount;
             if (connectionLossRetryCount >= 3) {
-              // Issue: https://github.com/apache/helix/issues/962
-              // Connection loss might be caused by an excessive number of children.
-              // Infinitely retrying connecting may cause high GC in ZK server and kill ZK server.
-              // This is a workaround to check numChildren to have a chance to exit retry loop.
-              // TODO: remove this check once we have a better way to exit infinite retry
-              Stat stat = getStat(path);
+              Stat stat = ((ZkConnection) getConnection()).getZookeeper().exists(path, false);
               if (stat != null) {
                 if (stat.getNumChildren() > NUM_CHILDREN_LIMIT) {
-                  LOG.error("Failed to get children for path {} because number of children {} "
-                          + "exceeds limit {}, aborting retry.", path, stat.getNumChildren(),
-                      NUM_CHILDREN_LIMIT);
+                  LOG.error("Failed to get children for path {} because of connection loss. "
+                          + "Number of children {} exceeds limit {}, aborting retry.", path,
+                      stat.getNumChildren(), NUM_CHILDREN_LIMIT);
                   // MarshallingErrorException could represent transport error: exceeding the
                   // Jute buffer size. So use it to exit retry loop and tell that zk is not able to
                   // transport the data because packet length is too large.
@@ -1555,14 +1554,12 @@ public class ZkClient implements Watcher {
         } catch (Exception e) {
           throw ExceptionUtil.convertToRuntimeException(e);
         }
-
         // before attempting a retry, check whether retry timeout has elapsed
         if (System.currentTimeMillis() - operationStartTime > _operationRetryTimeoutInMillis) {
           throw new ZkTimeoutException("Operation cannot be retried because of retry timeout ("
               + _operationRetryTimeoutInMillis + " milli seconds). Retry was caused by "
               + retryCauseCode);
         }
-        LOG.warn("Retrying operation, caused by {}", retryCauseCode);
       }
     } finally {
       if (_monitor != null) {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -76,7 +76,7 @@ public class ZkClient implements Watcher {
 
   // If number of children exceeds this limit, getChildren() should not retry on connection loss.
   // This is a workaround for exiting retry on connection loss because of large number of children.
-  //TODO: remove it once we have a better way to exit retry for this case
+  // TODO: remove it once we have a better way to exit retry for this case
   private static final int NUM_CHILDREN_LIMIT;
 
   private final IZkConnection _connection;
@@ -1024,9 +1024,8 @@ public class ZkClient implements Watcher {
                   LOG.error("Failed to get children for path {} because number of children {} "
                           + "exceeds limit {}, aborting retry.", path, stat.getNumChildren(),
                       NUM_CHILDREN_LIMIT);
-                  // There is not an accurate KeeperException for the purpose.
-                  // MarshallingErrorException could represent transport error,
-                  // so use it to exit retry loop and tell that zk is not able to
+                  // MarshallingErrorException could represent transport error: exceeding the
+                  // Jute buffer size. So use it to exit retry loop and tell that zk is not able to
                   // transport the data because packet length is too large.
                   throw new KeeperException.MarshallingErrorException();
                 } else {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -110,11 +110,7 @@ public class ZkClient implements Watcher {
   protected final ZkAsyncRetryThread _asyncCallRetryThread;
 
   static {
-    // 100K is specific for helix messages which use UUID.
-    // It makes messages packet length just below 4 MB.
-    // Tested and calculated: response packet length: 4 * 1024 * 1024 bytes.
-    // UUID string length: 36 bytes. Each child adds 4 bytes in packet.
-    // Estimate num children: (4 * 1024 * 1024) / (36 + 4) ~= 104.8K
+    // 100K is specific for helix messages which use UUID, making packet length just below 4 MB.
     // Set it here for unit test to use reflection to change value
     // because compilers optimize constants by replacing them inline.
     NUM_CHILDREN_LIMIT = 100 * 1000;

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -20,9 +20,12 @@ package org.apache.helix.zookeeper.impl.client;
  */
 
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -48,10 +51,12 @@ import org.apache.helix.zookeeper.zkclient.IZkStateListener;
 import org.apache.helix.zookeeper.zkclient.ZkConnection;
 import org.apache.helix.zookeeper.zkclient.ZkServer;
 import org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks;
+import org.apache.helix.zookeeper.zkclient.exception.ZkException;
 import org.apache.helix.zookeeper.zkclient.exception.ZkSessionMismatchedException;
 import org.apache.helix.zookeeper.zkclient.exception.ZkTimeoutException;
 import org.apache.helix.zookeeper.zkclient.metric.ZkClientMonitor;
 import org.apache.helix.zookeeper.zkclient.metric.ZkClientPathMonitor;
+import org.apache.zookeeper.ClientCnxn;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
@@ -540,9 +545,7 @@ public class TestRawZkClient extends ZkTestBase {
   @Test
   public void testCreateEphemeralWithMismatchedSession()
       throws Exception {
-    final String className = TestHelper.getTestClassName();
     final String methodName = TestHelper.getTestMethodName();
-    final String clusterName = className + "_" + methodName;
 
     final long originalSessionId = _zkClient.getSessionId();
     final String originalHexSessionId = Long.toHexString(originalSessionId);
@@ -797,6 +800,68 @@ public class TestRawZkClient extends ZkTestBase {
       }
       zkClient.delete("/tmp/async");
       zkClient.delete("/tmp/asyncOversize");
+    }
+  }
+
+  /*
+   * Tests getChildren() when there are an excessive number of children and connection loss happens,
+   * the operation should terminate and exit retry loop.
+   */
+  @Test
+  public void testGetChildrenOnLargeNumChildren() throws Exception {
+    // Default packetLen is 4M. It is static final and initialized
+    // when first zkClient is created.
+    // So we could not just set "jute.maxbuffer" to change the value.
+    // Reflection is needed to change the value.
+    // Remove "final" modifier
+    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    boolean isModifierAccessible = modifiersField.isAccessible();
+    modifiersField.setAccessible(true);
+
+    Field packetLenField = ClientCnxn.class.getDeclaredField("packetLen");
+    Field childrenLimitField =
+        org.apache.helix.zookeeper.zkclient.ZkClient.class.getDeclaredField("NUM_CHILDREN_LIMIT");
+    modifiersField.setInt(packetLenField, packetLenField.getModifiers() & ~Modifier.FINAL);
+    modifiersField.setInt(childrenLimitField, childrenLimitField.getModifiers() & ~Modifier.FINAL);
+
+    boolean isPacketLenAccessible = packetLenField.isAccessible();
+    packetLenField.setAccessible(true);
+    int originPacketLen = packetLenField.getInt(null);
+    // Keep 150 bytes for successfully creating each child node.
+    packetLenField.set(null, 150);
+
+    boolean isChildrenLimitAccessible = childrenLimitField.isAccessible();
+    childrenLimitField.setAccessible(true);
+    int originChildrenLimit = childrenLimitField.getInt(null);
+    childrenLimitField.set(null, 2);
+
+    String path = "/" + TestHelper.getTestMethodName();
+    // Create 5 children to make packet length of children exceed 150 bytes
+    // and cause connection loss for getChildren() operation
+    for (int i = 0; i < 5; i++) {
+      _zkClient.createPersistent(path + "/" + UUID.randomUUID().toString(), true);
+    }
+
+    try {
+      _zkClient.getChildren(path);
+      Assert.fail("Should not successfully get children.");
+    } catch (ZkException expected) {
+      Assert.assertEquals(expected.getMessage(),
+          "org.apache.zookeeper.KeeperException$MarshallingErrorException: "
+              + "KeeperErrorCode = MarshallingError");
+    } finally {
+      packetLenField.set(null, originPacketLen);
+      packetLenField.setAccessible(isPacketLenAccessible);
+
+      childrenLimitField.set(null, originChildrenLimit);
+      childrenLimitField.setAccessible(isChildrenLimitAccessible);
+
+      modifiersField.setAccessible(isModifierAccessible);
+
+      Assert.assertTrue(TestHelper.verify(() -> {
+        _zkClient.deleteRecursively(path);
+        return !_zkClient.exists(path);
+      }, TestHelper.WAIT_DURATION));
     }
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #962 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

For ZkClient's getChildren() operation, if there are a large number of children and the response packet size exceeds jute.maxbuffer default value 4MB on zk client side, ZkClient will get a ConnectionLossException and keep retrying connecting to ZK. The consequence is, the infinite retry may cause heavy GC on ZK server and kill ZK server.

We could consider getting number of children in the path and check if it exceeds the limit. If it exceeds the children limit, there is no need to retry and then exist retry.

The default children limit is set for helix messages length using UUID. Packet length of 100K messages doesn't exceed 4 MB.

This PR is the first phase to fix the issue: a workaround to exit retry loop. Once we have a better way to solve the problem on ZK server side, we should remove this check.

### Tests

- [x] The following tests are written for this issue:

- testGetChildrenOnLargeNumChildren

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
zookeeper-api

[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 54.839 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  58.964 s
[INFO] Finished at: 2020-07-22T16:12:28-07:00
[INFO] ------------------------------------------------------------------------

helix-core

[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestCustomizedViewAggregation.testCustomizedViewAggregation:389->validateAggregationSnapshot:233 expected:<true> but was:<false>
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[ERROR]   TestRebalanceRunningTask.testFixedTargetTaskAndEnabledRebalanceAndNodeAdded:330 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1145, Failures: 3, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:23 h
[INFO] Finished at: 2020-07-22T17:39:02-07:00
[INFO] ------------------------------------------------------------------------


[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.157 s - in org.apache.helix.integration.task.TestRebalanceRunningTask
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.442 s - in org.apache.helix.integration.TestCustomizedViewAggregation
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]


[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.025 s - in org.apache.helix.integration.task.TestJobQueueCleanUp
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)