### PR TITLE
Add sync() call first for new session handling

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
@@ -59,5 +59,5 @@ public class ZkSystemPropertyKeys {
    *   The default value is "true" (issuing sync)
    */
   public static final String ZK_AUTOSYNC_ENABLED =
-      "zk.autosync.enabled";
+      "zk.zkclient.autosync.enabled";
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
@@ -58,6 +58,6 @@ public class ZkSystemPropertyKeys {
    * <p>
    *   The default value is "true" (issuing sync)
    */
-  public static final String ZK_SYNC_UPON_NEWSESSION =
-      "zk.sync.upon.newsession";
+  public static final String ZK_AUTOSYNC_ENABLED =
+      "zk.autosync.enabled";
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
@@ -50,4 +50,14 @@ public class ZkSystemPropertyKeys {
    */
   public static final String ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES =
       "zk.serializer.znrecord.write.size.limit.bytes";
+
+  /**
+   * This property determines the behavior of ZkClient issuing an sync() to server upon new session
+   * established.
+   *
+   * <p>
+   *   The default value is "true" (issuing sync)
+   */
+  public static final String ZK_SYNC_UPON_NEWSESSION =
+      "zk.sync.upon.newsession";
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -81,6 +81,7 @@ import static org.apache.zookeeper.KeeperException.Code.SESSIONMOVED;
  * WARN: Do not use this class directly, use {@link org.apache.helix.zookeeper.impl.client.ZkClient} instead.
  */
 public class ZkClient implements Watcher {
+
   private static final Logger LOG = LoggerFactory.getLogger(ZkClient.class);
 
   private static final long MAX_RECONNECT_INTERVAL_MS = 30000; // 30 seconds
@@ -89,6 +90,9 @@ public class ZkClient implements Watcher {
   // This is a workaround for exiting retry on connection loss because of large number of children.
   // TODO: remove it once we have a better way to exit retry for this case
   private static final int NUM_CHILDREN_LIMIT;
+
+  private static String ZK_AUTOSYNC_ENABLED_DEFAULT = "true";
+
 
   private final IZkConnection _connection;
   private final long _operationRetryTimeoutInMillis;
@@ -213,7 +217,7 @@ public class ZkClient implements Watcher {
       throw new NullPointerException("Zookeeper connection is null!");
     }
 
-    String syncUpOnNewSession = System.getProperty(ZkSystemPropertyKeys.ZK_AUTOSYNC_ENABLED, "true");
+    String syncUpOnNewSession = System.getProperty(ZkSystemPropertyKeys.ZK_AUTOSYNC_ENABLED, ZK_AUTOSYNC_ENABLED_DEFAULT);
     _syncOnNewSession = Boolean.parseBoolean(syncUpOnNewSession);
 
     _connection = zkConnection;
@@ -1277,7 +1281,7 @@ public class ZkClient implements Watcher {
   private void doAsyncSync(final ZooKeeper zk, final String path, final long startT,
       final ZkAsyncCallbacks.SyncCallbackHandler cb) {
     zk.sync(path, cb,
-        new ZkAsyncRetryCallContext(_asyncCallRetryThread, cb, _monitor, startT, 0, false) {
+        new ZkAsyncRetryCallContext(_asyncCallRetryThread, cb, _monitor, startT, 0, true) {
           @Override
           protected void doRetry() throws Exception {
             doAsyncSync(zk, path, System.currentTimeMillis(), cb);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -88,7 +88,7 @@ public class ZkClient implements Watcher {
 
 
   private static final String ZK_AUTOSYNC_ENABLED_DEFAULT = "true";
-  
+
   private final IZkConnection _connection;
   private final long _operationRetryTimeoutInMillis;
   private final Map<String, Set<IZkChildListener>> _childListener = new ConcurrentHashMap<>();

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1313,10 +1313,7 @@ public class ZkClient implements Watcher {
       return true;
     }
 
-    // Not retryable error, including session expiration; Log the error and return
-    LOG.warn(
-        "sycnOnNewSession with sessionID {} async return code: {} and not retryable, stop calling handleNewSession",
-        sessionId, code);
+    // Not retryable error, including session expiration; return false.
     return false;
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1267,30 +1267,32 @@ public class ZkClient implements Watcher {
     }
     final String sessionId = getHexSessionId();
     for (final IZkStateListener stateListener : _stateListener) {
-      _eventThread.send(new ZkEventThread.ZkEvent("New session event sent to " + stateListener, sessionId) {
+      _eventThread
+          .send(new ZkEventThread.ZkEvent("New session event sent to " + stateListener, sessionId) {
 
-        @Override
-        public void run() throws Exception {
-          if (_syncOnNewSession) {
-            //System.out.println("syncOnNewSession with sessionID:" + sessionId);
-            LOG.info("syncOnNewSession with sessionId {}", sessionId);
-            final ZkConnection zkConnection = (ZkConnection) getConnection();
-            if (zkConnection == null || zkConnection.getZookeeper() == null) {
-              throw new IllegalStateException(
-                  "ZkConnection is in invalid state! Please close this ZkClient and create new client.");
-            }
-            final String syncPath = new String("/");
-            zkConnection.getZookeeper().sync(syncPath, new AsyncCallback.VoidCallback() {
-              @Override
-              public void processResult(int rt, String s, Object ctx) {
-                //System.out.println("sycnOnNewSession with sessionID " + sessionId + " async return code:" + rt);
-                LOG.info("sycnOnNewSession with sessionID {} async return code: {}", sessionId, rt);
+            @Override
+            public void run() throws Exception {
+              if (_syncOnNewSession) {
+                //System.out.println("syncOnNewSession with sessionID:" + sessionId);
+                LOG.info("syncOnNewSession with sessionId {}", sessionId);
+                final ZkConnection zkConnection = (ZkConnection) getConnection();
+                if (zkConnection == null || zkConnection.getZookeeper() == null) {
+                  throw new IllegalStateException(
+                      "ZkConnection is in invalid state! Please close this ZkClient and create new client.");
+                }
+                final String syncPath = new String("/");
+                zkConnection.getZookeeper().sync(syncPath, new AsyncCallback.VoidCallback() {
+                  @Override
+                  public void processResult(int rt, String s, Object ctx) {
+                    //System.out.println("sycnOnNewSession with sessionID " + sessionId + " async return code:" + rt);
+                    LOG.info("sycnOnNewSession with sessionID {} async return code: {}", sessionId,
+                        rt);
+                  }
+                }, syncPath);
               }
-            }, syncPath);
-          }
-          stateListener.handleNewSession(sessionId);
-        }
-      });
+              stateListener.handleNewSession(sessionId);
+            }
+          });
     }
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1337,6 +1337,7 @@ public class ZkClient implements Watcher {
     if (code == OK) {
       LOG.info("sycnOnNewSession with sessionID {} async return code: {} and proceeds", sessionId,
           code);
+      return true;
     }
 
     // Not retryable error, including session expiration; Log the error and return

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -127,7 +127,7 @@ public class ZkClient implements Watcher {
   }
 
   private final boolean _syncOnNewSession;
-  private static final String _syncPath = "/";
+  private static final String SYNC_PATH = "/";
 
   private class IZkDataListenerEntry {
     final IZkDataListener _dataListener;
@@ -1296,12 +1296,13 @@ public class ZkClient implements Watcher {
    *  the time sync() is invoked, the session expires. The sync() would fail with a stale session.
    *  This is exactly what we want. The newer session would ensure another fireNewSessionEvents.
    */
-  private boolean issueSync(String sessionId, ZooKeeper zk) throws ZkInterruptedException {
+  private boolean issueSync(ZooKeeper zk) {
+    String sessionId = Long.toHexString(zk.getSessionId());
     ZkAsyncCallbacks.SyncCallbackHandler callbackHandler =
         new ZkAsyncCallbacks.SyncCallbackHandler(sessionId);
 
     final long startT = System.currentTimeMillis();
-    doAsyncSync(zk, _syncPath, startT, callbackHandler);
+    doAsyncSync(zk, SYNC_PATH, startT, callbackHandler);
 
     callbackHandler.waitForSuccess();
 
@@ -1332,7 +1333,7 @@ public class ZkClient implements Watcher {
           sessionId) {
         @Override
         public void run() throws Exception {
-          if (issueSync(sessionId, zk) == false) {
+          if (issueSync(zk) == false) {
             LOG.warn("sync on session {} failed", sessionId);
           }
         }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
@@ -143,13 +143,11 @@ public class ZkAsyncCallbacks {
     @Override
     protected boolean needRetry(int rc) {
       try {
-        switch (KeeperException.Code.get(rc)) {
-          /** Connection to the server has been lost */
-          case CONNECTIONLOSS:
-            return true;
-          default:
-            return false;
-        }
+        // Connection to the server has been lost
+        if (KeeperException.Code.get(rc) == Code.CONNECTIONLOSS) {
+          return true;
+        } 
+        return false;
       } catch (ClassCastException | NullPointerException ex) {
         LOG.error("Session {} failed to handle unknown return code {}. Skip retrying. ex {}",
             _sessionId, rc, ex);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
@@ -146,7 +146,7 @@ public class ZkAsyncCallbacks {
         // Connection to the server has been lost
         if (KeeperException.Code.get(rc) == Code.CONNECTIONLOSS) {
           return true;
-        } 
+        }
         return false;
       } catch (ClassCastException | NullPointerException ex) {
         LOG.error("Session {} failed to handle unknown return code {}. Skip retrying. ex {}",

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
@@ -131,7 +131,7 @@ public class ZkAsyncCallbacks {
 
     @Override
     public void processResult(int rc, String path, Object ctx) {
-      LOG.info("sycnOnNewSession with sessionID {} async return code: {}", _sessionId, rc);
+      LOG.debug("sync() call with sessionID {} async return code: {}", _sessionId, rc);
       callback(rc, path, ctx);
     }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
@@ -215,7 +215,7 @@ public class ZkAsyncCallbacks {
      * @param rc the return code
      * @return true if the error is transient and the operation may succeed when being retried.
      */
-    private boolean needRetry(int rc) {
+    protected boolean needRetry(int rc) {
       try {
         switch (Code.get(rc)) {
         /** Connection to the server has been lost */

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
@@ -143,11 +143,13 @@ public class ZkAsyncCallbacks {
     @Override
     protected boolean needRetry(int rc) {
       try {
-        // Connection to the server has been lost
-        if (KeeperException.Code.get(rc) == Code.CONNECTIONLOSS) {
-          return true;
+        switch (KeeperException.Code.get(rc)) {
+          /** Connection to the server has been lost */
+          case CONNECTIONLOSS:
+            return true;
+          default:
+            return false;
         }
-        return false;
       } catch (ClassCastException | NullPointerException ex) {
         LOG.error("Session {} failed to handle unknown return code {}. Skip retrying. ex {}",
             _sessionId, rc, ex);

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -568,8 +568,7 @@ public class TestRawZkClient extends ZkTestBase {
     final String data = "Hello Helix 2";
 
     // Wait until the ZkClient has got a new session.
-    Assert.assertTrue(TestHelper
-        .verify(() -> _zkClient.getConnection().getZookeeperState().isConnected(), 1000L));
+    Assert.assertTrue(_zkClient.waitUntilConnected(1, TimeUnit.SECONDS));
 
     final long originalSessionId = _zkClient.getSessionId();
 
@@ -582,16 +581,6 @@ public class TestRawZkClient extends ZkTestBase {
 
     // Expire the original session.
     ZkTestHelper.expireSession(_zkClient);
-
-    // Wait until the ZkClient has got a new session.
-    Assert.assertTrue(TestHelper.verify(() -> {
-      try {
-        // New session id should not equal to expired session id.
-        return _zkClient.getSessionId() != originalSessionId;
-      } catch (ZkClientException ex) {
-        return false;
-      }
-    }, 1000L));
 
     // Verify the node is created and its data is correct.
     Stat stat = new Stat();

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -559,6 +559,52 @@ public class TestRawZkClient extends ZkTestBase {
   }
 
   /*
+   * This test validates that when ZK_AUTOSYNC_ENABLED_DEFAULT is enabled, sync() would be issued
+   * before handleNewSession. ZKclient would not see stale data.
+   */
+  @Test
+  public void testAutoSyncWithNewSessionEstablishment() throws Exception {
+    final String path = "/" + TestHelper.getTestMethodName();
+    final String data = "Hello Helix 2";
+
+    // Wait until the ZkClient has got a new session.
+    Assert.assertTrue(TestHelper
+        .verify(() -> _zkClient.getConnection().getZookeeperState().isConnected(), 1000L));
+
+    final long originalSessionId = _zkClient.getSessionId();
+
+    try {
+      // Create node.
+      _zkClient.create(path, data, CreateMode.PERSISTENT);
+    } catch (Exception ex) {
+      Assert.fail("Failed to create ephemeral node.", ex);
+    }
+
+    // Expire the original session.
+    ZkTestHelper.expireSession(_zkClient);
+
+    // Wait until the ZkClient has got a new session.
+    Assert.assertTrue(TestHelper.verify(() -> {
+      try {
+        // New session id should not equal to expired session id.
+        return _zkClient.getSessionId() != originalSessionId;
+      } catch (ZkClientException ex) {
+        return false;
+      }
+    }, 1000L));
+
+    // Verify the node is created and its data is correct.
+    Stat stat = new Stat();
+    String nodeData = null;
+    try {
+       nodeData = _zkClient.readData(path, stat, true);
+    } catch (ZkException e) {
+      Assert.fail("fail to read data");
+    }
+    Assert.assertEquals(nodeData, data, "Data is not correct.");
+  }
+
+  /*
    * This test checks that ephemeral creation fails because the expected zk session does not match
    * the actual zk session.
    * How this test does is:


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fix #1118 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

    Helix may see stale data when session expires and get reconnected to
    a slower ZKServer. This would cause various correctness problem.
    We would call sync() to ZKserver first. This ensures Helix would
    not see data that saw before.


### Tests

- [x] The following tests are written for this issue:

testAutoSyncWithNewSessionEstablishment()

- [x] The following is the result of the "mvn test" command on the appropriate module:


[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:116 » ThreadTimeout Method...
[INFO] 
[ERROR] Tests run: 1152, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:22 h
[INFO] Finished at: 2020-07-22T03:30:16-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/ksun/helix_kaisun2000/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ksun@ksun-ld1 helix-core]$ mvn test > test.out 2>& 1 

Individually run this timeout test would work.

second run result. Individually run it work pass.
[ERROR] org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas(org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2)
[ERROR]   Run 1: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:273 Total movements: 4 != expected 8, replica: 1
[ERROR]   Run 2: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:273 Total movements: 4 != expected 8, replica: 2
[ERROR]   Run 3: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:273 Total movements: 12 != expected 21, replica: 3
[INFO]   Run 4: PASS
[INFO]   Run 5: PASS
[INFO] 
[ERROR]   TestEnableCompression.testEnableCompressionResource:117 expected:<true> but was:<false>
[ERROR]   TestWagedRebalance.testChangeIdealState:303->validate:646 expected:<true> but was:<false>
[ERROR]   TestRebalanceRunningTask.testFixedTargetTaskAndEnabledRebalanceAndNodeAdded:330 expected:<true> but was:<false>
[ERROR]   TestTaskSchedulingTwoCurrentStates.testTargetedTaskTwoCurrentStates:150 expected:<true> but was:<false>
[ERROR]   TestClusterStatusMonitorLifecycle.testClusterStatusMonitorLifecycle:290 expected:<true> but was:<false>

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)