### PR TITLE
Shutdown the TaskStateModelFactory threads created in the tests.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.management.JMException;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.helix.HelixManager;
 import org.apache.helix.monitoring.mbeans.ThreadPoolExecutorMonitor;
 import org.apache.helix.participant.statemachine.StateModelFactory;
@@ -90,6 +91,15 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
     }
     _taskExecutor.shutdown();
     _timerTaskExecutor.shutdown();
+    if (_monitor != null) {
+      _monitor.unregister();
+    }
+  }
+
+  @VisibleForTesting
+  void shutdownNow() {
+    _taskExecutor.shutdownNow();
+    _timerTaskExecutor.shutdownNow();
     if (_monitor != null) {
       _monitor.unregister();
     }

--- a/helix-core/src/test/java/org/apache/helix/task/TaskSynchronizedTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TaskSynchronizedTestBase.java
@@ -35,6 +35,7 @@ import org.apache.helix.integration.task.MockTask;
 import org.apache.helix.integration.task.WorkflowGenerator;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.participant.statemachine.StateModelFactory;
 import org.apache.helix.tools.ClusterSetup;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier;
@@ -161,6 +162,10 @@ public class TaskSynchronizedTestBase extends ZkTestBase {
   }
 
   protected void startParticipant(String zkAddr, int i) {
+    if (_participants[i] != null) {
+      stopParticipant(i);
+    }
+
     Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
     taskFactoryReg.put(MockTask.TASK_COMMAND, MockTask::new);
     String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
@@ -181,12 +186,22 @@ public class TaskSynchronizedTestBase extends ZkTestBase {
 
   protected void stopParticipant(int i) {
     if (_participants.length <= i) {
-      throw new HelixException(
-          String.format("Can't stop participant %s, only %s participants" + "were set up.", i,
+      throw new HelixException(String
+          .format("Can't stop participant %s, only %s participants" + "were set up.", i,
               _participants.length));
     }
-    if (_participants[i] != null && _participants[i].isConnected()) {
-      _participants[i].syncStop();
+    if (_participants[i] != null) {
+      if (_participants[i].isConnected()) {
+        _participants[i].syncStop();
+      }
+      // Shutdown the state model factories to close all threads.
+      StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+      if (stateMachine != null) {
+        StateModelFactory stateModelFactory = stateMachine.getStateModelFactory("Task");
+        if (stateModelFactory != null && stateModelFactory instanceof TaskStateModelFactory) {
+          ((TaskStateModelFactory) stateModelFactory).shutdownNow();
+        }
+      }
     }
   }
 

--- a/helix-core/src/test/java/org/apache/helix/task/TaskSynchronizedTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TaskSynchronizedTestBase.java
@@ -173,7 +173,7 @@ public class TaskSynchronizedTestBase extends ZkTestBase {
 
     // Register a Task state model factory.
     StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
-    stateMachine.registerStateModelFactory("Task",
+    stateMachine.registerStateModelFactory(TaskConstants.STATE_MODEL_NAME,
         new TaskStateModelFactory(_participants[i], taskFactoryReg));
     _participants[i].syncStart();
   }
@@ -197,7 +197,8 @@ public class TaskSynchronizedTestBase extends ZkTestBase {
       // Shutdown the state model factories to close all threads.
       StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
       if (stateMachine != null) {
-        StateModelFactory stateModelFactory = stateMachine.getStateModelFactory("Task");
+        StateModelFactory stateModelFactory =
+            stateMachine.getStateModelFactory(TaskConstants.STATE_MODEL_NAME);
         if (stateModelFactory != null && stateModelFactory instanceof TaskStateModelFactory) {
           ((TaskStateModelFactory) stateModelFactory).shutdownNow();
         }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1139 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

The TaskStateModelFactory initialization creates a thread pool. The expectation is that the application code closes the thread pool and the threads when the participant instance is shutting down. In most cases, this means the JVM is going to be shutdown. So this operation is not a must. However, in the test cases, these thread pools leak thousands of threads.
This PR adds cleanup logic to shutdown thread pools that are created for the participant instances. Note that there is still thread leakage when the participants are created separately instead of using the general methods.

### Tests

- [X] The following tests are written for this issue:

No new tests.

- [X] The following is the result of the "mvn test" command on the appropriate module:

**This PR allows my MacBook to finish the tests. There are still some failures but it is the first time I saw the full test suite finishes without OutOfMemory! For sure we can fix those failures next.**

The following result is what I got from the Linux desktop.

**helix-core**
[ERROR] Failures:
[ERROR]   TestTaskSchedulingTwoCurrentStates.testTargetedTaskTwoCurrentStates:150 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1151, Failures: 1, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:17 h
[INFO] Finished at: 2020-07-04T13:56:23-07:00
[INFO] ------------------------------------------------------------------------
**rerun:**
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.791 s - in org.apache.helix.integration.task.TestTaskSchedulingTwoCurrentStates
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 25.598 s
[INFO] Finished at: 2020-07-04T15:40:37-07:00
[INFO] ------------------------------------------------------------------------

**helix-rest**

[INFO] Tests run: 163, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 46.031 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 163, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 52.914 s
[INFO] Finished at: 2020-07-04T15:55:23-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)



