### PR TITLE
Fix validation logic in GenericApiBuilders and add usage tests

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/GenericBaseDataAccessorBuilder.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/GenericBaseDataAccessorBuilder.java
@@ -132,7 +132,8 @@ public class GenericBaseDataAccessorBuilder<B extends GenericBaseDataAccessorBui
   private void validateZkClientType(ZkClientType zkClientType,
       RealmAwareZkClient.RealmMode realmMode) {
     if (realmMode == null) {
-      throw new HelixException("Cannot validate ZkClient type: realmMode is null!");
+      throw new HelixException(
+          "GenericBaseDataAccessorBuilder: Cannot validate ZkClient type! RealmMode is null!");
     }
     // If ZkClientType is DEDICATED or SHARED, the realm mode cannot be multi-realm.
     // If ZkClientType is FEDERATED, the realm mode cannot be single-realm.

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/GenericZkHelixApiBuilder.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/GenericZkHelixApiBuilder.java
@@ -22,7 +22,6 @@ package org.apache.helix.manager.zk;
 import java.io.IOException;
 
 import org.apache.helix.HelixException;
-import org.apache.helix.controller.GenericHelixController;
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
@@ -52,7 +51,7 @@ public abstract class GenericZkHelixApiBuilder<B extends GenericZkHelixApiBuilde
   /**
    * Note: If you set the ZK address explicitly, this setting will take priority over the ZK path
    * sharding key set in RealmAwareZkConnectionConfig.
-   * If this field is null, and the realm mode is single-realm, then we will try to look up the
+   * If this field is null, and the realm mode is single-realm, then it will try to look up the
    * ZK address based on the ZK path sharding key.
    * @param zkAddress
    * @return
@@ -82,15 +81,15 @@ public abstract class GenericZkHelixApiBuilder<B extends GenericZkHelixApiBuilde
   /**
    * Validates the given Builder parameters using a generic validation logic.
    *
-   * This validation function mostly checks whether realm mode has been set correctly, and
+   * This validation function checks whether realm mode has been set correctly, and
    * resolves them if not set at all.
    *
    * If realm mode is null, we look at zkAddress field or RealmAwareZkClient's connection config to
-   * see if we could deduce the Zk address.
+   * see if we could deduce the Zk address based on the MetadataStoreRoutingData.
    *
    * Note: If you set the ZK address explicitly, this setting will take priority over the ZK path
    * sharding key set in RealmAwareZkConnectionConfig.
-   * If this field is null, and the realm mode is single-realm, then we will try to look up the
+   * If this field is null, and the realm mode is single-realm, then it will try to look up the
    * ZK address based on the ZK path sharding key.
    */
   protected void validate() {
@@ -180,7 +179,8 @@ public abstract class GenericZkHelixApiBuilder<B extends GenericZkHelixApiBuilde
   }
 
   /**
-   * Resolve Zk address based on the zk realm sharding key.
+   * Resolve Zk address based on the zk realm sharding key. This method is only used if the
+   * ZK address is not given in this Builder.
    * @param connectionConfig
    * @return
    * @throws IOException

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.TreeMap;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -90,9 +89,9 @@ import org.testng.annotations.Test;
  */
 public class TestMultiZkHelixJavaApis {
   private static final int NUM_ZK = 3;
-  private static final Map<String, ZkServer> ZK_SERVER_MAP = new TreeMap<>();
-  private static final Map<String, HelixZkClient> ZK_CLIENT_MAP = new TreeMap<>();
-  private static final Map<String, ClusterControllerManager> MOCK_CONTROLLERS = new TreeMap<>();
+  private static final Map<String, ZkServer> ZK_SERVER_MAP = new HashMap<>();
+  private static final Map<String, HelixZkClient> ZK_CLIENT_MAP = new HashMap<>();
+  private static final Map<String, ClusterControllerManager> MOCK_CONTROLLERS = new HashMap<>();
   private static final Set<MockParticipantManager> MOCK_PARTICIPANTS = new HashSet<>();
   private static final List<String> CLUSTER_LIST =
       ImmutableList.of("CLUSTER_1", "CLUSTER_2", "CLUSTER_3");

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -383,7 +383,7 @@ public interface RealmAwareZkClient {
      */
     private String _zkRealmShardingKey;
     private String _msdsEndpoint;
-    private int _sessionTimeout;
+    private int _sessionTimeout = DEFAULT_SESSION_TIMEOUT;
 
     private RealmAwareZkConnectionConfig(Builder builder) {
       _zkRealmShardingKey = builder._zkRealmShardingKey;
@@ -430,27 +430,6 @@ public interface RealmAwareZkClient {
 
     public String getMsdsEndpoint() {
       return _msdsEndpoint;
-    }
-
-    public HelixZkClient.ZkConnectionConfig createZkConnectionConfig()
-        throws IOException, InvalidRoutingDataException {
-      // Convert to a single-realm HelixZkClient's ZkConnectionConfig
-      if (_zkRealmShardingKey == null || _zkRealmShardingKey.isEmpty()) {
-        throw new ZkClientException(
-            "Cannot create ZkConnectionConfig because ZK realm sharding key is either null or empty!");
-      }
-
-      String zkAddress;
-      // Look up the ZK address for the given ZK realm sharding key
-      if (_msdsEndpoint == null || _msdsEndpoint.isEmpty()) {
-        zkAddress = HttpRoutingDataReader.getMetadataStoreRoutingData()
-            .getMetadataStoreRealm(_zkRealmShardingKey);
-      } else {
-        zkAddress = HttpRoutingDataReader.getMetadataStoreRoutingData(_msdsEndpoint)
-            .getMetadataStoreRealm(_zkRealmShardingKey);
-      }
-
-      return new HelixZkClient.ZkConnectionConfig(zkAddress).setSessionTimeout(_sessionTimeout);
     }
 
     public static class Builder {
@@ -500,11 +479,12 @@ public interface RealmAwareZkClient {
         boolean isShardingKeySet = _zkRealmShardingKey != null && !_zkRealmShardingKey.isEmpty();
         if (_realmMode == RealmMode.MULTI_REALM && isShardingKeySet) {
           throw new IllegalArgumentException(
-              "ZK sharding key cannot be set on multi-realm mode! Sharding key: "
+              "RealmAwareZkConnectionConfig.Builder: ZK sharding key cannot be set on multi-realm mode! Sharding key: "
                   + _zkRealmShardingKey);
         }
         if (_realmMode == RealmMode.SINGLE_REALM && !isShardingKeySet) {
-          throw new IllegalArgumentException("ZK sharding key must be set on single-realm mode!");
+          throw new IllegalArgumentException(
+              "RealmAwareZkConnectionConfig.Builder: ZK sharding key must be set on single-realm mode!");
         }
       }
     }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ZkClientType.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/ZkClientType.java
@@ -25,18 +25,24 @@ public enum ZkClientType {
    * creation, callback functionality, and session management. But note that this is more
    * resource-heavy since it creates a dedicated ZK connection so should be used sparingly only
    * when the aforementioned features are needed.
+   *
+   * Valid on SINGLE_REALM only.
    */
   DEDICATED,
 
   /**
    * If a Helix API is created with the SHARED type, it only supports CRUD
    * functionalities. This will be the default mode of creation.
+   *
+   * Valid on SINGLE_REALM only.
    */
   SHARED,
 
   /**
    * Uses FederatedZkClient (applicable on multi-realm mode only) that queries Metadata Store
    * Directory Service for routing data.
+   *
+   * Valid on MULTI_REALM only.
    */
   FEDERATED
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
@@ -121,6 +122,7 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
   }
 
   // For testing purposes only
+  @VisibleForTesting
   public int getActiveConnectionCount() {
     int count = 0;
     synchronized (_connectionManagerPool) {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1121 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Some of the validation logic in GenericBaseDataAccessorBuilder and GenericZkHelixApiBuilder were confusing and there were no usage tests. This commit reviews the consistency between validate methods of BaseDataAccessor APIs and writes test cases to demonstrate how they should be used.

Also, connection timeout setting wasn't being honored in the createZkClient() methods, so this bug was fixed as well.

createZkConnectionConfig() was removed from RealmAwareZkClient because the intended purpose of this method isn't clear and was not being used anywhere else.


### Tests

- [x] The following tests are written for this issue:

TestMultiZkHelixJavaApis

- [x] The following is the result of the "mvn test" command on the appropriate module:

zookeeper-api:

```
[INFO] Tests run: 37, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 51.491 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 37, Failures: 0, Errors: 0, Skipped: 0
```

helix-core:

```
[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:116 » ThreadTimeout Method...
[ERROR]   TestAutoRebalanceWithDisabledInstance.testDisableEnableInstanceAutoRebalance:69 expected:<true> but was:<false>
[ERROR]   TestClusterInMaintenanceModeWhenReachingMaxPartition.testDisableCluster:119 expected:<true> but was:<false>
[ERROR]   TestTaskPerformanceMetrics.testTaskPerformanceMetrics:128 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1149, Failures: 4, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
```
Ran the failures individually:
```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 50.52 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  56.059 s
[INFO] Finished at: 2020-07-01T12:05:50-07:00
```

helix-rest:
```
[INFO] Tests run: 163, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.513 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 163, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)