### PR TITLE
Configurable Task Pool TaskDriver helpers fix

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -1177,6 +1177,7 @@ public class TaskDriver {
   public void setTargetTaskThreadPoolSize(String instanceName, int targetTaskThreadPoolSize) {
     InstanceConfig instanceConfig = getInstanceConfig(instanceName);
     instanceConfig.setTargetTaskThreadPoolSize(targetTaskThreadPoolSize);
+    _accessor.setProperty(_accessor.keyBuilder().instanceConfig(instanceName), instanceConfig);
   }
 
   private InstanceConfig getInstanceConfig(String instanceName) {
@@ -1211,6 +1212,7 @@ public class TaskDriver {
   public void setGlobalTargetTaskThreadPoolSize(int globalTargetTaskThreadPoolSize) {
     ClusterConfig clusterConfig = getClusterConfig();
     clusterConfig.setGlobalTargetTaskThreadPoolSize(globalTargetTaskThreadPoolSize);
+    _accessor.setProperty(_accessor.keyBuilder().clusterConfig(), clusterConfig);
   }
 
   private ClusterConfig getClusterConfig() {

--- a/helix-core/src/test/java/org/apache/helix/task/TestTaskDriver.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestTaskDriver.java
@@ -45,23 +45,6 @@ public class TestTaskDriver extends TaskTestBase {
   }
 
   @Test
-  public void testGetTargetTaskThreadPoolSize() {
-    String validInstanceName = _participants[0].getInstanceName();
-    InstanceConfig instanceConfig =
-        _configAccessor.getInstanceConfig(CLUSTER_NAME, validInstanceName);
-    instanceConfig.setTargetTaskThreadPoolSize(TEST_THREAD_POOL_SIZE);
-    _configAccessor.setInstanceConfig(CLUSTER_NAME, validInstanceName, instanceConfig);
-
-    Assert.assertEquals(_taskDriver.getTargetTaskThreadPoolSize(validInstanceName),
-        TEST_THREAD_POOL_SIZE);
-  }
-
-  @Test(dependsOnMethods = "testGetTargetTaskThreadPoolSize", expectedExceptions = IllegalArgumentException.class)
-  public void testGetTargetTaskThreadPoolSizeWrongInstanceName() {
-    _taskDriver.getTargetTaskThreadPoolSize(NON_EXISTENT_INSTANCE_NAME);
-  }
-
-  @Test(dependsOnMethods = "testGetTargetTaskThreadPoolSizeWrongInstanceName")
   public void testSetTargetTaskThreadPoolSize() {
     String validInstanceName = _participants[0].getInstanceName();
     _taskDriver.setTargetTaskThreadPoolSize(validInstanceName, TEST_THREAD_POOL_SIZE);
@@ -77,15 +60,19 @@ public class TestTaskDriver extends TaskTestBase {
   }
 
   @Test(dependsOnMethods = "testSetTargetTaskThreadPoolSizeWrongInstanceName")
-  public void testGetGlobalTargetTaskThreadPoolSize() {
-    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
-    clusterConfig.setGlobalTargetTaskThreadPoolSize(TEST_THREAD_POOL_SIZE);
-    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+  public void testGetTargetTaskThreadPoolSize() {
+    String validInstanceName = _participants[0].getInstanceName();
 
-    Assert.assertEquals(_taskDriver.getGlobalTargetTaskThreadPoolSize(), TEST_THREAD_POOL_SIZE);
+    Assert.assertEquals(_taskDriver.getTargetTaskThreadPoolSize(validInstanceName),
+        TEST_THREAD_POOL_SIZE);
   }
 
-  @Test(dependsOnMethods = "testGetGlobalTargetTaskThreadPoolSize")
+  @Test(dependsOnMethods = "testGetTargetTaskThreadPoolSize", expectedExceptions = IllegalArgumentException.class)
+  public void testGetTargetTaskThreadPoolSizeWrongInstanceName() {
+    _taskDriver.getTargetTaskThreadPoolSize(NON_EXISTENT_INSTANCE_NAME);
+  }
+
+  @Test(dependsOnMethods = "testGetTargetTaskThreadPoolSizeWrongInstanceName")
   public void testSetGlobalTargetTaskThreadPoolSize() {
     _taskDriver.setGlobalTargetTaskThreadPoolSize(TEST_THREAD_POOL_SIZE);
     ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
@@ -94,6 +81,11 @@ public class TestTaskDriver extends TaskTestBase {
   }
 
   @Test(dependsOnMethods = "testSetGlobalTargetTaskThreadPoolSize")
+  public void testGetGlobalTargetTaskThreadPoolSize() {
+    Assert.assertEquals(_taskDriver.getGlobalTargetTaskThreadPoolSize(), TEST_THREAD_POOL_SIZE);
+  }
+
+  @Test(dependsOnMethods = "testGetGlobalTargetTaskThreadPoolSize")
   public void testGetCurrentTaskThreadPoolSize() {
     String validInstanceName = _participants[0].getInstanceName();
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1320

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The setters were not actually setting the InstanceConfig/ClusterConfig. The test cases were also constructed incorrectly; the original ordering caused the "setting tests" to use the values set in the "getting tests" and therefore they are not correctly testing the setters. They are now ordered such that the setting tests are performed first.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[ERROR] Tests run: 1164, Failures: 5, Errors: 0, Skipped: 1, Time elapsed: 4,645.579 s <<< FAILURE! - in TestSuite
[ERROR] testChangeIdealState(org.apache.helix.integration.rebalancer.WagedRebalancer.TestWagedRebalance)  Time elapsed: 6.08 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.rebalancer.WagedRebalancer.TestWagedRebalance.validate(TestWagedRebalance.java:614)
        at org.apache.helix.integration.rebalancer.WagedRebalancer.TestWagedRebalance.testChangeIdealState(TestWagedRebalance.java:271)

[ERROR] testFixedTargetTaskAndEnabledRebalanceAndNodeAdded(org.apache.helix.integration.task.TestRebalanceRunningTask)  Time elapsed: 10.424 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.task.TestRebalanceRunningTask.testFixedTargetTaskAndEnabledRebalanceAndNodeAdded(TestRebalanceRunningTask.java:330)

[ERROR] testWorkflowJobFail(org.apache.helix.integration.task.TestWorkflowTermination)  Time elapsed: 10.139 s  <<< FAILURE!
org.apache.helix.HelixException: Workflow "testWorkflowJobFail" context is empty or not in states: "[FAILED]", current state: "IN_PROGRESS"
        at org.apache.helix.integration.task.TestWorkflowTermination.testWorkflowJobFail(TestWorkflowTermination.java:223)

[ERROR] testEnableCompressionResource(org.apache.helix.integration.TestEnableCompression)  Time elapsed: 285.579 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.TestEnableCompression.testEnableCompressionResource(TestEnableCompression.java:117)

[ERROR] testStateTransitionTimeOut(org.apache.helix.integration.paticipant.TestStateTransitionTimeout)  Time elapsed: 32.015 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.integration.paticipant.TestStateTransitionTimeout.testStateTransitionTimeOut(TestStateTransitionTimeout.java:166)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestEnableCompression.testEnableCompressionResource:117 expected:<true> but was:<false>
[ERROR]   TestStateTransitionTimeout.testStateTransitionTimeOut:166 expected:<true> but was:<false>
[ERROR]   TestWagedRebalance.testChangeIdealState:271->validate:614 expected:<true> but was:<false>
[ERROR]   TestRebalanceRunningTask.testFixedTargetTaskAndEnabledRebalanceAndNodeAdded:330 expected:<true> but was:<false>
[ERROR]   TestWorkflowTermination.testWorkflowJobFail:223 » Helix Workflow "testWorkflow...
[INFO] 
[ERROR] Tests run: 1164, Failures: 5, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:17 h
[INFO] Finished at: 2020-08-27T16:04:46-07:00
[INFO] ------------------------------------------------------------------------
```
Rerun
```
[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 111.927 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:57 min
[INFO] Finished at: 2020-08-27T16:36:17-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
