### PR TITLE
Update customized view after all calculation is done

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedViewAggregationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedViewAggregationStage.java
@@ -98,34 +98,34 @@ public class CustomizedViewAggregationStage extends AbstractAsyncBaseStage {
         try {
           computeCustomizedStateView(resource, stateType, customizedStateOutput, curCustomizedViews,
               updatedCustomizedViews);
-
-          List<PropertyKey> keys = new ArrayList<>();
-          for (Iterator<CustomizedView> it = updatedCustomizedViews.iterator(); it.hasNext(); ) {
-            CustomizedView view = it.next();
-            String resourceName = view.getResourceName();
-            keys.add(keyBuilder.customizedView(stateType, resourceName));
-          }
-          // add/update customized-views from zk and cache
-          if (updatedCustomizedViews.size() > 0) {
-            dataAccessor.setChildren(keys, updatedCustomizedViews);
-            cache.updateCustomizedViews(stateType, updatedCustomizedViews);
-          }
-
-          // remove stale customized views from zk and cache
-          List<String> customizedViewToRemove = new ArrayList<>();
-          for (String resourceName : curCustomizedViews.keySet()) {
-            if (!resourceMap.keySet().contains(resourceName)) {
-              LogUtil.logInfo(LOG, _eventId, "Remove customizedView for resource: " + resourceName);
-              dataAccessor.removeProperty(keyBuilder.customizedView(stateType, resourceName));
-              customizedViewToRemove.add(resourceName);
-            }
-          }
-          cache.removeCustomizedViews(stateType, customizedViewToRemove);
         } catch (HelixException ex) {
           LogUtil.logError(LOG, _eventId,
               "Failed to calculate customized view for resource " + resource.getResourceName(), ex);
         }
       }
+
+      List<PropertyKey> keys = new ArrayList<>();
+      for (Iterator<CustomizedView> it = updatedCustomizedViews.iterator(); it.hasNext(); ) {
+        CustomizedView view = it.next();
+        String resourceName = view.getResourceName();
+        keys.add(keyBuilder.customizedView(stateType, resourceName));
+      }
+      // add/update customized-views from zk and cache
+      if (updatedCustomizedViews.size() > 0) {
+        dataAccessor.setChildren(keys, updatedCustomizedViews);
+        cache.updateCustomizedViews(stateType, updatedCustomizedViews);
+      }
+
+      // remove stale customized views from zk and cache
+      List<String> customizedViewToRemove = new ArrayList<>();
+      for (String resourceName : curCustomizedViews.keySet()) {
+        if (!resourceMap.keySet().contains(resourceName)) {
+          LogUtil.logInfo(LOG, _eventId, "Remove customizedView for resource: " + resourceName);
+          dataAccessor.removeProperty(keyBuilder.customizedView(stateType, resourceName));
+          customizedViewToRemove.add(resourceName);
+        }
+      }
+      cache.removeCustomizedViews(stateType, customizedViewToRemove);
     }
   }
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

fixed #1224 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR changes one parenthesis to avoid updating customized view after each calculation. Instead, it will only update the customized view in zk and cache after calculation is done for all resources.

### Tests

- [X] The following tests are written for this issue:

No test is needed as there is no logic change.

- [X] The following is the result of the "mvn test" command on the appropriate module:
helix-core
[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestClusterInMaintenanceModeWhenReachingMaxPartition.testDisableCluster:119 expected:<true> but was:<false>
[ERROR]   TestClusterStatusMonitorLifecycle.testClusterStatusMonitorLifecycle:290 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1165, Failures: 2, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:15 h
[INFO] Finished at: 2020-08-06T14:41:29-07:00

The two failed tests have been run individually, and both passed.

helix-rest
[INFO] Tests run: 165, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 182.724 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 165, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:09 min
[INFO] Finished at: 2020-08-06T13:48:15-07:00

zookeeper-api
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 618.88 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10:23 min
[INFO] Finished at: 2020-08-06T13:35:21-07:00
[INFO] ------------------------------------------------------------------------

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
