### PR TITLE
Allow getIdealAssignmentForWagedFullAuto return preference list based results, add result filtering

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -174,11 +174,11 @@ public final class HelixUtil {
    * @param resourceConfigs
    * @return
    */
-  public static Map<String, ResourceAssignment> getIdealAssignmentForWagedFullAuto(
+  public static Map<String, ResourceAssignment> getTargetAssignmentForWagedFullAuto(
       String metadataStoreAddress, ClusterConfig clusterConfig,
       List<InstanceConfig> instanceConfigs, List<String> liveInstances,
       List<IdealState> idealStates, List<ResourceConfig> resourceConfigs) {
-    return getIdealAssignmentForWagedFullAutoImpl(metadataStoreAddress, clusterConfig,
+    return getAssignmentForWagedFullAutoImpl(metadataStoreAddress, clusterConfig,
         instanceConfigs, liveInstances, idealStates, resourceConfigs, true);
   }
 
@@ -194,11 +194,11 @@ public final class HelixUtil {
    * @param resourceConfigs
    * @return
    */
-  public static Map<String, ResourceAssignment> getIdealPartitionMapForWagedFullAuto(
+  public static Map<String, ResourceAssignment> getImmediateAssignmentForWagedFullAuto(
       String metadataStoreAddress, ClusterConfig clusterConfig,
       List<InstanceConfig> instanceConfigs, List<String> liveInstances,
       List<IdealState> idealStates, List<ResourceConfig> resourceConfigs) {
-    return getIdealAssignmentForWagedFullAutoImpl(metadataStoreAddress, clusterConfig,
+    return getAssignmentForWagedFullAutoImpl(metadataStoreAddress, clusterConfig,
         instanceConfigs, liveInstances, idealStates, resourceConfigs, false);
   }
 
@@ -207,7 +207,7 @@ public final class HelixUtil {
    * false, the returned assignment is based on partition state mapping, which may differ from
    * preference lists.
    */
-  private static Map<String, ResourceAssignment> getIdealAssignmentForWagedFullAutoImpl(
+  private static Map<String, ResourceAssignment> getAssignmentForWagedFullAutoImpl(
       String metadataStoreAddress, ClusterConfig clusterConfig,
       List<InstanceConfig> instanceConfigs, List<String> liveInstances,
       List<IdealState> idealStates, List<ResourceConfig> resourceConfigs, boolean usePrefLists) {

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -187,7 +187,7 @@ public final class HelixUtil {
    * calculated using the read-only WAGED rebalancer. The returned result is based on partition
    * state mapping. which is the immediate assignment. The immediate assignment is different from
    * the final target assignment; it could be an intermediate state where it contains replicas that
-   * need to be dropped later, for example. 
+   * need to be dropped later, for example.
    * @param metadataStoreAddress
    * @param clusterConfig
    * @param instanceConfigs

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
@@ -239,6 +239,18 @@ public class TestWagedRebalance extends ZkTestBase {
     // The newly added instances should contain some partitions
     Assert.assertTrue(instancesWithAssignments.contains(instance_0));
     Assert.assertTrue(instancesWithAssignments.contains(instance_1));
+
+    // Perform the same test with immediate assignment
+    utilResult = HelixUtil
+        .getImmediateAssignmentForWagedFullAuto(ZK_ADDR, clusterConfig, instanceConfigs,
+            liveInstances, idealStates, resourceConfigs);
+    Set<String> instancesWithAssignmentsImmediate = new HashSet<>();
+    utilResult.values().forEach(
+        resourceAssignment -> resourceAssignment.getRecord().getMapFields().values()
+            .forEach(entry -> instancesWithAssignmentsImmediate.addAll(entry.keySet())));
+    // The newly added instances should contain some partitions
+    Assert.assertTrue(instancesWithAssignmentsImmediate.contains(instance_0));
+    Assert.assertTrue(instancesWithAssignmentsImmediate.contains(instance_1));
   }
 
   @Test(dependsOnMethods = "test")

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
@@ -26,8 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.ConfigAccessor;
@@ -187,7 +185,7 @@ public class TestWagedRebalance extends ZkTestBase {
 
     // Verify that utilResult contains the assignment for the resources added
     Map<String, ResourceAssignment> utilResult = HelixUtil
-        .getIdealAssignmentForWagedFullAuto(ZK_ADDR, clusterConfig, instanceConfigs, liveInstances,
+        .getTargetAssignmentForWagedFullAuto(ZK_ADDR, clusterConfig, instanceConfigs, liveInstances,
             idealStates, resourceConfigs);
     Assert.assertNotNull(utilResult);
     Assert.assertEquals(utilResult.size(), _allDBs.size());
@@ -207,7 +205,7 @@ public class TestWagedRebalance extends ZkTestBase {
 
     // Verify that the partition state mapping mode also works
     Map<String, ResourceAssignment> paritionMappingBasedResult = HelixUtil
-        .getIdealPartitionMapForWagedFullAuto(ZK_ADDR, clusterConfig, instanceConfigs,
+        .getImmediateAssignmentForWagedFullAuto(ZK_ADDR, clusterConfig, instanceConfigs,
             liveInstances, idealStates, resourceConfigs);
     Assert.assertNotNull(paritionMappingBasedResult);
     Assert.assertEquals(paritionMappingBasedResult.size(), _allDBs.size());
@@ -231,7 +229,7 @@ public class TestWagedRebalance extends ZkTestBase {
     }
 
     utilResult = HelixUtil
-        .getIdealAssignmentForWagedFullAuto(ZK_ADDR, clusterConfig, instanceConfigs, liveInstances,
+        .getTargetAssignmentForWagedFullAuto(ZK_ADDR, clusterConfig, instanceConfigs, liveInstances,
             idealStates, resourceConfigs);
 
     Set<String> instancesWithAssignments = new HashSet<>();

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
@@ -188,7 +188,7 @@ public class TestWagedRebalance extends ZkTestBase {
         .getTargetAssignmentForWagedFullAuto(ZK_ADDR, clusterConfig, instanceConfigs, liveInstances,
             idealStates, resourceConfigs);
     Assert.assertNotNull(utilResult);
-    Assert.assertEquals(utilResult.size(), _allDBs.size());
+    Assert.assertEquals(utilResult.size(), idealStates.size());
     for (IdealState idealState : idealStates) {
       Assert.assertTrue(utilResult.containsKey(idealState.getResourceName()));
       StateModelDefinition stateModelDefinition =
@@ -208,7 +208,7 @@ public class TestWagedRebalance extends ZkTestBase {
         .getImmediateAssignmentForWagedFullAuto(ZK_ADDR, clusterConfig, instanceConfigs,
             liveInstances, idealStates, resourceConfigs);
     Assert.assertNotNull(paritionMappingBasedResult);
-    Assert.assertEquals(paritionMappingBasedResult.size(), _allDBs.size());
+    Assert.assertEquals(paritionMappingBasedResult.size(), idealStates.size());
     for (IdealState idealState : idealStates) {
       Assert.assertTrue(paritionMappingBasedResult.containsKey(idealState.getResourceName()));
       Assert.assertEquals(


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1133 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently, `getIdealAssignmentForWagedFullAuto()` gets its final resource assignment results from the partition state mapping of output, which is calculated within the best possible state calculation stage. However, the partition state mapping contains the N+1 cases, which isn't suitable for certain use cases.

We would like to allow this function to return an assignment result that's based on the preference lists, which are closer to be the "calculation result" done by Waged.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:
```
[ERROR] Tests run: 1151, Failures: 2, Errors: 0, Skipped: 1, Time elapsed: 4,678.895 s <<< FAILURE! - in TestSuite
[ERROR] testEnableCompressionResource(org.apache.helix.integration.TestEnableCompression)  Time elapsed: 218.88 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.TestEnableCompression.testEnableCompressionResource(TestEnableCompression.java:117)

[ERROR] testStateTransitionTimeoutByClusterLevel(org.apache.helix.integration.paticipant.TestStateTransitionTimeoutWithResource)  Time elapsed: 37.98 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.paticipant.TestStateTransitionTimeoutWithResource.testStateTransitionTimeoutByClusterLevel(TestStateTransitionTimeoutWithResource.java:196)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:117 expected:<true> but was:<false>
[ERROR]   TestStateTransitionTimeoutWithResource.testStateTransitionTimeoutByClusterLevel:196 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1151, Failures: 2, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:18 h
[INFO] Finished at: 2020-07-13T15:10:11-07:00
[INFO] ------------------------------------------------------------------------
```
Rerun
```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 40.697 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  45.758 s
[INFO] Finished at: 2020-07-13T15:29:29-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
