### PR TITLE
Use dedicated ZkClient in HelixPropertyFactory

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
@@ -112,11 +112,10 @@ public final class HelixPropertyFactory {
       // The try-catch logic is for backward compatibility reason only. Even if the cluster is not set
       // up yet, constructing a new ZKHelixManager should not throw an exception
       try {
-        cloudConfig =
-            configAccessor.getCloudConfig(clusterName) == null ? buildEmptyCloudConfig(clusterName)
-                : configAccessor.getCloudConfig(clusterName);
+        cloudConfig = configAccessor.getCloudConfig(clusterName) == null ? buildEmptyCloudConfig()
+            : configAccessor.getCloudConfig(clusterName);
       } catch (HelixException e) {
-        cloudConfig = buildEmptyCloudConfig(clusterName);
+        cloudConfig = buildEmptyCloudConfig();
       }
     } finally {
       // Use a try-finally to make sure zkclient connection is closed properly

--- a/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
@@ -23,20 +23,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
-import org.apache.helix.zookeeper.impl.client.DedicatedZkClient;
-import org.apache.helix.zookeeper.impl.client.FederatedZkClient;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
-import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.security.krb5.Realm;
 
 
 /**

--- a/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
@@ -70,7 +70,7 @@ public final class HelixPropertyFactory {
     return new HelixManagerProperty(properties, cloudConfig);
   }
 
-  public static CloudConfig buildEmptyCloudConfig(String clusterName) {
+  private static CloudConfig buildEmptyCloudConfig() {
     return new CloudConfig.Builder().setCloudEnabled(false).build();
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1106 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

It's been observed that sometimes using a shared Zk connection could cause issues when we write in-memory tests that shut down ZK server and restart it. This is because with a shared Zkconnection, we may see the client's zxid be higher than that of the server, which is an invalid state in ZooKeeper. Since HelixManager is a single-realm dedicated concept, it is okay to use a dedicated zk connection to pull CloudConfig in getHelixManagerProperty() method. This will solve issues caused by zxid mismatches.

### Tests

- [x] The following tests are written for this issue:

No tests needed.

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[ERROR] Failures: 
[ERROR]   TestCustomizedViewAggregation.testCustomizedViewAggregation:389->validateAggregationSnapshot:233 expected:<true> but was:<false>
[ERROR]   TestEnableCompression.testEnableCompressionResource:116 » ThreadTimeout Method...
[ERROR]   TestDeleteJobFromJobQueue.testForceDeleteJobFromJobQueue:75 » Helix Failed to ...
[ERROR]   TestRebalanceRunningTask.testFixedTargetTaskAndEnabledRebalanceAndNodeAdded:330 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1145, Failures: 4, Errors: 0, Skipped: 0

```
The failed 4 tests were run individually:

[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 52.745 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS



### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)