### PR TITLE
Add Helix rest Zookeeper delete API to allow removing ephemeral ZNode

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
@@ -52,8 +52,6 @@ public class ZooKeeperAccessor extends AbstractResource {
   private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperAccessor.class.getName());
   private BaseDataAccessor<byte[]> _zkBaseDataAccessor;
 
-  private static final String PATH_STR = "path";
-
   public enum ZooKeeperCommand {
     exists,
     getBinaryData,
@@ -213,7 +211,7 @@ public class ZooKeeperAccessor extends AbstractResource {
           .entity(String.format("The ZNode at path %s does not exist!", path)).build());
     }
     Map<String, String> result = ZKUtil.fromStatToMap(stat);
-    result.put(PATH_STR, path);
+    result.put("path", path);
     return JSONRepresentation(result);
   }
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
@@ -30,8 +30,6 @@ import org.apache.helix.AccessOption;
 import org.apache.helix.manager.zk.ZKUtil;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.rest.server.util.JerseyUriRequestBuilder;
-import org.apache.helix.zookeeper.impl.client.DedicatedZkClient;
-import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
 import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.apache.zookeeper.data.Stat;


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1189

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Add a new Helix rest API in the ZookeeperAccessor for deleting an ephemeral ZNode.

Note that before we have ACL/audit support in the Helix rest, allowing raw ZK write operation is dangerous.
This API is introduced prematurely for resolving the issue of "zombie" participant (the instance has an active zk connection, but refuse to do any work). Currently, the existence of such a node may block the normal state transitions and then impact the cluster's availability. This PR restricts that only an ephemeral node can be deleted to minimize the risk.

### Tests

- [X] The following tests are written for this issue:

TestZooKeeperAccessor.testDelete()

- [x] The following is the result of the "mvn test" command on the appropriate module:

helix-rest

[INFO] Tests run: 164, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 49.55 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 164, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 55.836 s
[INFO] Finished at: 2020-07-30T15:40:28-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)