### PR TITLE
Enhance logging for CallbackHandler and Zkclient

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -105,7 +105,7 @@ import static org.apache.helix.HelixConstants.ChangeType.TARGET_EXTERNAL_VIEW;
 @PreFetchChangedData(enabled = false)
 public class CallbackHandler implements IZkChildListener, IZkDataListener {
   private static Logger logger = LoggerFactory.getLogger(CallbackHandler.class);
-  private static final AtomicLong CALLBACK_HANDLER_UI = new AtomicLong();
+  private static final AtomicLong CALLBACK_HANDLER_UID = new AtomicLong();
 
   private final long _uid;
   /**
@@ -227,7 +227,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
           + monitor.getChangeType().name());
     }
 
-    _uid = CALLBACK_HANDLER_UI.getAndIncrement();
+    _uid = CALLBACK_HANDLER_UID.getAndIncrement();
 
 
     _manager = manager;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.helix.BaseDataAccessor;
@@ -106,7 +105,7 @@ import static org.apache.helix.HelixConstants.ChangeType.TARGET_EXTERNAL_VIEW;
 @PreFetchChangedData(enabled = false)
 public class CallbackHandler implements IZkChildListener, IZkDataListener {
   private static Logger logger = LoggerFactory.getLogger(CallbackHandler.class);
-  private static AtomicLong CB_UID = new AtomicLong();
+  private static final AtomicLong CALLBACK_HANDLER_UI = new AtomicLong();
 
   private final long _uid;
   /**
@@ -228,7 +227,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
           + monitor.getChangeType().name());
     }
 
-    _uid = CB_UID.getAndIncrement();
+    _uid = CALLBACK_HANDLER_UI.getAndIncrement();
 
 
     _manager = manager;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -359,10 +359,10 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
     // async mode only applicable to CALLBACK from ZK, During INIT and FINALIZE invoke the
     // callback's immediately.
     if (_batchModeEnabled && changeContext.getType() == NotificationContext.Type.CALLBACK) {
-      logger.debug("Callbackhandler {}, Enqueuing callback", this._uid );
+      logger.debug("Callbackhandler {}, Enqueuing callback", _uid );
       if (!isReady()) {
         logger.info("CallbackHandler {} is not ready, ignore change callback from path: {}, for "
-            + "listener: {}", this._uid, _path, _listener);
+            + "listener: {}", _uid, _path, _listener);
       } else {
         synchronized (this) {
           if (_batchCallbackProcessor != null) {
@@ -391,12 +391,12 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
       if (logger.isInfoEnabled()) {
         logger
             .info("{} START: CallbackHandler {}, INVOKE {} listener: {} type: {}", Thread.currentThread().getId(),
-                this._uid, _path, _listener, type);
+                _uid, _path, _listener, type);
       }
 
       if (!_expectTypes.contains(type)) {
         logger.warn("Callback handler {} received event in wrong order. Listener: {}, path: {}, "
-            + "expected types: {}, but was {}", this._uid, _listener, _path, _expectTypes, type);
+            + "expected types: {}, but was {}", _uid, _listener, _path, _expectTypes, type);
         return;
 
       }
@@ -516,13 +516,13 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         ControllerChangeListener controllerChangelistener = (ControllerChangeListener) _listener;
         controllerChangelistener.onControllerChange(changeContext);
       } else {
-        logger.warn("Callbackhandler {}, Unknown change type: {}", this._uid, _changeType);
+        logger.warn("Callbackhandler {}, Unknown change type: {}", _uid, _changeType);
       }
 
       long end = System.currentTimeMillis();
       if (logger.isInfoEnabled()) {
         logger.info("{} END:INVOKE CallbackHandler {}, {} listener: {} type: {} Took: {}ms",
-            Thread.currentThread().getId(), this._uid, _path, _listener, type, (end - start));
+            Thread.currentThread().getId(), _uid, _path, _listener, type, (end - start));
       }
       if (_monitor != null) {
         _monitor.increaseCallbackCounters(end - start);
@@ -543,7 +543,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         || callbackType == NotificationContext.Type.CALLBACK) {
       if (logger.isDebugEnabled()) {
         logger.debug("CallbackHandler {}, {} subscribes child-change. path: {} , listener: {}",
-            this._uid, _manager.getInstanceName(), path, _listener );
+            _uid, _manager.getInstanceName(), path, _listener );
       }
       // In the lifecycle of CallbackHandler, INIT is the first stage of registration of watch.
       // For some usage case such as current state, the path can be created later. Thus we would
@@ -554,14 +554,14 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
       // Note when path is removed, the CallbackHanler would remove itself from ZkHelixManager too
       // to avoid leaking a CallbackHandler.
       ChildrenSubscribeResult childrenSubscribeResult = _zkClient.subscribeChildChanges(path, this, callbackType != Type.INIT);
-      logger.debug("CallbackHandler {} subscribe data path {} result {}", this._uid, path,
+      logger.debug("CallbackHandler {} subscribe data path {} result {}", _uid, path,
           childrenSubscribeResult.isInstalled());
       if (!childrenSubscribeResult.isInstalled()) {
-        logger.info("CallbackHandler {} subscribe data path {} failed!", this._uid, path);
+        logger.info("CallbackHandler {} subscribe data path {} failed!", _uid, path);
       }
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info("CallbackHandler{}, {} unsubscribe child-change. path: {}, listener: {}",
-          this._uid ,_manager.getInstanceName(), path, _listener);
+          _uid ,_manager.getInstanceName(), path, _listener);
 
       _zkClient.unsubscribeChildChanges(path, this);
     }
@@ -572,16 +572,16 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
         || callbackType == NotificationContext.Type.CALLBACK) {
       if (logger.isDebugEnabled()) {
         logger.debug("CallbackHandler {}, {} subscribe data-change. path: {}, listener: {}",
-            this._uid, _manager.getInstanceName(), path, _listener);
+            _uid, _manager.getInstanceName(), path, _listener);
       }
       boolean subStatus = _zkClient.subscribeDataChanges(path, this, callbackType != Type.INIT);
-      logger.debug("CallbackHandler {} subscribe data path {} result {}", this._uid, path, subStatus);
+      logger.debug("CallbackHandler {} subscribe data path {} result {}", _uid, path, subStatus);
       if (!subStatus) {
-        logger.info("CallbackHandler {} subscribe data path {} failed!", this._uid, path);
+        logger.info("CallbackHandler {} subscribe data path {} failed!", _uid, path);
       }
     } else if (callbackType == NotificationContext.Type.FINALIZE) {
       logger.info("CallbackHandler{}, {} unsubscribe data-change. path: {}, listener: {}",
-          this._uid, _manager.getInstanceName(), path, _listener);
+          _uid, _manager.getInstanceName(), path, _listener);
 
       _zkClient.unsubscribeDataChanges(path, this);
     }
@@ -598,21 +598,21 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
   private void subscribeForChanges(NotificationContext.Type callbackType, String path,
       boolean watchChild) {
     logger.info("CallbackHandler {} Subscribing changes listener to path: {}, type: {}, listener: {}",
-        this._uid, path, callbackType, _listener);
+        _uid, path, callbackType, _listener);
 
     long start = System.currentTimeMillis();
     if (_eventTypes.contains(EventType.NodeDataChanged)
         || _eventTypes.contains(EventType.NodeCreated)
         || _eventTypes.contains(EventType.NodeDeleted)) {
-      logger.info("CallbackHandler{} Subscribing data change listener to path: {}", this._uid, path);
+      logger.info("CallbackHandler{} Subscribing data change listener to path: {}", _uid, path);
       subscribeDataChange(path, callbackType);
     }
 
     if (_eventTypes.contains(EventType.NodeChildrenChanged)) {
-      logger.info("CallbackHandler{}, Subscribing child change listener to path: {}", this._uid, path);
+      logger.info("CallbackHandler{}, Subscribing child change listener to path: {}", _uid, path);
       subscribeChildChange(path, callbackType);
       if (watchChild) {
-        logger.info("CallbackHandler{}, Subscribing data change listener to all children for path: {}", this._uid, path);
+        logger.info("CallbackHandler{}, Subscribing data change listener to all children for path: {}", _uid, path);
 
         try {
           switch (_changeType) {
@@ -666,17 +666,17 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
           if (_changeType == CUSTOMIZED_STATE_ROOT) {
             logger.warn(
                 "CallbackHandler {}, Failed to subscribe child/data change on path: {}, listener: {}. Instance "
-                    + "does not support Customized State!", this._uid, path, _listener);
+                    + "does not support Customized State!", _uid, path, _listener);
           } else {
             logger.warn("CallbackHandler {}, Failed to subscribe child/data change. path: {}, listener: {}",
-                this._uid, path, _listener, e);
+                _uid, path, _listener, e);
           }
         }
       }
     }
 
     long end = System.currentTimeMillis();
-    logger.info("CallbackHandler{}, Subscribing to path: {} took: {}", this._uid, path, (end - start));
+    logger.info("CallbackHandler{}, Subscribing to path: {} took: {}", _uid, path, (end - start));
   }
 
   public EventType[] getEventTypes() {
@@ -688,7 +688,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
    * exists
    */
   public void init() {
-    logger.info("initializing CallbackHandler: {}, content: {} ", this._uid, getContent());
+    logger.info("initializing CallbackHandler: {}, content: {} ", _uid, getContent());
 
     if (_batchModeEnabled) {
       synchronized (this) {
@@ -717,7 +717,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
   @Override
   public void handleDataChange(String dataPath, Object data) {
     if (logger.isDebugEnabled()) {
-      logger.debug("Data change callbackhandler {}: paths changed: {}", this._uid, dataPath);
+      logger.debug("Data change callbackhandler {}: paths changed: {}", _uid, dataPath);
     }
 
     try {
@@ -739,20 +739,20 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
   @Override
   public void handleDataDeleted(String dataPath) {
     if (logger.isDebugEnabled()) {
-      logger.debug("Data change callbackhandler {}: path deleted: {}", this._uid, dataPath);
+      logger.debug("Data change callbackhandler {}: path deleted: {}", _uid, dataPath);
     }
 
     try {
       updateNotificationTime(System.nanoTime());
       if (dataPath != null && dataPath.startsWith(_path)) {
         logger.info("CallbackHandler {}, {} unsubscribe data-change. path: {}, listener: {}",
-            this._uid, _manager.getInstanceName(), dataPath, _listener);
+            _uid, _manager.getInstanceName(), dataPath, _listener);
         _zkClient.unsubscribeDataChanges(dataPath, this);
 
         // only needed for bucketized parent, but OK if we don't have child-change
         // watch on the bucketized parent path
         logger.info("CallbackHandler {}, {} unsubscribe child-change. path: {}, listener: {}",
-            this._uid, _manager.getInstanceName(), dataPath, _listener);
+            _uid, _manager.getInstanceName(), dataPath, _listener);
         _zkClient.unsubscribeChildChanges(dataPath, this);
         // No need to invoke() since this event will handled by child-change on parent-node
       }
@@ -777,7 +777,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
           // _path has been removed, remove this listener
           // removeListener will call handler.reset(), which in turn call invoke() on FINALIZE type
           boolean rt = _manager.removeListener(_propertyKey, _listener);
-          logger.info("CallbackHandler {} removed with status {}", this._uid, rt);
+          logger.info("CallbackHandler {} removed with status {}", _uid, rt);
         } else {
           if (!isReady()) {
             // avoid leaking CallbackHandler
@@ -809,7 +809,7 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
   }
 
   void reset(boolean isShutdown) {
-    logger.info("Resetting CallbackHandler: {}. Is resetting for shutdown: {}.", this._uid,
+    logger.info("Resetting CallbackHandler: {}. Is resetting for shutdown: {}.", _uid,
         isShutdown);
     try {
       _ready = false;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -96,7 +96,7 @@ public class ZkClient implements Watcher {
   private static final String SYNC_PATH = "/";
 
   private static AtomicLong UID = new AtomicLong(0);
-  private long _uid;
+  public final long _uid;
 
   private final IZkConnection _connection;
   private final long _operationRetryTimeoutInMillis;
@@ -204,13 +204,6 @@ public class ZkClient implements Watcher {
     }
   }
 
-  @Override
-  public String toString() {
-    StringBuilder stringBuilder = new StringBuilder();
-    stringBuilder.append(_uid);
-    return stringBuilder.toString();
-  }
-
   protected ZkClient(IZkConnection zkConnection, int connectionTimeout, long operationRetryTimeout,
       PathBasedZkSerializer zkSerializer, String monitorType, String monitorKey,
       String monitorInstanceName, boolean monitorRootPathOnly) {
@@ -227,7 +220,7 @@ public class ZkClient implements Watcher {
 
     _asyncCallRetryThread = new ZkAsyncRetryThread(zkConnection.getServers());
     _asyncCallRetryThread.start();
-    LOG.debug("ZkClient created with _uid {}, _asyncCallRetryThread id {}", this.toString(), _asyncCallRetryThread.getId());
+    LOG.debug("ZkClient created with uid {}, _asyncCallRetryThread id {}", this._uid, _asyncCallRetryThread.getId());
 
     connect(connectionTimeout, this);
 
@@ -265,7 +258,7 @@ public class ZkClient implements Watcher {
     List<String> children = watchForChilds(path, skipWatchingNonExistNode);
     if (children == null && skipWatchingNonExistNode) {
       unsubscribeChildChanges(path, listener);
-      LOG.info("zkclient{}, watchForChilds failed to install no-existing watch and add listener. Path: {}", this.toString(), path);
+      LOG.info("zkclient{}, watchForChilds failed to install no-existing watch and add listener. Path: {}", this._uid, path);
       return new ChildrenSubscribeResult(children, false);
     }
 
@@ -296,7 +289,7 @@ public class ZkClient implements Watcher {
       if (prefetchEnabled) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("zkclient {} subscribed data changes for {}, listener {}, prefetch data {}",
-              this.toString(), path, listener, prefetchEnabled);
+              this._uid, path, listener, prefetchEnabled);
         }
       }
     }
@@ -306,12 +299,12 @@ public class ZkClient implements Watcher {
       // Now let us remove this handler.
       unsubscribeDataChanges(path, listener);
       LOG.info("zkclient {} watchForData failed to install no-existing path and thus add listener. Path: {}",
-          this.toString(), path);
+          this._uid, path);
       return false;
     }
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("zkclient {}, Subscribed data changes for {}", this.toString(), path);
+      LOG.debug("zkclient {}, Subscribed data changes for {}", this._uid, path);
     }
     return true;
   }
@@ -342,7 +335,7 @@ public class ZkClient implements Watcher {
       }
     } catch (NoSuchMethodException e) {
       LOG.warn("Zkclient {}, No method {} defined in listener {}",
-          this.toString(), callbackMethod.getName(), dataListener.getClass().getCanonicalName());
+          this._uid, callbackMethod.getName(), dataListener.getClass().getCanonicalName());
     }
 
     return true;
@@ -768,7 +761,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient {} create, path {}, time {} ms", this.toString(), path, (endT - startT));
+        LOG.trace("zkclient {} create, path {}, time {} ms", this._uid, path, (endT - startT));
       }
     }
   }
@@ -970,7 +963,7 @@ public class ZkClient implements Watcher {
   public void process(WatchedEvent event) {
     long notificationTime = System.currentTimeMillis();
     if (LOG.isDebugEnabled()) {
-      LOG.debug("zkclient {}, Received event: {} ", this.toString(), event);
+      LOG.debug("zkclient {}, Received event: {} ", this._uid, event);
     }
     _zookeeperEventThread = Thread.currentThread();
 
@@ -982,7 +975,7 @@ public class ZkClient implements Watcher {
             || event.getType() == EventType.NodeCreated
             || event.getType() == EventType.NodeChildrenChanged;
     if (event.getType() == EventType.NodeDeleted) {
-      LOG.debug("zkclient {}, Path {} is deleted", this.toString(), event.getPath());
+      LOG.debug("zkclient {}, Path {} is deleted", this._uid, event.getPath());
     }
 
     getEventLock().lock();
@@ -991,7 +984,7 @@ public class ZkClient implements Watcher {
       if (getShutdownTrigger()) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("zkclient {} ignoring event {}|{} since shutdown triggered",
-              this.toString(), event.getType(), event.getPath());
+              this._uid, event.getType(), event.getPath());
         }
         return;
       }
@@ -1027,7 +1020,7 @@ public class ZkClient implements Watcher {
       recordStateChange(stateChanged, dataChanged, sessionExpired);
 
       if (LOG.isDebugEnabled()) {
-        LOG.debug("zkclient {} Leaving process event", this.toString());
+        LOG.debug("zkclient {} Leaving process event", this._uid);
       }
     }
   }
@@ -1088,7 +1081,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient {} getChildren, path {} time: {} ms", this.toString(), path, (endT - startT) );
+        LOG.trace("zkclient {} getChildren, path {} time: {} ms", this._uid, path, (endT - startT) );
       }
     }
   }
