### PR TITLE
Support option to skip direct ZK read for health check API

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/client/CustomRestClientImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/client/CustomRestClientImpl.java
@@ -89,7 +89,9 @@ class CustomRestClientImpl implements CustomRestClient {
     // To avoid ImmutableMap as parameter
     Map<String, String> payLoads = new HashMap<>(customPayloads);
     // Add the entry: "partitions" : ["p1", "p3", "p9"]
-    payLoads.put(PARTITIONS, partitions.toString());
+    if (partitions != null) {
+      payLoads.put(PARTITIONS, partitions.toString());
+    }
     JsonConverter jsonConverter = jsonNode -> {
       Map<String, Boolean> result = new HashMap<>();
       jsonNode.fields().forEachRemaining(

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -218,10 +218,9 @@ public class InstancesAccessor extends AbstractHelixResource {
       ObjectNode failedStoppableInstances = result.putObject(
           InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
       InstanceService instanceService =
-          new InstanceServiceImpl(new HelixDataAccessorWrapper((ZKHelixDataAccessor) getDataAccssor(clusterId)), getConfigAccessor(),
-              skipZKRead);
-      ClusterService clusterService =
-          new ClusterServiceImpl(getDataAccssor(clusterId), getConfigAccessor());
+          new InstanceServiceImpl(new HelixDataAccessorWrapper((ZKHelixDataAccessor) getDataAccssor(clusterId)),
+              getConfigAccessor(), skipZKRead);
+      ClusterService clusterService = new ClusterServiceImpl(getDataAccssor(clusterId), getConfigAccessor());
       ClusterTopology clusterTopology = clusterService.getClusterTopology(clusterId);
       switch (selectionBase) {
       case zone_based:

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -144,7 +144,7 @@ public class InstancesAccessor extends AbstractHelixResource {
 
   @POST
   public Response instancesOperations(@PathParam("clusterId") String clusterId,
-      @QueryParam("command") String command, String content) {
+      @QueryParam("skipZKRead") String skipZKRead, @QueryParam("command") String command, String content) {
     Command cmd;
     try {
       cmd = Command.valueOf(command);
@@ -172,7 +172,7 @@ public class InstancesAccessor extends AbstractHelixResource {
         admin.enableInstance(clusterId, enableInstances, false);
         break;
       case stoppable:
-        return batchGetStoppableInstances(clusterId, node);
+        return batchGetStoppableInstances(clusterId, node, Boolean.valueOf(skipZKRead));
       default:
         _logger.error("Unsupported command :" + command);
         return badRequest("Unsupported command :" + command);
@@ -188,7 +188,7 @@ public class InstancesAccessor extends AbstractHelixResource {
     return OK();
   }
 
-  private Response batchGetStoppableInstances(String clusterId, JsonNode node) throws IOException {
+  private Response batchGetStoppableInstances(String clusterId, JsonNode node, boolean skipZKRead) throws IOException {
     try {
       // TODO: Process input data from the content
       InstancesAccessor.InstanceHealthSelectionBase selectionBase =
@@ -218,7 +218,8 @@ public class InstancesAccessor extends AbstractHelixResource {
       ObjectNode failedStoppableInstances = result.putObject(
           InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
       InstanceService instanceService =
-          new InstanceServiceImpl(new HelixDataAccessorWrapper((ZKHelixDataAccessor) getDataAccssor(clusterId)), getConfigAccessor());
+          new InstanceServiceImpl(new HelixDataAccessorWrapper((ZKHelixDataAccessor) getDataAccssor(clusterId)), getConfigAccessor(),
+              skipZKRead);
       ClusterService clusterService =
           new ClusterServiceImpl(getDataAccssor(clusterId), getConfigAccessor());
       ClusterTopology clusterTopology = clusterService.getClusterTopology(clusterId);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -85,7 +85,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
 
   @GET
   public Response getInstanceById(@PathParam("clusterId") String clusterId,
-      @PathParam("instanceName") String instanceName,
+      @PathParam("instanceName") String instanceName, @QueryParam("skipZKRead") String skipZKRead,
       @DefaultValue("getInstance") @QueryParam("command") String command) {
     // Get the command. If not provided, the default would be "getInstance"
     Command cmd;
@@ -100,8 +100,9 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       ObjectMapper objectMapper = new ObjectMapper();
       HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
       // TODO reduce GC by dependency injection
-      InstanceService instanceService = new InstanceServiceImpl(
-          new HelixDataAccessorWrapper((ZKHelixDataAccessor) dataAccessor), getConfigAccessor());
+      InstanceService instanceService =
+          new InstanceServiceImpl(new HelixDataAccessorWrapper((ZKHelixDataAccessor) dataAccessor), getConfigAccessor(),
+              Boolean.valueOf(skipZKRead));
       InstanceInfo instanceInfo = instanceService.getInstanceInfo(clusterId, instanceName,
           InstanceService.HealthCheck.STARTED_AND_HEALTH_CHECK_LIST);
       String instanceInfoString;
@@ -132,11 +133,12 @@ public class PerInstanceAccessor extends AbstractHelixResource {
   @Path("stoppable")
   @Consumes(MediaType.APPLICATION_JSON)
   public Response isInstanceStoppable(String jsonContent, @PathParam("clusterId") String clusterId,
-      @PathParam("instanceName") String instanceName) throws IOException {
+      @PathParam("instanceName") String instanceName, @QueryParam("skipZKRead") String skipZKRead) throws IOException {
     ObjectMapper objectMapper = new ObjectMapper();
     HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
     InstanceService instanceService =
-        new InstanceServiceImpl(new HelixDataAccessorWrapper((ZKHelixDataAccessor) dataAccessor), getConfigAccessor());
+        new InstanceServiceImpl(new HelixDataAccessorWrapper((ZKHelixDataAccessor) dataAccessor), getConfigAccessor(),
+            Boolean.valueOf(skipZKRead));
     StoppableCheck stoppableCheck = null;
     try {
       stoppableCheck =

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
@@ -61,6 +61,7 @@ public class InstanceServiceImpl implements InstanceService {
   private final HelixDataAccessorWrapper _dataAccessor;
   private final ConfigAccessor _configAccessor;
   private final CustomRestClient _customRestClient;
+  private boolean _skipZKRead;
 
   public InstanceServiceImpl(HelixDataAccessorWrapper dataAccessor, ConfigAccessor configAccessor) {
     _dataAccessor = dataAccessor;
@@ -68,12 +69,24 @@ public class InstanceServiceImpl implements InstanceService {
     _customRestClient = CustomRestClientFactory.get();
   }
 
+  public InstanceServiceImpl(HelixDataAccessorWrapper dataAccessor, ConfigAccessor configAccessor, boolean skipZKRead) {
+    this(dataAccessor,configAccessor);
+    this._skipZKRead = skipZKRead;
+  }
+
   @VisibleForTesting
   InstanceServiceImpl(HelixDataAccessorWrapper dataAccessor, ConfigAccessor configAccessor,
       CustomRestClient customRestClient) {
+    this(dataAccessor, configAccessor, customRestClient, false);
+  }
+
+  @VisibleForTesting
+  InstanceServiceImpl(HelixDataAccessorWrapper dataAccessor, ConfigAccessor configAccessor,
+      CustomRestClient customRestClient, boolean skipZKRead) {
     _dataAccessor = dataAccessor;
     _configAccessor = configAccessor;
     _customRestClient = customRestClient;
+    _skipZKRead = skipZKRead;
   }
 
   @Override
@@ -239,7 +252,7 @@ public class InstanceServiceImpl implements InstanceService {
   private Map<String, StoppableCheck> performPartitionsCheck(List<String> instances,
       RESTConfig restConfig, Map<String, String> customPayLoads) {
     Map<String, Map<String, Boolean>> allPartitionsHealthOnLiveInstance =
-        _dataAccessor.getAllPartitionsHealthOnLiveInstance(restConfig, customPayLoads);
+        _dataAccessor.getAllPartitionsHealthOnLiveInstance(restConfig, customPayLoads, _skipZKRead);
     List<ExternalView> externalViews =
         _dataAccessor.getChildValues(_dataAccessor.keyBuilder().externalViews(), true);
     Map<String, StoppableCheck> instanceStoppableChecks = new HashMap<>();

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
@@ -76,12 +76,6 @@ public class InstanceServiceImpl implements InstanceService {
 
   @VisibleForTesting
   InstanceServiceImpl(HelixDataAccessorWrapper dataAccessor, ConfigAccessor configAccessor,
-      CustomRestClient customRestClient) {
-    this(dataAccessor, configAccessor, customRestClient, false);
-  }
-
-  @VisibleForTesting
-  InstanceServiceImpl(HelixDataAccessorWrapper dataAccessor, ConfigAccessor configAccessor,
       CustomRestClient customRestClient, boolean skipZKRead) {
     _dataAccessor = dataAccessor;
     _configAccessor = configAccessor;

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -19,6 +19,8 @@ package org.apache.helix.rest.server;
  * under the License.
  */
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,19 +32,9 @@ import java.util.Set;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.TestHelper;
-import org.apache.helix.model.RESTConfig;
-import org.apache.helix.rest.common.HelixDataAccessorWrapper;
-import org.apache.helix.rest.server.json.instance.StoppableCheck;
-import org.apache.helix.rest.server.service.InstanceService;
-import org.apache.helix.rest.server.service.InstanceServiceImpl;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.InstanceConfig;
@@ -51,6 +43,7 @@ import org.apache.helix.rest.server.resources.AbstractResource;
 import org.apache.helix.rest.server.resources.helix.InstancesAccessor;
 import org.apache.helix.rest.server.resources.helix.PerInstanceAccessor;
 import org.apache.helix.rest.server.util.JerseyUriRequestBuilder;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.codehaus.jackson.JsonNode;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -33,9 +33,15 @@ import javax.ws.rs.core.Response;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.TestHelper;
+import org.apache.helix.model.RESTConfig;
+import org.apache.helix.rest.common.HelixDataAccessorWrapper;
+import org.apache.helix.rest.server.json.instance.StoppableCheck;
+import org.apache.helix.rest.server.service.InstanceService;
+import org.apache.helix.rest.server.service.InstanceServiceImpl;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.model.ClusterConfig;

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
@@ -20,16 +20,31 @@ package org.apache.helix.rest.server.service;
  */
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.helix.AccessOption;
+import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixProperty;
+import org.apache.helix.InstanceType;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.MasterSlaveSMD;
 import org.apache.helix.model.RESTConfig;
 import org.apache.helix.rest.client.CustomRestClient;
 import org.apache.helix.rest.common.HelixDataAccessorWrapper;
 import org.apache.helix.rest.server.json.instance.StoppableCheck;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.zookeeper.data.Stat;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -37,13 +52,9 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyMap;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
 
 public class TestInstanceService {
   private static final String TEST_CLUSTER = "TestCluster";
@@ -140,6 +151,70 @@ public class TestInstanceService {
     Assert.assertEquals(actual.getFailedChecks().get(0), expectedFailedCheck);
   }
 
+  @Test
+  public void testCustomPartitionCheckWithSkipZKRead() throws IOException {
+    // Let ZK result is health, but http request is unhealthy.
+    // We expect the check fail if we skipZKRead.
+
+    String testPartition = "PARTITION_0";
+    String slibilingInstance = "instance0.linkedin.com_1236";
+    String jsonContent = "{\n" + "   \"param1\": \"value1\",\n" + "\"param2\": \"value2\"\n" + "}";
+    BaseDataAccessor<ZNRecord> mockAccessor = mock(ZkBaseDataAccessor.class);
+    ZKHelixDataAccessor zkHelixDataAccessor =
+        new ZKHelixDataAccessor(TEST_CLUSTER, InstanceType.ADMINISTRATOR, mockAccessor);
+    ZNRecord successPartitionReport = new ZNRecord(HelixDataAccessorWrapper.PARTITION_HEALTH_KEY);
+
+    // Instance level check passed
+    when(_customRestClient.getInstanceStoppableCheck(anyString(), anyMap())).thenReturn(
+        Collections.singletonMap(TEST_INSTANCE, true));
+
+    // Mocks for partition level
+    when(mockAccessor.getChildNames(zkHelixDataAccessor.keyBuilder().liveInstances().getPath(), 2)).thenReturn(
+        Arrays.asList(TEST_INSTANCE, slibilingInstance));
+
+    // Mock ZK record is healthy
+    Map<String, String> partition0 = new HashMap<>();
+    partition0.put(HelixDataAccessorWrapper.EXPIRY_KEY, String.valueOf(System.currentTimeMillis() + 100000L));
+    partition0.put(HelixDataAccessorWrapper.IS_HEALTHY_KEY, "true");
+    partition0.put("lastWriteTime", String.valueOf(System.currentTimeMillis()));
+    successPartitionReport.setMapField(testPartition, partition0);
+    when(mockAccessor.get(Arrays.asList(zkHelixDataAccessor.keyBuilder()
+        .healthReport(TEST_INSTANCE, HelixDataAccessorWrapper.PARTITION_HEALTH_KEY)
+        .getPath(), zkHelixDataAccessor.keyBuilder()
+        .healthReport(slibilingInstance, HelixDataAccessorWrapper.PARTITION_HEALTH_KEY)
+        .getPath()), Arrays.asList(new Stat(), new Stat()), 0, false)).thenReturn(
+        Arrays.asList(successPartitionReport, successPartitionReport));
+
+    // Mock client call result is check fail.
+    when(_customRestClient.getPartitionStoppableCheck(anyString(), anyList(), anyMap())).thenReturn(
+        Collections.singletonMap(testPartition, false));
+
+    // Mock data for InstanceValidationUtil
+    ExternalView externalView = new ExternalView("TestResource");
+    externalView.setState(testPartition, TEST_INSTANCE, "MASTER");
+    externalView.setState(testPartition, slibilingInstance, "SLAVE");
+    externalView.getRecord().setSimpleField(IdealState.IdealStateProperty.STATE_MODEL_DEF_REF.name(), "MasterSlave");
+    when(mockAccessor.getChildren(zkHelixDataAccessor.keyBuilder().externalViews().getPath(), null,
+        AccessOption.PERSISTENT, 1, 0)).thenReturn(Arrays.asList(externalView.getRecord()));
+    when(mockAccessor.get(zkHelixDataAccessor.keyBuilder().stateModelDef("MasterSlave").getPath(), new Stat(),
+        AccessOption.PERSISTENT)).thenReturn(MasterSlaveSMD.build().getRecord());
+
+    // Valid data only from ZK, pass the check
+    InstanceService instanceServiceReadZK =
+        new MockInstanceServiceImpl(new HelixDataAccessorWrapper(zkHelixDataAccessor, _customRestClient),
+            _configAccessor, _customRestClient, false);
+    StoppableCheck stoppableCheck =
+        instanceServiceReadZK.getInstanceStoppableCheck(TEST_CLUSTER, TEST_INSTANCE, jsonContent);
+    Assert.assertTrue(stoppableCheck.isStoppable());
+
+    // Even ZK data is valid. Skip ZK read should fail the test.
+    InstanceService instanceServiceWithoutReadZK =
+        new MockInstanceServiceImpl(new HelixDataAccessorWrapper(zkHelixDataAccessor, _customRestClient),
+            _configAccessor, _customRestClient, true);
+    stoppableCheck = instanceServiceWithoutReadZK.getInstanceStoppableCheck(TEST_CLUSTER, TEST_INSTANCE, jsonContent);
+    Assert.assertFalse(stoppableCheck.isStoppable());
+  }
+
   // TODO re-enable the test when partition health checks get decoupled
   @Test(enabled = false)
   public void testGetInstanceStoppableCheckWhenPartitionsCheckFail() throws IOException {
@@ -161,5 +236,18 @@ public class TestInstanceService {
 
     Assert.assertFalse(actual.isStoppable());
     verify(_customRestClient, times(1)).getInstanceStoppableCheck(any(), any());
+  }
+
+  class MockInstanceServiceImpl extends InstanceServiceImpl {
+    MockInstanceServiceImpl(HelixDataAccessorWrapper dataAccessor, ConfigAccessor configAccessor,
+        CustomRestClient customRestClient, boolean skipZKRead) {
+      super(dataAccessor, configAccessor, customRestClient, skipZKRead);
+    }
+
+    @Override
+    protected Map<String, Boolean> getInstanceHealthStatus(String clusterId,
+        String instanceName, List<InstanceService.HealthCheck> healthChecks) {
+      return Collections.emptyMap();
+    }
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes (#1196)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This change support the option "skipZKRead" in multiple health check API call.
If the option is true, Helix will directly query custom partition health from provided source instead of ZK read.

### Tests

- [x] The following tests are written for this issue:

TestInstanceService.testCustomPartitionCheckWithSkipZKRead

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 164, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 53.755 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 164, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:00 min
[INFO] Finished at: 2020-07-31T12:17:50-07:00
[INFO] Final Memory: 30M/838M
[INFO] ------------------------------------------------------------------------

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
