### PR TITLE
Test routing data cache

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/spectator/TestRoutingDataCache.java
+++ b/helix-core/src/test/java/org/apache/helix/spectator/TestRoutingDataCache.java
@@ -24,20 +24,21 @@ import java.util.Map;
 import org.apache.helix.HelixConstants;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
+import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.mock.MockZkHelixDataAccessor;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class TestRoutingDataCache extends ZkStandAloneCMTestBase {
 
-  @Test()
-  public void testUpdateOnNotification() throws Exception {
+  @Test
+  public void testUpdateOnNotification() {
     MockZkHelixDataAccessor accessor =
         new MockZkHelixDataAccessor(CLUSTER_NAME, new ZkBaseDataAccessor<ZNRecord>(_gZkClient));
 
@@ -128,43 +129,60 @@ public class TestRoutingDataCache extends ZkStandAloneCMTestBase {
 
   @Test
   public void testCurrentStatesSelectiveUpdate() {
-    String clusterName = "CLUSTER_" + TestHelper.getTestClassName();
-    MockZkHelixDataAccessor accessor =
-        new MockZkHelixDataAccessor(CLUSTER_NAME, new ZkBaseDataAccessor<>(_gZkClient));
-    RoutingDataCache cache = new RoutingDataCache(clusterName, PropertyType.CURRENTSTATES);
+    // Add a live instance to the cluster so the original cluster is not affected
+    // by stopping a participant.
+    String instanceName = PARTICIPANT_PREFIX + "_" + (START_PORT + NODE_NR);
+    _gSetupTool.addInstanceToCluster(CLUSTER_NAME, instanceName);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, TEST_DB, _replica);
+    MockParticipantManager participant =
+        new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+    participant.syncStart();
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
-    // Empty current states map before refreshing.
-    Assert.assertTrue(cache.getCurrentStatesMap().isEmpty());
+    try {
+      MockZkHelixDataAccessor accessor =
+          new MockZkHelixDataAccessor(CLUSTER_NAME, new ZkBaseDataAccessor<>(_gZkClient));
+      RoutingDataCache cache = new RoutingDataCache(CLUSTER_NAME, PropertyType.CURRENTSTATES);
 
-    // 1. Initial cache refresh.
-    cache.refresh(accessor);
-    Map<String, Map<String, Map<String, CurrentState>>> currentStatesV1 =
-        cache.getCurrentStatesMap();
+      // Empty current states map before refreshing.
+      Assert.assertTrue(cache.getCurrentStatesMap().isEmpty());
 
-    // Current states map is not empty and size equals to number of live instances.
-    Assert.assertFalse(currentStatesV1.isEmpty());
-    Assert.assertEquals(currentStatesV1.size(), _participants.length);
+      // 1. Initial cache refresh.
+      cache.refresh(accessor);
+      Map<String, Map<String, Map<String, CurrentState>>> currentStatesV1 =
+          cache.getCurrentStatesMap();
 
-    // 2. Without any change, refresh routing data cache.
-    cache.refresh(accessor);
-    // Because of no current states change, current states cache doesn't refresh.
-    Assert.assertEquals(cache.getCurrentStatesMap(), currentStatesV1);
+      // Current states map is not empty and size equals to number of live instances.
+      Assert.assertFalse(currentStatesV1.isEmpty());
+      Assert.assertEquals(currentStatesV1.size(), _participants.length + 1);
 
-    // 3. Stop one participant to make live instance change and refresh routing data cache.
-    _participants[0].syncStop();
-    cache.notifyDataChange(HelixConstants.ChangeType.LIVE_INSTANCE);
-    cache.refresh(accessor);
-    Map<String, Map<String, Map<String, CurrentState>>> currentStatesV2 =
-        cache.getCurrentStatesMap();
+      // 2. Without any change, refresh routing data cache.
+      cache.refresh(accessor);
+      // Because of no current states change, current states cache doesn't refresh.
+      Assert.assertEquals(cache.getCurrentStatesMap(), currentStatesV1);
 
-    // Current states cache should refresh and change.
-    Assert.assertFalse(currentStatesV2.isEmpty());
-    Assert.assertEquals(currentStatesV2.size(), _participants.length - 1);
-    Assert.assertFalse(currentStatesV1.equals(currentStatesV2));
+      // 3. Stop one participant to make live instance change and refresh routing data cache.
+      participant.syncStop();
 
-    cache.refresh(accessor);
+      cache.notifyDataChange(HelixConstants.ChangeType.LIVE_INSTANCE);
+      cache.refresh(accessor);
+      Map<String, Map<String, Map<String, CurrentState>>> currentStatesV2 =
+          cache.getCurrentStatesMap();
 
-    // No change.
-    Assert.assertEquals(cache.getCurrentStatesMap(), currentStatesV2);
+      // Current states cache should refresh and change.
+      Assert.assertFalse(currentStatesV2.isEmpty());
+      Assert.assertEquals(currentStatesV2.size(), _participants.length);
+      Assert.assertFalse(currentStatesV1.equals(currentStatesV2));
+
+      cache.refresh(accessor);
+
+      // No change.
+      Assert.assertEquals(cache.getCurrentStatesMap(), currentStatesV2);
+    } finally {
+      _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, instanceName, false);
+      _gSetupTool.dropInstanceFromCluster(CLUSTER_NAME, instanceName);
+      _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, TEST_DB, _replica);
+      Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    }
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1252 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Different mvn versions may have different test running order.
If testCurrentStatesSelectiveUpdate is run before the other tests in TestRoutingDataCache, the later tests may fail. This PR fixes the test by adding a new participant to cluster and dropping the participant, verifying cluster state after the test.

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

(Before CI test pass, please copy & paste the result of "mvn test")

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
