### PR TITLE
Remove unused org.codehaus.jackson imports in pom file

### DIFF
--- a/helix-common/pom.xml
+++ b/helix-common/pom.xml
@@ -31,7 +31,6 @@
 
   <properties>
     <osgi.import>
-      org.codehaus.jackson*,
       org.slf4j*;version="[1.6,2)",
       *
     </osgi.import>

--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -38,7 +38,6 @@
       org.apache.commons.io*;version="[1.4,2)",
       org.apache.commons.math*;version="[2.1,4)",
       org.apache.jute*;resolution:=optional,
-      org.codehaus.jackson*;version="[1.8,2)",
       org.slf4j*;version="[1.6,2)",
       *
     </osgi.import>

--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -32,7 +32,6 @@
   <properties>
     <osgi.import>
       org.apache.helix*,
-      org.codehaus.jackson*,
       org.apache.commons.cli*,
       org.restlet*,
       org.slf4j*;version="[1.6,2)",


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
 Fix #401

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
We notice the following warning in CI test. This PR removes unused org.codehaus.jackson imports in pom file.
```
[WARNING] Manifest org.apache.helix:helix-core:bundle:1.0.2-SNAPSHOT : Unused Import-Package instructions: [org.codehaus.jackson*] 
```
### Tests

- [X] The following tests are written for this issue:

- [X] The following is the result of the "mvn test" command on the appropriate module:

```
[WARNING] Tests run: 1174, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 4,050.691 s - in TestSuite                                                                  
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 1174, Failures: 0, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:07 h
[INFO] Finished at: 2020-08-26T12:50:44-07:00
[INFO] ------------------------------------------------------------------------
```
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