@@ -1130,7 +1123,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient exists, path: {}, time: {} ms", this.toString(), path, (endT - startT));
+        LOG.trace("zkclient exists, path: {}, time: {} ms", this._uid, path, (endT - startT));
       }
     }
   }
@@ -1153,7 +1146,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient exists, path: {}, time: {} ms", this.toString(), path, (endT - startT));
+        LOG.trace("zkclient exists, path: {}, time: {} ms", this._uid, path, (endT - startT));
       }
     }
   }
@@ -1183,13 +1176,13 @@ public class ZkClient implements Watcher {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
         LOG.trace("zkclient getData (installWatchOnlyPathExist), path: {}, time: {} ms",
-            this.toString(), path, (endT - startT));
+            this._uid, path, (endT - startT));
       }
     }
   }
 
   protected void processStateChanged(WatchedEvent event) {
-    LOG.info("zkclient {}, zookeeper state changed ( {} )", this.toString(), event.getState());
+    LOG.info("zkclient {}, zookeeper state changed ( {} )", this._uid, event.getState());
     setCurrentState(event.getState());
     if (getShutdownTrigger()) {
       return;
@@ -1253,7 +1246,7 @@ public class ZkClient implements Watcher {
         reconnectException = e;
         long waitInterval = retryStrategy.getNextWaitInterval(retryCount++);
         LOG.warn("ZkClient {}, reconnect on expiring failed. Will retry after {} ms",
-            this.toString(), waitInterval, e);
+            this._uid, waitInterval, e);
         try {
           Thread.sleep(waitInterval);
         } catch (InterruptedException ex) {
@@ -1264,7 +1257,7 @@ public class ZkClient implements Watcher {
     }
 
     LOG.info("Zkclient {} unable to re-establish connection. Notifying consumer of the following exception:{}",
-        this.toString(), reconnectException);
+        this._uid, reconnectException);
     fireSessionEstablishmentError(reconnectException);
   }
 
@@ -1316,7 +1309,7 @@ public class ZkClient implements Watcher {
     KeeperException.Code code = KeeperException.Code.get(callbackHandler.getRc());
     if (code == KeeperException.Code.OK) {
       LOG.info("zkclient {}, sycnOnNewSession with sessionID {} async return code: {} and proceeds",
-          this.toString(), sessionId, code);
+          this._uid, sessionId, code);
       return true;
     }
 
@@ -1338,7 +1331,7 @@ public class ZkClient implements Watcher {
         @Override
         public void run() throws Exception {
           if (issueSync(zk) == false) {
-            LOG.warn("zkclient{}, Failed to call sync() on new session {}", this.toString(), sessionId);
+            LOG.warn("zkclient{}, Failed to call sync() on new session {}", _uid, sessionId);
           }
         }
       });
