### PR TITLE
Cleanup the persisted assignment state if no resource is on WAGED rebalancer.

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestAssignmentMetadataStore.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestAssignmentMetadataStore.java
@@ -19,6 +19,7 @@ package org.apache.helix.controller.rebalancer.waged;
  * under the License.
  */
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,8 +29,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.common.ZkTestBase;
-import org.apache.helix.integration.manager.ClusterControllerManager;
-import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZkBucketDataAccessor;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.ResourceAssignment;
 import org.testng.Assert;
@@ -37,58 +37,34 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-
 public class TestAssignmentMetadataStore extends ZkTestBase {
-  protected static final int NODE_NR = 5;
-  protected static final int START_PORT = 12918;
-  protected static final String STATE_MODEL = "MasterSlave";
-  protected static final String TEST_DB = "TestDB";
-  protected static final int _PARTITIONS = 20;
+  private static final int DEFAULT_BUCKET_SIZE = 50 * 1024; // 50KB
+  private static final String BASELINE_KEY = "BASELINE";
+  private static final String BEST_POSSIBLE_KEY = "BEST_POSSIBLE";
 
+  protected static final String TEST_DB = "TestDB";
   protected HelixManager _manager;
   protected final String CLASS_NAME = getShortClassName();
   protected final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + CLASS_NAME;
 
-  protected MockParticipantManager[] _participants = new MockParticipantManager[NODE_NR];
-  protected ClusterControllerManager _controller;
-  protected int _replica = 3;
-
   private AssignmentMetadataStore _store;
 
   @BeforeClass
-  public void beforeClass()
-      throws Exception {
+  public void beforeClass() throws Exception {
     super.beforeClass();
 
     // setup storage cluster
     _gSetupTool.addCluster(CLUSTER_NAME, true);
-    _gSetupTool.addResourceToCluster(CLUSTER_NAME, TEST_DB, _PARTITIONS, STATE_MODEL);
-    for (int i = 0; i < NODE_NR; i++) {
-      String storageNodeName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
-      _gSetupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
-    }
-    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, TEST_DB, _replica);
-
-    // start dummy participants
-    for (int i = 0; i < NODE_NR; i++) {
-      String instanceName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
-      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
-      _participants[i].syncStart();
-    }
-
-    // start controller
-    String controllerName = CONTROLLER_PREFIX + "_0";
-    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
-    _controller.syncStart();
 
     // create cluster manager
     _manager = HelixManagerFactory
         .getZKHelixManager(CLUSTER_NAME, "Admin", InstanceType.ADMINISTRATOR, ZK_ADDR);
     _manager.connect();
 
-    // create AssignmentMetadataStore
-    _store = new AssignmentMetadataStore(_manager.getMetadataStoreConnectionString(),
-        _manager.getClusterName());
+    // Create AssignmentMetadataStore. No version clean up to ensure the test result is stable.
+    _store = new AssignmentMetadataStore(
+        new ZkBucketDataAccessor(_manager.getMetadataStoreConnectionString(), DEFAULT_BUCKET_SIZE,
+            Integer.MAX_VALUE), _manager.getClusterName());
   }
 
   @AfterClass
@@ -96,6 +72,7 @@ public class TestAssignmentMetadataStore extends ZkTestBase {
     if (_store != null) {
       _store.close();
     }
+    _baseAccessor.remove("/" + CLUSTER_NAME + "/ASSIGNMENT_METADATA/", AccessOption.PERSISTENT);
   }
 
   /**
@@ -107,8 +84,13 @@ public class TestAssignmentMetadataStore extends ZkTestBase {
    */
   @Test
   public void testReadEmptyBaseline() {
-    Map<String, ResourceAssignment> baseline = _store.getBaseline();
-    Assert.assertTrue(baseline.isEmpty());
+    // This should be the first test. Assert there is no record in ZK.
+    // Check that only one version exists
+    Assert.assertEquals(getExistingVersionNumbers(BASELINE_KEY).size(), 0);
+    Assert.assertEquals(getExistingVersionNumbers(BEST_POSSIBLE_KEY).size(), 0);
+    // Read from cache and the result is empty.
+    Assert.assertTrue(_store.getBaseline().isEmpty());
+    Assert.assertTrue(_store.getBestPossibleAssignment().isEmpty());
   }
 
   /**
@@ -116,9 +98,6 @@ public class TestAssignmentMetadataStore extends ZkTestBase {
    */
   @Test(dependsOnMethods = "testReadEmptyBaseline")
   public void testAvoidingRedundantWrite() {
-    String baselineKey = "BASELINE";
-    String bestPossibleKey = "BEST_POSSIBLE";
-
     Map<String, ResourceAssignment> dummyAssignment = getDummyAssignment();
 
     // Call persist functions
@@ -126,36 +105,82 @@ public class TestAssignmentMetadataStore extends ZkTestBase {
     _store.persistBestPossibleAssignment(dummyAssignment);
 
     // Check that only one version exists
-    List<String> baselineVersions = getExistingVersionNumbers(baselineKey);
-    List<String> bestPossibleVersions = getExistingVersionNumbers(bestPossibleKey);
-    Assert.assertEquals(baselineVersions.size(), 1);
-    Assert.assertEquals(bestPossibleVersions.size(), 1);
+    Assert.assertEquals(getExistingVersionNumbers(BASELINE_KEY).size(), 1);
+    Assert.assertEquals(getExistingVersionNumbers(BEST_POSSIBLE_KEY).size(), 1);
 
     // Call persist functions again
     _store.persistBaseline(dummyAssignment);
     _store.persistBestPossibleAssignment(dummyAssignment);
 
     // Check that only one version exists still
-    baselineVersions = getExistingVersionNumbers(baselineKey);
-    bestPossibleVersions = getExistingVersionNumbers(bestPossibleKey);
-    Assert.assertEquals(baselineVersions.size(), 1);
-    Assert.assertEquals(bestPossibleVersions.size(), 1);
+    Assert.assertEquals(getExistingVersionNumbers(BASELINE_KEY).size(), 1);
+    Assert.assertEquals(getExistingVersionNumbers(BEST_POSSIBLE_KEY).size(), 1);
   }
 
-  @Test
+  @Test(dependsOnMethods = "testAvoidingRedundantWrite")
   public void testAssignmentCache() {
     Map<String, ResourceAssignment> dummyAssignment = getDummyAssignment();
     // Call persist functions
     _store.persistBaseline(dummyAssignment);
     _store.persistBestPossibleAssignment(dummyAssignment);
 
+    // Check that only one version exists
+    Assert.assertEquals(getExistingVersionNumbers(BASELINE_KEY).size(), 1);
+    Assert.assertEquals(getExistingVersionNumbers(BEST_POSSIBLE_KEY).size(), 1);
+
+    // Same data in cache
     Assert.assertEquals(_store._bestPossibleAssignment, dummyAssignment);
     Assert.assertEquals(_store._globalBaseline, dummyAssignment);
 
+    dummyAssignment.values().stream().forEach(assignment -> {
+      assignment.addReplicaMap(new Partition("foo"), Collections.emptyMap());
+    });
+
+    // Call persist functions
+    _store.persistBaseline(dummyAssignment);
+    _store.persistBestPossibleAssignment(dummyAssignment);
+
+    // Check that two versions exist
+    Assert.assertEquals(getExistingVersionNumbers(BASELINE_KEY).size(), 2);
+    Assert.assertEquals(getExistingVersionNumbers(BEST_POSSIBLE_KEY).size(), 2);
+
+    // Same data in cache
+    Assert.assertEquals(_store._bestPossibleAssignment, dummyAssignment);
+    Assert.assertEquals(_store._globalBaseline, dummyAssignment);
+
+    // Clear cache
     _store.reset();
 
     Assert.assertEquals(_store._bestPossibleAssignment, null);
     Assert.assertEquals(_store._globalBaseline, null);
+
+    // Check the persisted data is not changed.
+    Assert.assertEquals(getExistingVersionNumbers(BASELINE_KEY).size(), 2);
+    Assert.assertEquals(getExistingVersionNumbers(BEST_POSSIBLE_KEY).size(), 2);
+  }
+
+  @Test(dependsOnMethods = "testAssignmentCache")
+  void testClearAssignment() {
+    // Check the persisted data is not empty
+    List<String> baselineVersions = getExistingVersionNumbers(BASELINE_KEY);
+    List<String> bestPossibleVersions = getExistingVersionNumbers(BEST_POSSIBLE_KEY);
+    int baselineVersionCount = baselineVersions.size();
+    int bestPossibleVersionCount = bestPossibleVersions.size();
+    Assert.assertTrue(baselineVersionCount > 0);
+    Assert.assertTrue(bestPossibleVersionCount > 0);
+
+    _store.clearAssignmentMetadata();
+
+    // 1. cache is cleaned up
+    Assert.assertEquals(_store._bestPossibleAssignment, Collections.emptyMap());
+    Assert.assertEquals(_store._globalBaseline, Collections.emptyMap());
+    // 2. refresh the cache and then read from ZK again to ensure the persisted assignments is empty
+    _store.reset();
+    Assert.assertEquals(_store.getBaseline(), Collections.emptyMap());
+    Assert.assertEquals(_store.getBestPossibleAssignment(), Collections.emptyMap());
+    // 3. check that there is
+    Assert.assertEquals(getExistingVersionNumbers(BASELINE_KEY).size(), baselineVersionCount + 1);
+    Assert.assertEquals(getExistingVersionNumbers(BEST_POSSIBLE_KEY).size(), bestPossibleVersionCount + 1);
   }
 
   private Map<String, ResourceAssignment> getDummyAssignment() {
@@ -172,6 +197,7 @@ public class TestAssignmentMetadataStore extends ZkTestBase {
 
   /**
    * Returns a list of existing version numbers only.
+   *
    * @param metadataType
    * @return
    */
@@ -179,6 +205,9 @@ public class TestAssignmentMetadataStore extends ZkTestBase {
     List<String> children = _baseAccessor
         .getChildNames("/" + CLUSTER_NAME + "/ASSIGNMENT_METADATA/" + metadataType,
             AccessOption.PERSISTENT);
+    if (children == null) {
+      children = Collections.EMPTY_LIST;
+    }
     children.remove("LAST_SUCCESSFUL_WRITE");
     children.remove("LAST_WRITE");
     return children;

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestAssignmentMetadataStore.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestAssignmentMetadataStore.java
@@ -72,7 +72,7 @@ public class TestAssignmentMetadataStore extends ZkTestBase {
     if (_store != null) {
       _store.close();
     }
-    _baseAccessor.remove("/" + CLUSTER_NAME + "/ASSIGNMENT_METADATA", AccessOption.PERSISTENT);
+    _gSetupTool.deleteCluster(CLUSTER_NAME);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestAssignmentMetadataStore.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestAssignmentMetadataStore.java
@@ -72,7 +72,7 @@ public class TestAssignmentMetadataStore extends ZkTestBase {
     if (_store != null) {
       _store.close();
     }
-    _baseAccessor.remove("/" + CLUSTER_NAME + "/ASSIGNMENT_METADATA/", AccessOption.PERSISTENT);
+    _baseAccessor.remove("/" + CLUSTER_NAME + "/ASSIGNMENT_METADATA", AccessOption.PERSISTENT);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -139,6 +139,15 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     // Since there is no special condition, the calculated IdealStates should be exactly the same
     // as the mock algorithm result.
     validateRebalanceResult(resourceMap, newIdealStates, algorithmResult);
+
+    Assert.assertFalse(_metadataStore.getBaseline().isEmpty());
+    Assert.assertFalse(_metadataStore.getBestPossibleAssignment().isEmpty());
+    // Calculate with empty resource list. The rebalancer shall clean up all the assignment status.
+    newIdealStates = rebalancer
+        .computeNewIdealStates(clusterData, Collections.emptyMap(), new CurrentStateOutput());
+    Assert.assertTrue(newIdealStates.isEmpty());
+    Assert.assertTrue(_metadataStore.getBaseline().isEmpty());
+    Assert.assertTrue(_metadataStore.getBestPossibleAssignment().isEmpty());
   }
 
   @Test(dependsOnMethods = "testRebalance")


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#1120

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This is to prevent the WAGED rebalancer reads stale assignment records from the previous rebalance pipeline.
For example,
1. Resource A was the only resource. And it is rebalanced by WAGED, then we have a persisted assignment for A.
2. Resource A was reconfigured to using DelayedRebalancer, then we stop the WAGED rebalancer since there is no more resource using WAGED. So the persisted records are still in ZK.
3. Resource A is recreated and using WAGED again. In this case, the previous persisted assignment is no longer valid. We should treat A as a brand new resource instead of considering the stale assignment record.

Moreover, this change will help to clean up the ZK persisted data if no resource is using WAGED.

### Tests

- [X] The following tests are written for this issue:

TestAssignmentMetadataStore, TestWagedRebalancer

- [X] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestJobQueueCleanUp.testJobQueueAutoCleanUp » ThreadTimeout Method org.testng....
[INFO] 
[ERROR] Tests run: 1149, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:25 h
[INFO] Finished at: 2020-06-26T00:00:39-07:00
[INFO] ------------------------------------------------------------------------

Rerun

[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.508 s - in org.apache.helix.integration.task.TestJobQueueCleanUp
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 23.728 s
[INFO] Finished at: 2020-06-26T00:01:34-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
