### PR TITLE
Fix metrics-common ivy file

### DIFF
--- a/metrics-common/metrics-common-1.0.2-SNAPSHOT.ivy
+++ b/metrics-common/metrics-common-1.0.2-SNAPSHOT.ivy
@@ -43,6 +43,6 @@ under the License.
     <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.7.14" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)">
         <artifact name="slf4j-log4j12" ext="jar"/>
     </dependency>
-    <dependency org="io.dropwizard.metrics" name="metrics-core" rev="3.2.3" conf="compile->compile(*),master(*);runtime->runtime(*)/>
+    <dependency org="io.dropwizard.metrics" name="metrics-core" rev="3.2.3" conf="compile->compile(*),master(*);runtime->runtime(*)" />
 	</dependencies>
 </ivy-module>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1173

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Dependency `metrics-core` in `metrics-common` ivy file misses ending double quotas `"`.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

![](https://user-images.githubusercontent.com/5187721/88468574-9a770c00-ce9a-11ea-8ab8-b8a61516deb7.png)

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)