### PR TITLE
Reduce blank lines after package and imports from 2 to 1

### DIFF
--- a/helix-style-intellij.xml
+++ b/helix-style-intellij.xml
@@ -46,8 +46,8 @@
   <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
   <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
   <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
-  <option name="BLANK_LINES_AFTER_PACKAGE" value="2" />
-  <option name="BLANK_LINES_AFTER_IMPORTS" value="2" />
+  <option name="BLANK_LINES_AFTER_PACKAGE" value="1" />
+  <option name="BLANK_LINES_AFTER_IMPORTS" value="1" />
   <option name="BRACE_STYLE" value="2" />
   <option name="CLASS_BRACE_STYLE" value="2" />
   <option name="METHOD_BRACE_STYLE" value="2" />
@@ -88,7 +88,7 @@
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
-    <option name="BLANK_LINES_AFTER_IMPORTS" value="2" />
+    <option name="BLANK_LINES_AFTER_IMPORTS" value="1" />
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
     <option name="ALIGN_MULTILINE_FOR" value="false" />


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1152 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In helix style for IntelliJ, there are 2 blank lines after package and imports. We would like to reduce them to only 1 line.

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)