### PR TITLE
Fix flaky test testGetChildrenOnLargeNumChildren

### DIFF
--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -875,8 +875,9 @@ public class TestRawZkClient extends ZkTestBase {
     for (int i = 0; i < 110; i++) {
       List<Op> ops = new ArrayList<>(1000);
       for (int j = 0; j < 1000; j++) {
-        String child = path + "/" + UUID.randomUUID().toString();
-        ops.add(Op.create(child, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL));
+        String childPath = path + "/" + UUID.randomUUID().toString();
+        ops.add(
+            Op.create(childPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL));
       }
       // Reduce total creation time by batch creating znodes
       _zkClient.multi(ops);

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -20,8 +20,6 @@ package org.apache.helix.zookeeper.impl.client;
  */
 
 import java.lang.management.ManagementFactory;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -56,12 +54,13 @@ import org.apache.helix.zookeeper.zkclient.exception.ZkSessionMismatchedExceptio
 import org.apache.helix.zookeeper.zkclient.exception.ZkTimeoutException;
 import org.apache.helix.zookeeper.zkclient.metric.ZkClientMonitor;
 import org.apache.helix.zookeeper.zkclient.metric.ZkClientPathMonitor;
-import org.apache.zookeeper.ClientCnxn;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Op;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
+import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
@@ -69,7 +68,6 @@ import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
 
 public class TestRawZkClient extends ZkTestBase {
   private final String TEST_TAG = "test_monitor";
@@ -571,8 +569,6 @@ public class TestRawZkClient extends ZkTestBase {
     // Wait until the ZkClient has got a new session.
     Assert.assertTrue(_zkClient.waitUntilConnected(1, TimeUnit.SECONDS));
 
-    final long originalSessionId = _zkClient.getSessionId();
-
     try {
       // Create node.
       _zkClient.create(path, data, CreateMode.PERSISTENT);
@@ -868,59 +864,38 @@ public class TestRawZkClient extends ZkTestBase {
    * Tests getChildren() when there are an excessive number of children and connection loss happens,
    * the operation should terminate and exit retry loop.
    */
-  @Test
+  @Test(timeOut = 30 * 1000L)
   public void testGetChildrenOnLargeNumChildren() throws Exception {
-    // Default packetLen is 4M. It is static final and initialized
-    // when first zkClient is created.
-    // So we could not just set "jute.maxbuffer" to change the value.
-    // Reflection is needed to change the value.
-    // Remove "final" modifier
-    Field modifiersField = Field.class.getDeclaredField("modifiers");
-    boolean isModifierAccessible = modifiersField.isAccessible();
-    modifiersField.setAccessible(true);
-
-    Field packetLenField = ClientCnxn.class.getDeclaredField("packetLen");
-    Field childrenLimitField =
-        org.apache.helix.zookeeper.zkclient.ZkClient.class.getDeclaredField("NUM_CHILDREN_LIMIT");
-    modifiersField.setInt(packetLenField, packetLenField.getModifiers() & ~Modifier.FINAL);
-    modifiersField.setInt(childrenLimitField, childrenLimitField.getModifiers() & ~Modifier.FINAL);
-
-    boolean isPacketLenAccessible = packetLenField.isAccessible();
-    packetLenField.setAccessible(true);
-    int originPacketLen = packetLenField.getInt(null);
-    // Keep 150 bytes for successfully creating each child node.
-    packetLenField.set(null, 150);
-
-    boolean isChildrenLimitAccessible = childrenLimitField.isAccessible();
-    childrenLimitField.setAccessible(true);
-    int originChildrenLimit = childrenLimitField.getInt(null);
-    childrenLimitField.set(null, 2);
-
-    String path = "/" + TestHelper.getTestMethodName();
-    // Create 5 children to make packet length of children exceed 150 bytes
+    // Create 110K children to make packet length of children exceed 4 MB
     // and cause connection loss for getChildren() operation
-    for (int i = 0; i < 5; i++) {
-      _zkClient.createPersistent(path + "/" + UUID.randomUUID().toString(), true);
+    String path = "/" + TestHelper.getTestMethodName();
+    int toCreateChildrenCount = 110;
+
+    _zkClient.createPersistent(path);
+
+    for (int i = 0; i < toCreateChildrenCount; i++) {
+      List<Op> ops = new ArrayList<>(1000);
+      for (int j = 0; j < 1000; j++) {
+        String child = path + "/" + UUID.randomUUID().toString();
+        ops.add(Op.create(child, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL));
+      }
+      // Reduce total creation time by batch creating znodes
+      _zkClient.multi(ops);
     }
 
     try {
       _zkClient.getChildren(path);
-      Assert.fail("Should not successfully get children.");
+      Assert.fail("Should not successfully get children because of connection loss.");
     } catch (ZkException expected) {
       Assert.assertEquals(expected.getMessage(),
           "org.apache.zookeeper.KeeperException$MarshallingErrorException: "
               + "KeeperErrorCode = MarshallingError");
     } finally {
-      packetLenField.set(null, originPacketLen);
-      packetLenField.setAccessible(isPacketLenAccessible);
-
-      childrenLimitField.set(null, originChildrenLimit);
-      childrenLimitField.setAccessible(isChildrenLimitAccessible);
-
-      modifiersField.setAccessible(isModifierAccessible);
+      _zkClient.close();
+      _zkClient = new ZkClient(ZkTestBase.ZK_ADDR);
 
       Assert.assertTrue(TestHelper.verify(() -> {
-        _zkClient.deleteRecursively(path);
+        _zkClient.delete(path);
         return !_zkClient.exists(path);
       }, TestHelper.WAIT_DURATION));
     }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -866,9 +866,11 @@ public class TestRawZkClient extends ZkTestBase {
    */
   @Test(timeOut = 30 * 1000L)
   public void testGetChildrenOnLargeNumChildren() throws Exception {
+    final String methodName = TestHelper.getTestMethodName();
+    System.out.println("Start test: " + methodName);
     // Create 110K children to make packet length of children exceed 4 MB
     // and cause connection loss for getChildren() operation
-    String path = "/" + TestHelper.getTestMethodName();
+    String path = "/" + methodName;
 
     _zkClient.createPersistent(path);
 
@@ -876,6 +878,7 @@ public class TestRawZkClient extends ZkTestBase {
       List<Op> ops = new ArrayList<>(1000);
       for (int j = 0; j < 1000; j++) {
         String childPath = path + "/" + UUID.randomUUID().toString();
+        // Create ephemeral nodes so closing zkClient deletes them for cleanup
         ops.add(
             Op.create(childPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL));
       }
@@ -891,6 +894,7 @@ public class TestRawZkClient extends ZkTestBase {
           "org.apache.zookeeper.KeeperException$MarshallingErrorException: "
               + "KeeperErrorCode = MarshallingError");
     } finally {
+      // Delete children ephemeral znodes
       _zkClient.close();
       _zkClient = new ZkClient(ZkTestBase.ZK_ADDR);
 
@@ -902,5 +906,6 @@ public class TestRawZkClient extends ZkTestBase {
         }
       }, TestHelper.WAIT_DURATION));
     }
+    System.out.println("End test: " + methodName);
   }
 }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -869,11 +869,10 @@ public class TestRawZkClient extends ZkTestBase {
     // Create 110K children to make packet length of children exceed 4 MB
     // and cause connection loss for getChildren() operation
     String path = "/" + TestHelper.getTestMethodName();
-    int toCreateChildrenCount = 110;
 
     _zkClient.createPersistent(path);
 
-    for (int i = 0; i < toCreateChildrenCount; i++) {
+    for (int i = 0; i < 110; i++) {
       List<Op> ops = new ArrayList<>(1000);
       for (int j = 0; j < 1000; j++) {
         String child = path + "/" + UUID.randomUUID().toString();
@@ -895,8 +894,11 @@ public class TestRawZkClient extends ZkTestBase {
       _zkClient = new ZkClient(ZkTestBase.ZK_ADDR);
 
       Assert.assertTrue(TestHelper.verify(() -> {
-        _zkClient.delete(path);
-        return !_zkClient.exists(path);
+        try {
+          return _zkClient.delete(path);
+        } catch (ZkException e) {
+          return false;
+        }
       }, TestHelper.WAIT_DURATION));
     }
   }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1193 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The test testGetChildrenOnLargeNumChildren becomes flaky after more commits are checked in.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
zookeeper-api

[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 62.807 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:07 min
[INFO] Finished at: 2020-07-30T17:10:34-07:00
[INFO] ------------------------------------------------------------------------
```


### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)