### PR TITLE
fix TestRebalancePipeline test

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
@@ -64,7 +64,7 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     event.addAttribute(AttributeName.helixmanager.name(), manager);
     ResourceControllerDataProvider dataCache = new ResourceControllerDataProvider();
     // The AsyncTasksThreadPool needs to be set, otherwise to start pending message cleanup job
-    // will throw NPE and stop the pipeline.
+    // will throw NPE and stop the pipeline. Refer to: https://github.com/apache/helix/issues/1156
     dataCache.setAsyncTasksThreadPool(Executors.newSingleThreadExecutor());
     event.addAttribute(AttributeName.ControllerDataProvider.name(), dataCache);
 

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
@@ -63,6 +63,8 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     ClusterEvent event = new ClusterEvent(ClusterEventType.Unknown);
     event.addAttribute(AttributeName.helixmanager.name(), manager);
     ResourceControllerDataProvider dataCache = new ResourceControllerDataProvider();
+    // The AsyncTasksThreadPool needs to be set, otherwise to start pending message cleanup job
+    // will throw NPE and stop the pipeline.
     dataCache.setAsyncTasksThreadPool(Executors.newSingleThreadExecutor());
     event.addAttribute(AttributeName.ControllerDataProvider.name(), dataCache);
 

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.helix.HelixAdmin;
@@ -46,10 +47,17 @@ import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Partition;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 public class TestRebalancePipeline extends ZkUnitTestBase {
   private final String _className = getShortClassName();
+  private ExecutorService _executorService;
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    _executorService.shutdown();
+  }
 
   @Test
   public void testDuplicateMsg() {
@@ -65,7 +73,8 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     ResourceControllerDataProvider dataCache = new ResourceControllerDataProvider();
     // The AsyncTasksThreadPool needs to be set, otherwise to start pending message cleanup job
     // will throw NPE and stop the pipeline. TODO: https://github.com/apache/helix/issues/1158
-    dataCache.setAsyncTasksThreadPool(Executors.newSingleThreadExecutor());
+    _executorService = Executors.newSingleThreadExecutor();
+    dataCache.setAsyncTasksThreadPool(_executorService);
     event.addAttribute(AttributeName.ControllerDataProvider.name(), dataCache);
 
     final String resourceName = "testResource_dup";

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
@@ -64,7 +64,7 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     event.addAttribute(AttributeName.helixmanager.name(), manager);
     ResourceControllerDataProvider dataCache = new ResourceControllerDataProvider();
     // The AsyncTasksThreadPool needs to be set, otherwise to start pending message cleanup job
-    // will throw NPE and stop the pipeline. Refer to: https://github.com/apache/helix/issues/1156
+    // will throw NPE and stop the pipeline. TODO: https://github.com/apache/helix/issues/1158
     dataCache.setAsyncTasksThreadPool(Executors.newSingleThreadExecutor());
     event.addAttribute(AttributeName.ControllerDataProvider.name(), dataCache);
 

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
@@ -47,17 +47,10 @@ import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Partition;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 public class TestRebalancePipeline extends ZkUnitTestBase {
   private final String _className = getShortClassName();
-  private ExecutorService _executorService;
-
-  @AfterClass
-  public void afterClass() throws Exception {
-    _executorService.shutdown();
-  }
 
   @Test
   public void testDuplicateMsg() {
@@ -73,8 +66,8 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     ResourceControllerDataProvider dataCache = new ResourceControllerDataProvider();
     // The AsyncTasksThreadPool needs to be set, otherwise to start pending message cleanup job
     // will throw NPE and stop the pipeline. TODO: https://github.com/apache/helix/issues/1158
-    _executorService = Executors.newSingleThreadExecutor();
-    dataCache.setAsyncTasksThreadPool(_executorService);
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    dataCache.setAsyncTasksThreadPool(executorService);
     event.addAttribute(AttributeName.ControllerDataProvider.name(), dataCache);
 
     final String resourceName = "testResource_dup";
@@ -135,6 +128,7 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
 
     deleteLiveInstances(clusterName);
     deleteCluster(clusterName);
+    executorService.shutdown();
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
   }
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1156 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
In the test testDuplicateMsg from TestRebalancePipeline, currently an invalid session id is used. Here's the detail:
setCurrentState(clusterName, "localhost_0", resourceName, resourceName + "_0", "session_1", "SLAVE"); 
The wrong session id makes the following test and assertion meaningless. This PR uses the correct session id  liveInstances.get(0).getEphemeralOwner() instead. Meanwhile, we found a NPE thrown out during the pipeline and cause the pipeline to stop, which is due to the missing of `setAsyncTasksThreadPool` action. This PR also fixed the issue.

### Tests
helix-core
- [X] The following is the result of the "mvn test" command on the appropriate module:
[ERROR] Failures:
[ERROR]   TestClusterInMaintenanceModeWhenReachingMaxPartition.testDisableCluster:119 expected:<true> but was:<false>
[ERROR]   TestRebalanceRunningTask.testFixedTargetTaskAndEnabledRebalanceAndNodeAdded:330 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1153, Failures: 2, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:14 h
[INFO] Finished at: 2020-07-19T22:08:21-07:00


helix-rest:
[INFO] Tests run: 163, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 30.642 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 163, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  35.801 s
[INFO] Finished at: 2020-07-19T23:40:27-07:00
### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)