### PR TITLE
Allow all tests run in CI

### DIFF
--- a/.github/workflows/Helix-CI.yml
+++ b/.github/workflows/Helix-CI.yml
@@ -20,15 +20,22 @@ jobs:
       run: mvn clean install -Dmaven.test.skip.exec=true
     - name: Test metrics-common
       run: cd metrics-common; mvn test
+      if: ${{ success() || failure() }}
     - name: Test metadata-store-directory-common
       run: cd metadata-store-directory-common; mvn test
+      if: ${{ success() || failure() }}
     - name: Test zookeeper-api
       run: cd zookeeper-api; mvn test
+      if: ${{ success() || failure() }}
     - name: Test helix-common
       run: cd helix-common; mvn test
+      if: ${{ success() || failure() }}
     - name: Test helix-lock
       run: cd helix-lock; mvn test
+      if: ${{ success() || failure() }}
     - name: Test helix-rest
       run: cd helix-rest; mvn test
+      if: ${{ success() || failure() }}
     - name: Test helix-core
       run: cd helix-core; mvn test
+      if: ${{ success() || failure() }}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1286 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently in the merge CI workflow, if there is test failure, the following test steps are not run. We'd like all tests to be run even there is any failure.

After this change: https://github.com/pkuwm/helix/runs/992228496?check_suite_focus=true

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Before CI test pass, please copy & paste the result of "mvn test")

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
