### PR TITLE
Remove closed ZKConnectionManager from connection manager pool

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
@@ -117,6 +117,7 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
   private void cleanupConnectionManager(ZkConnectionManager zkConnectionManager) {
     synchronized (_connectionManagerPool) {
       zkConnectionManager.close(true);
+      _connectionManagerPool.remove(zkConnectionManager);
     }
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
@@ -116,8 +116,8 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
   // to avoid race condition.
   private void cleanupConnectionManager(ZkConnectionManager zkConnectionManager) {
     synchronized (_connectionManagerPool) {
-      zkConnectionManager.close(true);
-      if (!zkConnectionManager.hasSharedWatchers()) {
+      boolean canClose = zkConnectionManager.close(true);
+      if (canClose) {
         _connectionManagerPool.remove(zkConnectionManager);
       }
     }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
@@ -117,7 +117,9 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
   private void cleanupConnectionManager(ZkConnectionManager zkConnectionManager) {
     synchronized (_connectionManagerPool) {
       zkConnectionManager.close(true);
-      _connectionManagerPool.remove(zkConnectionManager);
+      if (!zkConnectionManager.hasSharedWatchers()) {
+        _connectionManagerPool.remove(zkConnectionManager);
+      }
     }
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
@@ -116,8 +116,7 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
   // to avoid race condition.
   private void cleanupConnectionManager(ZkConnectionManager zkConnectionManager) {
     synchronized (_connectionManagerPool) {
-      boolean canClose = zkConnectionManager.close(true);
-      if (canClose) {
+      if (zkConnectionManager.close(true)) {
         _connectionManagerPool.remove(zkConnectionManager);
       }
     }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/ZkConnectionManager.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/ZkConnectionManager.java
@@ -23,9 +23,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
+import org.apache.helix.zookeeper.exception.ZkClientException;
 import org.apache.helix.zookeeper.impl.client.SharedZkClient;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
-import org.apache.helix.zookeeper.exception.ZkClientException;
 import org.apache.helix.zookeeper.zkclient.IZkConnection;
 import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.SerializableSerializer;
@@ -33,7 +33,6 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * NOTE: DO NOT USE THIS CLASS DIRECTLY. Use ZkClientFactories instead.
@@ -48,12 +47,12 @@ import org.slf4j.LoggerFactory;
  * While multiple Shared ZkClients can use single connection manager if possible.
  */
 public class ZkConnectionManager extends ZkClient {
-  private static Logger LOG = LoggerFactory.getLogger(ZkConnectionManager.class);
   // Client type that is used in monitor, and metrics.
   private final static String MONITOR_TYPE = "ZkConnectionManager";
-  private final String _monitorKey;
+  private static Logger LOG = LoggerFactory.getLogger(ZkConnectionManager.class);
   // Set of all registered watchers
   protected final Set<Watcher> _sharedWatchers = new HashSet<>();
+  private final String _monitorKey;
 
   /**
    * Construct and init a ZkConnection Manager.
@@ -130,6 +129,10 @@ public class ZkConnectionManager extends ZkClient {
     }
     super.close();
     LOG.info("ZkConnection {} was closed.", _monitorKey);
+  }
+
+  protected boolean hasSharedWatchers() {
+    return _sharedWatchers != null && _sharedWatchers.size() > 0;
   }
 
   protected void cleanupInactiveWatchers() {

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestSharedZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestSharedZkClient.java
@@ -43,7 +43,6 @@ public class TestSharedZkClient extends RealmAwareZkClientFactoryTestBase {
   @Test
   public void testCreateEphemeralFailure() {
     _realmAwareZkClient.setZkSerializer(new ZNRecordSerializer());
-
     // Create a dummy ZNRecord
     ZNRecord znRecord = new ZNRecord("DummyRecord");
     znRecord.setSimpleField("Dummy", "Value");
@@ -66,4 +65,16 @@ public class TestSharedZkClient extends RealmAwareZkClientFactoryTestBase {
       // this is expected.
     }
   }
+
+   /*
+   Tests clean up of closed connection from pool
+   Use cases tested
+     -Not removal of connection when there is a active watchers
+     -Removal of connection when there are no active watchers
+   */
+   @Test
+    public void testCleanupOfClosedConnectionFromConnectionManager(){
+     // SharedZkClientFactory.getInstance().buildZkClient();
+     // _realmAwareZkClientFactory.buildZkClient();
+   }
 }


### PR DESCRIPTION
### Issues


- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes #1126
### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 44, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 380.898 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 44, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 06:29 min
[INFO] Finished at: 2020-08-19T11:25:45+05:30
[INFO] Final Memory: 22M/263M
[INFO] ------------------------------------------------------------------------


### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
