### PR TITLE
fix Github helix-core test running out of memory issue #1334

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -735,7 +735,7 @@
               See also: properties section and profiles section.
         -->
         <configuration>
-          <argLine>-Xms1024m -Xmx1024m</argLine>
+          <argLine>-Xms4096m -Xmx4096m</argLine>
           <suiteXmlFiles>
             <suiteXmlFile>src/test/conf/testng.xml</suiteXmlFile>
           </suiteXmlFiles>


### PR DESCRIPTION

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

fix #1334 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

As title, github run of helix-core can't be finished recently
due to out of memory issue. This config change hopefully fix
this issue.

### Tests

- [x] The following tests are written for this issue:

None
- [x] The following is the result of the "mvn test" command on the appropriate module:

running

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
