### PR TITLE
Identify and shutdown leaked timer threads

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -358,7 +358,7 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     }
   }
 
-  private void stopOnDemandTimer() {
+  private void shutdownOnDemandTimer() {
     logger.info("GenericHelixController stopping onDemand timer");
     if (_onDemandRebalanceTimer != null) {
       _onDemandRebalanceTimer.cancel();
@@ -1280,7 +1280,7 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
 
   public void shutdown() throws InterruptedException {
     stopPeriodRebalance();
-    stopOnDemandTimer();
+    shutdownOnDemandTimer();
     logger.info("Shutting down {} pipeline", Pipeline.Type.DEFAULT.name());
     shutdownPipeline(_eventThread, _eventQueue);
 

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -334,7 +334,8 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
       if (_periodicalRebalanceTimer != null) {
         _periodicalRebalanceTimer.cancel();
       }
-      _periodicalRebalanceTimer = new Timer(true);
+      _periodicalRebalanceTimer =
+          new Timer("GenericHelixController_" + _clusterName + "_periodical_Timer", true);
       _timerPeriod = period;
       _periodicalRebalanceTimer
           .scheduleAtFixedRate(new RebalanceTask(manager, ClusterEventType.PeriodicalRebalance),
@@ -357,6 +358,12 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     }
   }
 
+  private void stopOnDemandTimer() {
+    logger.info("GenericHelixController stopping onDemand timer");
+    if (_onDemandRebalanceTimer != null) {
+      _onDemandRebalanceTimer.cancel();
+    }
+  }
   /**
    * This function is deprecated. Please use RebalanceUtil.scheduleInstantPipeline method instead.
    * schedule a future rebalance pipeline run, delayed at given time.
@@ -600,7 +607,8 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     _asyncFIFOWorkerPool = new HashMap<>();
     initializeAsyncFIFOWorkers();
 
-    _onDemandRebalanceTimer = new Timer(true);
+    _onDemandRebalanceTimer =
+        new Timer("GenericHelixController_" + _clusterName + "_onDemand_Timer", true);
 
     // initialize pipelines at the end so we have everything else prepared
     if (_enabledPipelineTypes.contains(Pipeline.Type.DEFAULT)) {
@@ -1272,7 +1280,7 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
 
   public void shutdown() throws InterruptedException {
     stopPeriodRebalance();
-
+    stopOnDemandTimer();
     logger.info("Shutting down {} pipeline", Pipeline.Type.DEFAULT.name());
     shutdownPipeline(_eventThread, _eventQueue);
 

--- a/helix-core/src/main/java/org/apache/helix/messaging/AsyncCallback.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/AsyncCallback.java
@@ -109,7 +109,7 @@ public abstract class AsyncCallback {
       if (_startTimeStamp == 0) {
         _startTimeStamp = System.currentTimeMillis();
       }
-      _timer = new Timer(true);
+      _timer = new Timer("AsyncCallback-Timer", true);
       _timer.schedule(new TimeoutTask(this), _timeout);
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -175,7 +175,7 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
     _lock = new Object();
     _statusUpdateUtil = new StatusUpdateUtil();
 
-    _timer = new Timer(true); // created as a daemon timer thread to handle task timeout
+    _timer = new Timer("HelixTaskExecutor_timer", true); // created as a daemon timer thread to handle task timeout
 
     _isShuttingDown = false;
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

fixes #1200 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

    Unit test has leaked several hundreds to thousand leaked timer threads.
    This pull request give each timer thread a name to help identified the
    leaked threads. Also fix the major contributor of leaking in controller.

### Tests

- [ ] The following tests are written for this issue:

none.

- [ ] The following is the result of the "mvn test" command on the appropriate module:

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestZkConnectionLost.testLostZkConnection » ThreadTimeout Method org.testng.in...
[ERROR]   TestJobFailureTaskNotStarted.testTaskNotStarted » ThreadTimeout Method org.tes...
[ERROR]   TestRebalanceRunningTask.testFixedTargetTaskAndDisabledRebalanceAndNodeAdded:297 expected:<true> but was:<false>
[ERROR]   TestWorkflowTermination.testWorkflowJobFail:229 » Helix Workflow "testWorkflow...
[ERROR]   TestWorkflowTimeout.testWorkflowRunningTime:66 » Helix Workflow "testWorkflowR...
[INFO] 
[ERROR] Tests run: 1155, Failures: 5, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:29 h
[INFO] Finished at: 2020-07-31T23:45:55-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /Users/ksun/dev_branch_helix/helix/helix-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
ksun-mn1:helix-core ksun$ mvn test

### Commits

- [ ] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [ ] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)