### PR TITLE
Extend the task future tracking to a Map instead of a single object.

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -109,48 +109,58 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
     // Otherwise the nodes named with version number will be ordered in a different alphabet order.
     // This might hide some bugs in the GC code。
     int count = 5;
+    int pathCount = 2;
 
     Assert.assertTrue(VERSION_TTL_MS > 100,
         "This test should be executed with the TTL more than 100ms.");
-    // Write "count" times
-    for (int i = 0; i < count; i++) {
-      _bucketDataAccessor.compressedBucketWrite(PATH, new HelixProperty(record));
+
+    try {
+      // Write "count + 1" times, so the latest version will be "count"
+      for (int i = 0; i < count + 1; i++) {
+        for (int j = 0; j < pathCount; j++) {
+          _bucketDataAccessor.compressedBucketWrite(PATH + j, new HelixProperty(record));
+        }
+      }
+
+      for (int j = 0; j < pathCount; j++) {
+        String path = PATH + j;
+        // Last known good version number should be "count"
+        byte[] binarySuccessfulWriteVer = _zkBaseDataAccessor.get(path + "/" + LAST_SUCCESSFUL_WRITE_KEY, null, AccessOption.PERSISTENT);
+        long lastSuccessfulWriteVer = Long.parseLong(new String(binarySuccessfulWriteVer));
+        Assert.assertEquals(lastSuccessfulWriteVer, count);
+
+        // Last write version should be "count"
+        byte[] binaryWriteVer = _zkBaseDataAccessor.get(path + "/" + LAST_WRITE_KEY, null, AccessOption.PERSISTENT);
+        long writeVer = Long.parseLong(new String(binaryWriteVer));
+        Assert.assertEquals(writeVer, count);
+
+        // Test that all previous versions have been deleted
+        // Use Verifier because GC can take ZK delay
+        Assert.assertTrue(TestHelper.verify(() -> {
+          List<String> children = _zkBaseDataAccessor.getChildNames(path, AccessOption.PERSISTENT);
+          return children.size() == 3 && children.containsAll(ImmutableList
+              .of(LAST_SUCCESSFUL_WRITE_KEY, LAST_WRITE_KEY, new Long(lastSuccessfulWriteVer).toString()));
+        }, VERSION_TTL_MS * 2));
+
+        // Wait one more TTL to ensure that the GC has been done.
+        Thread.sleep(VERSION_TTL_MS);
+        List<String> children = _zkBaseDataAccessor.getChildNames(path, AccessOption.PERSISTENT);
+        Assert.assertTrue(children.size() == 3 && children.containsAll(ImmutableList
+            .of(LAST_SUCCESSFUL_WRITE_KEY, LAST_WRITE_KEY, new Long(lastSuccessfulWriteVer).toString())));
+      }
+    } finally {
+      for (int j = 0; j < pathCount; j++) {
+        _bucketDataAccessor.compressedBucketDelete(PATH + j);
+      }
     }
-
-    // Last known good version number should be "count"
-    byte[] binarySuccessfulWriteVer = _zkBaseDataAccessor
-        .get(PATH + "/" + LAST_SUCCESSFUL_WRITE_KEY, null, AccessOption.PERSISTENT);
-    long lastSuccessfulWriteVer = Long.parseLong(new String(binarySuccessfulWriteVer));
-    Assert.assertEquals(lastSuccessfulWriteVer, count);
-
-    // Last write version should be "count"
-    byte[] binaryWriteVer =
-        _zkBaseDataAccessor.get(PATH + "/" + LAST_WRITE_KEY, null, AccessOption.PERSISTENT);
-    long writeVer = Long.parseLong(new String(binaryWriteVer));
-    Assert.assertEquals(writeVer, count);
-
-    // Test that all previous versions have been deleted
-    // Use Verifier because GC can take ZK delay
-    Assert.assertTrue(TestHelper.verify(() -> {
-      List<String> children = _zkBaseDataAccessor.getChildNames(PATH, AccessOption.PERSISTENT);
-      return children.size() == 3 && children.containsAll(ImmutableList
-          .of(LAST_SUCCESSFUL_WRITE_KEY, LAST_WRITE_KEY,
-              new Long(lastSuccessfulWriteVer).toString()));
-    }, VERSION_TTL_MS * 2));
-
-    // Wait one more TTL to ensure that the GC has been done.
-    Thread.sleep(VERSION_TTL_MS);
-    List<String> children = _zkBaseDataAccessor.getChildNames(PATH, AccessOption.PERSISTENT);
-    Assert.assertTrue(children.size() == 3 && children.containsAll(ImmutableList
-        .of(LAST_SUCCESSFUL_WRITE_KEY, LAST_WRITE_KEY,
-            new Long(lastSuccessfulWriteVer).toString())));
   }
 
   /**
    * The record written in {@link #testCompressedBucketWrite()} is the same record that was written.
    */
   @Test(dependsOnMethods = "testMultipleWrites")
-  public void testCompressedBucketRead() {
+  public void testCompressedBucketRead() throws IOException {
+    _bucketDataAccessor.compressedBucketWrite(PATH, new HelixProperty(record));
     HelixProperty readRecord = _bucketDataAccessor.compressedBucketRead(PATH, HelixProperty.class);
     Assert.assertEquals(readRecord.getRecord().getSimpleField(NAME_KEY), NAME_KEY);
     Assert.assertEquals(readRecord.getRecord().getListField(NAME_KEY), LIST_FIELD);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1262 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Since the ZkBucketDataAccessor is used to access multiple paths, a single task future track is not enough. This change uses a map with the path as the key to track tasks for different paths.
Also, enhance the test case to cover the scenario of multiple paths being accessed in a short period.

### Tests

- [X] The following tests are written for this issue:

TestZkBucketDataAccessor test method modified to test with multiple paths.

- [X] The following is the result of the "mvn test" command on the appropriate module:

Helx-core

[ERROR] Failures: 
[ERROR]   TestP2PNoDuplicatedMessage.testP2PStateTransitionEnabled:174 expected:<2200> but was:<2196>
[INFO] 
[ERROR] Tests run: 1163, Failures: 1, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:20 h
[INFO] Finished at: 2020-08-12T21:25:40-07:00
[INFO] ------------------------------------------------------------------------

Re-run

[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 98.501 s - in org.apache.helix.integration.messaging.TestP2PNoDuplicatedMessage
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:45 min
[INFO] Finished at: 2020-08-12T21:34:55-07:00
[INFO] ------------------------------------------------------------------------

Helix-rest

[INFO] Tests run: 165, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 130.89 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 165, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:19 min
[INFO] Finished at: 2020-08-12T21:38:32-07:00
[INFO] ------------------------------------------------------------------------


### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
