### PR TITLE
Validate instance topology configuration before let it comes online 

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -981,10 +981,6 @@ public class ConfigAccessor {
     if (overwrite) {
       ZKUtil.createOrReplace(_zkClient, zkPath, newInstanceConfig.getRecord(), true);
     } else {
-      /* If overwrite is false, the new records will be appended to fields in current instanceConfig.
-       * We only need to do the check if Domain or ZoneId is updated to new value.
-       */
-      //validateTopologyFieldsInInstanceConfig(clusterName, newInstanceConfig.getRecord().getSimpleFields());
       ZKUtil.createOrUpdate(_zkClient, zkPath, newInstanceConfig.getRecord(), true, true);
     }
   }
@@ -1017,22 +1013,16 @@ public class ConfigAccessor {
 
   /**
    * Validate if the topology related settings (Domain or ZoneId) in the given instanceConfig
-   * is valid and aligns with current clusterConfig.
-   * This function should be called when instance added to cluster or caller updates instanceConfig
-   * by overwrites the current config with a new one.
+   * are valid and align with current clusterConfig.
+   * This function should be called when instance added to cluster or caller updates instanceConfig.
    *
-   * @param
-   * @param instanceName
-   * @param instanceConfig
    * @throws IllegalArgumentException
    */
   public static boolean validateTopologySettingInInstanceConfig(ClusterConfig clusterConfig,
       String instanceName, InstanceConfig instanceConfig) throws IllegalArgumentException{
-    //ClusterConfig clusterConfig = getClusterConfig(clusterName);
+    //IllegalArgumentException will be thrown here if the input is not valid.
     Topology.computeInstanceTopologyMap(clusterConfig, instanceName, instanceConfig,
         false /*earlyQuitForFaultZone*/);
     return true;
   }
-
-
 }

--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -20,17 +20,14 @@ package org.apache.helix;
  */
 
 import java.io.IOException;
-import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.apache.helix.controller.rebalancer.topology.Topology;
 import org.apache.helix.manager.zk.GenericZkHelixApiBuilder;
 import org.apache.helix.manager.zk.ZKUtil;
 import org.apache.helix.model.ClusterConfig;
@@ -372,6 +369,7 @@ public class ConfigAccessor {
     } else {
       update.setMapField(mapKey, keyValueMap);
     }
+
     ZKUtil.createOrMerge(_zkClient, zkPath, update, true, true);
   }
 
@@ -963,7 +961,7 @@ public class ConfigAccessor {
   }
 
   private void updateInstanceConfig(String clusterName, String instanceName,
-      InstanceConfig newInstanceConfig, boolean overwrite) {
+      InstanceConfig instanceConfig, boolean overwrite) {
     if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
       throw new HelixException("fail to setup config. cluster: " + clusterName + " is NOT setup.");
     }
@@ -978,10 +976,11 @@ public class ConfigAccessor {
           "updateInstanceConfig failed. Given InstanceConfig does not already exist. instance: "
               + instanceName);
     }
+
     if (overwrite) {
-      ZKUtil.createOrReplace(_zkClient, zkPath, newInstanceConfig.getRecord(), true);
+      ZKUtil.createOrReplace(_zkClient, zkPath, instanceConfig.getRecord(), true);
     } else {
-      ZKUtil.createOrUpdate(_zkClient, zkPath, newInstanceConfig.getRecord(), true, true);
+      ZKUtil.createOrUpdate(_zkClient, zkPath, instanceConfig.getRecord(), true, true);
     }
   }
 
@@ -1010,5 +1009,4 @@ public class ConfigAccessor {
               _zkAddress), false);
     }
   }
-
 }

