### PR TITLE
Refine the ZkHelixManager.disconnect() method so it won't be blocked when the ZK connection breaks.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -804,18 +804,18 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
 
     LOG.info("disconnect " + _instanceName + "(" + _instanceType + ") from " + _clusterName);
 
-    /**
-     * stop all timer tasks
-     */
-    stopTimerTasks();
-
-    /**
-     * shutdown thread pool first to avoid reset() being invoked in the middle of state
-     * transition
-     */
-    _messagingService.getExecutor().shutdown();
-
     try {
+      /**
+       * stop all timer tasks
+       */
+      stopTimerTasks();
+
+      /**
+       * shutdown thread pool first to avoid reset() being invoked in the middle of state
+       * transition
+       */
+      _messagingService.getExecutor().shutdown();
+
       cleanupCallbackHandlers();
     } catch (InterruptedException e) {
       LOG.warn(


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1148 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

The issue was that if ZkHelixManager.disconnect() is called when the ZK connection is not synConnected, the disconnect() call will hang and never return. This usually blocks Helix users' code when they try to clean up and finalize after ZK connection becomes unrecoverable.
This PR introduces a temporary thread to finish the cleanup work which relies on the ZK connection (or application code). This thread will be interrupted if ZK connection breaks before or during the disconnect process.

### Tests

- [X] The following tests are written for this issue:

TestZkConnectionLost.testDisconnectWhenConnectionBreak()

- [X] The following is the result of the "mvn test" command on the appropriate module:

helix-core

[INFO] Tests run: 1152, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4,613.998 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1152, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

helix-rest

[INFO] Tests run: 163, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 46.568 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 163, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
