### PR TITLE
Add initial callback when adding routing table listener

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -422,19 +422,19 @@ public class RoutingTableProvider
    * Add RoutingTableChangeListener with user defined context
    * @param routingTableChangeListener
    * @param context user defined context
-   * @param doInit whether to trigger the initial callback during adding listener
+   * @param isTriggerCallback whether to trigger the initial callback during adding listener
    */
   public void addRoutingTableChangeListener(
-      final RoutingTableChangeListener routingTableChangeListener, Object context, boolean doInit) {
+      final RoutingTableChangeListener routingTableChangeListener, Object context,
+      boolean isTriggerCallback) {
     _routingTableChangeListenerMap.put(routingTableChangeListener, new ListenerContext(context));
-    logger.info(
-        "Attach RoutingTableProviderChangeListener {}. The doInit value of this listener is {}",
-        routingTableChangeListener.getClass().getName(), doInit);
-    if (doInit) {
+    logger.info("Attach RoutingTableProviderChangeListener {}.",
+        routingTableChangeListener.getClass().getName(), isTriggerCallback);
+    if (isTriggerCallback) {
+      logger.info("The isTriggerCallback value for the listener is true");
       final NotificationContext periodicRefreshContext = new NotificationContext(_helixManager);
       periodicRefreshContext.setType(NotificationContext.Type.PERIODIC_REFRESH);
-      _routerUpdater.queueEvent(periodicRefreshContext, ClusterEventType.PeriodicalRebalance,
-          null);
+      _routerUpdater.queueEvent(periodicRefreshContext, ClusterEventType.PeriodicalRebalance, null);
       }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -431,32 +431,11 @@ public class RoutingTableProvider
         "Attach RoutingTableProviderChangeListener {}. The doInit value of this listener is {}",
         routingTableChangeListener.getClass().getName(), doInit);
     if (doInit) {
-      if (_sourceDataTypeMap.isEmpty()) {
-        routingTableChangeListener.onRoutingTableChange(getRoutingTableSnapshot(), context);
-      } else {
-        for (PropertyType propertyType : _sourceDataTypeMap.keySet()) {
-          switch (propertyType) {
-            case EXTERNALVIEW:
-            case TARGETEXTERNALVIEW:
-            case CURRENTSTATES:
-              routingTableChangeListener
-                  .onRoutingTableChange(getRoutingTableSnapshot(propertyType), context);
-              break;
-            case CUSTOMIZEDVIEW:
-              for (String customizedStateType : _sourceDataTypeMap
-                  .getOrDefault(PropertyType.CUSTOMIZEDVIEW, Collections.emptyList())) {
-                routingTableChangeListener.onRoutingTableChange(
-                    getRoutingTableSnapshot(PropertyType.CUSTOMIZEDVIEW, customizedStateType),
-                    context);
-              }
-              break;
-            default:
-              logger.warn("Unsupported source data type: {}, stop triggering callback!",
-                  propertyType);
-          }
-        }
+      final NotificationContext periodicRefreshContext = new NotificationContext(_helixManager);
+      periodicRefreshContext.setType(NotificationContext.Type.PERIODIC_REFRESH);
+      _routerUpdater.queueEvent(periodicRefreshContext, ClusterEventType.PeriodicalRebalance,
+          null);
       }
-    }
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -294,6 +294,10 @@ public class RoutingTableProvider
    * @param sourceDataTypeMap
    */
   private void validateSourceDataTypeMap(Map<PropertyType, List<String>> sourceDataTypeMap) {
+    if (sourceDataTypeMap == null) {
+      throw new IllegalArgumentException(
+          "The sourceDataTypeMap of Routing Table Provider should not be null");
+    }
     for (PropertyType propertyType : sourceDataTypeMap.keySet()) {
       if (propertyType.equals(PropertyType.CUSTOMIZEDVIEW)
           && sourceDataTypeMap.get(propertyType).size() == 0) {
@@ -302,10 +306,10 @@ public class RoutingTableProvider
       }
       if (!propertyType.equals(PropertyType.CUSTOMIZEDVIEW)
           && sourceDataTypeMap.get(propertyType).size() != 0) {
-        logger.error("Type has been used in addition to the propertyType {} !",
-            propertyType.name());
-        throw new HelixException(
-            String.format("Type %s has been used in addition to the propertyType %s !",
+        logger
+            .error("Type has been used in addition to the propertyType {} !", propertyType.name());
+        throw new HelixException(String
+            .format("Type %s has been used in addition to the propertyType %s !",
                 sourceDataTypeMap.get(propertyType), propertyType.name()));
       }
     }
@@ -426,7 +430,7 @@ public class RoutingTableProvider
     logger.info(
         "Attach RoutingTableProviderChangeListener {}. The doInit value of this listener is {}",
         routingTableChangeListener.getClass().getName(), doInit);
-    if (doInit && _sourceDataTypeMap != null) {
+    if (doInit) {
       if (_sourceDataTypeMap.isEmpty()) {
         routingTableChangeListener.onRoutingTableChange(getRoutingTableSnapshot(), context);
       } else {

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -423,8 +423,9 @@ public class RoutingTableProvider
   public void addRoutingTableChangeListener(
       final RoutingTableChangeListener routingTableChangeListener, Object context, boolean doInit) {
     _routingTableChangeListenerMap.put(routingTableChangeListener, new ListenerContext(context));
-    logger.info("Attach RoutingTableProviderChangeListener {}",
-        routingTableChangeListener.getClass().getName());
+    logger.info(
+        "Attach RoutingTableProviderChangeListener {}. The doInit value of this listener is {}",
+        routingTableChangeListener.getClass().getName(), doInit);
     if (doInit && _sourceDataTypeMap != null) {
       if (_sourceDataTypeMap.isEmpty()) {
         routingTableChangeListener.onRoutingTableChange(getRoutingTableSnapshot(), context);

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -403,6 +403,7 @@ public class RoutingTableProvider
     return snapshots;
   }
 
+
   /**
    * Add RoutingTableChangeListener with user defined context
    * @param routingTableChangeListener
@@ -410,31 +411,44 @@ public class RoutingTableProvider
    */
   public void addRoutingTableChangeListener(
       final RoutingTableChangeListener routingTableChangeListener, Object context) {
+    addRoutingTableChangeListener(routingTableChangeListener, context, false);
+  }
+
+  /**
+   * Add RoutingTableChangeListener with user defined context
+   * @param routingTableChangeListener
+   * @param context user defined context
+   * @param doInit whether to trigger the initial callback during adding listener
+   */
+  public void addRoutingTableChangeListener(
+      final RoutingTableChangeListener routingTableChangeListener, Object context, boolean doInit) {
     _routingTableChangeListenerMap.put(routingTableChangeListener, new ListenerContext(context));
     logger.info("Attach RoutingTableProviderChangeListener {}",
         routingTableChangeListener.getClass().getName());
-    if (_sourceDataTypeMap.isEmpty()) {
-      routingTableChangeListener.onRoutingTableChange(getRoutingTableSnapshot(), context);
-    } else {
-      for (PropertyType propertyType : _sourceDataTypeMap.keySet()) {
-        switch (propertyType) {
-          case EXTERNALVIEW:
-          case TARGETEXTERNALVIEW:
-          case CURRENTSTATES:
-            routingTableChangeListener
-                .onRoutingTableChange(getRoutingTableSnapshot(propertyType), context);
-            break;
-          case CUSTOMIZEDVIEW:
-            for (String customizedStateType : _sourceDataTypeMap
-                .getOrDefault(PropertyType.CUSTOMIZEDVIEW, Collections.emptyList())) {
-              routingTableChangeListener.onRoutingTableChange(
-                  getRoutingTableSnapshot(PropertyType.CUSTOMIZEDVIEW, customizedStateType),
-                  context);
-            }
-            break;
-          default:
-            logger.warn("Unsupported source data type: {}, stop triggering callback!",
-                propertyType);
+    if (doInit) {
+      if (_sourceDataTypeMap.isEmpty()) {
+        routingTableChangeListener.onRoutingTableChange(getRoutingTableSnapshot(), context);
+      } else {
+        for (PropertyType propertyType : _sourceDataTypeMap.keySet()) {
+          switch (propertyType) {
+            case EXTERNALVIEW:
+            case TARGETEXTERNALVIEW:
+            case CURRENTSTATES:
+              routingTableChangeListener
+                  .onRoutingTableChange(getRoutingTableSnapshot(propertyType), context);
+              break;
+            case CUSTOMIZEDVIEW:
+              for (String customizedStateType : _sourceDataTypeMap
+                  .getOrDefault(PropertyType.CUSTOMIZEDVIEW, Collections.emptyList())) {
+                routingTableChangeListener.onRoutingTableChange(
+                    getRoutingTableSnapshot(PropertyType.CUSTOMIZEDVIEW, customizedStateType),
+                    context);
+              }
+              break;
+            default:
+              logger.warn("Unsupported source data type: {}, stop triggering callback!",
+                  propertyType);
+          }
         }
       }
     }

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -429,9 +429,9 @@ public class RoutingTableProvider
       boolean isTriggerCallback) {
     _routingTableChangeListenerMap.put(routingTableChangeListener, new ListenerContext(context));
     logger.info("Attach RoutingTableProviderChangeListener {}.",
-        routingTableChangeListener.getClass().getName(), isTriggerCallback);
+        routingTableChangeListener.getClass().getName());
     if (isTriggerCallback) {
-      logger.info("The isTriggerCallback value for the listener is true");
+      logger.info("Force triggering a callback for the new listener in routing table provider");
       final NotificationContext periodicRefreshContext = new NotificationContext(_helixManager);
       periodicRefreshContext.setType(NotificationContext.Type.PERIODIC_REFRESH);
       _routerUpdater.queueEvent(periodicRefreshContext, ClusterEventType.PeriodicalRebalance, null);

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -425,7 +425,7 @@ public class RoutingTableProvider
     _routingTableChangeListenerMap.put(routingTableChangeListener, new ListenerContext(context));
     logger.info("Attach RoutingTableProviderChangeListener {}",
         routingTableChangeListener.getClass().getName());
-    if (doInit) {
+    if (doInit && _sourceDataTypeMap != null) {
       if (_sourceDataTypeMap.isEmpty()) {
         routingTableChangeListener.onRoutingTableChange(getRoutingTableSnapshot(), context);
       } else {

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -413,6 +413,31 @@ public class RoutingTableProvider
     _routingTableChangeListenerMap.put(routingTableChangeListener, new ListenerContext(context));
     logger.info("Attach RoutingTableProviderChangeListener {}",
         routingTableChangeListener.getClass().getName());
+    if (_sourceDataTypeMap.isEmpty()) {
+      routingTableChangeListener.onRoutingTableChange(getRoutingTableSnapshot(), context);
+    } else {
+      for (PropertyType propertyType : _sourceDataTypeMap.keySet()) {
+        switch (propertyType) {
+          case EXTERNALVIEW:
+          case TARGETEXTERNALVIEW:
+          case CURRENTSTATES:
+            routingTableChangeListener
+                .onRoutingTableChange(getRoutingTableSnapshot(propertyType), context);
+            break;
+          case CUSTOMIZEDVIEW:
+            for (String customizedStateType : _sourceDataTypeMap
+                .getOrDefault(PropertyType.CUSTOMIZEDVIEW, Collections.emptyList())) {
+              routingTableChangeListener.onRoutingTableChange(
+                  getRoutingTableSnapshot(PropertyType.CUSTOMIZEDVIEW, customizedStateType),
+                  context);
+            }
+            break;
+          default:
+            logger.warn("Unsupported source data type: {}, stop triggering callback!",
+                propertyType);
+        }
+      }
+    }
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
@@ -186,7 +186,8 @@ public class TestRoutingTableProvider extends ZkTestBase {
   public void testInvocation() throws Exception {
     MockRoutingTableChangeListener routingTableChangeListener =
         new TestRoutingTableProvider().new MockRoutingTableChangeListener();
-    _routingTableProvider_default.addRoutingTableChangeListener(routingTableChangeListener, null);
+    _routingTableProvider_default
+        .addRoutingTableChangeListener(routingTableChangeListener, null, true);
 
     // Initial add listener should trigger the first execution of the
     // listener callbacks
@@ -237,9 +238,10 @@ public class TestRoutingTableProvider extends ZkTestBase {
     Map<String, Set<String>> context = new HashMap<>();
     context.put("MASTER", Sets.newSet(_instances.get(0)));
     context.put("SLAVE", Sets.newSet(_instances.get(1), _instances.get(2)));
-    _routingTableProvider_default.addRoutingTableChangeListener(routingTableChangeListener, context);
     _routingTableProvider_default
-        .addRoutingTableChangeListener(new MockRoutingTableChangeListener(), null);
+        .addRoutingTableChangeListener(routingTableChangeListener, context, true);
+    _routingTableProvider_default
+        .addRoutingTableChangeListener(new MockRoutingTableChangeListener(), null, true);
     // reenable the master instance to cause change
     String prevMasterInstance = _instances.get(0);
     _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, prevMasterInstance, true);

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
@@ -54,7 +54,6 @@ import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier;
 import org.mockito.internal.util.collections.Sets;
 import org.testng.Assert;
-import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -182,16 +181,15 @@ public class TestRoutingTableProvider extends ZkTestBase {
     deleteCluster(CLUSTER_NAME);
   }
 
-  @Test()
+  @Test
   public void testInvocation() throws Exception {
-    MockRoutingTableChangeListener routingTableChangeListener =
-        new TestRoutingTableProvider().new MockRoutingTableChangeListener();
+    MockRoutingTableChangeListener routingTableChangeListener = new MockRoutingTableChangeListener();
     _routingTableProvider_default
         .addRoutingTableChangeListener(routingTableChangeListener, null, true);
 
     // Initial add listener should trigger the first execution of the
     // listener callbacks
-    AssertJUnit.assertTrue(routingTableChangeListener.routingTableChangeReceived);
+    Assert.assertTrue(routingTableChangeListener.routingTableChangeReceived);
   }
 
   @Test(dependsOnMethods = { "testInvocation" })


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1090 
### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR adds an initial callback when user adds a listener to Helix routing table. This initial callback will ensure uses are able to perform operations, e.g. read routing table data or some other actions, immediately after they add the listener instead of waiting for the first data change to trigger the callback.

### Tests

- [X] The following tests are modified for this issue:

TestRoutingTableProvider.java

- [X] The following is the result of the "mvn test" command on the appropriate module:

helix-core:
[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestResourceChangeDetector.testResetSnapshots:431 » ThreadTimeout Method org.t...
[INFO]
[ERROR] Tests run: 1209, Failures: 1, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:12 h
[INFO] Finished at: 2020-09-24T14:47:28-07:00
[INFO] ------------------------------------------------------------------------

Local test passed. 
### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)