### PR TITLE
Add HelixManager constructor with RealmAwareZkConnectionConfig

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/ConfigAccessor.java
@@ -113,7 +113,7 @@ public class ConfigAccessor {
     _usesExternalZkClient = false;
 
     // If the multi ZK config is enabled, use FederatedZkClient on multi-realm mode
-    if (Boolean.parseBoolean(System.getProperty(SystemPropertyKeys.MULTI_ZK_ENABLED))) {
+    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddress == null) {
       try {
         _zkClient = new FederatedZkClient(
             new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder().build(),

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
@@ -19,13 +19,6 @@ package org.apache.helix;
  * under the License.
  */
 
-/**
- * factory that creates cluster managers
- *
- * for zk-based cluster managers, the getZKXXX(..zkClient) that takes a zkClient parameter
- *   are intended for session expiry test purpose
- */
-
 import org.apache.helix.manager.zk.HelixManagerStateListener;
 import org.apache.helix.manager.zk.ZKHelixManager;
 import org.slf4j.Logger;
@@ -34,6 +27,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Obtain one of a set of Helix cluster managers, organized by the backing system.
+ * factory that creates cluster managers
+ *  *
+ *  * for zk-based cluster managers, the getZKXXX(..zkClient) that takes a zkClient parameter
+ *  *   are intended for session expiry test purpose
  */
 public final class HelixManagerFactory {
   private static final Logger LOG = LoggerFactory.getLogger(HelixManagerFactory.class);

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
@@ -27,10 +27,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Obtain one of a set of Helix cluster managers, organized by the backing system.
- * factory that creates cluster managers
- *  *
- *  * for zk-based cluster managers, the getZKXXX(..zkClient) that takes a zkClient parameter
- *  *   are intended for session expiry test purpose
+ * factory that creates cluster managers.
  */
 public final class HelixManagerFactory {
   private static final Logger LOG = LoggerFactory.getLogger(HelixManagerFactory.class);

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
@@ -28,7 +28,6 @@ package org.apache.helix;
 
 import org.apache.helix.manager.zk.HelixManagerStateListener;
 import org.apache.helix.manager.zk.ZKHelixManager;
-import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,8 +68,8 @@ public final class HelixManagerFactory {
   }
 
   /**
-   * Construct a ZkHelixManager using the HelixManagerProperty instance given. If a proper
-   * ZkConnectionConfig. HelixManagerProperty given must contain a valid ZkConnectionConfig.
+   * Construct a ZkHelixManager using the HelixManagerProperty instance given.
+   * HelixManagerProperty given must contain a valid ZkConnectionConfig.
    * @param clusterName
    * @param instanceName
    * @param type
@@ -86,12 +85,13 @@ public final class HelixManagerFactory {
   }
 
   /**
-   * Construct a ZkHelixManager using the HelixManagerProperty instance given. If a proper
-   * ZkConnectionConfig is given in HelixManagerProperty, zkAddr field will be overriden.
+   * Construct a ZkHelixManager using the HelixManagerProperty instance given.
+   * NOTE: if both zkAddr and a valid ZkConnectionConfig are given in HelixManagerProperty, the
+   * instantiation will fail - only one is required.
    * @param clusterName
    * @param instanceName
    * @param type
-   * @param zkAddr will be overriden if a valid ZkConnectionConfig is given in helixManagerProperty
+   * @param zkAddr
    * @param stateListener
    * @param helixManagerProperty
    * @return

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
@@ -77,23 +77,4 @@ public final class HelixManagerFactory {
     return new ZKHelixManager(clusterName, instanceName, type, null, stateListener,
         helixManagerProperty);
   }
-
-  /**
-   * Construct a ZkHelixManager using the HelixManagerProperty instance given.
-   * NOTE: if both zkAddr and a valid ZkConnectionConfig are given in HelixManagerProperty, the
-   * instantiation will fail - only one is required.
-   * @param clusterName
-   * @param instanceName
-   * @param type
-   * @param zkAddr
-   * @param stateListener
-   * @param helixManagerProperty
-   * @return
-   */
-  public static HelixManager getZKHelixManager(String clusterName, String instanceName,
-      InstanceType type, String zkAddr, HelixManagerStateListener stateListener,
-      HelixManagerProperty helixManagerProperty) {
-    return new ZKHelixManager(clusterName, instanceName, type, zkAddr, stateListener,
-        helixManagerProperty);
-  }
 }

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
@@ -25,10 +25,13 @@ package org.apache.helix;
  * for zk-based cluster managers, the getZKXXX(..zkClient) that takes a zkClient parameter
  *   are intended for session expiry test purpose
  */
+
 import org.apache.helix.manager.zk.HelixManagerStateListener;
 import org.apache.helix.manager.zk.ZKHelixManager;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 /**
  * Obtain one of a set of Helix cluster managers, organized by the backing system.
@@ -65,4 +68,38 @@ public final class HelixManagerFactory {
     return new ZKHelixManager(clusterName, instanceName, type, zkAddr, stateListener);
   }
 
+  /**
+   * Construct a ZkHelixManager using the HelixManagerProperty instance given. If a proper
+   * ZkConnectionConfig. HelixManagerProperty given must contain a valid ZkConnectionConfig.
+   * @param clusterName
+   * @param instanceName
+   * @param type
+   * @param stateListener
+   * @param helixManagerProperty must contain a valid ZkConnectionConfig
+   * @return
+   */
+  public static HelixManager getZKHelixManager(String clusterName, String instanceName,
+      InstanceType type, HelixManagerStateListener stateListener,
+      HelixManagerProperty helixManagerProperty) {
+    return new ZKHelixManager(clusterName, instanceName, type, null, stateListener,
+        helixManagerProperty);
+  }
+
+  /**
+   * Construct a ZkHelixManager using the HelixManagerProperty instance given. If a proper
+   * ZkConnectionConfig is given in HelixManagerProperty, zkAddr field will be overriden.
+   * @param clusterName
+   * @param instanceName
+   * @param type
+   * @param zkAddr will be overriden if a valid ZkConnectionConfig is given in helixManagerProperty
+   * @param stateListener
+   * @param helixManagerProperty
+   * @return
+   */
+  public static HelixManager getZKHelixManager(String clusterName, String instanceName,
+      InstanceType type, String zkAddr, HelixManagerStateListener stateListener,
+      HelixManagerProperty helixManagerProperty) {
+    return new ZKHelixManager(clusterName, instanceName, type, zkAddr, stateListener,
+        helixManagerProperty);
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
@@ -49,54 +49,82 @@ public class HelixManagerProperty {
   @Deprecated
   public HelixManagerProperty(Properties helixManagerProperties, CloudConfig cloudConfig) {
     _helixCloudProperty = new HelixCloudProperty(cloudConfig);
-    setVersion(helixManagerProperties.getProperty(SystemPropertyKeys.HELIX_MANAGER_VERSION));
-    setHealthReportLatency(
+    _version = helixManagerProperties.getProperty(SystemPropertyKeys.HELIX_MANAGER_VERSION);
+    _healthReportLatency = Long.parseLong(
         helixManagerProperties.getProperty(SystemPropertyKeys.PARTICIPANT_HEALTH_REPORT_LATENCY));
   }
 
-  public HelixManagerProperty() {
+  private HelixManagerProperty(String version, long healthReportLatency,
+      HelixCloudProperty helixCloudProperty,
+      RealmAwareZkClient.RealmAwareZkConnectionConfig zkConnectionConfig,
+      RealmAwareZkClient.RealmAwareZkClientConfig zkClientConfig) {
+    _version = version;
+    _healthReportLatency = healthReportLatency;
+    _helixCloudProperty = helixCloudProperty;
+    _zkConnectionConfig = zkConnectionConfig;
+    _zkClientConfig = zkClientConfig;
   }
 
   public HelixCloudProperty getHelixCloudProperty() {
     return _helixCloudProperty;
   }
 
-  public void setHelixCloudProperty(HelixCloudProperty helixCloudProperty) {
-    _helixCloudProperty = helixCloudProperty;
-  }
-
   public String getVersion() {
     return _version;
-  }
-
-  public void setVersion(String version) {
-    _version = version;
   }
 
   public long getHealthReportLatency() {
     return _healthReportLatency;
   }
 
-  public void setHealthReportLatency(String latency) {
-    _healthReportLatency = Long.valueOf(latency);
-  }
-
   public RealmAwareZkClient.RealmAwareZkConnectionConfig getZkConnectionConfig() {
     return _zkConnectionConfig;
-  }
-
-  public void setZkConnectionConfig(
-      RealmAwareZkClient.RealmAwareZkConnectionConfig zkConnectionConfig) {
-    _zkConnectionConfig = zkConnectionConfig;
   }
 
   public RealmAwareZkClient.RealmAwareZkClientConfig getZkClientConfig() {
     return _zkClientConfig;
   }
 
-  public void setZkClientConfig(RealmAwareZkClient.RealmAwareZkClientConfig zkClientConfig) {
-    _zkClientConfig = zkClientConfig;
-  }
+  public static class Builder {
+    private String _version;
+    private long _healthReportLatency;
+    private HelixCloudProperty _helixCloudProperty;
+    private RealmAwareZkClient.RealmAwareZkConnectionConfig _zkConnectionConfig;
+    private RealmAwareZkClient.RealmAwareZkClientConfig _zkClientConfig;
 
-  // TODO: migrate all other participant related properties to this file.
+    public Builder() {
+    }
+
+    public HelixManagerProperty build() {
+      return new HelixManagerProperty(_version, _healthReportLatency, _helixCloudProperty,
+          _zkConnectionConfig, _zkClientConfig);
+    }
+
+    public Builder setVersion(String version) {
+      _version = version;
+      return this;
+    }
+
+    public Builder setHealthReportLatency(long healthReportLatency) {
+      _healthReportLatency = healthReportLatency;
+      return this;
+    }
+
+    public Builder setHelixCloudProperty(HelixCloudProperty helixCloudProperty) {
+      _helixCloudProperty = helixCloudProperty;
+      return this;
+    }
+
+    public Builder setRealmAWareZkConnectionConfig(
+        RealmAwareZkClient.RealmAwareZkConnectionConfig zkConnectionConfig) {
+      _zkConnectionConfig = zkConnectionConfig;
+      return this;
+    }
+
+    public Builder setRealmAwareZkClientConfig(
+        RealmAwareZkClient.RealmAwareZkClientConfig zkClientConfig) {
+      _zkClientConfig = zkClientConfig;
+      return this;
+    }
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
@@ -20,25 +20,33 @@ package org.apache.helix;
  */
 
 import java.util.Properties;
+
 import org.apache.helix.model.CloudConfig;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
- * Hold Helix manager properties. The manager properties further hold Helix cloud properties
- * and some other properties specific for the manager.
+ * HelixManagerProperty is a general property/config object used for HelixManager creation.
  */
 public class HelixManagerProperty {
   private static final Logger LOG = LoggerFactory.getLogger(HelixManagerProperty.class.getName());
   private String _version;
   private long _healthReportLatency;
   private HelixCloudProperty _helixCloudProperty;
+  private RealmAwareZkClient.RealmAwareZkConnectionConfig _zkConnectionConfig;
+  private RealmAwareZkClient.RealmAwareZkClientConfig _zkClientConfig;
 
   /**
+   * ** Deprecated - HelixManagerProperty should be a general property/config object used for
+   * HelixManager creation, not tied only to Properties or CloudConfig **
+   *
    * Initialize Helix manager property with default value
    * @param helixManagerProperties helix manager related properties input as a map
    * @param cloudConfig cloudConfig read from Zookeeper
    */
+  @Deprecated
   public HelixManagerProperty(Properties helixManagerProperties, CloudConfig cloudConfig) {
     _helixCloudProperty = new HelixCloudProperty(cloudConfig);
     setVersion(helixManagerProperties.getProperty(SystemPropertyKeys.HELIX_MANAGER_VERSION));
@@ -46,28 +54,48 @@ public class HelixManagerProperty {
         helixManagerProperties.getProperty(SystemPropertyKeys.PARTICIPANT_HEALTH_REPORT_LATENCY));
   }
 
+  public HelixManagerProperty() {
+  }
+
   public HelixCloudProperty getHelixCloudProperty() {
     return _helixCloudProperty;
-  }
-
-  public String getVersion() {
-    return _version;
-  }
-
-  public long getHealthReportLatency() {
-    return _healthReportLatency;
   }
 
   public void setHelixCloudProperty(HelixCloudProperty helixCloudProperty) {
     _helixCloudProperty = helixCloudProperty;
   }
 
+  public String getVersion() {
+    return _version;
+  }
+
   public void setVersion(String version) {
     _version = version;
   }
 
+  public long getHealthReportLatency() {
+    return _healthReportLatency;
+  }
+
   public void setHealthReportLatency(String latency) {
     _healthReportLatency = Long.valueOf(latency);
+  }
+
+  public RealmAwareZkClient.RealmAwareZkConnectionConfig getZkConnectionConfig() {
+    return _zkConnectionConfig;
+  }
+
+  public void setZkConnectionConfig(
+      RealmAwareZkClient.RealmAwareZkConnectionConfig zkConnectionConfig) {
+    _zkConnectionConfig = zkConnectionConfig;
+  }
+
+  public RealmAwareZkClient.RealmAwareZkClientConfig getZkClientConfig() {
+    return _zkClientConfig;
+  }
+
+  public void setZkClientConfig(RealmAwareZkClient.RealmAwareZkClientConfig zkClientConfig) {
+    _zkClientConfig = zkClientConfig;
   }
 
   // TODO: migrate all other participant related properties to this file.

--- a/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
@@ -88,8 +88,9 @@ public final class HelixPropertyFactory {
     CloudConfig cloudConfig;
     RealmAwareZkClient dedicatedZkClient = null;
     try {
-      if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED)) {
-        // If the multi ZK config is enabled, use multi-realm mode with DedicatedZkClient
+      if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddress == null) {
+        // If the multi ZK config is enabled or zkAddress is null, use realm-aware mode with
+        // DedicatedZkClient
         try {
           RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =
               new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder()

--- a/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
@@ -33,7 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/***
+/**
  * Singleton factory that builds different types of Helix property, e.g. Helix manager property.
  */
 public final class HelixPropertyFactory {

--- a/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
@@ -34,8 +34,11 @@ import org.slf4j.LoggerFactory;
 
 
 /**
+ * ** Deprecated in favor of HelixManagerProperty.Builder() **
+ *
  * Singleton factory that builds different types of Helix property, e.g. Helix manager property.
  */
+@Deprecated
 public final class HelixPropertyFactory {
   private static final Logger LOG = LoggerFactory.getLogger(HelixPropertyFactory.class);
   private static final String HELIX_PARTICIPANT_PROPERTY_FILE =
@@ -45,6 +48,7 @@ public final class HelixPropertyFactory {
     private static final HelixPropertyFactory INSTANCE = new HelixPropertyFactory();
   }
 
+  @Deprecated
   public static HelixPropertyFactory getInstance() {
     return SingletonHelper.INSTANCE;
   }
@@ -53,6 +57,7 @@ public final class HelixPropertyFactory {
    * Retrieve Helix manager property. It returns the property object with default values.
    * Clients may override these values.
    */
+  @Deprecated
   public HelixManagerProperty getHelixManagerProperty(String zkAddress, String clusterName) {
     CloudConfig cloudConfig = getCloudConfig(zkAddress, clusterName);
     Properties properties = new Properties();

--- a/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
@@ -33,12 +33,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/**
- * ** Deprecated in favor of HelixManagerProperty.Builder() **
- *
+/***
  * Singleton factory that builds different types of Helix property, e.g. Helix manager property.
  */
-@Deprecated
 public final class HelixPropertyFactory {
   private static final Logger LOG = LoggerFactory.getLogger(HelixPropertyFactory.class);
   private static final String HELIX_PARTICIPANT_PROPERTY_FILE =
@@ -48,7 +45,6 @@ public final class HelixPropertyFactory {
     private static final HelixPropertyFactory INSTANCE = new HelixPropertyFactory();
   }
 
-  @Deprecated
   public static HelixPropertyFactory getInstance() {
     return SingletonHelper.INSTANCE;
   }
@@ -57,7 +53,6 @@ public final class HelixPropertyFactory {
    * Retrieve Helix manager property. It returns the property object with default values.
    * Clients may override these values.
    */
-  @Deprecated
   public HelixManagerProperty getHelixManagerProperty(String zkAddress, String clusterName) {
     CloudConfig cloudConfig = getCloudConfig(zkAddress, clusterName);
     Properties properties = new Properties();

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -127,8 +127,8 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   /**
    * There are 2 realm-aware modes to connect to ZK:
-   * 1. if system property {@link SystemPropertyKeys#MULTI_ZK_ENABLED} is set to <code>"true"</code>,
-   * it will connect on multi-realm mode;
+   * 1. if system property {@link SystemPropertyKeys#MULTI_ZK_ENABLED} is set to <code>"true"</code>
+   * , or zkAddress is null, it will connect on multi-realm mode;
    * 2. otherwise, it will connect on single-realm mode to the <code>zkAddress</code> provided.
    *
    * @param zkAddress ZK address
@@ -146,7 +146,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     RealmAwareZkClient zkClient;
 
-    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED)) {
+    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddress == null) {
       try {
         zkClient = new FederatedZkClient(
             new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder().build(), clientConfig);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -1503,7 +1503,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
    * @return
    */
   private String getZkConnectionInfo() {
-    String zkConnectionInfo = null;
+    String zkConnectionInfo;
     if (_zkAddress == null) {
       if (_helixManagerProperty != null && _helixManagerProperty.getZkConnectionConfig() != null) {
         zkConnectionInfo = _helixManagerProperty.getZkConnectionConfig().toString();

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKUtil.java
@@ -614,7 +614,7 @@ public final class ZKUtil {
    * @return
    */
   private static RealmAwareZkClient getHelixZkClient(String zkAddr) {
-    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED)) {
+    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddr == null) {
       try {
         // Create realm-aware ZkClient.
         RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =
@@ -626,8 +626,8 @@ public final class ZKUtil {
         throw new HelixException("Not able to connect on realm-aware mode", e);
       }
     }
-    if (zkAddr == null || zkAddr.isEmpty()) {
-      throw new HelixException("ZK Address given is either null or empty!");
+    if (zkAddr.isEmpty()) {
+      throw new HelixException("ZK Address given is empty!");
     }
     HelixZkClient.ZkClientConfig clientConfig = new HelixZkClient.ZkClientConfig();
     clientConfig.setZkSerializer(new ZNRecordSerializer());

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -1337,7 +1337,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
   static RealmAwareZkClient buildRealmAwareZkClientWithDefaultConfigs(
       RealmAwareZkClient.RealmAwareZkClientConfig clientConfig, String zkAddress,
       ZkClientType zkClientType) {
-    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED)) {
+    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddress == null) {
       // If the multi ZK config is enabled, use multi-realm mode with FederatedZkClient
       try {
         return new FederatedZkClient(

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
@@ -82,7 +82,7 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
    * @param versionTTLms in ms
    */
   public ZkBucketDataAccessor(String zkAddr, int bucketSize, long versionTTLms) {
-    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED)) {
+    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddr == null) {
       try {
         // Create realm-aware ZkClient.
         RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
@@ -83,6 +83,9 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
    */
   public ZkBucketDataAccessor(String zkAddr, int bucketSize, long versionTTLms) {
     if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddr == null) {
+      LOG.warn(
+          "ZkBucketDataAccessor: either multi-zk enabled or zkAddr is null - "
+              + "starting ZkBucketDataAccessor in multi-zk mode!");
       try {
         // Create realm-aware ZkClient.
         RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterSetup.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterSetup.java
@@ -156,7 +156,7 @@ public class ClusterSetup {
   @Deprecated
   public ClusterSetup(String zkServerAddress) {
     // If the multi ZK config is enabled, use FederatedZkClient on multi-realm mode
-    if (Boolean.parseBoolean(System.getProperty(SystemPropertyKeys.MULTI_ZK_ENABLED))) {
+    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkServerAddress == null) {
       try {
         _zkClient = new FederatedZkClient(
             new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder().build(),

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
@@ -111,7 +111,7 @@ public abstract class ZkHelixClusterVerifier
       throw new IllegalArgumentException("ZkHelixClusterVerifier: clusterName is null or empty!");
     }
     // If the multi ZK config is enabled, use DedicatedZkClient on multi-realm mode
-    if (Boolean.parseBoolean(System.getProperty(SystemPropertyKeys.MULTI_ZK_ENABLED))) {
+    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddr == null) {
       try {
         RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder connectionConfigBuilder =
             new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder();
@@ -370,7 +370,7 @@ public abstract class ZkHelixClusterVerifier
     protected RealmAwareZkClient createZkClient(RealmAwareZkClient.RealmMode realmMode,
         RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig,
         RealmAwareZkClient.RealmAwareZkClientConfig clientConfig, String zkAddress) {
-      if (Boolean.parseBoolean(System.getProperty(SystemPropertyKeys.MULTI_ZK_ENABLED))) {
+      if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddress == null) {
         try {
           // First, try to create a RealmAwareZkClient that's a DedicatedZkClient
           return DedicatedZkClientFactory.getInstance()

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -377,6 +377,19 @@ public class TestMultiZkHelixJavaApis {
       // Expected
     }
 
+    // Test that HelixManager instantiation fails if both zkAddress and a valid ZkConnectionConfig
+    // are given
+    try {
+      HelixManager invalidManager = HelixManagerFactory
+          .getZKHelixManager(clusterName, participantName, InstanceType.PARTICIPANT, "zkAddress",
+              null, helixManagerProperty);
+      Assert.fail(
+          "Should see a HelixException here because the connection config are zkAddress are both "
+              + "set!");
+    } catch (HelixException e) {
+      // Expected
+    }
+
     // Connect as a participant
     helixManagerProperty.setZkConnectionConfig(validZkConnectionConfig);
     HelixManager managerParticipant = HelixManagerFactory

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -376,20 +376,6 @@ public class TestMultiZkHelixJavaApis {
       // Expected
     }
 
-    // Test that HelixManager instantiation fails if both zkAddress and a valid ZkConnectionConfig
-    // are given
-    try {
-      HelixManager invalidManager = HelixManagerFactory
-          .getZKHelixManager(clusterName, participantName, InstanceType.PARTICIPANT, "zkAddress",
-              null,
-              propertyBuilder.setRealmAWareZkConnectionConfig(validZkConnectionConfig).build());
-      Assert.fail(
-          "Should see a HelixException here because the connection config are zkAddress are both "
-              + "set!");
-    } catch (HelixException e) {
-      // Expected
-    }
-
     // Connect as a participant
     HelixManager managerParticipant = HelixManagerFactory
         .getZKHelixManager(clusterName, participantName, InstanceType.PARTICIPANT, null,

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -365,12 +365,11 @@ public class TestMultiZkHelixJavaApis {
         connectionConfigBuilder.build();
     RealmAwareZkClient.RealmAwareZkConnectionConfig validZkConnectionConfig =
         connectionConfigBuilder.setZkRealmShardingKey("/" + clusterName).build();
-    HelixManagerProperty helixManagerProperty = new HelixManagerProperty();
-    helixManagerProperty.setZkConnectionConfig(invalidZkConnectionConfig);
+    HelixManagerProperty.Builder propertyBuilder = new HelixManagerProperty.Builder();
     try {
       HelixManager invalidManager = HelixManagerFactory
           .getZKHelixManager(clusterName, participantName, InstanceType.PARTICIPANT, null,
-              helixManagerProperty);
+              propertyBuilder.setRealmAWareZkConnectionConfig(invalidZkConnectionConfig).build());
       Assert.fail("Should see a HelixException here because the connection config doesn't have the "
           + "sharding key set!");
     } catch (HelixException e) {
@@ -382,7 +381,8 @@ public class TestMultiZkHelixJavaApis {
     try {
       HelixManager invalidManager = HelixManagerFactory
           .getZKHelixManager(clusterName, participantName, InstanceType.PARTICIPANT, "zkAddress",
-              null, helixManagerProperty);
+              null,
+              propertyBuilder.setRealmAWareZkConnectionConfig(validZkConnectionConfig).build());
       Assert.fail(
           "Should see a HelixException here because the connection config are zkAddress are both "
               + "set!");
@@ -391,16 +391,15 @@ public class TestMultiZkHelixJavaApis {
     }
 
     // Connect as a participant
-    helixManagerProperty.setZkConnectionConfig(validZkConnectionConfig);
     HelixManager managerParticipant = HelixManagerFactory
         .getZKHelixManager(clusterName, participantName, InstanceType.PARTICIPANT, null,
-            helixManagerProperty);
+            propertyBuilder.setRealmAWareZkConnectionConfig(validZkConnectionConfig).build());
     managerParticipant.connect();
 
     // Connect as an administrator
     HelixManager managerAdministrator = HelixManagerFactory
         .getZKHelixManager(clusterName, participantName, InstanceType.ADMINISTRATOR, null,
-            helixManagerProperty);
+            propertyBuilder.setRealmAWareZkConnectionConfig(validZkConnectionConfig).build());
     managerAdministrator.connect();
 
     // Perform assert checks to make sure the manager can read and register itself as a participant

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -36,6 +36,9 @@ import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixException;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.HelixManagerProperty;
 import org.apache.helix.InstanceType;
 import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.TestHelper;
@@ -346,10 +349,66 @@ public class TestMultiZkHelixJavaApis {
   }
 
   /**
+   * Test creation of HelixManager and makes sure it connects correctly.
+   */
+  @Test(dependsOnMethods = "testCreateParticipants")
+  public void testZKHelixManager() throws Exception {
+    String clusterName = "CLUSTER_1";
+    String participantName = "HelixManager";
+    InstanceConfig instanceConfig = new InstanceConfig(participantName);
+    _zkHelixAdmin.addInstance(clusterName, instanceConfig);
+
+    RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder connectionConfigBuilder =
+        new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder();
+    // Try with a connection config without ZK realm sharding key set (should fail)
+    RealmAwareZkClient.RealmAwareZkConnectionConfig invalidZkConnectionConfig =
+        connectionConfigBuilder.build();
+    RealmAwareZkClient.RealmAwareZkConnectionConfig validZkConnectionConfig =
+        connectionConfigBuilder.setZkRealmShardingKey("/" + clusterName).build();
+    HelixManagerProperty helixManagerProperty = new HelixManagerProperty();
+    helixManagerProperty.setZkConnectionConfig(invalidZkConnectionConfig);
+    try {
+      HelixManager invalidManager = HelixManagerFactory
+          .getZKHelixManager(clusterName, participantName, InstanceType.PARTICIPANT, null,
+              helixManagerProperty);
+      Assert.fail("Should see a HelixException here because the connection config doesn't have the "
+          + "sharding key set!");
+    } catch (HelixException e) {
+      // Expected
+    }
+
+    // Connect as a participant
+    helixManagerProperty.setZkConnectionConfig(validZkConnectionConfig);
+    HelixManager managerParticipant = HelixManagerFactory
+        .getZKHelixManager(clusterName, participantName, InstanceType.PARTICIPANT, null,
+            helixManagerProperty);
+    managerParticipant.connect();
+
+    // Connect as an administrator
+    HelixManager managerAdministrator = HelixManagerFactory
+        .getZKHelixManager(clusterName, participantName, InstanceType.ADMINISTRATOR, null,
+            helixManagerProperty);
+    managerAdministrator.connect();
+
+    // Perform assert checks to make sure the manager can read and register itself as a participant
+    InstanceConfig instanceConfigRead = managerAdministrator.getClusterManagmentTool()
+        .getInstanceConfig(clusterName, participantName);
+    Assert.assertNotNull(instanceConfigRead);
+    Assert.assertEquals(instanceConfig.getInstanceName(), participantName);
+    Assert.assertNotNull(managerAdministrator.getHelixDataAccessor().getProperty(
+        managerAdministrator.getHelixDataAccessor().keyBuilder().liveInstance(participantName)));
+
+    // Clean up
+    managerParticipant.disconnect();
+    managerAdministrator.disconnect();
+    _zkHelixAdmin.dropInstance(clusterName, instanceConfig);
+  }
+
+  /**
    * Test that clusters and instances are set up properly.
    * Helix Java APIs tested in this method is ZkUtil.
    */
-  @Test(dependsOnMethods = "testCreateParticipants")
+  @Test(dependsOnMethods = "testZKHelixManager")
   public void testZkUtil() {
     CLUSTER_LIST.forEach(cluster -> {
       _zkHelixAdmin.getInstancesInCluster(cluster).forEach(instance -> ZKUtil
@@ -816,8 +875,7 @@ public class TestMultiZkHelixJavaApis {
         new ClusterSetup.Builder().setRealmAwareZkConnectionConfig(connectionConfig).build();
 
     try {
-      verifyMsdsZkRealm(CLUSTER_ONE, true,
-          () -> firstClusterSetup.addCluster(CLUSTER_ONE, false));
+      verifyMsdsZkRealm(CLUSTER_ONE, true, () -> firstClusterSetup.addCluster(CLUSTER_ONE, false));
       verifyMsdsZkRealm(CLUSTER_FOUR, false,
           () -> firstClusterSetup.addCluster(CLUSTER_FOUR, false));
 
@@ -852,8 +910,7 @@ public class TestMultiZkHelixJavaApis {
         new ZKHelixAdmin.Builder().setRealmAwareZkConnectionConfig(connectionConfig).build();
 
     try {
-      verifyMsdsZkRealm(CLUSTER_ONE, true,
-          () -> firstHelixAdmin.enableCluster(CLUSTER_ONE, true));
+      verifyMsdsZkRealm(CLUSTER_ONE, true, () -> firstHelixAdmin.enableCluster(CLUSTER_ONE, true));
       verifyMsdsZkRealm(CLUSTER_FOUR, false,
           () -> firstHelixAdmin.enableCluster(CLUSTER_FOUR, true));
 
@@ -876,8 +933,7 @@ public class TestMultiZkHelixJavaApis {
         new ConfigAccessor.Builder().setRealmAwareZkConnectionConfig(connectionConfig).build();
 
     try {
-      verifyMsdsZkRealm(CLUSTER_ONE, true,
-          () -> firstConfigAccessor.getClusterConfig(CLUSTER_ONE));
+      verifyMsdsZkRealm(CLUSTER_ONE, true, () -> firstConfigAccessor.getClusterConfig(CLUSTER_ONE));
       verifyMsdsZkRealm(CLUSTER_FOUR, false,
           () -> firstConfigAccessor.getClusterConfig(CLUSTER_FOUR));
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes #1182

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Previously, there wasn't a way to use HelixManager with a custom routing data ZK connection config. This new way of constructing HelixManager allows users to use HelixManager with a custom RealmAwareZkConnectionConfig.

### Tests

- [x] The following tests are written for this issue:

testZKHelixManager

- [x] The following is the result of the "mvn test" command on the appropriate module:

zookeeper-api:
```
[ERROR] Failures: 
[ERROR]   TestRawZkClient.testGetChildrenOnLargeNumChildren:908 Should not successfully get children.
[INFO] 
[ERROR] Tests run: 39, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
```
This is a known failure due to https://github.com/apache/helix/pull/1186

helix-core:

```
[ERROR] Failures: 
[ERROR]   TestZKCallback.testInvocation:188
[ERROR]   TestEnableCompression.testEnableCompressionResource:117 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1156, Failures: 2, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE

```
For the two failures, the tests were run individually.
```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 28.056 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```



### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)