@@ -1408,7 +1401,7 @@ public class ZkClient implements Watcher {
       return true;
     } catch (ZkClientException e) {
       LOG.error("zkcient {}, Failed to recursively delete path {}, exception {}",
-          this.toString(), path, e);
+          this._uid, path, e);
       return false;
     }
   }
@@ -1437,7 +1430,7 @@ public class ZkClient implements Watcher {
     try {
       delete(path);
     } catch (Exception e) {
-      LOG.error("zkclient {}, Failed to delete {}, exception {}", this.toString(), path, e);
+      LOG.error("zkclient {}, Failed to delete {}, exception {}", this._uid, path, e);
       throw new ZkClientException("Failed to delete " + path, e);
     }
   }
@@ -1446,7 +1439,7 @@ public class ZkClient implements Watcher {
     final String path = event.getPath();
     final boolean pathExists = event.getType() != EventType.NodeDeleted;
     if (EventType.NodeDeleted == event.getType()) {
-      LOG.debug("zkclient{}, Event NodeDeleted: {}", this.toString(), event.getPath());
+      LOG.debug("zkclient{}, Event NodeDeleted: {}", this._uid, event.getPath());
     }
 
     if (event.getType() == EventType.NodeChildrenChanged || event.getType() == EventType.NodeCreated
@@ -1502,13 +1495,13 @@ public class ZkClient implements Watcher {
               Object data = null;
               if (listener.isPrefetchData()) {
                 if (LOG.isDebugEnabled()) {
-                  LOG.debug("zkclient {} Prefetch data for path: {}", this.toString(), path);
+                  LOG.debug("zkclient {} Prefetch data for path: {}", _uid, path);
                 }
                 try {
                   // TODO: the data is redundantly read multiple times when multiple listeners exist
                   data = readData(path, null, true);
                 } catch (ZkNoNodeException e) {
-                  LOG.warn("zkclient {} Prefetch data for path: {} failed.", this.toString(), path, e);
+                  LOG.warn("zkclient {} Prefetch data for path: {} failed.", _uid, path, e);
                   listener.getDataListener().handleDataDeleted(path);
                   return;
                 }
@@ -1519,7 +1512,7 @@ public class ZkClient implements Watcher {
         });
       }
     } catch (Exception e) {
-      LOG.error("zkclient {} Failed to fire data changed event for path: {}", this.toString(), path, e);
+      LOG.error("zkclient {} Failed to fire data changed event for path: {}", this._uid, path, e);
     }
   }
 
@@ -1546,7 +1539,7 @@ public class ZkClient implements Watcher {
               try {
                 children = getChildren(path);
               } catch (ZkNoNodeException e) {
-                LOG.warn("zkclient {} Get children under path: {} failed.", this.toString(), path, e);
+                LOG.warn("zkclient {} Get children under path: {} failed.", _uid, path, e);
                 // Continue trigger the change handler
               }
             }
@@ -1555,7 +1548,7 @@ public class ZkClient implements Watcher {
         });
       }
     } catch (Exception e) {
-      LOG.error("zkclient {} Failed to fire child changed event. Unable to getChildren.", this.toString(), e);
+      LOG.error("zkclient {} Failed to fire child changed event. Unable to getChildren.", this._uid, e);
     }
   }
 
