### PR TITLE
Fix customized view aggregation latency calculation

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedViewAggregationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CustomizedViewAggregationStage.java
@@ -211,12 +211,15 @@ public class CustomizedViewAggregationStage extends AbstractAsyncBaseStage {
 
           for (Map.Entry<String, String> stateMapEntry : newStateMap.entrySet()) {
             String instanceName = stateMapEntry.getKey();
-            if (!stateMapEntry.getValue().equals(oldStateMap.get(instanceName))) {
-              long timestamp = partitionStartTimeMap.get(instanceName);
-              if (timestamp > 0) {
+            String newVal = stateMapEntry.getValue();
+            // We do not calculate the latency for deleting customized state
+            // So new value shouldn't be empty
+            if (!newVal.isEmpty() && !newVal.equals(oldStateMap.get(instanceName))) {
+              Long timestamp = partitionStartTimeMap.get(instanceName);
+              if (timestamp != null && timestamp > 0) {
                 customizedViewMonitor.recordUpdateToAggregationLatency(curTime - timestamp);
               } else {
-                LOG.warn(
+                LOG.info(
                     "Failed to find customized state update time stamp for resource {} partition {}, instance {}, on cluster {} the number should be positive.",
                     resourceName, partitionName, instanceName, clusterName);
               }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/CustomizedViewMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/CustomizedViewMonitor.java
@@ -43,7 +43,6 @@ public class CustomizedViewMonitor extends DynamicMBeanProvider {
   private HistogramDynamicMetric _updateToAggregationLatencyGauge;
   public static final String UPDATE_TO_AGGREGATION_LATENCY_GAUGE =
       "UpdateToAggregationLatencyGauge";
-  private ClusterStatusMonitor _clusterStatusMonitor;
   private static final String TYPE_KEY = "Type";
   private static final String CLUSTER_KEY = "Cluster";
   private static final String CUSTOMIZED_VIEW = "CustomizedView";
@@ -51,8 +50,8 @@ public class CustomizedViewMonitor extends DynamicMBeanProvider {
   public CustomizedViewMonitor(String clusterName) {
     _clusterName = clusterName;
     _sensorName = String
-        .format("%s:%s=%s,%s=%s", MonitorDomainNames.AggregatedView.name(), TYPE_KEY,
-            CUSTOMIZED_VIEW, CLUSTER_KEY, _clusterName);
+        .format("%s.%s.%s", MonitorDomainNames.AggregatedView.name(),
+            CUSTOMIZED_VIEW, _clusterName);
     _updateToAggregationLatencyGauge =
         new HistogramDynamicMetric(UPDATE_TO_AGGREGATION_LATENCY_GAUGE, new Histogram(
             new SlidingTimeWindowArrayReservoir(getResetIntervalInMs(), TimeUnit.MILLISECONDS)));


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes #1313.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR contains two minor fixes to improve the customized view aggregation latency calculation.
1. Fix CustomizedViewMonitor sensor name
2. Add check for empty customized state value because it indicates a deletion and skip latency calculation for it
3. Reduce a logging level to info from warn
4. Add check for null value

### Tests

- [x] The following tests are written for this issue:

TestCustomizedViewStage -> testLatencyCalculationWithEmptyTimestamp

- [x] The following is the result of the "mvn test" command on the appropriate module:

[INFO]
[ERROR] Failures:
[ERROR]   TestZkConnectionLost.testLostZkConnection:162->restartZkServer:231 » ThreadTimeout
[ERROR]   TestExpandCluster.testClusterExpansion:61 expected:<false> but was:<true>
[ERROR]   TestRoutingTableProviderPeriodicRefresh.testPeriodicRefresh:211 expected:<4> but was:<3>
[ERROR]   TestJobFailureDependence.testWorkflowFailureJobThreshold » ThreadTimeout Metho...
[INFO]
[ERROR] Tests run: 1174, Failures: 4, Errors: 0, Skipped: 3
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:26 h
[INFO] Finished at: 2020-08-25T16:05:23-07:00


### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
