### PR TITLE
Add latency metric support for customized view aggregation

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/InstanceType.java
+++ b/helix-core/src/main/java/org/apache/helix/InstanceType.java
@@ -38,7 +38,7 @@ public enum InstanceType {
       MonitorDomainNames.HelixZkClient.name(),
       MonitorDomainNames.HelixCallback.name(),
       MonitorDomainNames.Rebalancer.name(),
-      MonitorDomainNames.CustomizedView.name()
+      MonitorDomainNames.AggregatedView.name()
   }),
 
   PARTICIPANT(new String[] {
@@ -55,7 +55,7 @@ public enum InstanceType {
       MonitorDomainNames.HelixThreadPoolExecutor.name(),
       MonitorDomainNames.CLMParticipantReport.name(),
       MonitorDomainNames.Rebalancer.name(),
-      MonitorDomainNames.CustomizedView.name()
+      MonitorDomainNames.AggregatedView.name()
   }),
 
   SPECTATOR(new String[] {

--- a/helix-core/src/main/java/org/apache/helix/InstanceType.java
+++ b/helix-core/src/main/java/org/apache/helix/InstanceType.java
@@ -37,7 +37,8 @@ public enum InstanceType {
       MonitorDomainNames.ClusterStatus.name(),
       MonitorDomainNames.HelixZkClient.name(),
       MonitorDomainNames.HelixCallback.name(),
-      MonitorDomainNames.Rebalancer.name()
+      MonitorDomainNames.Rebalancer.name(),
+      MonitorDomainNames.CustomizedView.name()
   }),
 
   PARTICIPANT(new String[] {
@@ -53,7 +54,8 @@ public enum InstanceType {
       MonitorDomainNames.HelixCallback.name(),
       MonitorDomainNames.HelixThreadPoolExecutor.name(),
       MonitorDomainNames.CLMParticipantReport.name(),
-      MonitorDomainNames.Rebalancer.name()
+      MonitorDomainNames.Rebalancer.name(),
+      MonitorDomainNames.CustomizedView.name()
   }),
 
   SPECTATOR(new String[] {

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.management.JMException;
 
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixDataAccessor;
@@ -38,7 +37,6 @@ import org.apache.helix.common.caches.CustomizedViewCache;
 import org.apache.helix.common.caches.PropertyCache;
 import org.apache.helix.controller.LogUtil;
 import org.apache.helix.controller.pipeline.Pipeline;
-import org.apache.helix.controller.stages.ClusterEvent;
 import org.apache.helix.controller.stages.MissingTopStateRecord;
 import org.apache.helix.model.CustomizedState;
 import org.apache.helix.model.CustomizedStateConfig;
@@ -46,7 +44,6 @@ import org.apache.helix.model.CustomizedView;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.ResourceAssignment;
-import org.apache.helix.monitoring.mbeans.CustomizedViewMonitor;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,7 +79,6 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
   // Maintain a set of all ChangeTypes for change detection
   private Set<HelixConstants.ChangeType> _refreshedChangeTypes;
   private Set<String> _aggregationEnabledTypes = new HashSet<>();
-  private Map<String, CustomizedViewMonitor> _customizedViewMonitors = new HashMap<>();
 
   // CrushEd strategy needs to have a stable partition list input. So this cached list persist the
   // previous seen partition lists. If the members in a list are not modified, the old list will be
@@ -441,17 +437,6 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
   public void clearMonitoringRecords() {
     _missingTopStateMap.clear();
     _lastTopStateLocationMap.clear();
-  }
-
-  public synchronized CustomizedViewMonitor getOrCreateCustomizedViewMonitor(ClusterEvent event)
-      throws JMException {
-    String clusterName = event.getClusterName();
-    if (_customizedViewMonitors.get(clusterName) == null) {
-      CustomizedViewMonitor monitor = new CustomizedViewMonitor(clusterName);
-      _customizedViewMonitors.put(clusterName, monitor);
-      monitor.register();
-    }
-    return _customizedViewMonitors.get(clusterName);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.management.JMException;
 
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixDataAccessor;
@@ -37,6 +38,7 @@ import org.apache.helix.common.caches.CustomizedViewCache;
 import org.apache.helix.common.caches.PropertyCache;
 import org.apache.helix.controller.LogUtil;
 import org.apache.helix.controller.pipeline.Pipeline;
+import org.apache.helix.controller.stages.ClusterEvent;
 import org.apache.helix.controller.stages.MissingTopStateRecord;
 import org.apache.helix.model.CustomizedState;
 import org.apache.helix.model.CustomizedStateConfig;
@@ -44,6 +46,7 @@ import org.apache.helix.model.CustomizedView;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.ResourceAssignment;
+import org.apache.helix.monitoring.mbeans.CustomizedViewMonitor;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,6 +82,7 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
   // Maintain a set of all ChangeTypes for change detection
   private Set<HelixConstants.ChangeType> _refreshedChangeTypes;
   private Set<String> _aggregationEnabledTypes = new HashSet<>();
+  private Map<String, CustomizedViewMonitor> _customizedViewMonitors = new HashMap<>();
 
   // CrushEd strategy needs to have a stable partition list input. So this cached list persist the
   // previous seen partition lists. If the members in a list are not modified, the old list will be
@@ -437,6 +441,17 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
   public void clearMonitoringRecords() {
     _missingTopStateMap.clear();
     _lastTopStateLocationMap.clear();
+  }
+
+  public synchronized CustomizedViewMonitor getOrCreateCustomizedViewMonitor(ClusterEvent event)
+      throws JMException {
+    String clusterName = event.getClusterName();
+    if (_customizedViewMonitors.get(clusterName) == null) {
+      CustomizedViewMonitor monitor = new CustomizedViewMonitor(clusterName);
+      _customizedViewMonitors.put(clusterName, monitor);
+      monitor.register();
+    }
+    return _customizedViewMonitors.get(clusterName);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
@@ -86,6 +86,9 @@ public class CustomizedStateComputationStage extends AbstractBaseStage {
           customizedStateOutput
               .setCustomizedState(customizedStateType, resourceName, partition, instanceName,
                   customizedState.getState(partitionName));
+          customizedStateOutput
+              .setStartTime(customizedStateType, resourceName, partition, instanceName,
+                  String.valueOf(customizedState.getStartTime(partitionName)));
         }
       }
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateComputationStage.java
@@ -32,7 +32,6 @@ import org.apache.helix.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class CustomizedStateComputationStage extends AbstractBaseStage {
   private static Logger LOG = LoggerFactory.getLogger(CustomizedStateComputationStage.class);
 
@@ -85,10 +84,8 @@ public class CustomizedStateComputationStage extends AbstractBaseStage {
         if (partition != null) {
           customizedStateOutput
               .setCustomizedState(customizedStateType, resourceName, partition, instanceName,
-                  customizedState.getState(partitionName));
-          customizedStateOutput
-              .setStartTime(customizedStateType, resourceName, partition, instanceName,
-                  String.valueOf(customizedState.getStartTime(partitionName)));
+                  customizedState.getState(partitionName),
+                  customizedState.getStartTime(partitionName));
         }
       }
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateOutput.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateOutput.java
@@ -70,9 +70,8 @@ public class CustomizedStateOutput {
     return Collections.emptyMap();
   }
 
-  public Map<String, Map<Partition, Map<String, Long>>> getStartTimeMap(String stateType) {
-    return Collections
-        .unmodifiableMap(_startTimeMap.getOrDefault(stateType, Collections.emptyMap()));
+  private Map<String, Map<Partition, Map<String, Long>>> getStartTimeMap(String stateType) {
+    return _startTimeMap.getOrDefault(stateType, Collections.emptyMap());
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateOutput.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedStateOutput.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 
 
 public class CustomizedStateOutput {
-  private static Logger LOG = LoggerFactory.getLogger(CustomizedStateOutput.class);
+  private static final Logger LOG = LoggerFactory.getLogger(CustomizedStateOutput.class);
 
   // stateType -> (resourceName -> (Partition -> (instanceName -> customizedState)))
   private final Map<String, Map<String, Map<Partition, Map<String, String>>>> _customizedStateMap;
@@ -67,20 +67,15 @@ public class CustomizedStateOutput {
         mapToUpdate = _startTimeMap;
         break;
       default:
-        LOG.error(
+        LOG.warn(
             "The customized state property is not supported, could not update customized state output.");
         return;
     }
-    if (!mapToUpdate.containsKey(stateType)) {
-      mapToUpdate.put(stateType, new HashMap<String, Map<Partition, Map<String, String>>>());
-    }
-    if (!mapToUpdate.get(stateType).containsKey(resourceName)) {
-      mapToUpdate.get(stateType).put(resourceName, new HashMap<Partition, Map<String, String>>());
-    }
-    if (!mapToUpdate.get(stateType).get(resourceName).containsKey(partition)) {
-      mapToUpdate.get(stateType).get(resourceName).put(partition, new HashMap<String, String>());
-    }
-    mapToUpdate.get(stateType).get(resourceName).get(partition).put(instanceName, state);
+
+    mapToUpdate.computeIfAbsent(stateType, k -> new HashMap<>())
+        .computeIfAbsent(resourceName, k -> new HashMap<>())
+        .computeIfAbsent(partition, k -> new HashMap<>())
+        .put(instanceName, state);
   }
 
   /**
@@ -110,7 +105,7 @@ public class CustomizedStateOutput {
         readFromMap = _startTimeMap;
         break;
       default:
-        LOG.error(
+        LOG.warn(
             "The customized state property is not supported, could not read from customized state output.");
         return Collections.emptyMap();
     }
@@ -168,7 +163,6 @@ public class CustomizedStateOutput {
     }
     return null;
   }
-
 
   public Map<Partition, Map<String, String>> getResourceStartTimeMap(String stateType,
       String resourceName) {

--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
@@ -54,8 +54,7 @@ public class CustomizedStateProvider {
   public void updateCustomizedState(String customizedStateName, String resourceName,
       String partitionName, String customizedState) {
     Map<String, String> customizedStateMap = new HashMap<>();
-    customizedStateMap
-        .put(CustomizedState.CustomizedStateProperty.CURRENT_STATE.name(), customizedState);
+    customizedStateMap.put(CustomizedState.CustomizedStateProperty.CURRENT_STATE.name(), customizedState);
     updateCustomizedState(customizedStateName, resourceName, partitionName, customizedStateMap);
   }
 
@@ -114,11 +113,7 @@ public class CustomizedStateProvider {
     _helixDataAccessor.updateProperty(propertyKey, new DataUpdater<ZNRecord>() {
       @Override
       public ZNRecord update(ZNRecord current) {
-        Map<String, String> customizedStateMap = new HashMap<>();
-        // Update start time field for monitoring purpose, updated value is current time
-        customizedStateMap.put(CustomizedState.CustomizedStateProperty.START_TIME.name(),
-            String.valueOf(System.currentTimeMillis()));
-        current.getMapFields().put(partitionName, customizedStateMap);
+        current.getMapFields().remove(partitionName);
         return current;
       }
     }, existingState);

--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
@@ -54,7 +54,8 @@ public class CustomizedStateProvider {
   public void updateCustomizedState(String customizedStateName, String resourceName,
       String partitionName, String customizedState) {
     Map<String, String> customizedStateMap = new HashMap<>();
-    customizedStateMap.put(CustomizedState.CustomizedStateProperty.CURRENT_STATE.name(), customizedState);
+    customizedStateMap
+        .put(CustomizedState.CustomizedStateProperty.CURRENT_STATE.name(), customizedState);
     updateCustomizedState(customizedStateName, resourceName, partitionName, customizedStateMap);
   }
 
@@ -68,6 +69,9 @@ public class CustomizedStateProvider {
     PropertyKey propertyKey =
         keyBuilder.customizedState(_instanceName, customizedStateName, resourceName);
     ZNRecord record = new ZNRecord(resourceName);
+    // Update start time field for monitoring purpose, updated value is current time
+    customizedStateMap.put(CustomizedState.CustomizedStateProperty.START_TIME.name(),
+        String.valueOf(System.currentTimeMillis()));
     record.setMapField(partitionName, customizedStateMap);
     if (!_helixDataAccessor.updateProperty(propertyKey, new CustomizedState(record))) {
       throw new HelixException(String
@@ -110,7 +114,11 @@ public class CustomizedStateProvider {
     _helixDataAccessor.updateProperty(propertyKey, new DataUpdater<ZNRecord>() {
       @Override
       public ZNRecord update(ZNRecord current) {
-        current.getMapFields().remove(partitionName);
+        Map<String, String> customizedStateMap = new HashMap<>();
+        // Update start time field for monitoring purpose, updated value is current time
+        customizedStateMap.put(CustomizedState.CustomizedStateProperty.START_TIME.name(),
+            String.valueOf(System.currentTimeMillis()));
+        current.getMapFields().put(partitionName, customizedStateMap);
         return current;
       }
     }, existingState);

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -334,6 +334,11 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     }
   }
 
+  /**
+   * Lazy initialization of customized view monitor
+   * @param clusterName the cluster name of the cluster to be monitored
+   * @return a customized view monitor instance
+   */
   public synchronized CustomizedViewMonitor getOrCreateCustomizedViewMonitor(String clusterName) {
     if (_customizedViewMonitor == null) {
       _customizedViewMonitor = new CustomizedViewMonitor(clusterName);

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -96,6 +96,8 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   protected final ConcurrentHashMap<String, ClusterEventMonitor> _clusterEventMonitorMap =
       new ConcurrentHashMap<>();
 
+  private CustomizedViewMonitor _customizedViewMonitor;
+
   /**
    * PerInstanceResource monitor map: beanName->monitor
    */
@@ -330,6 +332,18 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     if (monitor != null) {
       monitor.reportDuration(duration);
     }
+  }
+
+  public synchronized CustomizedViewMonitor getOrCreateCustomizedViewMonitor(String clusterName) {
+    if (_customizedViewMonitor == null) {
+      _customizedViewMonitor = new CustomizedViewMonitor(clusterName);
+      try {
+        _customizedViewMonitor.register();
+      } catch (JMException e) {
+        LOG.error("Failed to register CustomizedViewMonitorMBean for cluster " + _clusterName, e);
+      }
+    }
+    return _customizedViewMonitor;
   }
 
   private ClusterEventMonitor getOrCreateClusterEventMonitor(String phase) {

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/CustomizedViewMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/CustomizedViewMonitor.java
@@ -1,0 +1,190 @@
+package org.apache.helix.monitoring.mbeans;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.management.JMException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
+import org.apache.helix.model.CustomizedView;
+import org.apache.helix.model.Partition;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.collections.Lists;
+
+
+public class CustomizedViewMonitor extends DynamicMBeanProvider {
+  private static Logger LOG = LoggerFactory.getLogger(CustomizedViewMonitor.class);
+
+  private static final String MBEAN_DESCRIPTION = "Helix Customized View Aggregation Monitor";
+  private final String _clusterName;
+  private final String _sensorName;
+  private HistogramDynamicMetric _updateToAggregationLatencyGauge;
+
+  public CustomizedViewMonitor(String clusterName) {
+    _clusterName = clusterName;
+    _sensorName =
+        String.format("%s.%s", MonitorDomainNames.RoutingTableProvider.name(), _clusterName);
+    _updateToAggregationLatencyGauge = new HistogramDynamicMetric("UpdateToAggregationLatencyGauge",
+        new Histogram(
+            new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));
+  }
+
+  @Override
+  public DynamicMBeanProvider register() throws JMException {
+    List<DynamicMetric<?, ?>> attributeList = new ArrayList<>();
+    attributeList.add(_updateToAggregationLatencyGauge);
+    doRegister(attributeList, MBEAN_DESCRIPTION, getMBeanName());
+    return this;
+  }
+
+  private ObjectName getMBeanName() throws MalformedObjectNameException {
+    return new ObjectName(String
+        .format("%s:%s=%s", MonitorDomainNames.CustomizedView.name(), "Cluster", _clusterName));
+  }
+
+  @Override
+  public String getSensorName() {
+    return _sensorName;
+  }
+
+  private void recordUpdateToAggregationLatency(long latency) {
+    if (_updateToAggregationLatencyGauge != null) {
+      _updateToAggregationLatencyGauge.updateValue(latency);
+    }
+  }
+
+  /**
+   * Find updated customized states and report the aggregation latency of each customized state
+   * @param updatedCustomizedViews Customized views that have been updated, obtained from CustomizedStateOutput
+   * @param curCustomizedViews Current customized view values from the CustomizedViewCache
+   * @param updatedStartTimestamps All customized state START_TIME property values from CustomizedStateOutput
+   * @param updateSuccess If the customized view update to ZK is successful or not
+   * @param endTime The timestamp when the new customized view is updated to ZK
+   */
+  public void reportLatency(List<CustomizedView> updatedCustomizedViews,
+      Map<String, CustomizedView> curCustomizedViews,
+      Map<String, Map<Partition, Map<String, String>>> updatedStartTimestamps,
+      boolean[] updateSuccess, long endTime) {
+    for (int i = 0; i < updatedCustomizedViews.size(); i++) {
+      if (!updateSuccess[i]) {
+        continue;
+      }
+      CustomizedView updatedCustomizedView = updatedCustomizedViews.get(i);
+      String resourceName = updatedCustomizedView.getResourceName();
+      CustomizedView curCustomizedView =
+          curCustomizedViews.getOrDefault(resourceName, new CustomizedView(resourceName));
+      List<Long> startTimestamps = getStartTimestamps(updatedCustomizedView, curCustomizedView,
+          updatedStartTimestamps.get(resourceName));
+      startTimestamps.forEach(startTime -> recordUpdateToAggregationLatency(endTime - startTime));
+    }
+  }
+
+  private List<Long> getStartTimestamps(CustomizedView newCV, CustomizedView oldCV,
+      Map<Partition, Map<String, String>> partitionStartTimestamps) {
+    List<Long> collectedTimestamps = Lists.newArrayList();
+
+    if (newCV == null || oldCV == null || partitionStartTimestamps == null) {
+      LOG.warn(
+          "Cannot find updated time stamps for customized state at resource level, input parameter is null.");
+      return collectedTimestamps;
+    }
+    MapDifference<String, Map<String, String>> diff =
+        Maps.difference(newCV.getRecord().getMapFields(), oldCV.getRecord().getMapFields());
+
+    // Resource level value diff
+    Map<String, MapDifference.ValueDifference<Map<String, String>>> resourceDiffs =
+        diff.entriesDiffering();
+    if (resourceDiffs != null) {
+      resourceDiffs.forEach((key, value) -> {
+        compareAtPartitionLevel(key, value.leftValue(), value.rightValue(),
+            partitionStartTimestamps, collectedTimestamps);
+      });
+    }
+
+    // Resource level left only - newly added resource
+    Map<String, Map<String, String>> leftOnlyResourceStateMap = diff.entriesOnlyOnLeft();
+    if (leftOnlyResourceStateMap != null) {
+      leftOnlyResourceStateMap.forEach((key, value) -> {
+        compareAtPartitionLevel(key, value, Maps.newHashMap(), partitionStartTimestamps,
+            collectedTimestamps);
+      });
+    }
+
+    // Resource level right only - newly deleted resource
+    Map<String, Map<String, String>> rightOnlyResourceStateMap = diff.entriesOnlyOnRight();
+    if (rightOnlyResourceStateMap != null) {
+      rightOnlyResourceStateMap.forEach((key, value) -> {
+        compareAtPartitionLevel(key, Maps.newHashMap(), value, partitionStartTimestamps,
+            collectedTimestamps);
+      });
+    }
+
+    return collectedTimestamps;
+  }
+
+  private void compareAtPartitionLevel(String resourceName, Map<String, String> newStateMap,
+      Map<String, String> oldStateMap, Map<Partition, Map<String, String>> partitionStartTimeMaps,
+      List<Long> collectedTimestamps) {
+    if (newStateMap == null || oldStateMap == null || partitionStartTimeMaps == null
+        || collectedTimestamps == null) {
+      LOG.warn(
+          "Cannot find updated time stamps for customized state at partition level, input parameter is null.");
+      return;
+    }
+
+    Map<String, String> partitionStartTimeMap =
+        partitionStartTimeMaps.getOrDefault(new Partition(resourceName), Collections.emptyMap());
+    // Partition level comparison
+    MapDifference<String, String> stateMapDiff = Maps.difference(newStateMap, oldStateMap);
+
+    // Partition level value diff
+    Map<String, MapDifference.ValueDifference<String>> stateMapValueDiff =
+        stateMapDiff.entriesDiffering();
+    if (stateMapValueDiff != null) {
+      stateMapValueDiff
+          .forEach((key, value) -> parseTimestamp(partitionStartTimeMap, key, collectedTimestamps));
+    }
+
+    // Partition level left only -> newly added state
+    Map<String, String> leftOnlyStateMapDiff = stateMapDiff.entriesOnlyOnLeft();
+    if (leftOnlyStateMapDiff != null) {
+      leftOnlyStateMapDiff
+          .forEach((key, value) -> parseTimestamp(partitionStartTimeMap, key, collectedTimestamps));
+    }
+
+    // Partition level right only -> newly deleted state
+    Map<String, String> rightOnlyStateMapDiff = stateMapDiff.entriesOnlyOnRight();
+    if (rightOnlyStateMapDiff != null) {
+      rightOnlyStateMapDiff
+          .forEach((key, value) -> parseTimestamp(partitionStartTimeMap, key, collectedTimestamps));
+    }
+  }
+
+  private void parseTimestamp(Map<String, String> source, String instanceName,
+      List<Long> collectedTimestamps) {
+    if (source.get(instanceName) != null) {
+      try {
+        long timestamp = Long.parseLong(source.get(instanceName));
+        if (timestamp > 0) {
+          collectedTimestamps.add(timestamp);
+          return;
+        }
+      } catch (NumberFormatException e) {
+        LOG.warn("Error occurs while parsing customized state update time stamp");
+      }
+      LOG.warn(
+          "Failed to report latency, customized state is updated but no update time stamp found.");
+    }
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/CustomizedViewMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/CustomizedViewMonitor.java
@@ -38,7 +38,6 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.HistogramDynamicMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class CustomizedViewMonitor extends DynamicMBeanProvider {
   private static final Logger LOG = LoggerFactory.getLogger(CustomizedViewMonitor.class);
 
@@ -46,7 +45,8 @@ public class CustomizedViewMonitor extends DynamicMBeanProvider {
   private final String _clusterName;
   private final String _sensorName;
   private HistogramDynamicMetric _updateToAggregationLatencyGauge;
-  public static final String UPDATE_TO_AGGREGATION_LATENCY_GAUGE = "UpdateToAggregationLatencyGauge";
+  public static final String UPDATE_TO_AGGREGATION_LATENCY_GAUGE =
+      "UpdateToAggregationLatencyGauge";
 
   public CustomizedViewMonitor(String clusterName) {
     _clusterName = clusterName;

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/CustomizedViewMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/CustomizedViewMonitor.java
@@ -47,6 +47,7 @@ public class CustomizedViewMonitor extends DynamicMBeanProvider {
   private HistogramDynamicMetric _updateToAggregationLatencyGauge;
   public static final String UPDATE_TO_AGGREGATION_LATENCY_GAUGE =
       "UpdateToAggregationLatencyGauge";
+  private ClusterStatusMonitor _clusterStatusMonitor;
 
   public CustomizedViewMonitor(String clusterName) {
     _clusterName = clusterName;
@@ -66,7 +67,8 @@ public class CustomizedViewMonitor extends DynamicMBeanProvider {
 
   private ObjectName getMBeanName() throws MalformedObjectNameException {
     return new ObjectName(String
-        .format("%s:%s=%s", MonitorDomainNames.AggregatedView.name(), "Cluster", _clusterName));
+        .format("%s:%s=%s,%s=%s", MonitorDomainNames.AggregatedView.name(), "Type",
+            "CustomizedView", "Cluster", _clusterName));
   }
 
   @Override
@@ -82,9 +84,12 @@ public class CustomizedViewMonitor extends DynamicMBeanProvider {
 
   /**
    * Find updated customized states and report the aggregation latency of each customized state
+   * Latency reporting excludes: updating a customized state that is the same as previous customized state,
+   * deleting a customized state
    * @param updatedCustomizedViews Customized views that have been updated, obtained from CustomizedStateOutput
    * @param curCustomizedViews Current customized view values from the CustomizedViewCache
-   * @param updatedStartTimestamps All customized state START_TIME property values from CustomizedStateOutput
+   * @param updatedStartTimestamps All customized state START_TIME property values from CustomizedStateOutput.
+   * START_TIME field is automatically updated when a customized state for a partition is updated by CustomizedStateProvider.
    * @param updateSuccess If the customized view update to ZK is successful or not
    * @param endTime The timestamp when the new customized view is updated to ZK
    */

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/CustomizedViewMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/CustomizedViewMonitor.java
@@ -91,7 +91,7 @@ public class CustomizedViewMonitor extends DynamicMBeanProvider {
   public void reportLatency(List<CustomizedView> updatedCustomizedViews,
       Map<String, CustomizedView> curCustomizedViews,
       Map<String, Map<Partition, Map<String, Long>>> updatedStartTimestamps,
-      boolean[] updateSuccess, long endTime) {
+      boolean[] updateSuccess, long endTime, String clusterName) {
     if (updatedCustomizedViews == null || curCustomizedViews == null
         || updatedStartTimestamps == null) {
       LOG.warn("Cannot find updated time stamps for customized states, input parameter is null.");
@@ -101,11 +101,15 @@ public class CustomizedViewMonitor extends DynamicMBeanProvider {
     List<Long> collectedTimestamps = new ArrayList<>();
 
     for (int i = 0; i < updatedCustomizedViews.size(); i++) {
-      if (!updateSuccess[i]) {
-        continue;
-      }
       CustomizedView newCV = updatedCustomizedViews.get(i);
       String resourceName = newCV.getResourceName();
+
+      if (!updateSuccess[i]) {
+        LOG.warn("Customized views are not updated successfully for resource {} on cluster {}",
+            resourceName, clusterName);
+        continue;
+      }
+
       CustomizedView oldCV =
           curCustomizedViews.getOrDefault(resourceName, new CustomizedView(resourceName));
 
@@ -132,8 +136,8 @@ public class CustomizedViewMonitor extends DynamicMBeanProvider {
                 collectedTimestamps.add(timestamp);
               } else {
                 LOG.warn(
-                    "Failed to find customized state update time stamp for resource {} partition {} on instance {}, the number should be positive.",
-                    resourceName, partitionName, instanceName);
+                    "Failed to find customized state update time stamp for resource {} partition {}, instance {}, on cluster {} the number should be positive.",
+                    resourceName, partitionName, instanceName, clusterName);
               }
             }
           }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/CustomizedViewMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/CustomizedViewMonitor.java
@@ -78,8 +78,6 @@ public class CustomizedViewMonitor extends DynamicMBeanProvider {
   }
 
   public void recordUpdateToAggregationLatency(long latency) {
-    if (_updateToAggregationLatencyGauge != null) {
-      _updateToAggregationLatencyGauge.updateValue(latency);
-    }
+    _updateToAggregationLatencyGauge.updateValue(latency);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestCustomizedViewStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestCustomizedViewStage.java
@@ -160,9 +160,6 @@ public class TestCustomizedViewStage extends ZkUnitTestBase {
         CustomizedViewMonitor.UPDATE_TO_AGGREGATION_LATENCY_GAUGE + ".Max") != 0,
         TestHelper.WAIT_DURATION);
 
-    if (manager.isConnected()) {
-      manager.disconnect(); // For DummyClusterManager, this is not necessary
-    }
     deleteLiveInstances(clusterName);
     deleteCluster(clusterName);
   }

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestCustomizedViewStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestCustomizedViewStage.java
@@ -21,6 +21,8 @@ package org.apache.helix.controller.stages;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
 
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
@@ -34,6 +36,8 @@ import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.CustomizedState;
 import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.CustomizedView;
+import org.apache.helix.monitoring.mbeans.CustomizedViewMonitor;
+import org.apache.helix.monitoring.mbeans.MonitorDomainNames;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -54,14 +58,8 @@ public class TestCustomizedViewStage extends ZkUnitTestBase {
 
     // ideal state: node0 is MASTER, node1 is SLAVE
     // replica=2 means 1 master and 1 slave
-    setupIdealState(clusterName, new int[] {
-        0, 1
-    }, new String[] {
-        "TestDB"
-    }, 1, 2);
-    setupLiveInstances(clusterName, new int[] {
-        0, 1
-    });
+    setupIdealState(clusterName, new int[]{0, 1}, new String[]{"TestDB"}, 1, 2);
+    setupLiveInstances(clusterName, new int[]{0, 1});
     setupStateModel(clusterName);
 
     ClusterEvent event = new ClusterEvent(ClusterEventType.Unknown);
@@ -105,6 +103,62 @@ public class TestCustomizedViewStage extends ZkUnitTestBase {
       Assert.assertEquals(oldCustomizedViews.get(i).getStat().getVersion(),
           newCustomizedViews.get(i).getStat().getVersion());
     }
+
+    if (manager.isConnected()) {
+      manager.disconnect(); // For DummyClusterManager, this is not necessary
+    }
+    deleteLiveInstances(clusterName);
+    deleteCluster(clusterName);
+  }
+
+  @Test
+  public void testLatencyMetricReporting() throws Exception {
+    String clusterName = "CLUSTER_" + TestHelper.getTestMethodName();
+
+    HelixDataAccessor accessor =
+        new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_gZkClient));
+    HelixManager manager = new DummyClusterManager(clusterName, accessor);
+
+    // ideal state: node0 is MASTER, node1 is SLAVE
+    // replica=2 means 1 master and 1 slave
+    setupIdealState(clusterName, new int[]{0, 1}, new String[]{"TestDB"}, 1, 2);
+    setupLiveInstances(clusterName, new int[]{0, 1});
+    setupStateModel(clusterName);
+
+    ClusterEvent event = new ClusterEvent(clusterName, ClusterEventType.Unknown);
+    ResourceControllerDataProvider cache = new ResourceControllerDataProvider(clusterName);
+    event.addAttribute(AttributeName.helixmanager.name(), manager);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(), cache);
+
+    CustomizedStateConfig config = new CustomizedStateConfig();
+    List<String> aggregationEnabledTypes = new ArrayList<>();
+    aggregationEnabledTypes.add(CUSTOMIZED_STATE_NAME);
+    config.setAggregationEnabledTypes(aggregationEnabledTypes);
+
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    accessor.setProperty(keyBuilder.customizedStateConfig(), config);
+
+    CustomizedState customizedState = new CustomizedState(RESOURCE_NAME);
+    customizedState.setState(PARTITION_NAME, "STATE");
+    customizedState.setStartTime(PARTITION_NAME, 0);
+    accessor.setProperty(
+        keyBuilder.customizedState(INSTANCE_NAME, CUSTOMIZED_STATE_NAME, RESOURCE_NAME),
+        customizedState);
+
+    Pipeline dataRefresh = new Pipeline();
+    dataRefresh.addStage(new ReadClusterDataStage());
+    runPipeline(event, dataRefresh);
+    runStage(event, new ResourceComputationStage());
+    runStage(event, new CustomizedStateComputationStage());
+    runStage(event, new CustomizedViewAggregationStage());
+
+    ObjectName objectName = new ObjectName(String
+        .format("%s:%s=%s", MonitorDomainNames.CustomizedView.name(), "Cluster", clusterName));
+    ObjectInstance monitor = _server.getObjectInstance(objectName);
+    Assert.assertNotNull(monitor);
+    TestHelper.verify(() -> (long) _server.getAttribute(objectName,
+        CustomizedViewMonitor.UPDATE_TO_AGGREGATION_LATENCY_GAUGE + ".Max") == 0,
+        TestHelper.WAIT_DURATION);
 
     if (manager.isConnected()) {
       manager.disconnect(); // For DummyClusterManager, this is not necessary

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestCustomizedViewStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestCustomizedViewStage.java
@@ -59,8 +59,14 @@ public class TestCustomizedViewStage extends ZkUnitTestBase {
 
     // ideal state: node0 is MASTER, node1 is SLAVE
     // replica=2 means 1 master and 1 slave
-    setupIdealState(clusterName, new int[]{0, 1}, new String[]{"TestDB"}, 1, 2);
-    setupLiveInstances(clusterName, new int[]{0, 1});
+    setupIdealState(clusterName, new int[] {
+        0, 1
+    }, new String[] {
+        "TestDB"
+    }, 1, 2);
+    setupLiveInstances(clusterName, new int[] {
+        0, 1
+    });
     setupStateModel(clusterName);
 
     ClusterEvent event = new ClusterEvent(ClusterEventType.Unknown);

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestCustomizedViewStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestCustomizedViewStage.java
@@ -153,11 +153,11 @@ public class TestCustomizedViewStage extends ZkUnitTestBase {
     runStage(event, new CustomizedViewAggregationStage());
 
     ObjectName objectName = new ObjectName(String
-        .format("%s:%s=%s", MonitorDomainNames.CustomizedView.name(), "Cluster", clusterName));
+        .format("%s:%s=%s", MonitorDomainNames.AggregatedView.name(), "Cluster", clusterName));
     ObjectInstance monitor = _server.getObjectInstance(objectName);
     Assert.assertNotNull(monitor);
     TestHelper.verify(() -> (long) _server.getAttribute(objectName,
-        CustomizedViewMonitor.UPDATE_TO_AGGREGATION_LATENCY_GAUGE + ".Max") == 0,
+        CustomizedViewMonitor.UPDATE_TO_AGGREGATION_LATENCY_GAUGE + ".Max") != 0,
         TestHelper.WAIT_DURATION);
 
     if (manager.isConnected()) {

--- a/helix-core/src/test/java/org/apache/helix/integration/TestCustomizedViewAggregation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestCustomizedViewAggregation.java
@@ -203,7 +203,7 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
             Map<String, Map<String, String>> localPerResourceCustomizedView = localSnapshot
                 .getOrDefault(resourceCustomizedView.getResourceName(), Maps.newHashMap());
 
-            if (resourceStateMap.isEmpty() && !localPerResourceCustomizedView.isEmpty()) {
+            if (resourceStateMap.size() != localPerResourceCustomizedView.size()) {
               return false;
             }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestCustomizedViewAggregation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestCustomizedViewAggregation.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
 
 import com.google.common.collect.Maps;
 import org.apache.helix.HelixDataAccessor;
@@ -45,6 +47,7 @@ import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.model.CustomizedState;
 import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.CustomizedView;
+import org.apache.helix.monitoring.mbeans.MonitorDomainNames;
 import org.apache.helix.spectator.RoutingTableProvider;
 import org.apache.helix.spectator.RoutingTableSnapshot;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -78,6 +81,8 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
   private final String PARTITION_11 = "TestDB1_1";
   private MockParticipantManager[] _participants;
   private ClusterControllerManager _controller;
+  private static String _clusterName;
+
   // Customized state values used for test, TYPE_A_0 - TYPE_A_2 are values for Customized state TypeA, etc.
   private enum CurrentStateValues {
     TYPE_A_0, TYPE_A_1, TYPE_A_2, TYPE_B_0, TYPE_B_1, TYPE_B_2, TYPE_C_0, TYPE_C_1, TYPE_C_2
@@ -91,12 +96,12 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
   public void beforeClass() throws Exception {
     super.beforeClass();
 
-    String clusterName = TestHelper.getTestClassName();
+    _clusterName = TestHelper.getTestClassName();
     int n = 2;
 
-    System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+    System.out.println("START " + _clusterName + " at " + new Date(System.currentTimeMillis()));
 
-    TestHelper.setupCluster(clusterName, ZK_ADDR, 12918, // participant port
+    TestHelper.setupCluster(_clusterName, ZK_ADDR, 12918, // participant port
         "localhost", // participant name prefix
         "TestDB", // resource name prefix
         2, // resources
@@ -105,8 +110,7 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
         2, // replicas
         "MasterSlave", true); // do rebalance
 
-    _controller =
-        new ClusterControllerManager(ZK_ADDR, clusterName, "controller_0");
+    _controller = new ClusterControllerManager(ZK_ADDR, _clusterName, "controller_0");
     _controller.syncStart();
 
     // start participants
@@ -114,7 +118,7 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
     for (int i = 0; i < n; i++) {
       String instanceName = "localhost_" + (12918 + i);
 
-      _participants[i] = new MockParticipantManager(ZK_ADDR, clusterName, instanceName);
+      _participants[i] = new MockParticipantManager(ZK_ADDR, _clusterName, instanceName);
       _participants[i].syncStart();
     }
 
@@ -122,11 +126,11 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
     INSTANCE_1 = _participants[1].getInstanceName();
 
     _manager = HelixManagerFactory
-        .getZKHelixManager(clusterName, "admin", InstanceType.ADMINISTRATOR, ZK_ADDR);
+        .getZKHelixManager(_clusterName, "admin", InstanceType.ADMINISTRATOR, ZK_ADDR);
     _manager.connect();
 
     _spectator = HelixManagerFactory
-        .getZKHelixManager(clusterName, "spectator", InstanceType.SPECTATOR, ZK_ADDR);
+        .getZKHelixManager(_clusterName, "spectator", InstanceType.SPECTATOR, ZK_ADDR);
     _spectator.connect();
 
     // Initialize customized state provider
@@ -409,8 +413,8 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
 
     // Aggregating: Type A
     // Routing table: Type A, Type B, Type C
-    setAggregationEnabledTypes(Arrays.asList(CustomizedStateType.TYPE_A));
-    validateAggregationSnapshot();
+//    setAggregationEnabledTypes(Arrays.asList(CustomizedStateType.TYPE_A));
+//    validateAggregationSnapshot();
 
     // Test get customized state and get per partition customized state via customized state provider, this part of test doesn't change customized view
     CustomizedState customizedState = _customizedStateProvider_participant1
@@ -422,6 +426,8 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
     Map<String, String> perPartitionCustomizedState = _customizedStateProvider_participant1
         .getPerPartitionCustomizedState(CustomizedStateType.TYPE_A.name(), RESOURCE_1,
             PARTITION_10);
+    // Remove this field because it's automatically updated for monitoring purpose and we don't need to compare it
+    perPartitionCustomizedState.remove(CustomizedState.CustomizedStateProperty.START_TIME.name());
     Map<String, String> actualPerPartitionCustomizedState = Maps.newHashMap();
     actualPerPartitionCustomizedState
         .put(CustomizedState.CustomizedStateProperty.CURRENT_STATE.name(),
@@ -456,9 +462,9 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
 
     // Aggregating: Type A, Type B, Type C
     // Routing table: Type A, Type B, Type C
-    setAggregationEnabledTypes(Arrays.asList(CustomizedStateType.TYPE_A, CustomizedStateType.TYPE_B,
-        CustomizedStateType.TYPE_C));
-    validateAggregationSnapshot();
+//    setAggregationEnabledTypes(Arrays.asList(CustomizedStateType.TYPE_A, CustomizedStateType.TYPE_B,
+//        CustomizedStateType.TYPE_C));
+//    validateAggregationSnapshot();
 
     update(INSTANCE_0, CustomizedStateType.TYPE_B, RESOURCE_0, PARTITION_01,
         CurrentStateValues.TYPE_B_2);
@@ -469,5 +475,11 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
     update(INSTANCE_0, CustomizedStateType.TYPE_A, RESOURCE_1, PARTITION_11,
         CurrentStateValues.TYPE_A_0);
     validateAggregationSnapshot();
+
+    // Test monitor is properly registered
+    ObjectName objectName = new ObjectName(String
+        .format("%s:%s=%s", MonitorDomainNames.CustomizedView.name(), "Cluster", _clusterName));
+    ObjectInstance monitor = _server.getObjectInstance(objectName);
+    assert monitor != null;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/TestCustomizedViewAggregation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestCustomizedViewAggregation.java
@@ -1,5 +1,24 @@
 package org.apache.helix.integration;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -233,7 +252,7 @@ public class TestCustomizedViewAggregation extends ZkUnitTestBase {
         }
         return true;
       }
-    }, 12000);
+    }, TestHelper.WAIT_DURATION);
 
     Assert.assertTrue(result);
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestCustomizedStateUpdate.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestCustomizedStateUpdate.java
@@ -87,7 +87,8 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     Map<String, Map<String, String>> mapView = customizedState.getRecord().getMapFields();
     Assert.assertEquals(mapView.keySet().size(), 1);
     Assert.assertEquals(mapView.keySet().iterator().next(), PARTITION_NAME1);
-    Assert.assertEquals(mapView.get(PARTITION_NAME1).keySet().size(), 2);
+    // Updated 2 fields + START_TIME field is automatically updated for monitoring
+    Assert.assertEquals(mapView.get(PARTITION_NAME1).keySet().size(), 3);
     Assert.assertEquals(mapView.get(PARTITION_NAME1).get("PREVIOUS_STATE"), "STARTED");
     Assert.assertEquals(mapView.get(PARTITION_NAME1).get("CURRENT_STATE"), "END_OF_PUSH_RECEIVED");
 
@@ -103,7 +104,7 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     mapView = customizedState.getRecord().getMapFields();
     Assert.assertEquals(mapView.keySet().size(), 1);
     Assert.assertEquals(mapView.keySet().iterator().next(), PARTITION_NAME1);
-    Assert.assertEquals(mapView.get(PARTITION_NAME1).keySet().size(), 2);
+    Assert.assertEquals(mapView.get(PARTITION_NAME1).keySet().size(), 3);
     Assert.assertEquals(mapView.get(PARTITION_NAME1).get("PREVIOUS_STATE"), "END_OF_PUSH_RECEIVED");
     Assert.assertEquals(mapView.get(PARTITION_NAME1).get("CURRENT_STATE"), "END_OF_PUSH_RECEIVED");
 
@@ -120,7 +121,7 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     mapView = customizedState.getRecord().getMapFields();
     Assert.assertEquals(mapView.keySet().size(), 1);
     Assert.assertEquals(mapView.keySet().iterator().next(), PARTITION_NAME1);
-    Assert.assertEquals(mapView.get(PARTITION_NAME1).keySet().size(), 2);
+    Assert.assertEquals(mapView.get(PARTITION_NAME1).keySet().size(), 3);
     Assert.assertEquals(mapView.get(PARTITION_NAME1).get("PREVIOUS_STATE"), "END_OF_PUSH_RECEIVED");
     Assert.assertEquals(mapView.get(PARTITION_NAME1).get("CURRENT_STATE"), "COMPLETED");
 
@@ -141,13 +142,13 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
 
     Map<String, String> partitionMap1 = _mockProvider
         .getPerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME1);
-    Assert.assertEquals(partitionMap1.keySet().size(), 2);
+    Assert.assertEquals(partitionMap1.keySet().size(), 3);
     Assert.assertEquals(partitionMap1.get("PREVIOUS_STATE"), "END_OF_PUSH_RECEIVED");
     Assert.assertEquals(partitionMap1.get("CURRENT_STATE"), "COMPLETED");
 
     Map<String, String> partitionMap2 = _mockProvider
         .getPerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME2);
-    Assert.assertEquals(partitionMap2.keySet().size(), 2);
+    Assert.assertEquals(partitionMap2.keySet().size(), 3);
     Assert.assertEquals(partitionMap2.get("PREVIOUS_STATE"), "STARTED");
     Assert.assertEquals(partitionMap2.get("CURRENT_STATE"), "END_OF_PUSH_RECEIVED");
 
@@ -170,6 +171,7 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     // get customized state
     CustomizedState customizedState =
         _mockProvider.getCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME);
+    // START_TIME field is automatically updated for monitoring
     Assert.assertEquals(
         customizedState.getPartitionStateMap(CustomizedState.CustomizedStateProperty.CURRENT_STATE)
             .size(), 1);
@@ -178,8 +180,8 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     Assert.assertEquals(customizedState
         .getPartitionStateMap(CustomizedState.CustomizedStateProperty.PREVIOUS_STATE), map);
     Assert.assertEquals(
-        customizedState.getPartitionStateMap(CustomizedState.CustomizedStateProperty.START_TIME),
-        map);
+        customizedState.getPartitionStateMap(CustomizedState.CustomizedStateProperty.START_TIME).size(),
+        1);
     Assert.assertEquals(
         customizedState.getPartitionStateMap(CustomizedState.CustomizedStateProperty.END_TIME),
         map);
@@ -192,6 +194,7 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     map.put(CustomizedState.CustomizedStateProperty.CURRENT_STATE.name(), PARTITION_STATE);
     Map<String, String> partitionCustomizedState = _mockProvider
         .getPerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME1);
+    partitionCustomizedState.remove(CustomizedState.CustomizedStateProperty.START_TIME.name());
     Assert.assertEquals(partitionCustomizedState, map);
     Assert.assertNull(_mockProvider
         .getPerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME2));
@@ -218,6 +221,7 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     map.put(CustomizedState.CustomizedStateProperty.CURRENT_STATE.name(), null);
     Map<String, String> partitionCustomizedState = _mockProvider
         .getPerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME1);
+    partitionCustomizedState.remove(CustomizedState.CustomizedStateProperty.START_TIME.name());
     Assert.assertEquals(partitionCustomizedState, map);
     Assert.assertNull(_mockProvider
         .getPerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME2));
@@ -244,7 +248,8 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     // get per partition customized state
     Map<String, String> partitionCustomizedState = _mockProvider
         .getPerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME1);
-    Assert.assertEquals(partitionCustomizedState.size(), 0);
+    // START_TIME field is automatically updated for monitoring
+    Assert.assertEquals(partitionCustomizedState.size(), 1);
     Assert.assertNull(_mockProvider
         .getPerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME2));
   }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestCustomizedViewMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestCustomizedViewMonitor.java
@@ -39,7 +39,7 @@ public class TestCustomizedViewMonitor {
 
   private ObjectName buildObjectName(int duplicateNum) throws MalformedObjectNameException {
     ObjectName objectName = new ObjectName(String
-        .format("%s:%s=%s", MonitorDomainNames.CustomizedView.name(), "Cluster", TEST_CLUSTER));
+        .format("%s:%s=%s", MonitorDomainNames.AggregatedView.name(), "Cluster", TEST_CLUSTER));
     if (duplicateNum == 0) {
       return objectName;
     } else {

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestCustomizedViewMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestCustomizedViewMonitor.java
@@ -26,6 +26,7 @@ import javax.management.JMException;
 import javax.management.MBeanServerConnection;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+
 import org.apache.helix.TestHelper;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestCustomizedViewMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestCustomizedViewMonitor.java
@@ -1,0 +1,5 @@
+package org.apache.helix.monitoring.mbeans;
+
+public class TestCustomizedViewMonitor {
+
+}

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestCustomizedViewMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestCustomizedViewMonitor.java
@@ -1,5 +1,100 @@
 package org.apache.helix.monitoring.mbeans;
 
-public class TestCustomizedViewMonitor {
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.Stack;
+import javax.management.JMException;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import org.apache.helix.TestHelper;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestCustomizedViewMonitor {
+  private static final MBeanServerConnection _server = ManagementFactory.getPlatformMBeanServer();
+  private final String TEST_CLUSTER = "test_cluster";
+  private final String MAX_SUFFIX = ".Max";
+  private final String MEAN_SUFFIX = ".Mean";
+
+  private ObjectName buildObjectName(int duplicateNum) throws MalformedObjectNameException {
+    ObjectName objectName = new ObjectName(String
+        .format("%s:%s=%s", MonitorDomainNames.CustomizedView.name(), "Cluster", TEST_CLUSTER));
+    if (duplicateNum == 0) {
+      return objectName;
+    } else {
+      return new ObjectName(
+          String.format("%s,%s=%s", objectName.toString(), MBeanRegistrar.DUPLICATE, duplicateNum));
+    }
+  }
+
+  @Test
+  public void testMBeanRegistration() throws JMException, IOException {
+    int numOfMonitors = 5;
+
+    Stack<CustomizedViewMonitor> monitors = new Stack<>();
+    for (int i = 0; i < numOfMonitors; i++) {
+      CustomizedViewMonitor monitor = new CustomizedViewMonitor(TEST_CLUSTER);
+      monitor.register();
+      monitors.push(monitor);
+    }
+
+    for (int i = 0; i < numOfMonitors; i++) {
+      if (i == numOfMonitors - 1) {
+        Assert.assertTrue(_server.isRegistered(buildObjectName(0)));
+      } else {
+        Assert.assertTrue(_server.isRegistered(buildObjectName(numOfMonitors - i - 1)));
+      }
+      CustomizedViewMonitor monitor = monitors.pop();
+      assert monitor != null;
+      monitor.unregister();
+      if (i == numOfMonitors - 1) {
+        Assert.assertFalse(_server.isRegistered(buildObjectName(0)));
+      } else {
+        Assert.assertFalse(_server.isRegistered(buildObjectName(numOfMonitors - i - 1)));
+      }
+    }
+  }
+
+  @Test
+  public void testMetricInitialization() throws Exception {
+    CustomizedViewMonitor monitor = new CustomizedViewMonitor(TEST_CLUSTER);
+    monitor.register();
+    int sum = 0;
+    for (int i = 0; i < 10; i++) {
+      System.out.println("i = " + i);
+      monitor.recordUpdateToAggregationLatency(i);
+      sum += i;
+      int expectedMax = i;
+      double expectedMean = sum / (i + 1.0);
+      System.out.println("max = " + (long) _server.getAttribute(buildObjectName(0),
+          CustomizedViewMonitor.UPDATE_TO_AGGREGATION_LATENCY_GAUGE + MAX_SUFFIX));
+      Assert.assertTrue(TestHelper.verify(() -> (long) _server.getAttribute(buildObjectName(0),
+          CustomizedViewMonitor.UPDATE_TO_AGGREGATION_LATENCY_GAUGE + MAX_SUFFIX) == expectedMax,
+          TestHelper.WAIT_DURATION));
+      Assert.assertTrue(TestHelper.verify(() -> (double) _server.getAttribute(buildObjectName(0),
+          CustomizedViewMonitor.UPDATE_TO_AGGREGATION_LATENCY_GAUGE + MEAN_SUFFIX) == expectedMean,
+          TestHelper.WAIT_DURATION));
+    }
+    monitor.unregister();
+  }
 }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestCustomizedViewMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestCustomizedViewMonitor.java
@@ -39,7 +39,8 @@ public class TestCustomizedViewMonitor {
 
   private ObjectName buildObjectName(int duplicateNum) throws MalformedObjectNameException {
     ObjectName objectName = new ObjectName(String
-        .format("%s:%s=%s", MonitorDomainNames.AggregatedView.name(), "Cluster", TEST_CLUSTER));
+        .format("%s:%s=%s,%s=%s", MonitorDomainNames.AggregatedView.name(), "Type",
+            "CustomizedView", "Cluster", TEST_CLUSTER));
     if (duplicateNum == 0) {
       return objectName;
     } else {
@@ -82,13 +83,10 @@ public class TestCustomizedViewMonitor {
     monitor.register();
     int sum = 0;
     for (int i = 0; i < 10; i++) {
-      System.out.println("i = " + i);
       monitor.recordUpdateToAggregationLatency(i);
       sum += i;
       int expectedMax = i;
       double expectedMean = sum / (i + 1.0);
-      System.out.println("max = " + (long) _server.getAttribute(buildObjectName(0),
-          CustomizedViewMonitor.UPDATE_TO_AGGREGATION_LATENCY_GAUGE + MAX_SUFFIX));
       Assert.assertTrue(TestHelper.verify(() -> (long) _server.getAttribute(buildObjectName(0),
           CustomizedViewMonitor.UPDATE_TO_AGGREGATION_LATENCY_GAUGE + MAX_SUFFIX) == expectedMax,
           TestHelper.WAIT_DURATION));

--- a/metrics-common/src/main/java/org/apache/helix/monitoring/mbeans/MonitorDomainNames.java
+++ b/metrics-common/src/main/java/org/apache/helix/monitoring/mbeans/MonitorDomainNames.java
@@ -30,5 +30,5 @@ public enum MonitorDomainNames {
   RoutingTableProvider,
   CLMParticipantReport,
   Rebalancer,
-  CustomizedView
+  AggregatedView
 }

--- a/metrics-common/src/main/java/org/apache/helix/monitoring/mbeans/MonitorDomainNames.java
+++ b/metrics-common/src/main/java/org/apache/helix/monitoring/mbeans/MonitorDomainNames.java
@@ -29,5 +29,6 @@ public enum MonitorDomainNames {
   HelixCallback,
   RoutingTableProvider,
   CLMParticipantReport,
-  Rebalancer
+  Rebalancer,
+  CustomizedView
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1214

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds support for latency metric reporting between the time when user updates customized state for a partition using CustomizedStateProvider, and the time this change shows up in aggregated customized view and written to zk. With that, we can 1. compare this latency with other pipeline latencies, so we know if this newly added feature saturate our controller or not 2. get an understanding of the pipeline performance 3. better monitor this feature and diagnose any problems in the future

- [x] The following tests are written for this issue:

Added: 
1. TestCustomizedViewMonitor
2. TestCustomizedViewStage -> testLatencyMetricReporting

Modified:
1. TestCustomizedStateUpdate
2. TestCustomizedViewAggregation

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 1168, Failures: 0, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:13 h
[INFO] Finished at: 2020-08-13T19:47:48-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)