@@ -1563,7 +1556,7 @@ public class ZkClient implements Watcher {
       throws ZkInterruptedException {
     Date timeout = new Date(System.currentTimeMillis() + timeUnit.toMillis(time));
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Waiting until znode {} becomes available.", this.toString(), path);
+      LOG.debug("Waiting until znode {} becomes available.", this._uid, path);
     }
     if (exists(path)) {
       return true;
@@ -1613,7 +1606,7 @@ public class ZkClient implements Watcher {
     validateCurrentThread();
     Date timeout = new Date(System.currentTimeMillis() + timeUnit.toMillis(time));
 
-    LOG.debug("zkclient {}, Waiting for keeper state {} ", this.toString(), keeperState);
+    LOG.debug("zkclient {}, Waiting for keeper state {} ", this._uid, keeperState);
     acquireEventLock();
     try {
       boolean stillWaiting = true;
@@ -1624,7 +1617,7 @@ public class ZkClient implements Watcher {
         stillWaiting = getEventLock().getStateChangedCondition().awaitUntil(timeout);
       }
       LOG.debug("zkclient {} State is {}",
-          this.toString(), (_currentState == null ? "CLOSED" : _currentState));
+          this._uid, (_currentState == null ? "CLOSED" : _currentState));
       return true;
     } catch (InterruptedException e) {
       throw new ZkInterruptedException(e);
@@ -1702,7 +1695,7 @@ public class ZkClient implements Watcher {
           throw ExceptionUtil.convertToRuntimeException(e);
         }
 
-        LOG.debug("zkclient {}, Retrying operation, caused by {}", this.toString(),retryCauseCode);
+        LOG.debug("zkclient {}, Retrying operation, caused by {}", this._uid,retryCauseCode);
         // before attempting a retry, check whether retry timeout has elapsed
         if (System.currentTimeMillis() - operationStartTime > _operationRetryTimeoutInMillis) {
           throw new ZkTimeoutException("Operation cannot be retried because of retry timeout ("
@@ -1765,18 +1758,18 @@ public class ZkClient implements Watcher {
       } catch (ZkNoNodeException e) {
         success = false;
         if (LOG.isDebugEnabled()) {
-          LOG.debug("zkclient {}, Failed to delete path {}, znode does not exist!", this.toString(), path);
+          LOG.debug("zkclient {}, Failed to delete path {}, znode does not exist!", this._uid, path);
         }
       }
       record(path, null, startT, ZkClientMonitor.AccessType.WRITE);
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.WRITE);
-      LOG.warn("zkclient {}, Failed to delete path {}! ", this.toString(), path, e);
+      LOG.warn("zkclient {}, Failed to delete path {}! ", this._uid, path, e);
       throw e;
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient {} delete, path: {}, time {} ms", this.toString(), path, (endT - startT));
+        LOG.trace("zkclient {} delete, path: {}, time {} ms", this._uid, path, (endT - startT));
       }
     }
     return success;
@@ -1852,7 +1845,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient {}, getData, path {}, time {} ms", this.toString(), path, (endT - startT));
+        LOG.trace("zkclient {}, getData, path {}, time {} ms", this._uid, path, (endT - startT));
       }
     }
   }
@@ -1929,7 +1922,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient {}, setData, path {}, time {} ms", this.toString(), path, (endT - startT));
+        LOG.trace("zkclient {}, setData, path {}, time {} ms", this._uid, path, (endT - startT));
       }
     }
   }
@@ -2061,7 +2054,7 @@ public class ZkClient implements Watcher {
       }
     } catch (ZkNoNodeException e) {
       // Do nothing, this is what we want as this is not going to leak watch in ZooKeeepr server.
-      LOG.info("zkclient {}, watchForData path not existing: {} ", this.toString(), path);
+      LOG.info("zkclient {}, watchForData path not existing: {} ", this._uid, path);
       return false;
     }
     return true;
@@ -2117,7 +2110,7 @@ public class ZkClient implements Watcher {
         } catch (ZkNoNodeException e) {
           // ignore, the "exists" watch will listen for the parent node to appear
           LOG.info("zkclient{} watchForChilds path not existing:{} skipWatchingNodeNoteExist: {}",
-              this.toString(), path, skipWatchingNonExistNode);
+              _uid, path, skipWatchingNonExistNode);
         }
         return null;
       }
@@ -2166,11 +2159,11 @@ public class ZkClient implements Watcher {
       _eventThread = new ZkEventThread(zkConnection.getServers());
       _eventThread.start();
 
-      LOG.debug("ZkClient {},  _eventThread {}", this.toString(), _eventThread.getId());
+      LOG.debug("ZkClient {},  _eventThread {}", this._uid, _eventThread.getId());
 
       if (isManagingZkConnection()) {
         zkConnection.connect(watcher);
-        LOG.debug("zkclient{} Awaiting connection to Zookeeper server", this.toString());
+        LOG.debug("zkclient{} Awaiting connection to Zookeeper server", this._uid);
         if (!waitUntilConnected(maxMsToWaitUntilConnected, TimeUnit.MILLISECONDS)) {
           throw new ZkTimeoutException(
               "Unable to connect to zookeeper server within timeout: " + maxMsToWaitUntilConnected);
@@ -2224,7 +2217,7 @@ public class ZkClient implements Watcher {
   public void close() throws ZkInterruptedException {
     if (LOG.isTraceEnabled()) {
       StackTraceElement[] calls = Thread.currentThread().getStackTrace();
-      LOG.trace("zkclient {} closing a zkclient. callStack: {} ", this.toString(), Arrays.asList(calls));
+      LOG.trace("zkclient {} closing a zkclient. callStack: {} ", this._uid, Arrays.asList(calls));
     }
     getEventLock().lock();
     IZkConnection connection = getConnection();
@@ -2240,7 +2233,7 @@ public class ZkClient implements Watcher {
       _eventThread.interrupt();
       _eventThread.join(2000);
       if (isManagingZkConnection()) {
-        LOG.info("zkclient{}, Closing zkclient zk: {} ", this.toString(), ((ZkConnection) connection).getZookeeper());
+        LOG.info("zkclient{}, Closing zkclient zk: {} ", this._uid, ((ZkConnection) connection).getZookeeper());
         connection.close();
       }
       _closed = true;
@@ -2277,7 +2270,7 @@ public class ZkClient implements Watcher {
       if (_monitor != null) {
         _monitor.unregister();
       }
-      LOG.info("Zkclient {} Closed zkclient", this.toString());
+      LOG.info("Zkclient {} Closed zkclient", this._uid);
     }
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -220,7 +220,7 @@ public class ZkClient implements Watcher {
 
     _asyncCallRetryThread = new ZkAsyncRetryThread(zkConnection.getServers());
     _asyncCallRetryThread.start();
-    LOG.debug("ZkClient created with uid {}, _asyncCallRetryThread id {}", this._uid, _asyncCallRetryThread.getId());
+    LOG.debug("ZkClient created with uid {}, _asyncCallRetryThread id {}", _uid, _asyncCallRetryThread.getId());
 
     connect(connectionTimeout, this);
 
@@ -258,7 +258,7 @@ public class ZkClient implements Watcher {
     List<String> children = watchForChilds(path, skipWatchingNonExistNode);
     if (children == null && skipWatchingNonExistNode) {
       unsubscribeChildChanges(path, listener);
-      LOG.info("zkclient{}, watchForChilds failed to install no-existing watch and add listener. Path: {}", this._uid, path);
+      LOG.info("zkclient{}, watchForChilds failed to install no-existing watch and add listener. Path: {}", _uid, path);
       return new ChildrenSubscribeResult(children, false);
     }
 
@@ -289,7 +289,7 @@ public class ZkClient implements Watcher {
       if (prefetchEnabled) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("zkclient {} subscribed data changes for {}, listener {}, prefetch data {}",
-              this._uid, path, listener, prefetchEnabled);
+              _uid, path, listener, prefetchEnabled);
         }
       }
     }
@@ -299,12 +299,12 @@ public class ZkClient implements Watcher {
       // Now let us remove this handler.
       unsubscribeDataChanges(path, listener);
       LOG.info("zkclient {} watchForData failed to install no-existing path and thus add listener. Path: {}",
-          this._uid, path);
+          _uid, path);
       return false;
     }
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("zkclient {}, Subscribed data changes for {}", this._uid, path);
+      LOG.debug("zkclient {}, Subscribed data changes for {}", _uid, path);
     }
     return true;
   }
@@ -335,7 +335,7 @@ public class ZkClient implements Watcher {
       }
     } catch (NoSuchMethodException e) {
       LOG.warn("Zkclient {}, No method {} defined in listener {}",
-          this._uid, callbackMethod.getName(), dataListener.getClass().getCanonicalName());
+          _uid, callbackMethod.getName(), dataListener.getClass().getCanonicalName());
     }
 
     return true;
