### PR TITLE
Reduce unnecessary getChildren call in subscribeForChanges

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -538,7 +538,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
     }
   }
 
-  private void subscribeChildChange(String path, NotificationContext.Type callbackType) {
+  private List<String> subscribeChildChange(String path, NotificationContext.Type callbackType) {
     if (callbackType == NotificationContext.Type.INIT
         || callbackType == NotificationContext.Type.CALLBACK) {
       if (logger.isDebugEnabled()) {
@@ -559,12 +559,15 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
       if (!childrenSubscribeResult.isInstalled()) {
         logger.info("CallbackHandler {} subscribe data path {} failed!", _uid, path);
       }
+      return childrenSubscribeResult.getChildren();
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info("CallbackHandler{}, {} unsubscribe child-change. path: {}, listener: {}",
           _uid ,_manager.getInstanceName(), path, _listener);
 
       _zkClient.unsubscribeChildChanges(path, this);
     }
+
+    return null;
   }
 
   private void subscribeDataChange(String path, NotificationContext.Type callbackType) {
@@ -597,23 +600,21 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
 
   private void subscribeForChanges(NotificationContext.Type callbackType, String path,
       boolean watchChild) {
-    logger.info("CallbackHandler {} Subscribing changes listener to path: {}, type: {}, listener: {}",
-        _uid, path, callbackType, _listener);
+    logger.info("CallbackHandler {} subscribing changes listener to path: {}, callback type: {}, "
+            + "event types: {}, listener: {}, watchChild: {}",
+        _uid, path, callbackType, _eventTypes, _listener, watchChild);
 
     long start = System.currentTimeMillis();
     if (_eventTypes.contains(EventType.NodeDataChanged)
         || _eventTypes.contains(EventType.NodeCreated)
         || _eventTypes.contains(EventType.NodeDeleted)) {
-      logger.info("CallbackHandler{} Subscribing data change listener to path: {}", _uid, path);
+      logger.info("CallbackHandler {} subscribing data change listener to path: {}", _uid, path);
       subscribeDataChange(path, callbackType);
     }
 
     if (_eventTypes.contains(EventType.NodeChildrenChanged)) {
-      logger.info("CallbackHandler{}, Subscribing child change listener to path: {}", _uid, path);
-      subscribeChildChange(path, callbackType);
+      List<String> children = subscribeChildChange(path, callbackType);
       if (watchChild) {
-        logger.info("CallbackHandler{}, Subscribing data change listener to all children for path: {}", _uid, path);
-
         try {
           switch (_changeType) {
             case CURRENT_STATE:
@@ -633,11 +634,10 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
                 if (bucketSize > 0) {
                   // subscribe both data-change and child-change on bucketized parent node
                   // data-change gives a delete-callback which is used to remove watch
-                  subscribeChildChange(childPath, callbackType);
+                  List<String> bucketizedChildNames = subscribeChildChange(childPath, callbackType);
                   subscribeDataChange(childPath, callbackType);
 
                   // subscribe data-change on bucketized child
-                  List<String> bucketizedChildNames = _zkClient.getChildren(childPath);
                   if (bucketizedChildNames != null) {
                     for (String bucketizedChildName : bucketizedChildNames) {
                       String bucketizedChildPath = childPath + "/" + bucketizedChildName;
@@ -651,10 +651,14 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
               break;
             }
             default: {
-              List<String> childNames = _zkClient.getChildren(path);
-              if (childNames != null) {
-                for (String childName : childNames) {
-                  String childPath = path + "/" + childName;
+              // When callback type is FINALIZE, subscribeChildChange doesn't
+              // get children list. We need to read children to unsubscribe data change listeners.
+              if (callbackType == Type.FINALIZE) {
+                children = _zkClient.getChildren(path);
+              }
+              if (children != null) {
+                for (String child : children) {
+                  String childPath = path + "/" + child;
                   subscribeDataChange(childPath, callbackType);
                 }
               }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -541,7 +541,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
   /*
    * If callback type is INIT or CALLBACK, subscribes child change listener to the path
    * and returns the path's children names. The children list might be null when the path
-   * doesn't exist or callback type is other than INIT/CALLBACK.
+   * doesn't exist or callback type is other than INIT/CALLBACK/FINALIZE.
    */
   private List<String> subscribeChildChange(String path, NotificationContext.Type callbackType) {
     if (callbackType == NotificationContext.Type.INIT
@@ -574,7 +574,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
       _zkClient.unsubscribeChildChanges(path, this);
     }
 
-    return null;
+    return _zkClient.getChildren(path);
   }
 
   private void subscribeDataChange(String path, NotificationContext.Type callbackType) {
@@ -658,11 +658,6 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
               break;
             }
             default: {
-              // When callback type is FINALIZE, subscribeChildChange doesn't
-              // get children list. We need to read children to unsubscribe data change listeners.
-              if (callbackType == Type.FINALIZE) {
-                children = _zkClient.getChildren(path);
-              }
               if (children != null) {
                 for (String child : children) {
                   String childPath = path + "/" + child;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -541,7 +541,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
   /*
    * If callback type is INIT or CALLBACK, subscribes child change listener to the path
    * and returns the path's children names. The children list might be null when the path
-   * doesn't exist or callback type is other than INIT/CALLBACK/FINALIZE.
+   * doesn't exist or callback type is INIT/CALLBACK.
    */
   private List<String> subscribeChildChange(String path, NotificationContext.Type callbackType) {
     if (callbackType == NotificationContext.Type.INIT
@@ -574,6 +574,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
       _zkClient.unsubscribeChildChanges(path, this);
     }
 
+    // List of children could be empty, but won't be null.
     return _zkClient.getChildren(path);
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1343 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In CallbackHanlder's subscribeForChanges(), children names need to be fetched. subscribeChildChange(path, callbackType) does actually have the children list, but it doesn't return, and later getChildren() is called again. It wastes one zk call: not only wasting time in handling a callback, but also adds more read pressure to zk server.

We could use the return result from subscribeChildChange() and save one getChildren() call.

This PR also adds event types logging and removes two logs. When debugging, we can actually use the event types to determine the code logic. No need to print those two logs, which saves logging overhead when there are intensive callbacks.

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestCardDealingAdjustmentAlgorithmV2.testAlgorithmConstructor:127 expected:<9> but was:<6>
[ERROR] org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas(org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2)
[ERROR]   Run 1: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:273 Total movements: 4 != expected 8, replica: 1
[ERROR]   Run 2: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:273 Total movements: 4 != expected 8, replica: 2
[ERROR]   Run 3: TestCardDealingAdjustmentAlgorithmV2.testComputeMappingForDifferentReplicas:273 Total movements: 14 != expected 21, replica: 3
[INFO]   Run 4: PASS
[INFO]   Run 5: PASS
[INFO]
[INFO]
[ERROR] Tests run: 1204, Failures: 2, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:12 h
[INFO] Finished at: 2020-09-24T16:30:00-07:00
[INFO] ------------------------------------------------------------------------


[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.483 s - in org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.198 s
[INFO] Finished at: 2020-09-24T17:35:52-07:00
[INFO] ------------------------------------------------------------------------
```
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
