### PR TITLE
Fix ClusterManager thread leak 

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalance.java
@@ -49,7 +49,7 @@ public class TestDelayedAutoRebalance extends ZkTestBase {
   protected static final int PARTITIONS = 5;
   // TODO: remove this wait time once we have a better way to determine if the rebalance has been
   // TODO: done as a reaction of the test operations.
-  protected static final int DEFAULT_REBALANCE_PROCESSING_WAIT_TIME = 1000;
+  protected static final int DEFAULT_REBALANCE_PROCESSING_WAIT_TIME = 3000;
 
   protected final String CLASS_NAME = getShortClassName();
   protected final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + CLASS_NAME;

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestNoDoubleAssign.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestNoDoubleAssign.java
@@ -42,7 +42,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class TestNoDoubleAssign extends TaskTestBase {
-  private static final int THREAD_COUNT = 1;
+  private static final int THREAD_COUNT = 10;
   private static final long CONNECTION_DELAY = 100L;
   private static final long POLL_DELAY = 50L;
   private static final String TASK_DURATION = "200";

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestNoDoubleAssign.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestNoDoubleAssign.java
@@ -155,16 +155,14 @@ public class TestNoDoubleAssign extends TaskTestBase {
    * Randomly causes Participants to lost connection temporarily.
    */
   private void breakConnection() {
-    // Note, THREAD_COUNT == 1 is a must to avoid leaking ClusterManager (participant).
-    // Otherwise, multiple thread has race of stopping and starting the same slot of index
-    // This would cause a vast amount (hundreds to thousand) leaking threads.
-    // The design of this test itself releys on randomness too, which is also not a good idea.
-    _executorServiceConnection = Executors.newSingleThreadScheduledExecutor();
+    _executorServiceConnection = Executors.newScheduledThreadPool(THREAD_COUNT);
     _executorServiceConnection.scheduleAtFixedRate(() -> {
       // Randomly pick a Participant and cause a transient connection issue
-      int participantIndex = RANDOM.nextInt(_numNodes);
-      stopParticipant(participantIndex);
-      startParticipant(participantIndex);
+      synchronized (this){
+        int participantIndex = RANDOM.nextInt(_numNodes);
+        stopParticipant(participantIndex);
+        startParticipant(participantIndex);
+      }
     }, 0L, CONNECTION_DELAY, TimeUnit.MILLISECONDS);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestNoDoubleAssign.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestNoDoubleAssign.java
@@ -155,15 +155,14 @@ public class TestNoDoubleAssign extends TaskTestBase {
    * Randomly causes Participants to lost connection temporarily.
    */
   private void breakConnection() {
-    // Note, send to THREAD_COUNT == 1 is a must to avoid leaking ClusterManager (participant).
+    // Note, THREAD_COUNT == 1 is a must to avoid leaking ClusterManager (participant).
     // Otherwise, multiple thread has race of stopping and starting the same slot of index
-    // this would cause a vast amount hundreds to thousand leaking threads.
-    // The design of this test itself relys on randomness too, which is also not a good idea.
-    _executorServiceConnection = Executors.newScheduledThreadPool(THREAD_COUNT);
+    // This would cause a vast amount (hundreds to thousand) leaking threads.
+    // The design of this test itself releys on randomness too, which is also not a good idea.
+    _executorServiceConnection = Executors.newSingleThreadScheduledExecutor();
     _executorServiceConnection.scheduleAtFixedRate(() -> {
       // Randomly pick a Participant and cause a transient connection issue
       int participantIndex = RANDOM.nextInt(_numNodes);
-      // _participants[participantIndex].disconnect();
       stopParticipant(participantIndex);
       startParticipant(participantIndex);
     }, 0L, CONNECTION_DELAY, TimeUnit.MILLISECONDS);

--- a/helix-core/src/test/resources/log4j.properties
+++ b/helix-core/src/test/resources/log4j.properties
@@ -27,6 +27,7 @@ log4j.appender.R=org.apache.log4j.RollingFileAppender
 log4j.appender.R.layout=org.apache.log4j.PatternLayout
 log4j.appender.R.layout.ConversionPattern=%5p [%C:%M] (%F:%L) - %m%n
 log4j.appender.R.File=target/ClusterManagerLogs/log.txt
+log4j.appender.R.MaxBackupIndex=20 rolling
 
 log4j.appender.STATUSDUMP=org.apache.log4j.RollingFileAppender
 log4j.appender.STATUSDUMP.layout=org.apache.log4j.SimpleLayout
@@ -36,5 +37,6 @@ log4j.logger.org.I0Itec=ERROR
 log4j.logger.org.apache=ERROR
 log4j.logger.com.noelios=ERROR
 log4j.logger.org.restlet=ERROR
+# log4j.logger.org.apache.helix=INFO
 
 log4j.logger.org.apache.helix.monitoring.ZKPathDataDumpTask=ERROR,STATUSDUMP

--- a/helix-core/src/test/resources/log4j.properties
+++ b/helix-core/src/test/resources/log4j.properties
@@ -16,7 +16,11 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+# Set root logger level to DEBUG and its only appender to R.
 log4j.rootLogger=ERROR, C
+#log4j.rootLogger=ERROR, C, R
+
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.C=org.apache.log4j.ConsoleAppender
@@ -27,7 +31,7 @@ log4j.appender.R=org.apache.log4j.RollingFileAppender
 log4j.appender.R.layout=org.apache.log4j.PatternLayout
 log4j.appender.R.layout.ConversionPattern=%5p [%C:%M] (%F:%L) - %m%n
 log4j.appender.R.File=target/ClusterManagerLogs/log.txt
-log4j.appender.R.MaxBackupIndex=20 rolling
+#log4j.appender.R.MaxBackupIndex=20 rolling
 
 log4j.appender.STATUSDUMP=org.apache.log4j.RollingFileAppender
 log4j.appender.STATUSDUMP.layout=org.apache.log4j.SimpleLayout


### PR DESCRIPTION

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

fix #1216 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

TestNoDoubleAssign relies on randomness of creating a lot of participant or
ClusterManager. Due to race condition of stopping/starting participants, the
Test leaks hundreds ClusterManager thread and ZkClient threads associated.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Copy & paste the result of "mvn test")

### Commits

- [ ] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)