@@ -761,7 +761,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient {} create, path {}, time {} ms", this._uid, path, (endT - startT));
+        LOG.trace("zkclient {} create, path {}, time {} ms", _uid, path, (endT - startT));
       }
     }
   }
@@ -963,7 +963,7 @@ public class ZkClient implements Watcher {
   public void process(WatchedEvent event) {
     long notificationTime = System.currentTimeMillis();
     if (LOG.isDebugEnabled()) {
-      LOG.debug("zkclient {}, Received event: {} ", this._uid, event);
+      LOG.debug("zkclient {}, Received event: {} ", _uid, event);
     }
     _zookeeperEventThread = Thread.currentThread();
 
@@ -975,7 +975,7 @@ public class ZkClient implements Watcher {
             || event.getType() == EventType.NodeCreated
             || event.getType() == EventType.NodeChildrenChanged;
     if (event.getType() == EventType.NodeDeleted) {
-      LOG.debug("zkclient {}, Path {} is deleted", this._uid, event.getPath());
+      LOG.debug("zkclient {}, Path {} is deleted", _uid, event.getPath());
     }
 
     getEventLock().lock();
@@ -984,7 +984,7 @@ public class ZkClient implements Watcher {
       if (getShutdownTrigger()) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("zkclient {} ignoring event {}|{} since shutdown triggered",
-              this._uid, event.getType(), event.getPath());
+              _uid, event.getType(), event.getPath());
         }
         return;
       }
@@ -1020,7 +1020,7 @@ public class ZkClient implements Watcher {
       recordStateChange(stateChanged, dataChanged, sessionExpired);
 
       if (LOG.isDebugEnabled()) {
-        LOG.debug("zkclient {} Leaving process event", this._uid);
+        LOG.debug("zkclient {} Leaving process event", _uid);
       }
     }
   }
@@ -1081,7 +1081,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient {} getChildren, path {} time: {} ms", this._uid, path, (endT - startT) );
+        LOG.trace("zkclient {} getChildren, path {} time: {} ms", _uid, path, (endT - startT) );
       }
     }
   }
@@ -1123,7 +1123,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient exists, path: {}, time: {} ms", this._uid, path, (endT - startT));
+        LOG.trace("zkclient exists, path: {}, time: {} ms", _uid, path, (endT - startT));
       }
     }
   }
@@ -1146,7 +1146,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient exists, path: {}, time: {} ms", this._uid, path, (endT - startT));
+        LOG.trace("zkclient exists, path: {}, time: {} ms", _uid, path, (endT - startT));
       }
     }
   }
@@ -1176,13 +1176,13 @@ public class ZkClient implements Watcher {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
         LOG.trace("zkclient getData (installWatchOnlyPathExist), path: {}, time: {} ms",
-            this._uid, path, (endT - startT));
+            _uid, path, (endT - startT));
       }
     }
   }
 
   protected void processStateChanged(WatchedEvent event) {
-    LOG.info("zkclient {}, zookeeper state changed ( {} )", this._uid, event.getState());
+    LOG.info("zkclient {}, zookeeper state changed ( {} )", _uid, event.getState());
     setCurrentState(event.getState());
     if (getShutdownTrigger()) {
       return;
@@ -1246,7 +1246,7 @@ public class ZkClient implements Watcher {
         reconnectException = e;
         long waitInterval = retryStrategy.getNextWaitInterval(retryCount++);
         LOG.warn("ZkClient {}, reconnect on expiring failed. Will retry after {} ms",
-            this._uid, waitInterval, e);
+            _uid, waitInterval, e);
         try {
           Thread.sleep(waitInterval);
         } catch (InterruptedException ex) {
@@ -1257,7 +1257,7 @@ public class ZkClient implements Watcher {
     }
 
     LOG.info("Zkclient {} unable to re-establish connection. Notifying consumer of the following exception:{}",
-        this._uid, reconnectException);
+        _uid, reconnectException);
     fireSessionEstablishmentError(reconnectException);
   }
 
@@ -1309,7 +1309,7 @@ public class ZkClient implements Watcher {
     KeeperException.Code code = KeeperException.Code.get(callbackHandler.getRc());
     if (code == KeeperException.Code.OK) {
       LOG.info("zkclient {}, sycnOnNewSession with sessionID {} async return code: {} and proceeds",
-          this._uid, sessionId, code);
+          _uid, sessionId, code);
       return true;
     }
 
@@ -1401,7 +1401,7 @@ public class ZkClient implements Watcher {
       return true;
     } catch (ZkClientException e) {
       LOG.error("zkcient {}, Failed to recursively delete path {}, exception {}",
-          this._uid, path, e);
+          _uid, path, e);
       return false;
     }
   }
@@ -1430,7 +1430,7 @@ public class ZkClient implements Watcher {
     try {
       delete(path);
     } catch (Exception e) {
-      LOG.error("zkclient {}, Failed to delete {}, exception {}", this._uid, path, e);
+      LOG.error("zkclient {}, Failed to delete {}, exception {}", _uid, path, e);
       throw new ZkClientException("Failed to delete " + path, e);
     }
   }
@@ -1439,7 +1439,7 @@ public class ZkClient implements Watcher {
     final String path = event.getPath();
     final boolean pathExists = event.getType() != EventType.NodeDeleted;
     if (EventType.NodeDeleted == event.getType()) {
-      LOG.debug("zkclient{}, Event NodeDeleted: {}", this._uid, event.getPath());
+      LOG.debug("zkclient{}, Event NodeDeleted: {}", _uid, event.getPath());
     }
 
     if (event.getType() == EventType.NodeChildrenChanged || event.getType() == EventType.NodeCreated
@@ -1512,7 +1512,7 @@ public class ZkClient implements Watcher {
         });
       }
     } catch (Exception e) {
-      LOG.error("zkclient {} Failed to fire data changed event for path: {}", this._uid, path, e);
+      LOG.error("zkclient {} Failed to fire data changed event for path: {}", _uid, path, e);
     }
   }
 
@@ -1548,7 +1548,7 @@ public class ZkClient implements Watcher {
         });
       }
     } catch (Exception e) {
-      LOG.error("zkclient {} Failed to fire child changed event. Unable to getChildren.", this._uid, e);
+      LOG.error("zkclient {} Failed to fire child changed event. Unable to getChildren.", _uid, e);
     }
   }
 
@@ -1556,7 +1556,7 @@ public class ZkClient implements Watcher {
       throws ZkInterruptedException {
     Date timeout = new Date(System.currentTimeMillis() + timeUnit.toMillis(time));
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Waiting until znode {} becomes available.", this._uid, path);
+      LOG.debug("Waiting until znode {} becomes available.", _uid, path);
     }
     if (exists(path)) {
       return true;
@@ -1606,7 +1606,7 @@ public class ZkClient implements Watcher {
     validateCurrentThread();
     Date timeout = new Date(System.currentTimeMillis() + timeUnit.toMillis(time));
 
-    LOG.debug("zkclient {}, Waiting for keeper state {} ", this._uid, keeperState);
+    LOG.debug("zkclient {}, Waiting for keeper state {} ", _uid, keeperState);
     acquireEventLock();
     try {
       boolean stillWaiting = true;
@@ -1617,7 +1617,7 @@ public class ZkClient implements Watcher {
         stillWaiting = getEventLock().getStateChangedCondition().awaitUntil(timeout);
       }
       LOG.debug("zkclient {} State is {}",
-          this._uid, (_currentState == null ? "CLOSED" : _currentState));
+          _uid, (_currentState == null ? "CLOSED" : _currentState));
       return true;
     } catch (InterruptedException e) {
       throw new ZkInterruptedException(e);
@@ -1695,7 +1695,7 @@ public class ZkClient implements Watcher {
           throw ExceptionUtil.convertToRuntimeException(e);
         }
 
-        LOG.debug("zkclient {}, Retrying operation, caused by {}", this._uid,retryCauseCode);
+        LOG.debug("zkclient {}, Retrying operation, caused by {}", _uid,retryCauseCode);
         // before attempting a retry, check whether retry timeout has elapsed
         if (System.currentTimeMillis() - operationStartTime > _operationRetryTimeoutInMillis) {
           throw new ZkTimeoutException("Operation cannot be retried because of retry timeout ("
@@ -1758,18 +1758,18 @@ public class ZkClient implements Watcher {
       } catch (ZkNoNodeException e) {
         success = false;
         if (LOG.isDebugEnabled()) {
-          LOG.debug("zkclient {}, Failed to delete path {}, znode does not exist!", this._uid, path);
+          LOG.debug("zkclient {}, Failed to delete path {}, znode does not exist!", _uid, path);
         }
       }
       record(path, null, startT, ZkClientMonitor.AccessType.WRITE);
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.WRITE);
-      LOG.warn("zkclient {}, Failed to delete path {}! ", this._uid, path, e);
+      LOG.warn("zkclient {}, Failed to delete path {}! ", _uid, path, e);
       throw e;
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient {} delete, path: {}, time {} ms", this._uid, path, (endT - startT));
+        LOG.trace("zkclient {} delete, path: {}, time {} ms", _uid, path, (endT - startT));
       }
     }
     return success;
@@ -1845,7 +1845,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient {}, getData, path {}, time {} ms", this._uid, path, (endT - startT));
+        LOG.trace("zkclient {}, getData, path {}, time {} ms", _uid, path, (endT - startT));
       }
     }
   }
@@ -1922,7 +1922,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("zkclient {}, setData, path {}, time {} ms", this._uid, path, (endT - startT));
+        LOG.trace("zkclient {}, setData, path {}, time {} ms", _uid, path, (endT - startT));
       }
     }
   }
@@ -2054,7 +2054,7 @@ public class ZkClient implements Watcher {
       }
     } catch (ZkNoNodeException e) {
       // Do nothing, this is what we want as this is not going to leak watch in ZooKeeepr server.
-      LOG.info("zkclient {}, watchForData path not existing: {} ", this._uid, path);
+      LOG.info("zkclient {}, watchForData path not existing: {} ", _uid, path);
       return false;
     }
     return true;
@@ -2159,11 +2159,11 @@ public class ZkClient implements Watcher {
       _eventThread = new ZkEventThread(zkConnection.getServers());
       _eventThread.start();
 
-      LOG.debug("ZkClient {},  _eventThread {}", this._uid, _eventThread.getId());
+      LOG.debug("ZkClient {},  _eventThread {}", _uid, _eventThread.getId());
 
       if (isManagingZkConnection()) {
         zkConnection.connect(watcher);
-        LOG.debug("zkclient{} Awaiting connection to Zookeeper server", this._uid);
+        LOG.debug("zkclient{} Awaiting connection to Zookeeper server", _uid);
         if (!waitUntilConnected(maxMsToWaitUntilConnected, TimeUnit.MILLISECONDS)) {
           throw new ZkTimeoutException(
               "Unable to connect to zookeeper server within timeout: " + maxMsToWaitUntilConnected);
@@ -2217,7 +2217,7 @@ public class ZkClient implements Watcher {
   public void close() throws ZkInterruptedException {
     if (LOG.isTraceEnabled()) {
       StackTraceElement[] calls = Thread.currentThread().getStackTrace();
-      LOG.trace("Closing a zkclient uid:{}, callStack: {} ", this._uid, Arrays.asList(calls));
+      LOG.trace("Closing a zkclient uid:{}, callStack: {} ", _uid, Arrays.asList(calls));
     }
     getEventLock().lock();
     IZkConnection connection = getConnection();
@@ -2233,7 +2233,7 @@ public class ZkClient implements Watcher {
       _eventThread.interrupt();
       _eventThread.join(2000);
       if (isManagingZkConnection()) {
-        LOG.info("Closing zkclient uid:{}, zk:{}", this._uid, ((ZkConnection) connection).getZookeeper());
+        LOG.info("Closing zkclient uid:{}, zk:{}", _uid, ((ZkConnection) connection).getZookeeper());
         connection.close();
       }
       _closed = true;
@@ -2270,7 +2270,7 @@ public class ZkClient implements Watcher {
       if (_monitor != null) {
         _monitor.unregister();
       }
-      LOG.info("Closed zkclient with uid:{}", this._uid);
+      LOG.info("Closed zkclient with uid:{}", _uid);
     }
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -2217,7 +2217,7 @@ public class ZkClient implements Watcher {
   public void close() throws ZkInterruptedException {
     if (LOG.isTraceEnabled()) {
       StackTraceElement[] calls = Thread.currentThread().getStackTrace();
-      LOG.trace("zkclient {} closing a zkclient. callStack: {} ", this._uid, Arrays.asList(calls));
+      LOG.trace("Closing a zkclient uid:{}, callStack: {} ", this._uid, Arrays.asList(calls));
     }
     getEventLock().lock();
     IZkConnection connection = getConnection();
@@ -2233,7 +2233,7 @@ public class ZkClient implements Watcher {
       _eventThread.interrupt();
       _eventThread.join(2000);
       if (isManagingZkConnection()) {
-        LOG.info("zkclient{}, Closing zkclient zk: {} ", this._uid, ((ZkConnection) connection).getZookeeper());
+        LOG.info("Closing zkclient uid:{}, zk:{}", this._uid, ((ZkConnection) connection).getZookeeper());
         connection.close();
       }
       _closed = true;
@@ -2270,7 +2270,7 @@ public class ZkClient implements Watcher {
       if (_monitor != null) {
         _monitor.unregister();
       }
-      LOG.info("Zkclient {} Closed zkclient", this._uid);
+      LOG.info("Closed zkclient with uid:{}", this._uid);
     }
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -204,6 +204,13 @@ public class ZkClient implements Watcher {
     }
   }
 
+  @Override
+  public String toString() {
+    StringBuilder stringBuilder = new StringBuilder();
+    stringBuilder.append(_uid);
+    return stringBuilder.toString();
+  }
+
   protected ZkClient(IZkConnection zkConnection, int connectionTimeout, long operationRetryTimeout,
       PathBasedZkSerializer zkSerializer, String monitorType, String monitorKey,
       String monitorInstanceName, boolean monitorRootPathOnly) {
@@ -220,7 +227,7 @@ public class ZkClient implements Watcher {
 
     _asyncCallRetryThread = new ZkAsyncRetryThread(zkConnection.getServers());
     _asyncCallRetryThread.start();
-    LOG.debug("ZkClient created with _uid {}, _asyncCallRetryThread id {}", _uid, _asyncCallRetryThread.getId());
+    LOG.debug("ZkClient created with _uid {}, _asyncCallRetryThread id {}", this.toString(), _asyncCallRetryThread.getId());
 
     connect(connectionTimeout, this);
 
@@ -258,7 +265,7 @@ public class ZkClient implements Watcher {
     List<String> children = watchForChilds(path, skipWatchingNonExistNode);
     if (children == null && skipWatchingNonExistNode) {
       unsubscribeChildChanges(path, listener);
-      LOG.info("watchForChilds failed to install no-existing watch and add listener. Path: {}", path);
+      LOG.info("zkclient{}, watchForChilds failed to install no-existing watch and add listener. Path: {}", this.toString(), path);
       return new ChildrenSubscribeResult(children, false);
     }
 
@@ -288,8 +295,8 @@ public class ZkClient implements Watcher {
       listenerEntries.add(listenerEntry);
       if (prefetchEnabled) {
         if (LOG.isDebugEnabled()) {
-          LOG.debug("Subscribed data changes for " + path + ", listener: " + listener
-              + ", prefetch data: " + prefetchEnabled);
+          LOG.debug("zkclient {} subscribed data changes for {}, listener {}, prefetch data {}",
+              this.toString(), path, listener, prefetchEnabled);
         }
       }
     }
@@ -298,12 +305,13 @@ public class ZkClient implements Watcher {
     if (!watchInstalled) {
       // Now let us remove this handler.
       unsubscribeDataChanges(path, listener);
-      LOG.info("watchForData failed to install no-existing path and thus add listener. Path:" + path);
+      LOG.info("zkclient {} watchForData failed to install no-existing path and thus add listener. Path: {}",
+          this.toString(), path);
       return false;
     }
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Subscribed data changes for " + path);
+      LOG.debug("zkclient {}, Subscribed data changes for {}", this.toString(), path);
     }
     return true;
   }
@@ -333,8 +341,8 @@ public class ZkClient implements Watcher {
         return preFetchInMethod.enabled();
       }
     } catch (NoSuchMethodException e) {
-      LOG.warn("No method " + callbackMethod.getName() + " defined in listener " + dataListener
-          .getClass().getCanonicalName());
+      LOG.warn("Zkclient {}, No method {} defined in listener {}",
+          this.toString(), callbackMethod.getName(), dataListener.getClass().getCanonicalName());
     }
 
     return true;
@@ -760,7 +768,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("create, path: " + path + ", time: " + (endT - startT) + " ms");
+        LOG.trace("zkclient {} create, path {}, time {} ms", this.toString(), path, (endT - startT));
       }
     }
   }
@@ -962,7 +970,7 @@ public class ZkClient implements Watcher {
   public void process(WatchedEvent event) {
     long notificationTime = System.currentTimeMillis();
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Received event: " + event);
+      LOG.debug("zkclient {}, Received event: {} ", this.toString(), event);
     }
     _zookeeperEventThread = Thread.currentThread();
 
@@ -974,7 +982,7 @@ public class ZkClient implements Watcher {
             || event.getType() == EventType.NodeCreated
             || event.getType() == EventType.NodeChildrenChanged;
     if (event.getType() == EventType.NodeDeleted) {
-      LOG.debug("Path {} is deleted", event.getPath());
+      LOG.debug("zkclient {}, Path {} is deleted", this.toString(), event.getPath());
     }
 
     getEventLock().lock();
@@ -982,8 +990,8 @@ public class ZkClient implements Watcher {
       // We might have to install child change event listener if a new node was created
       if (getShutdownTrigger()) {
         if (LOG.isDebugEnabled()) {
-          LOG.debug("ignoring event '{" + event.getType() + " | " + event.getPath()
-              + "}' since shutdown triggered");
+          LOG.debug("zkclient {} ignoring event {}|{} since shutdown triggered",
+              this.toString(), event.getType(), event.getPath());
         }
         return;
       }
@@ -1019,7 +1027,7 @@ public class ZkClient implements Watcher {
       recordStateChange(stateChanged, dataChanged, sessionExpired);
 
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Leaving process event");
+        LOG.debug("zkclient {} Leaving process event", this.toString());
       }
     }
   }
@@ -1080,7 +1088,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("getChildren, path: " + path + ", time: " + (endT - startT) + " ms");
+        LOG.trace("zkclient {} getChildren, path {} time: {} ms", this.toString(), path, (endT - startT) );
       }
     }
   }
@@ -1122,7 +1130,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("exists, path: " + path + ", time: " + (endT - startT) + " ms");
+        LOG.trace("zkclient exists, path: {}, time: {} ms", this.toString(), path, (endT - startT));
       }
     }
   }
@@ -1145,7 +1153,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("exists, path: " + path + ", time: " + (endT - startT) + " ms");
+        LOG.trace("zkclient exists, path: {}, time: {} ms", this.toString(), path, (endT - startT));
       }
     }
   }
@@ -1174,13 +1182,14 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("getData (installWatchOnlyPathExist), path: " + path + ", time: " + (endT - startT) + " ms");
+        LOG.trace("zkclient getData (installWatchOnlyPathExist), path: {}, time: {} ms",
+            this.toString(), path, (endT - startT));
       }
     }
   }
 
   protected void processStateChanged(WatchedEvent event) {
-    LOG.info("zookeeper state changed (" + event.getState() + ")");
+    LOG.info("zkclient {}, zookeeper state changed ( {} )", this.toString(), event.getState());
     setCurrentState(event.getState());
     if (getShutdownTrigger()) {
       return;
@@ -1243,7 +1252,8 @@ public class ZkClient implements Watcher {
       } catch (Exception e) {
         reconnectException = e;
         long waitInterval = retryStrategy.getNextWaitInterval(retryCount++);
-        LOG.warn("ZkClient reconnect on expiring failed. Will retry after {} ms", waitInterval, e);
+        LOG.warn("ZkClient {}, reconnect on expiring failed. Will retry after {} ms",
+            this.toString(), waitInterval, e);
         try {
           Thread.sleep(waitInterval);
         } catch (InterruptedException ex) {
@@ -1253,8 +1263,8 @@ public class ZkClient implements Watcher {
       }
     }
 
-    LOG.info("Unable to re-establish connection. Notifying consumer of the following exception: ",
-        reconnectException);
+    LOG.info("Zkclient {} unable to re-establish connection. Notifying consumer of the following exception:{}",
+        this.toString(), reconnectException);
     fireSessionEstablishmentError(reconnectException);
   }
 
@@ -1305,8 +1315,8 @@ public class ZkClient implements Watcher {
 
     KeeperException.Code code = KeeperException.Code.get(callbackHandler.getRc());
     if (code == KeeperException.Code.OK) {
-      LOG.info("sycnOnNewSession with sessionID {} async return code: {} and proceeds", sessionId,
-          code);
+      LOG.info("zkclient {}, sycnOnNewSession with sessionID {} async return code: {} and proceeds",
+          this.toString(), sessionId, code);
       return true;
     }
 
@@ -1328,7 +1338,7 @@ public class ZkClient implements Watcher {
         @Override
         public void run() throws Exception {
           if (issueSync(zk) == false) {
-            LOG.warn("Failed to call sync() on new session {}", sessionId);
+            LOG.warn("zkclient{}, Failed to call sync() on new session {}", this.toString(), sessionId);
           }
         }
       });
@@ -1397,7 +1407,8 @@ public class ZkClient implements Watcher {
       deleteRecursively(path);
       return true;
     } catch (ZkClientException e) {
-      LOG.error("Failed to recursively delete path " + path, e);
+      LOG.error("zkcient {}, Failed to recursively delete path {}, exception {}",
+          this.toString(), path, e);
       return false;
     }
   }
@@ -1426,7 +1437,7 @@ public class ZkClient implements Watcher {
     try {
       delete(path);
     } catch (Exception e) {
-      LOG.error("Failed to delete " + path, e);
+      LOG.error("zkclient {}, Failed to delete {}, exception {}", this.toString(), path, e);
       throw new ZkClientException("Failed to delete " + path, e);
     }
   }
@@ -1435,7 +1446,7 @@ public class ZkClient implements Watcher {
     final String path = event.getPath();
     final boolean pathExists = event.getType() != EventType.NodeDeleted;
     if (EventType.NodeDeleted == event.getType()) {
-      LOG.debug("Event NodeDeleted: {}", event.getPath());
+      LOG.debug("zkclient{}, Event NodeDeleted: {}", this.toString(), event.getPath());
     }
 
     if (event.getType() == EventType.NodeChildrenChanged || event.getType() == EventType.NodeCreated
@@ -1491,13 +1502,13 @@ public class ZkClient implements Watcher {
               Object data = null;
               if (listener.isPrefetchData()) {
                 if (LOG.isDebugEnabled()) {
-                  LOG.debug("Prefetch data for path: {}", path);
+                  LOG.debug("zkclient {} Prefetch data for path: {}", this.toString(), path);
                 }
                 try {
                   // TODO: the data is redundantly read multiple times when multiple listeners exist
                   data = readData(path, null, true);
                 } catch (ZkNoNodeException e) {
-                  LOG.warn("Prefetch data for path: {} failed.", path, e);
+                  LOG.warn("zkclient {} Prefetch data for path: {} failed.", this.toString(), path, e);
                   listener.getDataListener().handleDataDeleted(path);
                   return;
                 }
@@ -1508,7 +1519,7 @@ public class ZkClient implements Watcher {
         });
       }
     } catch (Exception e) {
-      LOG.error("Failed to fire data changed event for path: {}", path, e);
+      LOG.error("zkclient {} Failed to fire data changed event for path: {}", this.toString(), path, e);
     }
   }
 
@@ -1535,7 +1546,7 @@ public class ZkClient implements Watcher {
               try {
                 children = getChildren(path);
               } catch (ZkNoNodeException e) {
-                LOG.warn("Get children under path: {} failed.", path, e);
+                LOG.warn("zkclient {} Get children under path: {} failed.", this.toString(), path, e);
                 // Continue trigger the change handler
               }
             }
@@ -1544,7 +1555,7 @@ public class ZkClient implements Watcher {
         });
       }
     } catch (Exception e) {
-      LOG.error("Failed to fire child changed event. Unable to getChildren.", e);
+      LOG.error("zkclient {} Failed to fire child changed event. Unable to getChildren.", this.toString(), e);
     }
   }
 
@@ -1552,7 +1563,7 @@ public class ZkClient implements Watcher {
       throws ZkInterruptedException {
     Date timeout = new Date(System.currentTimeMillis() + timeUnit.toMillis(time));
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Waiting until znode '" + path + "' becomes available.");
+      LOG.debug("Waiting until znode {} becomes available.", this.toString(), path);
     }
     if (exists(path)) {
       return true;
@@ -1602,7 +1613,7 @@ public class ZkClient implements Watcher {
     validateCurrentThread();
     Date timeout = new Date(System.currentTimeMillis() + timeUnit.toMillis(time));
 
-    LOG.debug("Waiting for keeper state " + keeperState);
+    LOG.debug("zkclient {}, Waiting for keeper state {} ", this.toString(), keeperState);
     acquireEventLock();
     try {
       boolean stillWaiting = true;
@@ -1612,7 +1623,8 @@ public class ZkClient implements Watcher {
         }
         stillWaiting = getEventLock().getStateChangedCondition().awaitUntil(timeout);
       }
-      LOG.debug("State is " + (_currentState == null ? "CLOSED" : _currentState));
+      LOG.debug("zkclient {} State is {}",
+          this.toString(), (_currentState == null ? "CLOSED" : _currentState));
       return true;
     } catch (InterruptedException e) {
       throw new ZkInterruptedException(e);
@@ -1690,7 +1702,7 @@ public class ZkClient implements Watcher {
           throw ExceptionUtil.convertToRuntimeException(e);
         }
 
-        LOG.debug("Retrying operation, caused by {}", retryCauseCode);
+        LOG.debug("zkclient {}, Retrying operation, caused by {}", this.toString(),retryCauseCode);
         // before attempting a retry, check whether retry timeout has elapsed
         if (System.currentTimeMillis() - operationStartTime > _operationRetryTimeoutInMillis) {
           throw new ZkTimeoutException("Operation cannot be retried because of retry timeout ("
@@ -1753,18 +1765,18 @@ public class ZkClient implements Watcher {
       } catch (ZkNoNodeException e) {
         success = false;
         if (LOG.isDebugEnabled()) {
-          LOG.debug("Failed to delete path " + path + ", znode does not exist!");
+          LOG.debug("zkclient {}, Failed to delete path {}, znode does not exist!", this.toString(), path);
         }
       }
       record(path, null, startT, ZkClientMonitor.AccessType.WRITE);
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.WRITE);
-      LOG.warn("Failed to delete path " + path + "! " + e);
+      LOG.warn("zkclient {}, Failed to delete path {}! ", this.toString(), path, e);
       throw e;
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("delete, path: " + path + ", time: " + (endT - startT) + " ms");
+        LOG.trace("zkclient {} delete, path: {}, time {} ms", this.toString(), path, (endT - startT));
       }
     }
     return success;
@@ -1840,7 +1852,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("getData, path: " + path + ", time: " + (endT - startT) + " ms");
+        LOG.trace("zkclient {}, getData, path {}, time {} ms", this.toString(), path, (endT - startT));
       }
     }
   }
@@ -1917,7 +1929,7 @@ public class ZkClient implements Watcher {
     } finally {
       long endT = System.currentTimeMillis();
       if (LOG.isTraceEnabled()) {
-        LOG.trace("setData, path: " + path + ", time: " + (endT - startT) + " ms");
+        LOG.trace("zkclient {}, setData, path {}, time {} ms", this.toString(), path, (endT - startT));
       }
     }
   }
@@ -2049,7 +2061,7 @@ public class ZkClient implements Watcher {
       }
     } catch (ZkNoNodeException e) {
       // Do nothing, this is what we want as this is not going to leak watch in ZooKeeepr server.
-      LOG.info("watchForData path not existing: " + path);
+      LOG.info("zkclient {}, watchForData path not existing: {} ", this.toString(), path);
       return false;
     }
     return true;
@@ -2104,8 +2116,8 @@ public class ZkClient implements Watcher {
           return getChildren(path, true);
         } catch (ZkNoNodeException e) {
           // ignore, the "exists" watch will listen for the parent node to appear
-          LOG.info("watchForChilds path not existing:{} skipWatchingNodeNoteExist: {}",
-              path, skipWatchingNonExistNode);
+          LOG.info("zkclient{} watchForChilds path not existing:{} skipWatchingNodeNoteExist: {}",
+              this.toString(), path, skipWatchingNonExistNode);
         }
         return null;
       }
@@ -2154,11 +2166,11 @@ public class ZkClient implements Watcher {
       _eventThread = new ZkEventThread(zkConnection.getServers());
       _eventThread.start();
 
-      LOG.debug("ZkClient created with _uid {}, _eventThread {}", _uid, _eventThread.getId());
+      LOG.debug("ZkClient {},  _eventThread {}", this.toString(), _eventThread.getId());
 
       if (isManagingZkConnection()) {
         zkConnection.connect(watcher);
-        LOG.debug("Awaiting connection to Zookeeper server");
+        LOG.debug("zkclient{} Awaiting connection to Zookeeper server", this.toString());
         if (!waitUntilConnected(maxMsToWaitUntilConnected, TimeUnit.MILLISECONDS)) {
           throw new ZkTimeoutException(
               "Unable to connect to zookeeper server within timeout: " + maxMsToWaitUntilConnected);
@@ -2212,7 +2224,7 @@ public class ZkClient implements Watcher {
   public void close() throws ZkInterruptedException {
     if (LOG.isTraceEnabled()) {
       StackTraceElement[] calls = Thread.currentThread().getStackTrace();
-      LOG.trace("closing a zkclient. callStack: " + Arrays.asList(calls));
+      LOG.trace("zkclient {} closing a zkclient. callStack: {} ", this.toString(), Arrays.asList(calls));
     }
     getEventLock().lock();
     IZkConnection connection = getConnection();
@@ -2228,7 +2240,7 @@ public class ZkClient implements Watcher {
       _eventThread.interrupt();
       _eventThread.join(2000);
       if (isManagingZkConnection()) {
-        LOG.info("Closing zkclient: " + ((ZkConnection) connection).getZookeeper());
+        LOG.info("zkclient{}, Closing zkclient zk: {} ", this.toString(), ((ZkConnection) connection).getZookeeper());
         connection.close();
       }
       _closed = true;
@@ -2265,7 +2277,7 @@ public class ZkClient implements Watcher {
       if (_monitor != null) {
         _monitor.unregister();
       }
-      LOG.info("Closed zkclient");
+      LOG.info("Zkclient {} Closed zkclient", this.toString());
     }
   }
 


### PR DESCRIPTION


### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

resolve #1352

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

    CallbackHandlder and ZkClient methods are invoked over multiple threads.
    It can be hard to correlate one object's execution threads over multiple
    java threads. This poses a serious issue in production log examination.
    
    We propose to add unique id to each methods' logging to help the
    correlation and also track the object's life cycle.



### Tests

- [x] The following tests are written for this issue:

None

- [x] The following is the result of the "mvn test" command on the appropriate module:

running

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
