### PR TITLE
Change TestInstanceAutoJoin to adapt to cloud environment

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformationProcessor.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/azure/AzureCloudInstanceInformationProcessor.java
@@ -109,7 +109,7 @@ public class AzureCloudInstanceInformationProcessor
       CloseableHttpResponse response = _closeableHttpClient.execute(httpGet);
       if (response == null || response.getStatusLine().getStatusCode() != 200) {
         String errorMsg = String.format(
-            "Failed to get an HTTP Response for the request. Response: {}. Status code: {}",
+            "Failed to get an HTTP Response for the request. Response: %s. Status code: %s",
             (response == null ? "NULL" : response.getStatusLine().getReasonPhrase()),
             response.getStatusLine().getStatusCode());
         throw new HelixException(errorMsg);
@@ -119,7 +119,7 @@ public class AzureCloudInstanceInformationProcessor
       return responseString;
     } catch (IOException e) {
       throw new HelixException(
-          String.format("Failed to get Azure cloud instance information from url {}", url), e);
+          String.format("Failed to get Azure cloud instance information from url %s", url), e);
     }
   }
 
@@ -153,7 +153,7 @@ public class AzureCloudInstanceInformationProcessor
       }
     } catch (IOException e) {
       throw new HelixException(
-          String.format("Error in parsing cloud instance information: {}", response, e));
+          String.format("Error in parsing cloud instance information: %s", response, e));
     }
     return azureCloudInstanceInformation;
   }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fixed #1260  

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

The previous test testAutoRegistrationShouldFailWhenWaitingRespons in TestInstanceAutoJoin will fail in github test, although it always pass locally. The reason is that the test was written with the assumption that it is only run in on-prem environment and auto registration will fail with no cloud response returned. However, github tests are run in cloud environment, and the auto registration will succeed. This PR changed the test to make it adapt to both on-prem and cloud environment. 

### Tests

- [X] The following is the result of the "mvn test" command on the appropriate module:


### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
