### PR TITLE
Add HelixRestObjectNameFactory to create namespaced ObjectName

### DIFF
--- a/helix-core/helix-core-1.0.2-SNAPSHOT.ivy
+++ b/helix-core/helix-core-1.0.2-SNAPSHOT.ivy
@@ -62,7 +62,7 @@ under the License.
     <dependency org="com.google.guava" name="guava" rev="15.0" conf="compile->compile(default);runtime->runtime(default);default->default"/>
     <dependency org="org.yaml" name="snakeyaml" rev="1.12" conf="compile->compile(default);runtime->runtime(default);default->default"/>
     <dependency org="commons-logging" name="commons-logging-api" rev="1.1" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
-    <dependency org="io.dropwizard.metrics" name="metrics-core" rev="3.2.3" conf="compile->compile(default);runtime->runtime(default);default->default"/>
+    <dependency org="io.dropwizard.metrics" name="metrics-core" rev="4.1.12.1" conf="compile->compile(default);runtime->runtime(default);default->default"/>
 	</dependencies>
 </ivy-module>
 

--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -145,7 +145,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>3.2.3</version>
+      <version>${metrics-core.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/helix-rest/helix-rest-1.0.2-SNAPSHOT.ivy
+++ b/helix-rest/helix-rest-1.0.2-SNAPSHOT.ivy
@@ -50,5 +50,7 @@ under the License.
 		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.11.0" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.11.0" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="io.dropwizard.metrics" name="metrics-jersey2" rev="4.1.12.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="io.dropwizard.metrics" name="metrics-jmx" rev="4.1.12.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 	</dependencies>
 </ivy-module>

--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -154,6 +154,11 @@
       <version>${metrics-jersey2.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jmx</artifactId>
+      <version>${metrics-jmx.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestObjectNameFactory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestObjectNameFactory.java
@@ -1,0 +1,88 @@
+package org.apache.helix.rest.server;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Hashtable;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import com.codahale.metrics.jmx.ObjectNameFactory;
+import org.apache.helix.HelixException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Creates an {@link ObjectName} that has "name", "type" and "namespace" properties
+ * for metrics registry in Helix rest service.
+ *
+ * <p>It is recommended to only be used within Helix REST.
+ */
+class HelixRestObjectNameFactory implements ObjectNameFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(HelixRestObjectNameFactory.class);
+
+  private static final String KEY_NAME = "name";
+  private static final String KEY_TYPE = "type";
+  private static final String KEY_NAMESPACE = "namespace";
+
+  private final String _namespace;
+
+  HelixRestObjectNameFactory(String nameSpace) {
+    _namespace = nameSpace;
+  }
+
+  public ObjectName createName(String type, String domain, String name) {
+    Hashtable<String, String> properties = new Hashtable<>();
+
+    properties.put(KEY_NAME, name);
+    properties.put(KEY_TYPE, type);
+    properties.put(KEY_NAMESPACE, _namespace);
+
+    try {
+      /*
+       * The only way we can find out if we need to quote the properties is by
+       * checking an ObjectName that we've constructed. Eg. when regex is used in
+       * object name, quoting is needed.
+       */
+      ObjectName objectName = new ObjectName(domain, properties);
+      boolean needQuote = false;
+
+      if (objectName.isDomainPattern()) {
+        domain = ObjectName.quote(domain);
+        needQuote = true;
+      }
+
+      if (objectName.isPropertyValuePattern(KEY_NAME)) {
+        properties.put(KEY_NAME, ObjectName.quote(name));
+        needQuote = true;
+      }
+
+      if (objectName.isPropertyValuePattern(KEY_TYPE)) {
+        properties.put(KEY_TYPE, ObjectName.quote(type));
+        needQuote = true;
+      }
+
+      return needQuote ? new ObjectName(domain, properties) : objectName;
+    } catch (MalformedObjectNameException e) {
+      throw new HelixException(String
+          .format("Unable to register metrics: domain=%s, name=%s, namespace=%s", domain, name,
+              _namespace), e);
+    }
+  }
+}

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestHelixRestObjectNameFactory.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestHelixRestObjectNameFactory.java
@@ -1,0 +1,44 @@
+package org.apache.helix.rest.server;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.management.ObjectName;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestHelixRestObjectNameFactory {
+  @Test
+  public void createsObjectNameWithDomainInInput() {
+    HelixRestObjectNameFactory f = new HelixRestObjectNameFactory("namespace");
+    ObjectName objectName = f.createName("type", "org.apache.helix.rest", "something.with.dots");
+    Assert.assertEquals(objectName.getDomain(), "org.apache.helix.rest");
+  }
+
+  @Test
+  public void createsObjectNameWithNameAsKeyPropertyName() {
+    HelixRestObjectNameFactory f = new HelixRestObjectNameFactory("helix.rest");
+    ObjectName objectName =
+        f.createName("counter", "org.apache.helix.rest", "something.with.dots");
+    Assert.assertEquals(objectName.getKeyProperty("name"), "something.with.dots");
+    Assert.assertEquals(objectName.getKeyProperty("namespace"), "helix.rest");
+    Assert.assertEquals(objectName.getKeyProperty("type"), "counter");
+  }
+}

--- a/metrics-common/pom.xml
+++ b/metrics-common/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>3.2.3</version>
+      <version>${metrics-core.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,9 @@
     <SKIP_INTEGRATION_TESTS>true</SKIP_INTEGRATION_TESTS>
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
 
+    <metrics-core.version>4.1.12.1</metrics-core.version>
     <metrics-jersey2.version>4.1.12.1</metrics-jersey2.version>
+    <metrics-jmx.version>4.1.12.1</metrics-jmx.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1356 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We need helix rest service metrics for each namespace. To achieve this, the namespace info needs to be contained in the MBean's object name, eg: `domain:name=getClusters,namespace=myNamespace,type=counters`. But DropWizard's default ObjectNameFactory doesn't have the namespace parameter.

This PR implements a custom object name factory and add the namespace to object name.

### Tests

- [x] The following tests are written for this issue:

TestHelixRestObjectNameFactory

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 167, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 43.615 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 167, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  49.751 s
[INFO] Finished at: 2020-09-11T00:08:46-07:00
[INFO] ------------------------------------------------------------------------
```

Final run:
```
[INFO] Tests run: 168, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 39.041 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 168, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  45.121 s
[INFO] Finished at: 2020-09-21T18:16:05-07:00
[INFO] ------------------------------------------------------------------------
```
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
