### PR TITLE
Change getBaselineAasignment/getBestPossibleAssignment to account for partial-WAGED clusters

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -647,7 +647,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     if (assignmentMetadataStore != null) {
       try {
         _stateReadLatency.startMeasuringLatency();
-        currentBaseline = assignmentMetadataStore.getBaseline();
+        currentBaseline = new HashMap<>(assignmentMetadataStore.getBaseline());
         _stateReadLatency.endMeasuringLatency();
       } catch (Exception ex) {
         throw new HelixRebalanceException(

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -34,6 +34,8 @@ import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.strategy.CrushRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.waged.constraints.MockRebalanceAlgorithm;
 import org.apache.helix.controller.rebalancer.waged.model.AbstractTestClusterModel;
+import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
+import org.apache.helix.controller.rebalancer.waged.model.OptimalAssignment;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.CurrentState;
@@ -46,7 +48,10 @@ import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.monitoring.metrics.WagedRebalancerMetricCollector;
 import org.apache.helix.monitoring.metrics.model.CountMetric;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -54,6 +59,8 @@ import org.testng.annotations.Test;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class TestWagedRebalancer extends AbstractTestClusterModel {
@@ -238,6 +245,90 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     Assert.assertEquals(
         droppedIdealState.getInstanceStateMap(droppingPartitionName).get(droppingFromInstance),
         "DROPPED");
+  }
+
+  @Test(dependsOnMethods = "testRebalance")
+  public void testPartialBaselineAvailability() throws IOException, HelixRebalanceException {
+    Map<String, ResourceAssignment> testResourceAssignmentMap = new HashMap<>();
+    ZNRecord mappingNode = new ZNRecord(_resourceNames.get(0));
+    HashMap<String, String> mapping = new HashMap<>();
+    mapping.put(_partitionNames.get(0), "MASTER");
+    mappingNode.setMapField(_testInstanceId, mapping);
+    testResourceAssignmentMap.put(_resourceNames.get(0), new ResourceAssignment(mappingNode));
+
+    _metadataStore.reset();
+    _metadataStore.persistBaseline(testResourceAssignmentMap);
+    _metadataStore.persistBestPossibleAssignment(testResourceAssignmentMap);
+
+    // Test algorithm that passes along the best possible assignment
+    RebalanceAlgorithm algorithm = Mockito.mock(RebalanceAlgorithm.class);
+    when(algorithm.calculate(any())).thenAnswer(new Answer<OptimalAssignment>() {
+      @Override
+      public OptimalAssignment answer(InvocationOnMock invocation) throws Throwable {
+        Object[] args = invocation.getArguments();
+        ClusterModel argClusterModel = (ClusterModel) args[0];
+
+        OptimalAssignment optimalAssignment = Mockito.mock(OptimalAssignment.class);
+        when(optimalAssignment.getOptimalResourceAssignment())
+            .thenReturn(argClusterModel.getContext().getBestPossibleAssignment());
+        new OptimalAssignment();
+        return optimalAssignment;
+      }
+    });
+
+    WagedRebalancer rebalancer = new WagedRebalancer(_metadataStore, algorithm, Optional.empty());
+
+    // Generate the input for the rebalancer.
+    ResourceControllerDataProvider clusterData = setupClusterDataCache();
+    Map<String, Resource> resourceMap = clusterData.getIdealStates().entrySet().stream()
+        .collect(Collectors.toMap(entry -> entry.getKey(), entry -> {
+          Resource resource = new Resource(entry.getKey());
+          entry.getValue().getPartitionSet().stream()
+              .forEach(partition -> resource.addPartition(partition));
+          return resource;
+        }));
+    // Mocking the change types for triggering a baseline rebalance.
+    when(clusterData.getRefreshedChangeTypes())
+        .thenReturn(Collections.singleton(HelixConstants.ChangeType.CLUSTER_CONFIG));
+
+    // Mock a current state
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    currentStateOutput.setCurrentState(_resourceNames.get(1), new Partition(_partitionNames.get(1)),
+        _testInstanceId, "SLAVE");
+    // Record current states into testBaseline; the logic should have loaded current state into
+    // baseline as a fallback mechanism
+    ZNRecord mappingNode2 = new ZNRecord(_resourceNames.get(1));
+    HashMap<String, String> mapping2 = new HashMap<>();
+    mapping2.put(_testInstanceId, "SLAVE");
+    mappingNode2.setMapField(_partitionNames.get(1), mapping2);
+    testResourceAssignmentMap.put(_resourceNames.get(1), new ResourceAssignment(mappingNode2));
+
+    // Call compute, calculate() should have been called twice in global and partial rebalance
+    rebalancer.computeNewIdealStates(clusterData, resourceMap, currentStateOutput);
+    ArgumentCaptor<ClusterModel> argumentCaptor = ArgumentCaptor.forClass(ClusterModel.class);
+    verify(algorithm, times(2)).calculate(argumentCaptor.capture());
+
+    // In the first execution, the past baseline is loaded into the new best possible state
+    Map<String, ResourceAssignment> firstCallBestPossibleAssignment =
+        argumentCaptor.getAllValues().get(0).getContext().getBestPossibleAssignment();
+    Assert.assertEquals(firstCallBestPossibleAssignment.size(), testResourceAssignmentMap.size());
+    Assert.assertEquals(firstCallBestPossibleAssignment, testResourceAssignmentMap);
+    // In the second execution, the result from the algorithm (which is just the best possible
+    // state) is loaded as the baseline, and the best possible state is from persisted + current state
+    Map<String, ResourceAssignment> secondCallBaselineAssignment =
+        argumentCaptor.getAllValues().get(1).getContext().getBaselineAssignment();
+    Map<String, ResourceAssignment> secondCallBestPossibleAssignment =
+        argumentCaptor.getAllValues().get(1).getContext().getBestPossibleAssignment();
+    Assert.assertEquals(secondCallBaselineAssignment.size(), testResourceAssignmentMap.size());
+    Assert.assertEquals(secondCallBaselineAssignment, testResourceAssignmentMap);
+    Assert.assertEquals(secondCallBestPossibleAssignment.size(), testResourceAssignmentMap.size());
+    Assert.assertEquals(secondCallBestPossibleAssignment, testResourceAssignmentMap);
+
+    Assert.assertEquals(_metadataStore.getBaseline().size(), testResourceAssignmentMap.size());
+    Assert.assertEquals(_metadataStore.getBestPossibleAssignment().size(),
+        testResourceAssignmentMap.size());
+    Assert.assertEquals(_metadataStore.getBaseline(), testResourceAssignmentMap);
+    Assert.assertEquals(_metadataStore.getBestPossibleAssignment(), testResourceAssignmentMap);
   }
 
   @Test(dependsOnMethods = "testRebalance", expectedExceptions = HelixRebalanceException.class, expectedExceptionsMessageRegExp = "Input contains invalid resource\\(s\\) that cannot be rebalanced by the WAGED rebalancer. \\[Resource1\\] Failure Type: INVALID_INPUT")


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1166 

### Description

- [x] The following tests are written for this issue:
testPartialBaselineAvailability

- [x] Here are some details about my PR, including screenshots of any UI changes:

WAGED Rebalancer by design only supports one-off migration of resources. As a result, its `getBaselineAssignment()` did not consider the case of a cluster that's partially managed by WAGED. It tries to get baselines for all resources from the cluster; if there's no baseline data, it gets current states for all resources as a fallback. It doesn't care for resources that don't have baseline while other resources have baselines - when that's the case, the resources that don't have baseline will not fallback to their current states; they will simply not have baselines. A similar problem happens to `getBestPossibleAssignment()`. 

The logic is now changed to a per resource level. If a resource has baseline, the baseline will be used; else, the current state will be used. `getBestPossibleAssignment()` will be fixed the same way. 

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:
```
[ERROR] Tests run: 1155, Failures: 5, Errors: 0, Skipped: 1, Time elapsed: 4,324.66 s <<< FAILURE! - in TestSuite
[ERROR] testResourceSubset(org.apache.helix.tools.TestClusterStateVerifier)  Time elapsed: 1.025 s  <<< FAILURE!
org.apache.helix.HelixException: Failed to create pause signal
        at org.apache.helix.tools.TestClusterStateVerifier.testResourceSubset(TestClusterStateVerifier.java:115)

[ERROR] afterMethod(org.apache.helix.tools.TestClusterStateVerifier)  Time elapsed: 1.062 s  <<< FAILURE!
java.lang.IllegalStateException: ZkClient already closed!
        at org.apache.helix.tools.TestClusterStateVerifier.afterMethod(TestClusterStateVerifier.java:98)

[ERROR] testCustomizedViewAggregation(org.apache.helix.integration.TestCustomizedViewAggregation)  Time elapsed: 12.133 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.TestCustomizedViewAggregation.validateAggregationSnapshot(TestCustomizedViewAggregation.java:238)
        at org.apache.helix.integration.TestCustomizedViewAggregation.testCustomizedViewAggregation(TestCustomizedViewAggregation.java:394)

[ERROR] testStateTransitionTimeOut(org.apache.helix.integration.paticipant.TestStateTransitionTimeoutWithResource)  Time elapsed: 36.061 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.paticipant.TestStateTransitionTimeoutWithResource.testStateTransitionTimeOut(TestStateTransitionTimeoutWithResource.java:171)

[ERROR] testPeriodicRefresh(org.apache.helix.integration.spectator.TestRoutingTableProviderPeriodicRefresh)  Time elapsed: 2.015 s  <<< FAILURE!
java.lang.AssertionError: expected:<7> but was:<6>
        at org.apache.helix.integration.spectator.TestRoutingTableProviderPeriodicRefresh.testPeriodicRefresh(TestRoutingTableProviderPeriodicRefresh.java:192)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestCustomizedViewAggregation.testCustomizedViewAggregation:394->validateAggregationSnapshot:238 expected:<true> but was:<false>
[ERROR]   TestStateTransitionTimeoutWithResource.testStateTransitionTimeOut:171 expected:<true> but was:<false>
[ERROR]   TestRoutingTableProviderPeriodicRefresh.testPeriodicRefresh:192 expected:<7> but was:<6>
[ERROR]   TestClusterStateVerifier.afterMethod:98 » IllegalState ZkClient already closed...
[ERROR]   TestClusterStateVerifier.testResourceSubset:115 » Helix Failed to create pause...
[INFO] 
[ERROR] Tests run: 1155, Failures: 5, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:12 h
[INFO] Finished at: 2020-07-22T18:49:39-07:00
[INFO] ------------------------------------------------------------------------
```
Rerun
```
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.505 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  43.912 s
[INFO] Finished at: 2020-07-22T19:12:42-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
