### PR TITLE
Remove the unnecessary checks to allow cleaning up map/list fields in the ClusterConfig and InstanceConfig.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -870,15 +870,16 @@ public class ClusterConfig extends HelixProperty {
    *                    If null, the resolver map item will be removed from the config.
    */
   public void setAbnormalStateResolverMap(Map<String, String> resolverMap) {
-    if (resolverMap != null && resolverMap.values().stream()
-        .anyMatch(className -> className == null)) {
-      throw new IllegalArgumentException(
-          "Invalid Abnormal State Resolver Map definition. Class name cannot be empty.");
-    }
     if (resolverMap == null) {
       _record.getMapFields().remove(ClusterConfigProperty.ABNORMAL_STATES_RESOLVER_MAP.name());
+    } else {
+      if (resolverMap.values().stream()
+          .anyMatch(className -> className == null || className.isEmpty())) {
+        throw new IllegalArgumentException(
+            "Invalid Abnormal State Resolver Map definition. Class name cannot be empty.");
+      }
+      _record.setMapField(ClusterConfigProperty.ABNORMAL_STATES_RESOLVER_MAP.name(), resolverMap);
     }
-    _record.setMapField(ClusterConfigProperty.ABNORMAL_STATES_RESOLVER_MAP.name(), resolverMap);
   }
 
   public Map<String, String> getAbnormalStateResolverMap() {

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -873,10 +873,14 @@ public class ClusterConfig extends HelixProperty {
     if (resolverMap == null) {
       _record.getMapFields().remove(ClusterConfigProperty.ABNORMAL_STATES_RESOLVER_MAP.name());
     } else {
-      if (resolverMap.values().stream()
-          .anyMatch(className -> className == null || className.isEmpty())) {
+      if (resolverMap.entrySet().stream().anyMatch(e -> {
+        String stateModelDefName = e.getKey();
+        String className = e.getValue();
+        return stateModelDefName == null || stateModelDefName.isEmpty() || className == null
+            || className.isEmpty();
+      })) {
         throw new IllegalArgumentException(
-            "Invalid Abnormal State Resolver Map definition. Class name cannot be empty.");
+            "Invalid Abnormal State Resolver Map definition. StateModel definition name and the resolver class name cannot be empty.");
       }
       _record.setMapField(ClusterConfigProperty.ABNORMAL_STATES_RESOLVER_MAP.name(), resolverMap);
     }

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -706,9 +706,13 @@ public class ClusterConfig extends HelixProperty {
 
   /**
    * Set the required Instance Capacity Keys.
-   * @param capacityKeys
+   * @param capacityKeys - the capacity key list.
+   *                     If null, the capacity keys item will be removed from the config.
    */
   public void setInstanceCapacityKeys(List<String> capacityKeys) {
+    if (capacityKeys == null) {
+      _record.getListFields().remove(ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name());
+    }
     _record.setListField(ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name(), capacityKeys);
   }
 
@@ -741,6 +745,7 @@ public class ClusterConfig extends HelixProperty {
    * If the instance capacity is not configured in either Instance Config nor Cluster Config, the
    * cluster topology is considered invalid. So the rebalancer may stop working.
    * @param capacityDataMap - map of instance capacity data
+   *                         If null, the default capacity map item will be removed from the config.
    * @throws IllegalArgumentException - when any of the data value is a negative number
    */
   public void setDefaultInstanceCapacityMap(Map<String, Integer> capacityDataMap)
@@ -766,6 +771,7 @@ public class ClusterConfig extends HelixProperty {
    * If the partition weight is not configured in either Resource Config nor Cluster Config, the
    * cluster topology is considered invalid. So the rebalancer may stop working.
    * @param weightDataMap - map of partition weight data
+   *                      If null, the default weight map item will be removed from the config.
    * @throws IllegalArgumentException - when any of the data value is a negative number
    */
   public void setDefaultPartitionWeightMap(Map<String, Integer> weightDataMap)
@@ -785,7 +791,7 @@ public class ClusterConfig extends HelixProperty {
   private void setDefaultCapacityMap(ClusterConfigProperty capacityPropertyType,
       Map<String, Integer> capacityDataMap) throws IllegalArgumentException {
     if (capacityDataMap == null) {
-      _record.setMapField(capacityPropertyType.name(), null);
+      _record.getMapFields().remove(capacityPropertyType.name());
     } else {
       Map<String, String> data = new HashMap<>();
       capacityDataMap.entrySet().stream().forEach(entry -> {
@@ -804,10 +810,11 @@ public class ClusterConfig extends HelixProperty {
    * Set the global rebalancer's assignment preference.
    * @param preference A map of the GlobalRebalancePreferenceKey and the corresponding weight.
    *                   The ratio of the configured weights will determine the rebalancer's behavior.
+   *                   If null, the preference item will be removed from the config.
    */
   public void setGlobalRebalancePreference(Map<GlobalRebalancePreferenceKey, Integer> preference) {
     if (preference == null) {
-      _record.setMapField(ClusterConfigProperty.REBALANCE_PREFERENCE.name(), null);
+      _record.getMapFields().remove(ClusterConfigProperty.REBALANCE_PREFERENCE.name());
     } else {
       Map<String, String> preferenceMap = new HashMap<>();
       preference.entrySet().stream().forEach(entry -> {
@@ -859,12 +866,17 @@ public class ClusterConfig extends HelixProperty {
 
   /**
    * Set the abnormal state resolver class map.
+   * @param resolverMap - the resolver map
+   *                    If null, the resolver map item will be removed from the config.
    */
   public void setAbnormalStateResolverMap(Map<String, String> resolverMap) {
     if (resolverMap != null && resolverMap.values().stream()
         .anyMatch(className -> className == null)) {
       throw new IllegalArgumentException(
           "Invalid Abnormal State Resolver Map definition. Class name cannot be empty.");
+    }
+    if (resolverMap == null) {
+      _record.getMapFields().remove(ClusterConfigProperty.ABNORMAL_STATES_RESOLVER_MAP.name());
     }
     _record.setMapField(ClusterConfigProperty.ABNORMAL_STATES_RESOLVER_MAP.name(), resolverMap);
   }

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -880,7 +880,7 @@ public class ClusterConfig extends HelixProperty {
             || className.isEmpty();
       })) {
         throw new IllegalArgumentException(
-            "Invalid Abnormal State Resolver Map definition. StateModel definition name and the resolver class name cannot be empty.");
+            "Invalid Abnormal State Resolver Map definition. StateModel definition name and the resolver class name cannot be null or empty.");
       }
       _record.setMapField(ClusterConfigProperty.ABNORMAL_STATES_RESOLVER_MAP.name(), resolverMap);
     }

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Splitter;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.util.HelixUtil;
@@ -534,7 +533,7 @@ public class InstanceConfig extends HelixProperty {
   /**
    * Set the instance capacity information with an Integer mapping.
    * @param capacityDataMap - map of instance capacity data
-   * @throws IllegalArgumentException - when any of the data value is a negative number or when the map is incomplete
+   * @throws IllegalArgumentException - when any of the data value is a negative number
    *
    * This information is required by the global rebalancer.
    * @see <a href="Rebalance Algorithm">
@@ -547,21 +546,19 @@ public class InstanceConfig extends HelixProperty {
   public void setInstanceCapacityMap(Map<String, Integer> capacityDataMap)
       throws IllegalArgumentException {
     if (capacityDataMap == null) {
-      throw new IllegalArgumentException("Capacity Data is null");
+      _record.setMapField(InstanceConfigProperty.INSTANCE_CAPACITY_MAP.name(), null);
+    } else {
+      Map<String, String> capacityData = new HashMap<>();
+      capacityDataMap.entrySet().stream().forEach(entry -> {
+        if (entry.getValue() < 0) {
+          throw new IllegalArgumentException(String
+              .format("Capacity Data contains a negative value: %s = %d", entry.getKey(),
+                  entry.getValue()));
+        }
+        capacityData.put(entry.getKey(), Integer.toString(entry.getValue()));
+      });
+      _record.setMapField(InstanceConfigProperty.INSTANCE_CAPACITY_MAP.name(), capacityData);
     }
-
-    Map<String, String> capacityData = new HashMap<>();
-
-    capacityDataMap.entrySet().stream().forEach(entry -> {
-      if (entry.getValue() < 0) {
-        throw new IllegalArgumentException(String
-            .format("Capacity Data contains a negative value: %s = %d", entry.getKey(),
-                entry.getValue()));
-      }
-      capacityData.put(entry.getKey(), Integer.toString(entry.getValue()));
-    });
-
-    _record.setMapField(InstanceConfigProperty.INSTANCE_CAPACITY_MAP.name(), capacityData);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -533,6 +533,7 @@ public class InstanceConfig extends HelixProperty {
   /**
    * Set the instance capacity information with an Integer mapping.
    * @param capacityDataMap - map of instance capacity data
+   *                        If null, the capacity map item will be removed from the config.
    * @throws IllegalArgumentException - when any of the data value is a negative number
    *
    * This information is required by the global rebalancer.
@@ -546,7 +547,7 @@ public class InstanceConfig extends HelixProperty {
   public void setInstanceCapacityMap(Map<String, Integer> capacityDataMap)
       throws IllegalArgumentException {
     if (capacityDataMap == null) {
-      _record.setMapField(InstanceConfigProperty.INSTANCE_CAPACITY_MAP.name(), null);
+      _record.getMapFields().remove(InstanceConfigProperty.INSTANCE_CAPACITY_MAP.name());
     } else {
       Map<String, String> capacityData = new HashMap<>();
       capacityDataMap.entrySet().stream().forEach(entry -> {

--- a/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
@@ -62,12 +62,17 @@ public class TestClusterConfig {
 
     Assert.assertEquals(keys, testConfig.getRecord()
         .getListField(ClusterConfig.ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name()));
-  }
 
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testSetCapacityKeysEmptyList() {
-    ClusterConfig testConfig = new ClusterConfig("testId");
     testConfig.setInstanceCapacityKeys(Collections.emptyList());
+
+    Assert.assertEquals(testConfig.getRecord()
+            .getListField(ClusterConfig.ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name()),
+        Collections.emptyList());
+
+    testConfig.setInstanceCapacityKeys(null);
+
+    Assert.assertTrue(testConfig.getRecord()
+        .getListField(ClusterConfig.ClusterConfigProperty.INSTANCE_CAPACITY_KEYS.name()) == null);
   }
 
   @Test
@@ -119,6 +124,17 @@ public class TestClusterConfig {
     Assert.assertEquals(testConfig.getRecord()
             .getMapField(ClusterConfig.ClusterConfigProperty.REBALANCE_PREFERENCE.name()),
         mapFieldData);
+
+    testConfig.setGlobalRebalancePreference(Collections.emptyMap());
+
+    Assert.assertEquals(testConfig.getRecord()
+            .getMapField(ClusterConfig.ClusterConfigProperty.REBALANCE_PREFERENCE.name()),
+        Collections.emptyMap());
+
+    testConfig.setGlobalRebalancePreference(null);
+
+    Assert.assertTrue(testConfig.getRecord()
+        .getMapField(ClusterConfig.ClusterConfigProperty.REBALANCE_PREFERENCE.name()) == null);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
@@ -165,17 +181,17 @@ public class TestClusterConfig {
 
     Assert.assertEquals(testConfig.getRecord().getMapField(ClusterConfig.ClusterConfigProperty.
         DEFAULT_INSTANCE_CAPACITY_MAP.name()), capacityDataMapString);
-  }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Default capacity data is null")
-  public void testSetInstanceCapacityMapEmpty() {
-    Map<String, Integer> capacityDataMap = new HashMap<>();
-
-    ClusterConfig testConfig = new ClusterConfig("testConfig");
     // The following operation can be done, this will clear the default values
-    testConfig.setDefaultInstanceCapacityMap(capacityDataMap);
-    // The following operation will fail
+    testConfig.setDefaultInstanceCapacityMap(Collections.emptyMap());
+
+    Assert.assertEquals(testConfig.getRecord().getMapField(ClusterConfig.ClusterConfigProperty.
+        DEFAULT_INSTANCE_CAPACITY_MAP.name()), Collections.emptyMap());
+
     testConfig.setDefaultInstanceCapacityMap(null);
+
+    Assert.assertTrue(testConfig.getRecord().getMapField(ClusterConfig.ClusterConfigProperty.
+        DEFAULT_INSTANCE_CAPACITY_MAP.name()) == null);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Default capacity data contains a negative value: item3 = -3")
@@ -220,17 +236,17 @@ public class TestClusterConfig {
 
     Assert.assertEquals(testConfig.getRecord().getMapField(ClusterConfig.ClusterConfigProperty.
         DEFAULT_PARTITION_WEIGHT_MAP.name()), weightDataMapString);
-  }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Default capacity data is null")
-  public void testSetPartitionWeightMapEmpty() {
-    Map<String, Integer> weightDataMap = new HashMap<>();
-
-    ClusterConfig testConfig = new ClusterConfig("testConfig");
     // The following operation can be done, this will clear the default values
-    testConfig.setDefaultPartitionWeightMap(weightDataMap);
-    // The following operation will fail
+    testConfig.setDefaultPartitionWeightMap(Collections.emptyMap());
+
+    Assert.assertEquals(testConfig.getRecord().getMapField(ClusterConfig.ClusterConfigProperty.
+        DEFAULT_PARTITION_WEIGHT_MAP.name()), Collections.emptyMap());
+
     testConfig.setDefaultPartitionWeightMap(null);
+
+    Assert.assertTrue(testConfig.getRecord().getMapField(ClusterConfig.ClusterConfigProperty.
+        DEFAULT_PARTITION_WEIGHT_MAP.name()) == null);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Default capacity data contains a negative value: item3 = -3")
@@ -264,12 +280,17 @@ public class TestClusterConfig {
     // Default value is empty
     Assert.assertEquals(testConfig.getAbnormalStateResolverMap(), Collections.EMPTY_MAP);
     // Test set
-    Map<String, String> resolverMap = ImmutableMap.of(MasterSlaveSMD.name,
-        MockAbnormalStateResolver.class.getName());
+    Map<String, String> resolverMap =
+        ImmutableMap.of(MasterSlaveSMD.name, MockAbnormalStateResolver.class.getName());
     testConfig.setAbnormalStateResolverMap(resolverMap);
     Assert.assertEquals(testConfig.getAbnormalStateResolverMap(), resolverMap);
     // Test empty the map
     testConfig.setAbnormalStateResolverMap(Collections.emptyMap());
     Assert.assertEquals(testConfig.getAbnormalStateResolverMap(), Collections.EMPTY_MAP);
+
+    testConfig.setAbnormalStateResolverMap(null);
+    Assert.assertTrue(testConfig.getRecord()
+        .getMapField(ClusterConfig.ClusterConfigProperty.ABNORMAL_STATES_RESOLVER_MAP.name())
+        == null);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
@@ -293,4 +293,35 @@ public class TestClusterConfig {
         .getMapField(ClusterConfig.ClusterConfigProperty.ABNORMAL_STATES_RESOLVER_MAP.name())
         == null);
   }
+
+  @Test
+  public void testSetInvalidAbnormalStatesResolverConfig() {
+    ClusterConfig testConfig = new ClusterConfig("testConfig");
+
+    Map<String, String> resolverMap = new HashMap<>();
+    resolverMap.put(null, MockAbnormalStateResolver.class.getName());
+    trySetInvalidAbnormalStatesResolverMap(testConfig, resolverMap);
+
+    resolverMap.clear();
+    resolverMap.put("", MockAbnormalStateResolver.class.getName());
+    trySetInvalidAbnormalStatesResolverMap(testConfig, resolverMap);
+
+    resolverMap.clear();
+    resolverMap.put(MasterSlaveSMD.name, null);
+    trySetInvalidAbnormalStatesResolverMap(testConfig, resolverMap);
+
+    resolverMap.clear();
+    resolverMap.put(MasterSlaveSMD.name, "");
+    trySetInvalidAbnormalStatesResolverMap(testConfig, resolverMap);
+  }
+
+  private void trySetInvalidAbnormalStatesResolverMap(ClusterConfig testConfig,
+      Map<String, String> resolverMap) {
+    try {
+      testConfig.setAbnormalStateResolverMap(resolverMap);
+      Assert.fail("Invalid resolver setup shall fail.");
+    } catch (IllegalArgumentException ex) {
+      // expected
+    }
+  }
 }

--- a/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
@@ -19,14 +19,13 @@ package org.apache.helix.model;
  * under the License.
  */
 
+import java.util.Collections;
+import java.util.Map;
+
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Created with IntelliJ IDEA.
@@ -91,26 +90,26 @@ public class TestInstanceConfig {
         "item2", 2,
         "item3", 3);
 
-    Map<String, String> capacityDataMapString = ImmutableMap.of("item1", "1",
-        "item2", "2",
-        "item3", "3");
+    Map<String, String> capacityDataMapString =
+        ImmutableMap.of("item1", "1", "item2", "2", "item3", "3");
 
     InstanceConfig testConfig = new InstanceConfig("testConfig");
     testConfig.setInstanceCapacityMap(capacityDataMap);
 
     Assert.assertEquals(testConfig.getRecord().getMapField(InstanceConfig.InstanceConfigProperty.
         INSTANCE_CAPACITY_MAP.name()), capacityDataMapString);
-  }
 
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Capacity Data is null")
-  public void testSetInstanceCapacityMapEmpty() {
-    Map<String, Integer> capacityDataMap = new HashMap<>();
-
-    InstanceConfig testConfig = new InstanceConfig("testConfig");
     // This operation shall be done. This will clear the instance capacity map in the InstanceConfig
-    testConfig.setInstanceCapacityMap(capacityDataMap);
-    // This operation will fall.
+    testConfig.setInstanceCapacityMap(Collections.emptyMap());
+
+    Assert.assertEquals(testConfig.getRecord().getMapField(InstanceConfig.InstanceConfigProperty.
+        INSTANCE_CAPACITY_MAP.name()), Collections.emptyMap());
+
+    // This operation shall be done. This will remove the instance capacity map in the InstanceConfig
     testConfig.setInstanceCapacityMap(null);
+
+    Assert.assertTrue(testConfig.getRecord().getMapField(InstanceConfig.InstanceConfigProperty.
+        INSTANCE_CAPACITY_MAP.name()) == null);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class,


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolves #627 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

The null check or empty check disallow class users to clean up the corresponding fields.
This change remove these checkes in follow methods,
- ClusterConfig.setDefaultCapacityMap
- ClusterConfig.setGlobalRebalancePreference
- ClusterConfig.setAbnormalStateResolverMap
- InstanceConfig.setInstanceCapacityMap

### Tests

- [X] The following tests are written for this issue:

Modify the existing tests to cover the new change.

- [X] The following is the result of the "mvn test" command on the appropriate module:

helix-core
[ERROR] Failures:
[ERROR]   TestAutoRebalance.testAutoRebalance:177 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1151, Failures: 1, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:17 h
[INFO] Finished at: 2020-08-04T00:12:37-07:00
[INFO] ------------------------------------------------------------------------

Rerun
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 19.694 s
[INFO] Finished at: 2020-08-04T11:03:57-07:00
[INFO] ------------------------------------------------------------------------

helix-rest
[INFO] Tests run: 164, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 53.047 s
[INFO] Finished at: 2020-08-04T11:05:11-07:00
[INFO] ------------------------------------------------------------------------

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