--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -953,13 +953,13 @@ public class ConfigAccessor {
    *
    * @param clusterName
    * @param instanceName
-   * @param newInstanceConfig
+   * @param instanceConfig
    *
    * @return
    */
   public void updateInstanceConfig(String clusterName, String instanceName,
-      InstanceConfig newInstanceConfig) {
-    updateInstanceConfig(clusterName, instanceName, newInstanceConfig, false);
+      InstanceConfig instanceConfig) {
+    updateInstanceConfig(clusterName, instanceName, instanceConfig, false);
   }
 
   private void updateInstanceConfig(String clusterName, String instanceName,
@@ -1011,18 +1011,4 @@ public class ConfigAccessor {
     }
   }
 
-  /**
-   * Validate if the topology related settings (Domain or ZoneId) in the given instanceConfig
-   * are valid and align with current clusterConfig.
-   * This function should be called when instance added to cluster or caller updates instanceConfig.
-   *
-   * @throws IllegalArgumentException
-   */
-  public static boolean validateTopologySettingInInstanceConfig(ClusterConfig clusterConfig,
-      String instanceName, InstanceConfig instanceConfig) throws IllegalArgumentException{
-    //IllegalArgumentException will be thrown here if the input is not valid.
-    Topology.computeInstanceTopologyMap(clusterConfig, instanceName, instanceConfig,
-        false /*earlyQuitForFaultZone*/);
-    return true;
-  }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
@@ -247,17 +247,11 @@ public class Topology {
   }
 
   /**
-   * This function returns a LinkedHashMap<String, String> object representing
-   * the topology path for an instance.
-   * LinkedHashMap is used here since the order of the path needs to be preserved
-   * when creating the topology tree.
-   *
    * @param clusterTopologyKeyDefaultValue  a LinkedHashMap where keys are cluster topology path and
    *                                       values are their corresponding default value. The entries
    *                                        are ordered by ClusterConfig.topology setting.
    * @param faultZoneForEarlyQuit   this flag is set to true only if caller wants the path
    *                                to faultZone instead the whole path for the instance.
-   * @return an LinkedHashMap object representing the topology path for the input instance.
    */
   private static LinkedHashMap<String, String> computeInstanceTopologyMapHelper(
       boolean isTopologyAwareEnabled, String instanceName, InstanceConfig instanceConfig,
@@ -317,6 +311,19 @@ public class Topology {
     return instanceTopologyMap;
   }
 
+  /**
+   * This function returns a LinkedHashMap<String, String> object representing
+   * the topology path for an instance.
+   * LinkedHashMap is used here since the order of the path needs to be preserved
+   * when creating the topology tree.
+   *
+   * @param clusterConfig         clusterConfig of the given cluster.
+   * @param instanceName          name of the instance.
+   * @param instanceConfig        instanceConfig to be checked.
+   * @param earlyQuitForFaultZone Set to true if we only need the path till faultZone.
+   *
+   * @return an LinkedHashMap object representing the topology path for the input instance.
+   */
   public static LinkedHashMap<String, String> computeInstanceTopologyMap(
       ClusterConfig clusterConfig, String instanceName, InstanceConfig instanceConfig,
       boolean earlyQuitForFaultZone) throws IllegalArgumentException {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
@@ -41,11 +41,11 @@ import org.slf4j.LoggerFactory;
  */
 public class Topology {
   private static Logger logger = LoggerFactory.getLogger(Topology.class);
-
   public enum Types {
-    ROOT, ZONE, INSTANCE
+    ROOT,
+    ZONE,
+    INSTANCE
   }
-
   private static final int DEFAULT_NODE_WEIGHT = 1000;
 
   private final MessageDigest _md;
@@ -55,7 +55,6 @@ public class Topology {
   private final Map<String, InstanceConfig> _instanceConfigMap;
   private final ClusterConfig _clusterConfig;
   private static final String DEFAULT_DOMAIN_PREFIX = "Helix_default_";
-
 
   static class ClusterTopologyConfig {
     String endNodeType;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
@@ -322,10 +322,11 @@ public class Topology {
    * @param earlyQuitForFaultZone Set to true if we only need the path till faultZone.
    *
    * @return an LinkedHashMap object representing the topology path for the input instance.
+   * @throws IllegalArgumentException if input is not valid.
    */
   public static LinkedHashMap<String, String> computeInstanceTopologyMap(
       ClusterConfig clusterConfig, String instanceName, InstanceConfig instanceConfig,
-      boolean earlyQuitForFaultZone) throws IllegalArgumentException {
+      boolean earlyQuitForFaultZone) {
     ClusterTopologyConfig clusterTopologyConfig = getClusterTopologySetting(clusterConfig);
     String faultZoneForEarlyQuit =
         earlyQuitForFaultZone ? clusterTopologyConfig.faultZoneType : null;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
@@ -231,7 +231,7 @@ public class Topology {
    *                                  this cluster uses zone instead of domains.
    * @return lastValidType in clusterConfig.topology
    */
-  public static String populateClusterTopologySetting(ClusterConfig clusterConfig,
+  private static String populateClusterTopologySetting(ClusterConfig clusterConfig,
       LinkedHashSet<String> clusterTopologyKeys /*OUT*/,
       Map<String, String> defaultDomainPathValues /*OUT*/) {
 
@@ -263,7 +263,7 @@ public class Topology {
    * when creating the topology tree.
    *
    * @param defaultDomainPathValues a const map for default path key.
-   * @param faultZoneForEarlyQuit   this flag os set to true only if caller wants the path
+   * @param faultZoneForEarlyQuit   this flag is set to true only if caller wants the path
    *                                to faultZone instead the whole path for the instance.
    * @return an LinkedHashMap object representing the topology path for the input instance.
    */
@@ -328,7 +328,7 @@ public class Topology {
 
   public static LinkedHashMap<String, String> computeInstanceTopologyMap(
       ClusterConfig clusterConfig, String instanceName, InstanceConfig instanceConfig,
-      boolean earlyQuitTillFaultZone)
+      boolean earlyQuitForFaultZone)
       throws IllegalArgumentException {
     LinkedHashSet<String> clusterTopologyKeys = new LinkedHashSet<>();
     Map<String, String> defaultDomainPathValues = new HashMap<>();
@@ -336,7 +336,7 @@ public class Topology {
     String endNodeType =
         populateClusterTopologySetting(clusterConfig, clusterTopologyKeys, defaultDomainPathValues);
     String faultZoneForEarlyQuit =
-        earlyQuitTillFaultZone ? (clusterConfig.getFaultZoneType() == null ? endNodeType
+        earlyQuitForFaultZone ? (clusterConfig.getFaultZoneType() == null ? endNodeType
             : clusterConfig.getFaultZoneType()) : null;
     return computeInstanceTopologyMapHelper(clusterConfig.isTopologyAwareEnabled(), instanceName,
         instanceConfig, clusterTopologyKeys, defaultDomainPathValues, faultZoneForEarlyQuit);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
@@ -193,7 +193,7 @@ public class Topology {
       InstanceConfig insConfig = _instanceConfigMap.get(instanceName);
       try {
         LinkedHashMap<String, String> instanceTopologyMap =
-            computeInstanceTopologyMap(_clusterConfig.isTopologyAwareEnabled(), instanceName,
+            computeInstanceTopologyMapHelper(_clusterConfig.isTopologyAwareEnabled(), instanceName,
                 insConfig, _clusterTopologyKeys, _defaultDomainPathValues,
                 null /*faultZoneForEarlyQuit*/);
         int weight = insConfig.getWeight();
@@ -221,10 +221,14 @@ public class Topology {
   }
 
   /**
-   * Populate  clusterTopologyKeys and defaultDomainPathValues from clusterConfig
-   * @param clusterConfig
-   * @param clusterTopologyKeys
-   * @param defaultDomainPathValues
+   * Populate clusterTopologyKeys and defaultDomainPathValues from clusterConfig
+   *
+   * @param clusterTopologyKeys       out parameter. LinkedHashSet to be populated for cluster
+   *                                  topology keys. The set will remain empty if topology aware is
+   *                                  not enabled or this cluster uses zone instead of domains.
+   * @param defaultDomainPathValues   out parameter. Map to be populated for all default path keys.
+   *                                  The map will remain empty if topology aware is not enabled or
+   *                                  this cluster uses zone instead of domains.
    * @return lastValidType in clusterConfig.topology
    */
   public static String populateClusterTopologySetting(ClusterConfig clusterConfig,
@@ -258,10 +262,12 @@ public class Topology {
    * LinkedHashMap is used here since the order of the path needs to be preserved
    * when creating the topology tree.
    *
-   * @param defaultDomainPathValues a const map for default path kay
+   * @param defaultDomainPathValues a const map for default path key.
+   * @param faultZoneForEarlyQuit   this flag os set to true only if caller wants the path
+   *                                to faultZone instead the whole path for the instance.
    * @return an LinkedHashMap object representing the topology path for the input instance.
    */
-  public static LinkedHashMap<String, String> computeInstanceTopologyMap(
+  private static LinkedHashMap<String, String> computeInstanceTopologyMapHelper(
       boolean isTopologyAwareEnabled, String instanceName, InstanceConfig instanceConfig,
       LinkedHashSet<String> clusterTopologyKeys, Map<String, String> defaultDomainPathValues,
       String faultZoneForEarlyQuit)
@@ -332,7 +338,7 @@ public class Topology {
     String faultZoneForEarlyQuit =
         earlyQuitTillFaultZone ? (clusterConfig.getFaultZoneType() == null ? endNodeType
             : clusterConfig.getFaultZoneType()) : null;
-    return computeInstanceTopologyMap(clusterConfig.isTopologyAwareEnabled(), instanceName,
+    return computeInstanceTopologyMapHelper(clusterConfig.isTopologyAwareEnabled(), instanceName,
         instanceConfig, clusterTopologyKeys, defaultDomainPathValues, faultZoneForEarlyQuit);
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,6 +33,7 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.helix.HelixException;
+import org.apache.helix.controller.rebalancer.topology.Topology;
 import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.InstanceConfig;
@@ -278,43 +281,18 @@ public class AssignableNode implements Comparable<AssignableNode> {
    * simpler than the CRUSH based rebalancer.
    */
   private String computeFaultZone(ClusterConfig clusterConfig, InstanceConfig instanceConfig) {
-    if (!clusterConfig.isTopologyAwareEnabled()) {
-      // Instance name is the default fault zone if topology awareness is false.
-      return instanceConfig.getInstanceName();
-    }
-    String topologyStr = clusterConfig.getTopology();
-    String faultZoneType = clusterConfig.getFaultZoneType();
-    if (topologyStr == null || faultZoneType == null) {
-      LOG.debug("Topology configuration is not complete. Topology define: {}, Fault Zone Type: {}",
-          topologyStr, faultZoneType);
-      // Use the instance name, or the deprecated ZoneId field (if exists) as the default fault
-      // zone.
-      String zoneId = instanceConfig.getZoneId();
-      return zoneId == null ? instanceConfig.getInstanceName() : zoneId;
-    } else {
-      // Get the fault zone information from the complete topology definition.
-      String[] topologyKeys = topologyStr.trim().split("/");
-      if (topologyKeys.length == 0 || Arrays.stream(topologyKeys)
-          .noneMatch(type -> type.equals(faultZoneType))) {
-        throw new HelixException(
-            "The configured topology definition is empty or does not contain the fault zone type.");
-      }
+    LinkedHashMap<String, String> instanceTopologyMap = Topology
+        .computeInstanceTopologyMap(clusterConfig, instanceConfig.getInstanceName(), instanceConfig,
+            true /*earlyQuitTillFaultZone*/);
 
-      Map<String, String> domainAsMap = instanceConfig.getDomainAsMap();
-      StringBuilder faultZoneStringBuilder = new StringBuilder();
-      for (String key : topologyKeys) {
-        if (!key.isEmpty()) {
-          // if a key does not exist in the instance domain config, apply the default domain value.
-          faultZoneStringBuilder.append(domainAsMap.getOrDefault(key, "Default_" + key));
-          if (key.equals(faultZoneType)) {
-            break;
-          } else {
-            faultZoneStringBuilder.append('/');
-          }
-        }
-      }
-      return faultZoneStringBuilder.toString();
+    StringBuilder faultZoneStringBuilder = new StringBuilder();
+    for (Map.Entry<String, String> entry : instanceTopologyMap.entrySet()) {
+      faultZoneStringBuilder.append(entry.getValue());
+      faultZoneStringBuilder.append('/');
     }
+    faultZoneStringBuilder.setLength(faultZoneStringBuilder.length() - 1);
+    return faultZoneStringBuilder.toString();
+
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
@@ -292,7 +292,6 @@ public class AssignableNode implements Comparable<AssignableNode> {
     }
     faultZoneStringBuilder.setLength(faultZoneStringBuilder.length() - 1);
     return faultZoneStringBuilder.toString();
-
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -207,9 +207,9 @@ public class ParticipantManager {
       }
       _helixAdmin.addInstance(_clusterName, instanceConfig);
     } else {
-      ConfigAccessor.validateTopologySettingInInstanceConfig(
-          _configAccessor.getClusterConfig(_clusterName), _instanceName,
-          _configAccessor.getInstanceConfig(_clusterName,_instanceName));
+      _configAccessor.getInstanceConfig(_clusterName, _instanceName)
+          .validateTopologySettingInInstanceConfig(_configAccessor.getClusterConfig(_clusterName),
+              _instanceName);
     }
 
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -205,11 +205,15 @@ public class ParticipantManager {
         instanceConfig = HelixUtil.composeInstanceConfig(_instanceName);
         instanceConfig.setDomain(domain);
       }
+      instanceConfig
+          .validateTopologySettingInInstanceConfig(_configAccessor.getClusterConfig(_clusterName),
+              _instanceName);
       _helixAdmin.addInstance(_clusterName, instanceConfig);
+    } else {
+      _configAccessor.getInstanceConfig(_clusterName, _instanceName)
+          .validateTopologySettingInInstanceConfig(_configAccessor.getClusterConfig(_clusterName),
+              _instanceName);
     }
-    _configAccessor.getInstanceConfig(_clusterName, _instanceName)
-        .validateTopologySettingInInstanceConfig(_configAccessor.getClusterConfig(_clusterName),
-            _instanceName);
   }
 
   private CloudInstanceInformation getCloudInstanceInformation() {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -140,10 +140,6 @@ public class ParticipantManager {
 
     joinCluster();
 
-   /* ConfigAccessor.validateTopologySettingInInstanceConfig(
-        _configAccessor.getClusterConfig(_clusterName), _instanceName,
-        _configAccessor.getInstanceConfig(_clusterName,_instanceName));*/
-
     /**
      * Invoke PreConnectCallbacks
      */
@@ -211,10 +207,6 @@ public class ParticipantManager {
       }
       _helixAdmin.addInstance(_clusterName, instanceConfig);
     } else {
-      /*String instanceConfigPath = _keyBuilder.instanceConfig(_instanceName).getPath();
-      Stat stat = new Stat();
-      ZNRecord record = _zkclient.readData(instanceConfigPath, stat, true);
-      instanceConfig = new InstanceConfig(record);*/
       ConfigAccessor.validateTopologySettingInInstanceConfig(
           _configAccessor.getClusterConfig(_clusterName), _instanceName,
           _configAccessor.getInstanceConfig(_clusterName,_instanceName));

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -206,13 +206,10 @@ public class ParticipantManager {
         instanceConfig.setDomain(domain);
       }
       _helixAdmin.addInstance(_clusterName, instanceConfig);
-    } else {
-      _configAccessor.getInstanceConfig(_clusterName, _instanceName)
-          .validateTopologySettingInInstanceConfig(_configAccessor.getClusterConfig(_clusterName),
-              _instanceName);
     }
-
-
+    _configAccessor.getInstanceConfig(_clusterName, _instanceName)
+        .validateTopologySettingInInstanceConfig(_configAccessor.getClusterConfig(_clusterName),
+            _instanceName);
   }
 
   private CloudInstanceInformation getCloudInstanceInformation() {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -288,6 +288,7 @@ public class ZKHelixAdmin implements HelixAdmin {
               + " is different from new hostname: " + newInstanceConfig.getHostName()
               + "and new port: " + newInstanceConfig.getPort());
     }
+
     return accessor.setProperty(instanceConfigPropertyKey, newInstanceConfig);
   }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -288,7 +288,6 @@ public class ZKHelixAdmin implements HelixAdmin {
               + " is different from new hostname: " + newInstanceConfig.getHostName()
               + "and new port: " + newInstanceConfig.getPort());
     }
-
     return accessor.setProperty(instanceConfigPropertyKey, newInstanceConfig);
   }
 

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -148,13 +148,14 @@ public class InstanceConfig extends HelixProperty {
    * @return
    */
   public Map<String, String> getDomainAsMap() {
-    String domain = getDomainAsString();
+    String domainAsString = getDomainAsString();
+
     Map<String, String> domainAsMap = new HashMap<>();
-    if (domain == null || domain.isEmpty()) {
+    if (domainAsString == null || domainAsString.isEmpty()) {
       return domainAsMap;
     }
 
-    String[] pathPairs = domain.trim().split(",");
+    String[] pathPairs = domainAsString.trim().split(",");
     for (String pair : pathPairs) {
       String[] values = pair.split("=");
       if (values.length != 2 || values[0].isEmpty() || values[1].isEmpty()) {

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
+import org.apache.helix.controller.rebalancer.topology.Topology;
 import org.apache.helix.util.HelixUtil;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
@@ -634,5 +635,20 @@ public class InstanceConfig extends HelixProperty {
       config.setHostName(instanceId);
     }
     return config;
+  }
+
+  /**
+   * Validate if the topology related settings (Domain or ZoneId) in the given instanceConfig
+   * are valid and align with current clusterConfig.
+   * This function should be called when instance added to cluster or caller updates instanceConfig.
+   *
+   * @throws IllegalArgumentException
+   */
+  public boolean validateTopologySettingInInstanceConfig(ClusterConfig clusterConfig,
+      String instanceName) throws IllegalArgumentException{
+    //IllegalArgumentException will be thrown here if the input is not valid.
+    Topology.computeInstanceTopologyMap(clusterConfig, instanceName, this,
+        false /*earlyQuitForFaultZone*/);
+    return true;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -148,14 +148,13 @@ public class InstanceConfig extends HelixProperty {
    * @return
    */
   public Map<String, String> getDomainAsMap() {
-    String domainAsString = getDomainAsString();
-
+    String domain = getDomainAsString();
     Map<String, String> domainAsMap = new HashMap<>();
-    if (domainAsString == null || domainAsString.isEmpty()) {
+    if (domain == null || domain.isEmpty()) {
       return domainAsMap;
     }
 
-    String[] pathPairs = domainAsString.trim().split(",");
+    String[] pathPairs = domain.trim().split(",");
     for (String pair : pathPairs) {
       String[] values = pair.split("=");
       if (values.length != 2 || values[0].isEmpty() || values[1].isEmpty()) {

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -645,7 +645,7 @@ public class InstanceConfig extends HelixProperty {
    * @throws IllegalArgumentException
    */
   public boolean validateTopologySettingInInstanceConfig(ClusterConfig clusterConfig,
-      String instanceName) throws IllegalArgumentException{
+      String instanceName) {
     //IllegalArgumentException will be thrown here if the input is not valid.
     Topology.computeInstanceTopologyMap(clusterConfig, instanceName, this,
         false /*earlyQuitForFaultZone*/);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
@@ -211,7 +211,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
 
     AssignableNode node = new AssignableNode(testCache.getClusterConfig(),
         testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
-    Assert.assertEquals(node.getFaultZone(), "Default_zone");
+    Assert.assertEquals(node.getFaultZone(), "Helix_default_zone");
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
@@ -149,6 +149,7 @@ public class TestParticipantManager extends ZkTestBase {
     // We are expecting an IllegalArgumentException since the domain is not set.
     try {
       participant.connect();
+      Assert.fail();  // connect will throw exception. The assertion will never be reached.
     } catch (IllegalArgumentException expected) {
       Assert.assertEquals(expected.getMessage(),
           "Domain for instance localhost_12918 is not set, fail the topology-aware placement!");

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -313,20 +313,20 @@ public class PerInstanceAccessor extends AbstractHelixResource {
     ConfigAccessor configAccessor = getConfigAccessor();
 
     try {
-      /*
-       * Even if the instance is disabled, non-valid instance topology config will cause rebalance
-       * failure. We are doing the check whenever user updates InstanceConfig.
-       */
-      if (command == Command.delete || command == Command.update) {
-        validateDeltaTopologySettingInInstanceConfig(clusterId, instanceName, configAccessor,
-            instanceConfig, command);
-      }
       switch (command) {
         case update:
-          // The new instanceConfig will be merged with existing one
+          /*
+           * The new instanceConfig will be merged with existing one.
+           * Even if the instance is disabled, non-valid instance topology config will cause rebalance
+           * failure. We are doing the check whenever user updates InstanceConfig.
+           */
+          validateDeltaTopologySettingInInstanceConfig(clusterId, instanceName, configAccessor,
+              instanceConfig, command);
           configAccessor.updateInstanceConfig(clusterId, instanceName, instanceConfig);
           break;
         case delete:
+          validateDeltaTopologySettingInInstanceConfig(clusterId, instanceName, configAccessor,
+              instanceConfig, command);
           HelixConfigScope instanceScope =
               new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.PARTICIPANT)
                   .forCluster(clusterId).forParticipant(instanceName).build();

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -319,7 +319,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
        */
       if (command == Command.delete || command == Command.update) {
         validateDeltaTopologySettingInInstanceConfig(clusterId, instanceName, configAccessor,
-            instanceConfig, command == Command.delete);
+            instanceConfig, command);
       }
       switch (command) {
         case update:
@@ -336,7 +336,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
           return badRequest(String.format("Unsupported command: %s", command));
       }
     } catch (IllegalArgumentException ex) {
-      LOG.error(String.format("Invalid topology setting for Instance : %s. Fail the config update",
+      LOG.error(String.format("Invalid topology setting for Instance : {}. Fail the config update",
           instanceName), ex);
       return serverError(ex);
     } catch (HelixException ex) {
@@ -560,12 +560,12 @@ public class PerInstanceAccessor extends AbstractHelixResource {
     return instanceName.equals(node.get(Properties.id.name()).getValueAsText());
   }
 
-  private boolean validateDeltaTopologySettingInInstanceConfig(String clusterName, String instanceName,
-      ConfigAccessor configAccessor, InstanceConfig newInstanceConfig, boolean isDelete)
-      throws IllegalArgumentException {
+  private boolean validateDeltaTopologySettingInInstanceConfig(String clusterName,
+      String instanceName, ConfigAccessor configAccessor, InstanceConfig newInstanceConfig,
+      Command command) {
     InstanceConfig originalInstanceConfigCopy =
         configAccessor.getInstanceConfig(clusterName, instanceName);
-    if (isDelete) {
+    if (command == Command.delete) {
       for (Map.Entry<String, String> entry : newInstanceConfig.getRecord().getSimpleFields()
           .entrySet()) {
         originalInstanceConfigCopy.getRecord().getSimpleFields().remove(entry.getKey());

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -466,6 +466,10 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
+  /**
+   * Test the sanity check when updating the instance config.
+   * The config is validated at rest server side.
+   */
   @Test(dependsOnMethods = "testValidateWeightForInstance")
   public void testValidateDeltaInstanceConfigForUpdate() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1042

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Helix does not check if an instance's topology config is defined correctly when the instance is added or joins cluster. This will cause Helix to fail the rebalance. This change adds the sanity check when
1. Instance joins cluster
2. User update InstanceConfig using RestApi
3. Controller prepares the topology structure for rebalance <-- Currently we only check here

This change also centralized the logic for topology sanity check. 
There are 2 behavior change for AssignableNode.computeFaultZone. The new logic is the same as in class Topology. It is better to have a centralized util function for both places. The two behavior changes are:
1. Originally, if clusterConfig.topology is null and Instance zoneId is none, AssignableNode.computeFaultZone will use instance's name while the logic in Topology class throws exception. 
2. Originally, if clusterConfig.topology is not null but clusterConfig.faultZoneType is null, AssignableNode.computeFaultZone will throw exception while the logic in Topology class uses the last valid type in clusterConfig.topology.

This changes makes the behavior consistent and use the logic in Topology class.




### Tests

- [X] The following tests are written for this issue:
TestParticipantManager.testValidateDeltaInstanceConfigForUpdate
TestPerInstanceAccessor.simpleIntegrationTestNeg

- [X] The following is the result of the "mvn test" command on the appropriate module:
```
Failures:                                                                                                                                                 
[ERROR]   TestResourceChangeDetector.testResetSnapshots:431 » ThreadTimeout Method org.t...                                                                       
[ERROR] org.apache.helix.integration.TestDisablePartition.testDisableFullAuto(org.apache.helix.integration.TestDisablePartition)                                  
[ERROR]   Run 1: TestDisablePartition.testDisableFullAuto:202 expected:<OFFLINE> but was:<LEADER>                                                                 
[ERROR]   Run 2: TestDisablePartition.testDisableFullAuto:114 » ZkClient Failed to delete /Test...                                                                
[INFO]
[ERROR]   TestNoThrottleDisabledPartitions.testDisablingTopStateReplicaByDisablingInstance:98 expected:<false> but was:<true>                                     
[ERROR]   TestControllerLeadershipChange.testMissingTopStateDurationMonitoring:262 expected:<true> but was:<false>                                                
[INFO]                                                                                                                                                            
[ERROR] Tests run: 1162, Failures: 4, Errors: 0, Skipped: 1
[INFO]                                                                                                                    

[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.329 s - in org.apache.helix.controller.changedetector.TestResourceChangeDetector
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.066 s - in org.apache.helix.integration.TestDisablePartition                
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 26.942 s - in org.apache.helix.integration.TestNoThrottleDisabledPartitions
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.773 s - in org.apache.helix.integration.controller.TestControllerLeadershipChange
```

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [X] In case of new functionality, my PR adds documentation in the following wiki page:

NA

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)