### PR TITLE
Fix TestRawZkClient metric 

### DIFF
--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -290,7 +290,8 @@ public class TestRawZkClient extends ZkTestBase {
     Assert.assertEquals((long) beanServer.getAttribute(name, "StateChangeEventCounter"), 0);
     Assert.assertEquals((long) beanServer.getAttribute(name, "ExpiredSessionCounter"), 0);
     Assert.assertEquals((long) beanServer.getAttribute(name, "OutstandingRequestGauge"), 0);
-    Assert.assertEquals((long) beanServer.getAttribute(name, "TotalCallbackCounter"), 0);
+    // account for doAsyncSync()
+    Assert.assertEquals((long) beanServer.getAttribute(name, "TotalCallbackCounter"), 1);
 
     // Test exists
     Assert.assertEquals((long) beanServer.getAttribute(rootname, "ReadCounter"), 0);
@@ -414,8 +415,8 @@ public class TestRawZkClient extends ZkTestBase {
     Assert.assertTrue(callbackFinish.await(10, TimeUnit.SECONDS));
     Assert.assertEquals((long) beanServer.getAttribute(name, "DataChangeEventCounter"), 1);
     Assert.assertEquals((long) beanServer.getAttribute(name, "OutstandingRequestGauge"), 0);
-    Assert.assertEquals((long) beanServer.getAttribute(name, "TotalCallbackCounter"), 1);
-    Assert.assertEquals((long) beanServer.getAttribute(name, "TotalCallbackHandledCounter"), 1);
+    Assert.assertEquals((long) beanServer.getAttribute(name, "TotalCallbackCounter"), 2);
+    Assert.assertEquals((long) beanServer.getAttribute(name, "TotalCallbackHandledCounter"), 2);
     Assert.assertEquals((long) beanServer.getAttribute(name, "PendingCallbackGauge"), 0);
 
     // Simulate a delayed callback


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

fixes #1118 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

    Fix TestRawZkClient callbackcnt related metrics in ZkMonitor. In
    sum, sync() call is used asynchronously as the first request to
    ZooKeeper server. We just need to account metrics for this call.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

mvn test in zookeeper-api passed.

[INFO] -------------------------------------------------------
[INFO] Running TestSuite
Starting ZK server at localhost:2127
Starting TestFederatedZkClient
Ending TestFederatedZkClient
Starting ZK server at localhost:54402
Starting ZK server at localhost:54500
1    [Thread-61] ERROR org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks  - Interrupted waiting for success
java.lang.InterruptedException
	at java.lang.Object.wait(Native Method)
	at java.lang.Object.wait(Object.java:502)
	at org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks$DefaultCallback.waitForSuccess(ZkAsyncCallbacks.java:220)
	at org.apache.helix.zookeeper.impl.client.TestZkClientAsyncRetry.lambda$waitAsyncOperation$0(TestZkClientAsyncRetry.java:64)
	at java.lang.Thread.run(Thread.java:748)
28   [main] ERROR org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer  - Data size: 311979 is greater than 204800 bytes, is compressed: false, ZNRecord.id: record. Data will not be written to Zookeeper.
92   [main] ERROR org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer  - Data size: 5445 is greater than 2000 bytes, is compressed: true, ZNRecord.id: record. Data will not be written to Zookeeper.
109  [main] ERROR org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer  - Data size: 8821 is greater than 2000 bytes, is compressed: true, ZNRecord.id: Oversize. Data will not be written to Zookeeper.
124  [main] ERROR org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer  - Data size: 8821 is greater than 2000 bytes, is compressed: true, ZNRecord.id: Oversize. Data will not be written to Zookeeper.
Shut down zookeeper at port 2127 in thread TestNGInvoker-testConnectionLossWhileCreateEphemeral()
91484 [main] ERROR org.apache.helix.zookeeper.zkclient.ZkClient  - Failed to get children for path /testGetChildrenOnLargeNumChildren because of connection loss. Number of children 5 exceeds limit 2, aborting retry.
Shut down zookeeper at port 2127 in thread TestNGInvoker-testRetryUntilConnectedAfterConnectionLoss()
Keep creation thread retrying to connect for 10 seconds...
Trying to create ephemeral node...
Restarting zk server...
Ephemeral node created.
old sessionId= 72185780671807489
In New connection In process event:WatchedEvent state:SyncConnected type:None path:null
In Old connection New state Disconnected
In Old connection New state SyncConnected
In New connection In process event:WatchedEvent state:Disconnected type:None path:null
New sessionId= 72185780671807489
In New connection In process event:WatchedEvent state:SyncConnected type:None path:null
In Old connection New state Disconnected
In Old connection New state SyncConnected
In New connection In process event:WatchedEvent state:Disconnected type:None path:null
In New connection In process event:WatchedEvent state:SyncConnected type:None path:null
In Old connection New state Disconnected
In Old connection New state Expired
In Old connection New state SyncConnected
In Old connection New session
After session expiry sessionId= 72185787018051585
Shut down zookeeper at port 2127 in thread main
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 615.105 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10:19 min
[INFO] Finished at: 2020-07-28T19:38:31-07:00
[INFO] ------------------------------------------------------------------------
ksun-mn1:zookeeper-api ksun$ mvn test 


### Commits

- [ ] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [ ] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)