### PR TITLE
Terminal State Job Purging

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/AbstractTaskDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/AbstractTaskDispatcher.java
@@ -906,7 +906,7 @@ public abstract class AbstractTaskDispatcher {
       workflowContext.setFinishTime(currentTime);
       updateWorkflowMonitor(workflowContext, workflowConfig);
     }
-    scheduleJobCleanUp(jobConfigMap.get(jobName), workflowConfig, currentTime);
+    scheduleJobCleanUp(jobConfigMap.get(jobName).getExpiry(), workflowConfig, currentTime);
 
     // Job has completed successfully so report ControllerInducedDelay
     JobConfig jobConfig = jobConfigMap.get(jobName);
@@ -930,17 +930,18 @@ public abstract class AbstractTaskDispatcher {
       workflowContext.setFinishTime(currentTime);
       updateWorkflowMonitor(workflowContext, workflowConfig);
     }
-    scheduleJobCleanUp(jobConfigMap.get(jobName), workflowConfig, currentTime);
+    scheduleJobCleanUp(jobConfigMap.get(jobName).getTerminalStateExpiry(), workflowConfig,
+        currentTime);
   }
 
-  protected void scheduleJobCleanUp(JobConfig jobConfig, WorkflowConfig workflowConfig,
+  protected void scheduleJobCleanUp(long expiry, WorkflowConfig workflowConfig,
       long currentTime) {
     long currentScheduledTime =
         _rebalanceScheduler.getRebalanceTime(workflowConfig.getWorkflowId()) == -1 ? Long.MAX_VALUE
             : _rebalanceScheduler.getRebalanceTime(workflowConfig.getWorkflowId());
-    if (currentTime + jobConfig.getExpiry() < currentScheduledTime) {
+    if (currentTime + expiry < currentScheduledTime) {
       _rebalanceScheduler.scheduleRebalance(_manager, workflowConfig.getWorkflowId(),
-          currentTime + jobConfig.getExpiry());
+          currentTime + expiry);
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/task/JobConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobConfig.java
@@ -147,9 +147,16 @@ public class JobConfig extends ResourceConfig {
     StartTime,
 
     /**
-     * The expiration time for the job
+     * The expiration time for the job if it's completed; once the expiry is reached and the job is
+     * completed, the job will be purged
      */
     Expiry,
+
+    /**
+     * The expiration time for the job if it's failed or timed out; once the expiry is reached and
+     * the job has failed or timed out, the job will be purged
+     */
+    TerminalStateExpiry,
 
     /**
      * Whether or not enable running task rebalance
@@ -170,6 +177,7 @@ public class JobConfig extends ResourceConfig {
   public static final long DEFAULT_JOB_EXECUTION_START_TIME = -1L;
   public static final long DEFAULT_Job_EXECUTION_DELAY_TIME = -1L;
   public static final boolean DEFAULT_REBALANCE_RUNNING_TASK = false;
+  public static final long DEFAULT_TERMINAL_STATE_EXPIRY = -1L; // do not purge
 
   // Cache TaskConfig objects for targeted jobs' tasks to reduce object creation/GC overload
   private Map<String, TaskConfig> _targetedTaskConfigMap = new HashMap<>();
@@ -188,7 +196,7 @@ public class JobConfig extends ResourceConfig {
         jobConfig.isIgnoreDependentJobFailure(), jobConfig.getTaskConfigMap(),
         jobConfig.getJobType(), jobConfig.getInstanceGroupTag(), jobConfig.getExecutionDelay(),
         jobConfig.getExecutionStart(), jobId, jobConfig.getExpiry(),
-        jobConfig.isRebalanceRunningTask());
+        jobConfig.getTerminalStateExpiry(), jobConfig.isRebalanceRunningTask());
   }
 
   private JobConfig(String workflow, String targetResource, List<String> targetPartitions,
@@ -197,7 +205,7 @@ public class JobConfig extends ResourceConfig {
       int maxForcedReassignmentsPerTask, int failureThreshold, long retryDelay,
       boolean disableExternalView, boolean ignoreDependentJobFailure,
       Map<String, TaskConfig> taskConfigMap, String jobType, String instanceGroupTag,
-      long executionDelay, long executionStart, String jobId, long expiry,
+      long executionDelay, long executionStart, String jobId, long expiry, long terminalStateExpiry,
       boolean rebalanceRunningTask) {
     super(jobId);
     putSimpleConfig(JobConfigProperty.WorkflowID.name(), workflow);
@@ -257,6 +265,9 @@ public class JobConfig extends ResourceConfig {
     }
     if (expiry > 0) {
       getRecord().setLongField(JobConfigProperty.Expiry.name(), expiry);
+    }
+    if (terminalStateExpiry > 0) {
+      getRecord().setLongField(JobConfigProperty.TerminalStateExpiry.name(), terminalStateExpiry);
     }
     putSimpleConfig(ResourceConfigProperty.MONITORING_DISABLED.toString(),
         String.valueOf(WorkflowConfig.DEFAULT_MONITOR_DISABLE));
@@ -418,6 +429,10 @@ public class JobConfig extends ResourceConfig {
     return getRecord().getLongField(JobConfigProperty.Expiry.name(), WorkflowConfig.DEFAULT_EXPIRY);
   }
 
+  public Long getTerminalStateExpiry() {
+    return getRecord().getLongField(JobConfigProperty.TerminalStateExpiry.name(), DEFAULT_TERMINAL_STATE_EXPIRY);
+  }
+
   public boolean isRebalanceRunningTask() {
     return getRecord().getBooleanField(JobConfigProperty.RebalanceRunningTask.name(),
         DEFAULT_REBALANCE_RUNNING_TASK);
@@ -453,6 +468,7 @@ public class JobConfig extends ResourceConfig {
     private long _executionStart = DEFAULT_JOB_EXECUTION_START_TIME;
     private long _executionDelay = DEFAULT_Job_EXECUTION_DELAY_TIME;
     private long _expiry = WorkflowConfig.DEFAULT_EXPIRY;
+    private long _terminalStateExpiry = DEFAULT_TERMINAL_STATE_EXPIRY;
     private boolean _disableExternalView = DEFAULT_DISABLE_EXTERNALVIEW;
     private boolean _ignoreDependentJobFailure = DEFAULT_IGNORE_DEPENDENT_JOB_FAILURE;
     private int _numberOfTasks = DEFAULT_NUMBER_OF_TASKS;
@@ -477,7 +493,7 @@ public class JobConfig extends ResourceConfig {
           _maxAttemptsPerTask, _maxForcedReassignmentsPerTask, _failureThreshold, _retryDelay,
           _disableExternalView, _ignoreDependentJobFailure, _taskConfigMap, _jobType,
           _instanceGroupTag, _executionDelay, _executionStart, _jobId, _expiry,
-          _rebalanceRunningTask);
+          _terminalStateExpiry, _rebalanceRunningTask);
     }
 
     /**
@@ -553,6 +569,10 @@ public class JobConfig extends ResourceConfig {
       }
       if (cfg.containsKey(JobConfigProperty.Expiry.name())) {
         b.setExpiry(Long.valueOf(cfg.get(JobConfigProperty.Expiry.name())));
+      }
+      if (cfg.containsKey(JobConfigProperty.TerminalStateExpiry.name())) {
+        b.setTerminalStateExpiry(
+            Long.valueOf(cfg.get(JobConfigProperty.TerminalStateExpiry.name())));
       }
       if (cfg.containsKey(JobConfigProperty.RebalanceRunningTask.name())) {
         b.setRebalanceRunningTask(
@@ -688,6 +708,11 @@ public class JobConfig extends ResourceConfig {
 
     public Builder setExpiry(Long expiry) {
       _expiry = expiry;
+      return this;
+    }
+
+    public Builder setTerminalStateExpiry(Long terminalStateExpiry) {
+      _terminalStateExpiry = terminalStateExpiry;
       return this;
     }
 

--- a/helix-core/src/main/java/org/apache/helix/task/JobDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobDispatcher.java
@@ -87,9 +87,10 @@ public class JobDispatcher extends AbstractTaskDispatcher {
     TaskState jobState = workflowCtx.getJobState(jobName);
     // The job is already in a final state (completed/failed).
     if (workflowState == TaskState.FAILED || workflowState == TaskState.COMPLETED
-        || jobState == TaskState.FAILED || jobState == TaskState.COMPLETED || jobState == TaskState.TIMED_OUT) {
+        || jobState == TaskState.FAILED || jobState == TaskState.COMPLETED
+        || jobState == TaskState.TIMED_OUT) {
       LOG.info(String.format(
-          "Workflow %s or job %s is already failed or completed, workflow state (%s), job state (%s), clean up job IS.",
+          "Workflow %s or job %s is already in final state, workflow state (%s), job state (%s), clean up job IS.",
           workflowResource, jobName, workflowState, jobState));
       finishJobInRuntimeJobDag(_dataProvider.getTaskDataCache(), workflowResource, jobName);
       TaskUtil.cleanupJobIdealStateExtView(_manager.getHelixDataAccessor(), jobName);

--- a/helix-core/src/main/java/org/apache/helix/task/JobDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobDispatcher.java
@@ -87,7 +87,7 @@ public class JobDispatcher extends AbstractTaskDispatcher {
     TaskState jobState = workflowCtx.getJobState(jobName);
     // The job is already in a final state (completed/failed).
     if (workflowState == TaskState.FAILED || workflowState == TaskState.COMPLETED
-        || jobState == TaskState.FAILED || jobState == TaskState.COMPLETED) {
+        || jobState == TaskState.FAILED || jobState == TaskState.COMPLETED || jobState == TaskState.TIMED_OUT) {
       LOG.info(String.format(
           "Workflow %s or job %s is already failed or completed, workflow state (%s), job state (%s), clean up job IS.",
           workflowResource, jobName, workflowState, jobState));

--- a/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
@@ -787,7 +787,7 @@ public class TaskUtil {
       JobConfig jobConfig = workflowControllerDataProvider.getJobConfig(job);
       JobContext jobContext = workflowControllerDataProvider.getJobContext(job);
       TaskState jobState = jobStates.get(job);
-      if (isJobExpired(job, jobConfig, jobContext, jobStates.get(job))) {
+      if (isJobExpired(job, jobConfig, jobContext, jobState)) {
         expiredJobs.add(job);
 
         // Failed jobs propagation

--- a/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Stack;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
@@ -733,10 +734,29 @@ public class TaskUtil {
     if (workflowContext != null) {
       Map<String, TaskState> jobStates = workflowContext.getJobStates();
       for (String job : workflowConfig.getJobDag().getAllNodes()) {
+        if (expiredJobs.contains(job)) {
+          continue;
+        }
         JobConfig jobConfig = TaskUtil.getJobConfig(dataAccessor, job);
         JobContext jobContext = TaskUtil.getJobContext(propertyStore, job);
-        if (isJobExpired(job, jobConfig, jobContext, jobStates.get(job))) {
+        TaskState jobState = jobStates.get(job);
+        if (isJobExpired(job, jobConfig, jobContext, jobState)) {
           expiredJobs.add(job);
+
+          // Failed jobs propagation
+          if (jobState == TaskState.FAILED || jobState == TaskState.TIMED_OUT) {
+            Stack<String> childrenJobs = new Stack<>();
+            workflowConfig.getJobDag().getDirectChildren(job).forEach(childrenJobs::push);
+            while (!childrenJobs.isEmpty()) {
+              String childJob = childrenJobs.pop();
+              // Failed and without context means it's failed due to parental job failure
+              if (!expiredJobs.contains(childJob) && jobStates.get(childJob) == TaskState.FAILED
+                  && TaskUtil.getJobContext(propertyStore, childJob) == null) {
+                expiredJobs.add(childJob);
+                workflowConfig.getJobDag().getDirectChildren(childJob).forEach(childrenJobs::push);
+              }
+            }
+          }
         }
       }
     }
@@ -761,10 +781,29 @@ public class TaskUtil {
     Set<String> expiredJobs = new HashSet<>();
     Map<String, TaskState> jobStates = workflowContext.getJobStates();
     for (String job : workflowConfig.getJobDag().getAllNodes()) {
+      if (expiredJobs.contains(job)) {
+        continue;
+      }
       JobConfig jobConfig = workflowControllerDataProvider.getJobConfig(job);
       JobContext jobContext = workflowControllerDataProvider.getJobContext(job);
+      TaskState jobState = jobStates.get(job);
       if (isJobExpired(job, jobConfig, jobContext, jobStates.get(job))) {
         expiredJobs.add(job);
+
+        // Failed jobs propagation
+        if (jobState == TaskState.FAILED || jobState == TaskState.TIMED_OUT) {
+          Stack<String> childrenJobs = new Stack<>();
+          workflowConfig.getJobDag().getDirectChildren(job).forEach(childrenJobs::push);
+          while (!childrenJobs.isEmpty()) {
+            String childJob = childrenJobs.pop();
+            // Failed and without context means it's failed due to parental job failure
+            if (!expiredJobs.contains(childJob) && jobStates.get(childJob) == TaskState.FAILED
+                && workflowControllerDataProvider.getJobContext(childJob) == null) {
+              expiredJobs.add(childJob);
+              workflowConfig.getJobDag().getDirectChildren(childJob).forEach(childrenJobs::push);
+            }
+          }
+        }
       }
     }
     return expiredJobs;
@@ -783,10 +822,16 @@ public class TaskUtil {
           jobName);
       return true;
     }
+    if (jobContext == null || jobContext.getFinishTime() == WorkflowContext.UNFINISHED) {
+      return false;
+    }
+    long jobFinishTime = jobContext.getFinishTime();
     long expiry = jobConfig.getExpiry();
-    return jobContext != null && jobState == TaskState.COMPLETED
-        && jobContext.getFinishTime() != WorkflowContext.UNFINISHED
-        && System.currentTimeMillis() >= jobContext.getFinishTime() + expiry;
+    long terminalStateExpiry = jobConfig.getTerminalStateExpiry();
+    return jobState == TaskState.COMPLETED && System.currentTimeMillis() >= jobFinishTime + expiry
+        || (jobState == TaskState.FAILED || jobState == TaskState.TIMED_OUT)
+        && terminalStateExpiry > 0
+        && System.currentTimeMillis() >= jobFinishTime + terminalStateExpiry;
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobQueueCleanUp.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobQueueCleanUp.java
@@ -19,12 +19,10 @@ package org.apache.helix.integration.task;
  * under the License.
  */
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
 import org.apache.helix.TestHelper;
 import org.apache.helix.task.JobConfig;
 import org.apache.helix.task.JobContext;
@@ -149,11 +147,10 @@ public class TestJobQueueCleanUp extends TaskTestBase {
     }
     _driver.start(builder.build());
 
-    Assert
-        .assertTrue(TestHelper.verify(() -> {
-          WorkflowConfig config = _driver.getWorkflowConfig(queueName);
-          return config.getJobDag().getAllNodes().isEmpty();
-        }, TestHelper.WAIT_DURATION));
+    Assert.assertTrue(TestHelper.verify(() -> {
+      WorkflowConfig config = _driver.getWorkflowConfig(queueName);
+      return config.getJobDag().getAllNodes().isEmpty();
+    }, TestHelper.WAIT_DURATION));
 
     Assert.assertTrue(TestHelper.verify(() -> {
       WorkflowContext context = _driver.getWorkflowContext(queueName);
@@ -181,11 +178,10 @@ public class TestJobQueueCleanUp extends TaskTestBase {
     }
     _driver.start(builder.build());
 
-    Assert
-        .assertTrue(TestHelper.verify(() -> {
-          WorkflowConfig config = _driver.getWorkflowConfig(queueName);
-          return config.getJobDag().getAllNodes().isEmpty();
-        }, TestHelper.WAIT_DURATION));
+    Assert.assertTrue(TestHelper.verify(() -> {
+      WorkflowConfig config = _driver.getWorkflowConfig(queueName);
+      return config.getJobDag().getAllNodes().isEmpty();
+    }, TestHelper.WAIT_DURATION));
 
     Assert.assertTrue(TestHelper.verify(() -> {
       WorkflowContext context = _driver.getWorkflowContext(queueName);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobQueueCleanUp.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobQueueCleanUp.java
@@ -19,10 +19,12 @@ package org.apache.helix.integration.task;
  * under the License.
  */
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import org.apache.helix.TestHelper;
 import org.apache.helix.task.JobConfig;
 import org.apache.helix.task.JobContext;
@@ -60,7 +62,8 @@ public class TestJobQueueCleanUp extends TaskTestBase {
     Assert.assertEquals(_driver.getWorkflowConfig(queueName).getJobDag().size(), 0);
   }
 
-  @Test public void testJobQueueNotCleanupRunningJobs() throws InterruptedException {
+  @Test(dependsOnMethods = "testJobQueueCleanUp")
+  public void testJobQueueNotCleanupRunningJobs() throws InterruptedException {
     String queueName = TestHelper.getTestMethodName();
     JobQueue.Builder builder = TaskTestUtil.buildJobQueue(queueName);
     JobConfig.Builder jobBuilder =
@@ -79,7 +82,7 @@ public class TestJobQueueCleanUp extends TaskTestBase {
     Assert.assertEquals(_driver.getWorkflowConfig(queueName).getJobDag().size(), 2);
   }
 
-  @Test
+  @Test(dependsOnMethods = "testJobQueueNotCleanupRunningJobs")
   public void testJobQueueAutoCleanUp() throws Exception {
     int capacity = 10;
     String queueName = TestHelper.getTestMethodName();
@@ -125,5 +128,68 @@ public class TestJobQueueCleanUp extends TaskTestBase {
       Assert.assertNull(ctx);
     }
 
+  }
+
+  @Test(dependsOnMethods = "testJobQueueAutoCleanUp")
+  public void testJobQueueFailedCleanUp() throws Exception {
+    int capacity = 10;
+    String queueName = TestHelper.getTestMethodName();
+    JobQueue.Builder builder = TaskTestUtil.buildJobQueue(queueName, capacity);
+    WorkflowConfig.Builder cfgBuilder = new WorkflowConfig.Builder(builder.getWorkflowConfig());
+    cfgBuilder.setJobPurgeInterval(1000);
+    builder.setWorkflowConfig(cfgBuilder.build());
+
+    JobConfig.Builder jobBuilder =
+        new JobConfig.Builder().setTargetResource(WorkflowGenerator.DEFAULT_TGT_DB)
+            .setCommand(MockTask.TASK_COMMAND).setMaxAttemptsPerTask(2).setJobCommandConfigMap(
+            ImmutableMap.of(MockTask.SUCCESS_COUNT_BEFORE_FAIL, "0"))
+            .setExpiry(200L).setTerminalStateExpiry(200L);
+    for (int i = 0; i < capacity; i++) {
+      builder.enqueueJob("JOB" + i, jobBuilder);
+    }
+    _driver.start(builder.build());
+
+    Assert
+        .assertTrue(TestHelper.verify(() -> {
+          WorkflowConfig config = _driver.getWorkflowConfig(queueName);
+          return config.getJobDag().getAllNodes().isEmpty();
+        }, TestHelper.WAIT_DURATION));
+
+    Assert.assertTrue(TestHelper.verify(() -> {
+      WorkflowContext context = _driver.getWorkflowContext(queueName);
+      return context.getJobStates().isEmpty();
+    }, TestHelper.WAIT_DURATION));
+  }
+
+
+  @Test(dependsOnMethods = "testJobQueueFailedCleanUp")
+  public void testJobQueueTimedOutCleanUp() throws Exception {
+    int capacity = 10;
+    String queueName = TestHelper.getTestMethodName();
+    JobQueue.Builder builder = TaskTestUtil.buildJobQueue(queueName, capacity);
+    WorkflowConfig.Builder cfgBuilder = new WorkflowConfig.Builder(builder.getWorkflowConfig());
+    cfgBuilder.setJobPurgeInterval(1000);
+    builder.setWorkflowConfig(cfgBuilder.build());
+
+    JobConfig.Builder jobBuilder =
+        new JobConfig.Builder().setTargetResource(WorkflowGenerator.DEFAULT_TGT_DB)
+            .setCommand(MockTask.TASK_COMMAND).setMaxAttemptsPerTask(2).setTimeout(100)
+            .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "10000"))
+            .setTerminalStateExpiry(200L);
+    for (int i = 0; i < capacity; i++) {
+      builder.enqueueJob("JOB" + i, jobBuilder);
+    }
+    _driver.start(builder.build());
+
+    Assert
+        .assertTrue(TestHelper.verify(() -> {
+          WorkflowConfig config = _driver.getWorkflowConfig(queueName);
+          return config.getJobDag().getAllNodes().isEmpty();
+        }, TestHelper.WAIT_DURATION));
+
+    Assert.assertTrue(TestHelper.verify(() -> {
+      WorkflowContext context = _driver.getWorkflowContext(queueName);
+      return context.getJobStates().isEmpty();
+    }, TestHelper.WAIT_DURATION));
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/task/TestTaskUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestTaskUtil.java
@@ -148,10 +148,10 @@ public class TestTaskUtil extends TaskTestBase {
           .thenReturn(jobConfig);
     }
 
-    Long currentTime = System.currentTimeMillis();
     JobContext inProgressJobContext = mock(JobContext.class);
     JobContext failedJobContext = mock(JobContext.class);
-    when(failedJobContext.getFinishTime()).thenReturn(currentTime);
+    when(failedJobContext.getFinishTime()).thenReturn(System.currentTimeMillis() - 1L);
+    when(inProgressJobContext.getFinishTime()).thenReturn((long) WorkflowContext.UNFINISHED);
 
     when(workflowControllerDataProvider.getJobContext(workflowName + "_Job_0"))
         .thenReturn(failedJobContext);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1230 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

- A new field is added to JobConfig in order to support terminal state job purging: TerminalStateExpiry. Necessary functions are implemented to support the new field. 
- A new set of logic is added to TaskGarbageCollectionStage. When purging jobs, terminal state jobs will be considered based on the new expiry value. In addition, a "failed job propagation" logic is put in place. This accounts for the jobs that fail due to parental job failures, because these jobs would not have JobContexts, preventing them to be purged through normal means; with the propagation logic they can be purged along with the failed parental jobs. 
- Modify scheduleJobCleanUp usage to correctly reflect the expiry used. The previous code wasn't necessary as FAILED jobs were not cleaned up anyways, but now it has a meaning. 
- Modify jobDispatcher to honor TIMED_OUT job states. 

### Tests

- [x] The following tests are written for this issue:

testJobQueueFailedCleanUp, testJobQueueTimedOutCleanUp, testGetExpiredJobsFromCacheFailPropagation

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[ERROR] Tests run: 1169, Failures: 5, Errors: 0, Skipped: 1, Time elapsed: 4,517.039 s <<< FAILURE! - in TestSuite
[ERROR] testResourceSubset(org.apache.helix.tools.TestClusterStateVerifier)  Time elapsed: 1.028 s  <<< FAILURE!
org.apache.helix.HelixException: Failed to create pause signal
        at org.apache.helix.tools.TestClusterStateVerifier.testResourceSubset(TestClusterStateVerifier.java:115)

[ERROR] afterMethod(org.apache.helix.tools.TestClusterStateVerifier)  Time elapsed: 1.064 s  <<< FAILURE!
java.lang.IllegalStateException: ZkClient already closed!
        at org.apache.helix.tools.TestClusterStateVerifier.afterMethod(TestClusterStateVerifier.java:98)

[ERROR] TestMessageSimpleSendReceiveAsync(org.apache.helix.integration.messaging.TestCrossClusterMessagingService)  Time elapsed: 2.118 s  <<< FAILURE!
java.lang.AssertionError: 
        at org.apache.helix.integration.messaging.TestCrossClusterMessagingService.TestMessageSimpleSendReceiveAsync(TestCrossClusterMessagingService.java:145)

[ERROR] testEnableCompressionResource(org.apache.helix.integration.TestEnableCompression)  Time elapsed: 168.201 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.TestEnableCompression.testEnableCompressionResource(TestEnableCompression.java:117)

[ERROR] testStateTransitionTimeOut(org.apache.helix.integration.paticipant.TestStateTransitionTimeoutWithResource)  Time elapsed: 36.072 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.paticipant.TestStateTransitionTimeoutWithResource.testStateTransitionTimeOut(TestStateTransitionTimeoutWithResource.java:171)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:117 expected:<true> but was:<false>
[ERROR]   TestCrossClusterMessagingService.TestMessageSimpleSendReceiveAsync:145
[ERROR]   TestStateTransitionTimeoutWithResource.testStateTransitionTimeOut:171 expected:<true> but was:<false>
[ERROR]   TestClusterStateVerifier.afterMethod:98 » IllegalState ZkClient already closed...
[ERROR]   TestClusterStateVerifier.testResourceSubset:115 » Helix Failed to create pause...
[INFO] 
[ERROR] Tests run: 1169, Failures: 5, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:15 h
[INFO] Finished at: 2020-08-13T13:11:21-07:00
[INFO] ------------------------------------------------------------------------
```

Rerun
```
[ERROR] Tests run: 11, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 77.624 s <<< FAILURE! - in TestSuite
[ERROR] afterMethod(org.apache.helix.tools.TestClusterStateVerifier)  Time elapsed: 1.13 s  <<< FAILURE!
java.lang.IllegalStateException: ZkClient already closed!
        at org.apache.helix.tools.TestClusterStateVerifier.afterMethod(TestClusterStateVerifier.java:98)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestClusterStateVerifier.afterMethod:98 » IllegalState ZkClient already closed...
[INFO] 
[ERROR] Tests run: 11, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:22 min
[INFO] Finished at: 2020-08-13T14:10:06-07:00
[INFO] ------------------------------------------------------------------------
```

Rerun
```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.392 s - in org.apache.helix.tools.TestClusterStateVerifier
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14.566 s
[INFO] Finished at: 2020-08-13T14:12:20-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
