### PR TITLE
Clean up instance validation logic and test

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
@@ -159,12 +159,14 @@ public class InstanceValidationUtil {
     PropertyKey.Builder keyBuilder = dataAccessor.keyBuilder();
     ClusterConfig clusterConfig = dataAccessor.getProperty(keyBuilder.clusterConfig());
     if (clusterConfig == null) {
-      throw new HelixException("Cluster config is missing in cluster " + clusterId);
+      _logger.error("Cluster config is missing in cluster " + clusterId);
+      return false;
     }
     if (!clusterConfig.isPersistIntermediateAssignment()) {
-      throw new HelixException(String.format(
+      _logger.error(String.format(
           "Cluster config %s is not turned on, which is required for instance stability check.",
           ClusterConfig.ClusterConfigProperty.PERSIST_INTERMEDIATE_ASSIGNMENT.toString()));
+      return false;
     }
     PropertyKey propertyKey = keyBuilder.instanceConfig(instanceName);
     InstanceConfig instanceConfig = dataAccessor.getProperty(propertyKey);
@@ -267,6 +269,10 @@ public class InstanceValidationUtil {
    */
   public static boolean isInstanceStable(HelixDataAccessor dataAccessor, String instanceName) {
     PropertyKey.Builder keyBuilder = dataAccessor.keyBuilder();
+    ClusterConfig clusterConfig = dataAccessor.getProperty(keyBuilder.clusterConfig());
+    if (clusterConfig == null) {
+      throw new HelixException("Missing cluster config!");
+    }
     List<String> idealStateNames = dataAccessor.getChildNames(keyBuilder.idealStates());
     for (String idealStateName : idealStateNames) {
       IdealState idealState = dataAccessor.getProperty(keyBuilder.idealStates(idealStateName));

--- a/helix-core/src/test/java/org/apache/helix/util/TestInstanceValidationUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestInstanceValidationUtil.java
@@ -43,6 +43,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doReturn;
@@ -216,7 +217,14 @@ public class TestInstanceValidationUtil {
   @Test
   public void TestHasValidConfig_true() {
     Mock mock = new Mock();
-    when(mock.dataAccessor.getProperty(any(PropertyKey.class)))
+    PropertyKey.Builder keyBuilder = mock.dataAccessor.keyBuilder();
+    PropertyKey clusterProperty = keyBuilder.clusterConfig();
+    ClusterConfig clusterConfig = new ClusterConfig(TEST_CLUSTER);
+    clusterConfig.setPersistIntermediateAssignment(true);
+    when(mock.dataAccessor.getProperty(eq(clusterProperty)))
+        .thenReturn(clusterConfig);
+    PropertyKey instanceProperty = keyBuilder.instanceConfig(TEST_INSTANCE);
+    when(mock.dataAccessor.getProperty(eq(instanceProperty)))
         .thenReturn(new InstanceConfig(TEST_INSTANCE));
 
     Assert.assertTrue(
@@ -272,14 +280,14 @@ public class TestInstanceValidationUtil {
         InstanceValidationUtil.hasErrorPartitions(mock.dataAccessor, TEST_CLUSTER, TEST_INSTANCE));
   }
 
-  @Test(expectedExceptions = HelixException.class)
-  public void TestIsInstanceStable_exception_whenPersistAssignmentOff() {
+  @Test
+  public void TestIsInstanceStable_NoException_whenPersistAssignmentOff() {
     Mock mock = new Mock();
     ClusterConfig clusterConfig = new ClusterConfig(TEST_CLUSTER);
     clusterConfig.setPersistIntermediateAssignment(false);
     when(mock.dataAccessor.getProperty(any(PropertyKey.class))).thenReturn(clusterConfig);
 
-    InstanceValidationUtil.hasValidConfig(mock.dataAccessor, TEST_CLUSTER, TEST_INSTANCE);
+    InstanceValidationUtil.isInstanceStable(mock.dataAccessor, TEST_INSTANCE);
   }
 
   @Test(expectedExceptions = HelixException.class)

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/util/TestInstanceValidationUtilInRest.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/util/TestInstanceValidationUtilInRest.java
@@ -37,7 +37,7 @@ import org.testng.annotations.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TestInstanceValidationUtil{
+public class TestInstanceValidationUtilInRest{
   private static final String RESOURCE_NAME = "TestResource";
   private static final String TEST_CLUSTER = "TestCluster";
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fixed #1341 
### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

The cluster config null check and instance validation check are tangled together right now. We would like to make them clear and return proper error message to users. Also there are two tests in helix-core and helix-rest with exactly name about instance validation. We want to distinguish them to avoid confusion.
This PR put cluster config null check into valid instance config check, together with persist intermediate state check. If either of them is false, the instance validation check will fail with a "false" return, instead of throwing an exception.
It also renamed one of the test in `TestInstanceValidationUtil` so that helix-core and helix-rest don't have duplicated test names.

### Tests


- [X] The following is the result of the "mvn test" command on the appropriate module:

[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 1200, Failures: 0, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:10 h
[INFO] Finished at: 2020-09-02T19:28:18-07:00

[INFO] 
[ERROR] Failures: 
[ERROR]   TestClusterAccessor.testUpdateConfigFields:167 » IndexOutOfBounds Index: 0, Si...
[INFO] 
[ERROR] Tests run: 166, Failures: 1, Errors: 0, Skipped: 25
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33.981 s
[INFO] Finished at: 2020-09-02T20:01:32-07:00

The failed test is a known issue: https://github.com/apache/helix/issues/1336
Will be addressed later.

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
