### PR TITLE
Fix flaky test testMBeanApplicationName

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestDefaultMonitoringMbeans.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestDefaultMonitoringMbeans.java
@@ -28,7 +28,6 @@ import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanException;
 import javax.management.MBeanServer;
-import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
 import javax.ws.rs.core.Response;
@@ -83,26 +82,20 @@ public class TestDefaultMonitoringMbeans extends AbstractTestClass {
   }
 
   @Test
-  public void testMBeanApplicationName()
-      throws MalformedObjectNameException {
+  public void testMBeanApplicationName() throws Exception {
     Set<String> namespaces =
         new HashSet<>(Arrays.asList(HelixRestNamespace.DEFAULT_NAMESPACE_NAME, TEST_NAMESPACE));
     MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-    Set<ObjectName> objectNames =
-        mBeanServer.queryNames(new ObjectName(DEFAULT_METRIC_DOMAIN + ":*"), null);
 
-    Set<String> appNames = new HashSet<>();
-    for (ObjectName mBeanName : objectNames) {
-      appNames.add(mBeanName.getKeyProperty("type"));
-    }
+    TestHelper.verify(() -> {
+      Set<ObjectName> objectNames =
+          mBeanServer.queryNames(new ObjectName(DEFAULT_METRIC_DOMAIN + ":*"), null);
 
-    Assert.assertEquals(appNames.size(), namespaces.size(), String
-        .format("appNames: %s does't have the same size as namespaces: %s.", appNames, namespaces));
-
-    for (String appName : appNames) {
-      Assert.assertTrue(namespaces.contains(appName), String
-          .format("Application name: %s is not one of the namespaces: %s.", appName, namespaces));
-      namespaces.remove(appName);
-    }
+      Set<String> appNames = new HashSet<>();
+      for (ObjectName mBeanName : objectNames) {
+        appNames.add(mBeanName.getKeyProperty("type"));
+      }
+      return namespaces.equals(appNames);
+    }, TestHelper.WAIT_DURATION);
   }
 }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1297 

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

The test intermittently fails on GitHub CI because default namespace may not be registered to mbean server yet, if there is a race condition between test and mbean server. This PR fixes it by using TestHelper.verify() to check the result.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Before CI test pass, please copy & paste the result of "mvn test")

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
