### PR TITLE
Stabilize TestUpdateWorkflow

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestUpdateWorkflow.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestUpdateWorkflow.java
@@ -40,7 +40,7 @@ public class TestUpdateWorkflow extends TaskTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(TestUpdateWorkflow.class);
 
   @Test
-  public void testUpdateRunningQueue() throws InterruptedException {
+  public void testUpdateRunningQueue() throws Exception {
     String queueName = TestHelper.getTestMethodName();
 
     // Create a queue
@@ -70,7 +70,10 @@ public class TestUpdateWorkflow extends TaskTestBase {
     // ensure current schedule is completed
     _driver.pollForWorkflowState(scheduledQueue, TaskState.COMPLETED);
 
-    Thread.sleep(1000);
+    // Make sure next round of the recurrent workflow is scheduled
+    Assert
+        .assertTrue(TestHelper.verify(() -> (TaskTestUtil.pollForWorkflowContext(_driver, queueName)
+            .getScheduledWorkflows().size() > 1), TestHelper.WAIT_DURATION));
 
     wCtx = TaskTestUtil.pollForWorkflowContext(_driver, queueName);
     scheduledQueue = wCtx.getLastScheduledSingleWorkflow();
@@ -86,7 +89,7 @@ public class TestUpdateWorkflow extends TaskTestBase {
   }
 
   @Test
-  public void testUpdateStoppedQueue() throws InterruptedException {
+  public void testUpdateStoppedQueue() throws Exception {
     String queueName = TestHelper.getTestMethodName();
 
     // Create a queue
@@ -124,7 +127,10 @@ public class TestUpdateWorkflow extends TaskTestBase {
     // ensure current schedule is completed
     _driver.pollForWorkflowState(scheduledQueue, TaskState.COMPLETED);
 
-    Thread.sleep(1000);
+    // Make sure next round of the recurrent workflow is scheduled
+    Assert
+        .assertTrue(TestHelper.verify(() -> (TaskTestUtil.pollForWorkflowContext(_driver, queueName)
+            .getScheduledWorkflows().size() > 1), TestHelper.WAIT_DURATION));
 
     wCtx = TaskTestUtil.pollForWorkflowContext(_driver, queueName);
     scheduledQueue = wCtx.getLastScheduledSingleWorkflow();


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR title:
Fixes #1134 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In this PR, Thread.sleep usages have been removed from TestUpdateWorkflow and replaced with TestHelper.verify.

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:

helix-core:
```
[INFO] Tests run: 1151, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4,808.221 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1151, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:20 h
[INFO] Finished at: 2020-07-01T19:57:47-07:00
[INFO] ------------------------------------------------------------------------
```
helix-rest:
```
[INFO] Tests run: 163, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 41.365 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 163, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  46.985 s
[INFO] Finished at: 2020-07-01T20:13:47-07:00
[INFO] ------------------------------------------------------------------------
```


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml