### PR TITLE
Fix enableWagedRebalance by respecting resource names argument

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1863,7 +1863,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
     List<IdealState> enabledIdealStates = new ArrayList<>();
     List<PropertyKey> enabledIdealStateKeys = new ArrayList<>();
-    List<String> enabledResourceNames = new ArrayList<>();
+    Set<String> enabledResourceNames = new HashSet<>();
 
     List<IdealState> idealStates = accessor.getChildValues(keyBuilder.idealStates(), true);
     for (IdealState idealState : idealStates) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1867,7 +1867,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     List<IdealState> idealStates = accessor.getChildValues(keyBuilder.idealStates(), true);
     for (IdealState idealState : idealStates) {
-      if (resourceNames.contains(idealState.getResourceName())) {
+      if (idealState != null && resourceNames.contains(idealState.getResourceName())) {
         idealState.setRebalancerClassName(WagedRebalancer.class.getName());
         idealState.setRebalanceMode(RebalanceMode.FULL_AUTO);
         enabledIdealStates.add(idealState);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -764,6 +764,15 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     Assert.assertEquals(is.getRebalancerClassName(), WagedRebalancer.class.getName());
     is = admin.getResourceIdealState(clusterName, unaffectedResource);
     Assert.assertNotSame(is.getRebalancerClassName(), WagedRebalancer.class.getName());
+
+    // Test non existent resource case
+    try {
+      admin.enableWagedRebalance(clusterName, Collections.singletonList("FakeResourceName"));
+      Assert.fail("Expected HelixException");
+    } catch (HelixException e) {
+      Assert.assertEquals(e.getMessage(),
+          "Some resources do not have IdealStates: [FakeResourceName]");
+    }
   }
 
   @Test


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1150 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

enableWagedRebalance() is not currently respecting the resource names that are passed to it - it's enabling waged for all resources, which isn't correct. The fix is to only enable waged for the provided resource names.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:
```
[ERROR] Tests run: 1153, Failures: 6, Errors: 0, Skipped: 1, Time elapsed: 4,443.367 s <<< FAILURE! - in TestSuite
[ERROR] testResourceSubset(org.apache.helix.tools.TestClusterStateVerifier)  Time elapsed: 1.034 s  <<< FAILURE!
org.apache.helix.HelixException: Failed to create pause signal
        at org.apache.helix.tools.TestClusterStateVerifier.testResourceSubset(TestClusterStateVerifier.java:115)

[ERROR] afterMethod(org.apache.helix.tools.TestClusterStateVerifier)  Time elapsed: 1.06 s  <<< FAILURE!
java.lang.IllegalStateException: ZkClient already closed!
        at org.apache.helix.tools.TestClusterStateVerifier.afterMethod(TestClusterStateVerifier.java:98)

[ERROR] testWorkflowJobFail(org.apache.helix.integration.task.TestWorkflowTermination)  Time elapsed: 10.085 s  <<< FAILURE!
org.apache.helix.HelixException: Workflow "testWorkflowJobFail" context is empty or not in states: "[FAILED]", current state: "IN_PROGRESS"
        at org.apache.helix.integration.task.TestWorkflowTermination.testWorkflowJobFail(TestWorkflowTermination.java:229)

[ERROR] TestMessageSimpleSendReceiveAsync(org.apache.helix.integration.messaging.TestCrossClusterMessagingService)  Time elapsed: 2.29 s  <<< FAILURE!
java.lang.AssertionError: 
        at org.apache.helix.integration.messaging.TestCrossClusterMessagingService.TestMessageSimpleSendReceiveAsync(TestCrossClusterMessagingService.java:145)

[ERROR] testEnableCompressionResource(org.apache.helix.integration.TestEnableCompression)  Time elapsed: 170.378 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.TestEnableCompression.testEnableCompressionResource(TestEnableCompression.java:117)

[ERROR] testStateTransitionTimeoutByClusterLevel(org.apache.helix.integration.paticipant.TestStateTransitionTimeoutWithResource)  Time elapsed: 37.223 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.paticipant.TestStateTransitionTimeoutWithResource.testStateTransitionTimeoutByClusterLevel(TestStateTransitionTimeoutWithResource.java:196)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:117 expected:<true> but was:<false>
[ERROR]   TestCrossClusterMessagingService.TestMessageSimpleSendReceiveAsync:145
[ERROR]   TestStateTransitionTimeoutWithResource.testStateTransitionTimeoutByClusterLevel:196 expected:<true> but was:<false>
[ERROR]   TestWorkflowTermination.testWorkflowJobFail:229 » Helix Workflow "testWorkflow...
[ERROR]   TestClusterStateVerifier.afterMethod:98 » IllegalState ZkClient already closed...
[ERROR]   TestClusterStateVerifier.testResourceSubset:115 » Helix Failed to create pause...
[INFO] 
[ERROR] Tests run: 1153, Failures: 6, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:14 h
[INFO] Finished at: 2020-07-14T18:35:17-07:00
[INFO] ------------------------------------------------------------------------
```
Rerun
```
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 107.433 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:52 min
[INFO] Finished at: 2020-07-14T20:22:25-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
