### PR TITLE
Use the DelayedAutoRebalancer as the default rebalancer.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -35,8 +35,8 @@ import org.apache.helix.controller.LogUtil;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.pipeline.AbstractBaseStage;
 import org.apache.helix.controller.pipeline.StageException;
-import org.apache.helix.controller.rebalancer.AutoRebalancer;
 import org.apache.helix.controller.rebalancer.CustomRebalancer;
+import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
 import org.apache.helix.controller.rebalancer.MaintenanceRebalancer;
 import org.apache.helix.controller.rebalancer.Rebalancer;
 import org.apache.helix.controller.rebalancer.SemiAutoRebalancer;
@@ -446,7 +446,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
         if (customizedRebalancer != null) {
           rebalancer = customizedRebalancer;
         } else {
-          rebalancer = new AutoRebalancer();
+          rebalancer = new DelayedAutoRebalancer();
         }
       }
       break;

--- a/helix-core/src/test/java/org/apache/helix/integration/TestAlertingRebalancerFailure.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestAlertingRebalancerFailure.java
@@ -33,6 +33,7 @@ import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.TestHelper;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.strategy.CrushRebalanceStrategy;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
@@ -169,7 +170,8 @@ public class TestAlertingRebalancerFailure extends ZkStandAloneCMTestBase {
   @Test(dependsOnMethods = "testParticipantUnavailable")
   public void testTagSetIncorrect() throws Exception {
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, testDb, 5,
-        BuiltInStateModelDefinitions.MasterSlave.name(), RebalanceMode.FULL_AUTO.name());
+        BuiltInStateModelDefinitions.MasterSlave.name(), RebalanceMode.FULL_AUTO.name(),
+        CrushEdRebalanceStrategy.class.getName());
     ZkHelixClusterVerifier verifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
         .setZkClient(_gZkClient).setResources(new HashSet<>(Collections.singleton(testDb))).build();
     _gSetupTool.getClusterManagementTool().rebalance(CLUSTER_NAME, testDb, 3);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestDisableExternalView.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestDisableExternalView.java
@@ -23,8 +23,8 @@ import java.util.Date;
 
 import org.apache.helix.HelixProperty;
 import org.apache.helix.PropertyKey;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
@@ -33,6 +33,7 @@ import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.tools.ClusterStateVerifier;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -77,14 +78,14 @@ public class TestDisableExternalView extends ZkTestBase {
     _gSetupTool.addCluster(CLUSTER_NAME, true);
 
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, TEST_DB1, _PARTITIONS, STATE_MODEL,
-        IdealState.RebalanceMode.FULL_AUTO + "");
+        IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
 
     IdealState idealState = _admin.getResourceIdealState(CLUSTER_NAME, TEST_DB1);
     idealState.setDisableExternalView(true);
     _admin.setResourceIdealState(CLUSTER_NAME, TEST_DB1, idealState);
 
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, TEST_DB2, _PARTITIONS, STATE_MODEL,
-        IdealState.RebalanceMode.FULL_AUTO + "");
+        IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
 
     for (int i = 0; i < NODE_NR; i++) {
       instances[i] = PARTICIPANT_PREFIX + "_" + (START_PORT + i);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestPartitionMovementThrottle.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestPartitionMovementThrottle.java
@@ -38,6 +38,7 @@ import org.apache.helix.NotificationContext;
 import org.apache.helix.TestHelper;
 import org.apache.helix.api.config.StateTransitionThrottleConfig;
 import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
@@ -137,7 +138,7 @@ public class TestPartitionMovementThrottle extends ZkStandAloneCMTestBase {
     for (int i = 0; i < 5; i++) {
       String dbName = "TestDB-" + i;
       _gSetupTool.addResourceToCluster(CLUSTER_NAME, dbName, 10, STATE_MODEL,
-          RebalanceMode.FULL_AUTO + "");
+          RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, dbName, _replica);
       _dbs.add(dbName);
     }
@@ -170,8 +171,9 @@ public class TestPartitionMovementThrottle extends ZkStandAloneCMTestBase {
     for (int i = 0; i < NODE_NR - 2; i++) {
       _participants[i].syncStart();
     }
-    _gSetupTool.addResourceToCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, 10,
-        STATE_MODEL, RebalanceMode.FULL_AUTO.name());
+    _gSetupTool
+        .addResourceToCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, 10, STATE_MODEL,
+            RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, _replica);
 
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
@@ -203,9 +205,9 @@ public class TestPartitionMovementThrottle extends ZkStandAloneCMTestBase {
       _participants[i].syncStart();
     }
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB + "_ANY", 20,
-        STATE_MODEL, RebalanceMode.FULL_AUTO.name());
-    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB + "_ANY",
-        _replica);
+        STATE_MODEL, RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
+    _gSetupTool
+        .rebalanceStorageCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB + "_ANY", _replica);
 
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
@@ -236,8 +238,9 @@ public class TestPartitionMovementThrottle extends ZkStandAloneCMTestBase {
       _participants[i].syncStart();
     }
     // Add resource: TestDB_ANY of 20 partitions
-    _gSetupTool.addResourceToCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB + "_OnlyANY",
-        20, STATE_MODEL, RebalanceMode.FULL_AUTO.name());
+    _gSetupTool
+        .addResourceToCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB + "_OnlyANY", 20,
+            STATE_MODEL, RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
     // Act the rebalance process
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB + "_OnlyANY",
         _replica);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestRebalancerPersistAssignments.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestRebalancerPersistAssignments.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
+import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
@@ -85,7 +87,9 @@ public class TestRebalancerPersistAssignments extends ZkStandAloneCMTestBase {
     String testDb = "TestDB2-" + rebalanceMode.name();
 
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, testDb, 5,
-        BuiltInStateModelDefinitions.LeaderStandby.name(), rebalanceMode.name());
+        BuiltInStateModelDefinitions.LeaderStandby.name(), rebalanceMode.name(),
+        rebalanceMode.equals(RebalanceMode.FULL_AUTO) ? CrushEdRebalanceStrategy.class.getName()
+            : RebalanceStrategy.DEFAULT_REBALANCE_STRATEGY);
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, testDb, 3);
 
     BestPossibleExternalViewVerifier.Builder verifierBuilder =
@@ -124,7 +128,9 @@ public class TestRebalancerPersistAssignments extends ZkStandAloneCMTestBase {
     enablePersistBestPossibleAssignment(_gZkClient, CLUSTER_NAME, true);
 
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, testDb, 5,
-        BuiltInStateModelDefinitions.LeaderStandby.name(), rebalanceMode.name());
+        BuiltInStateModelDefinitions.LeaderStandby.name(), rebalanceMode.name(),
+        rebalanceMode.equals(RebalanceMode.FULL_AUTO) ? CrushEdRebalanceStrategy.class.getName()
+            : RebalanceStrategy.DEFAULT_REBALANCE_STRATEGY);
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, testDb, 3);
 
     BestPossibleExternalViewVerifier.Builder verifierBuilder =

--- a/helix-core/src/test/java/org/apache/helix/integration/TestSwapInstance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestSwapInstance.java
@@ -21,7 +21,7 @@ package org.apache.helix.integration;
 
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
-import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
 import org.apache.helix.model.IdealState;
 import org.testng.Assert;
@@ -45,7 +45,7 @@ public class TestSwapInstance extends ZkStandAloneCMTestBase {
 
     // Create full-auto resource
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, "db-fa", 64, STATE_MODEL,
-        IdealState.RebalanceMode.FULL_AUTO.name(), RebalanceStrategy.DEFAULT_REBALANCE_STRATEGY);
+        IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, "db-fa", _replica);
 
     // Wait for cluster converge

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.integration.task.TaskTestBase;
 import org.apache.helix.integration.task.WorkflowGenerator;
@@ -104,7 +105,7 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
   public void testMaintenanceModeAddNewResource() {
     _gSetupTool.getClusterManagementTool().addResource(CLUSTER_NAME,
         newResourceAddedDuringMaintenanceMode, 7, "MasterSlave",
-        IdealState.RebalanceMode.FULL_AUTO.name());
+        IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
     _gSetupTool.getClusterManagementTool().rebalance(CLUSTER_NAME,
         newResourceAddedDuringMaintenanceMode, 3);
     Assert.assertTrue(_clusterVerifier.verifyByPolling());

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -447,7 +447,7 @@ public class TestMultiZkHelixJavaApis {
       for (int i = 0; i < numResources; i++) {
         String resource = cluster + "_" + resourceNamePrefix + i;
         _zkHelixAdmin.addResource(cluster, resource, numPartitions, "MasterSlave",
-            IdealState.RebalanceMode.FULL_AUTO.name());
+            IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
         _zkHelixAdmin.rebalance(cluster, resource, 3);
         resourceNames.add(resource);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
@@ -6,6 +6,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.TestHelper;
 import org.apache.helix.cloud.constants.CloudProvider;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.manager.zk.ZKHelixManager;
@@ -45,7 +46,7 @@ public class TestInstanceAutoJoin extends ZkStandAloneCMTestBase {
     HelixDataAccessor accessor = manager.getHelixDataAccessor();
 
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, db2, 60, "OnlineOffline",
-        RebalanceMode.FULL_AUTO + "");
+        RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
 
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db2, 1);
     String instance2 = "localhost_279699";
@@ -93,7 +94,7 @@ public class TestInstanceAutoJoin extends ZkStandAloneCMTestBase {
     HelixDataAccessor accessor = manager.getHelixDataAccessor();
 
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, db3, 60, "OnlineOffline",
-        RebalanceMode.FULL_AUTO + "");
+        RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db3, 1);
     String instance3 = "localhost_279700";
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalanceWithDisabledInstance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalanceWithDisabledInstance.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.TestHelper;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.model.ExternalView;
@@ -41,7 +42,7 @@ public class TestAutoRebalanceWithDisabledInstance extends ZkStandAloneCMTestBas
   public void beforeClass() throws Exception {
     super.beforeClass();
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, TEST_DB_2, _PARTITIONS, STATE_MODEL,
-        RebalanceMode.FULL_AUTO.name());
+        RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
     _gSetupTool.rebalanceResource(CLUSTER_NAME, TEST_DB_2, _replica);
 
     Assert.assertTrue(_clusterVerifier.verifyByPolling());

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderFromCurrentStates.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderFromCurrentStates.java
@@ -38,6 +38,7 @@ import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.api.listeners.PreFetch;
 import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.model.ClusterConfig;
@@ -125,7 +126,7 @@ public class TestRoutingTableProviderFromCurrentStates extends ZkTestBase {
     try {
       String db1 = "TestDB-1";
       _gSetupTool.addResourceToCluster(CLUSTER_NAME, db1, NUM_PARTITIONS, "MasterSlave",
-          IdealState.RebalanceMode.FULL_AUTO.name());
+          IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
       long startTime = System.currentTimeMillis();
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db1, NUM_REPLICAS);
 
@@ -143,7 +144,7 @@ public class TestRoutingTableProviderFromCurrentStates extends ZkTestBase {
       // add new DB
       String db2 = "TestDB-2";
       _gSetupTool.addResourceToCluster(CLUSTER_NAME, db2, NUM_PARTITIONS, "MasterSlave",
-          IdealState.RebalanceMode.FULL_AUTO.name());
+          IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
       startTime = System.currentTimeMillis();
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db2, NUM_REPLICAS);
 
@@ -218,7 +219,7 @@ public class TestRoutingTableProviderFromCurrentStates extends ZkTestBase {
       // current state change.
       String db = "TestDB-" + TestHelper.getTestMethodName();
       _gSetupTool.addResourceToCluster(CLUSTER_NAME, db, NUM_PARTITIONS, "MasterSlave",
-          IdealState.RebalanceMode.FULL_AUTO.name());
+          IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, NUM_REPLICAS);
       ZkHelixClusterVerifier clusterVerifier =
           new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderFromTargetEV.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderFromTargetEV.java
@@ -31,6 +31,7 @@ import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.integration.task.WorkflowGenerator;
@@ -69,7 +70,8 @@ public class TestRoutingTableProviderFromTargetEV extends ZkTestBase {
     }
 
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, NUM_PARTITIONS,
-        MASTER_SLAVE_STATE_MODEL, IdealState.RebalanceMode.FULL_AUTO.name());
+        MASTER_SLAVE_STATE_MODEL, IdealState.RebalanceMode.FULL_AUTO.name(),
+        CrushEdRebalanceStrategy.class.getName());
 
     _gSetupTool
         .rebalanceStorageCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, NUM_REPLICAS);

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableSnapshot.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableSnapshot.java
@@ -27,6 +27,7 @@ import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyType;
 import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.model.IdealState;
@@ -100,7 +101,7 @@ public class TestRoutingTableSnapshot extends ZkTestBase {
     try {
       String db1 = "TestDB-1";
       _gSetupTool.addResourceToCluster(CLUSTER_NAME, db1, NUM_PARTITIONS, "MasterSlave",
-          IdealState.RebalanceMode.FULL_AUTO.name());
+          IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db1, NUM_REPLICAS);
 
       Thread.sleep(200);
@@ -122,7 +123,7 @@ public class TestRoutingTableSnapshot extends ZkTestBase {
       // add new DB and shutdown an instance
       String db2 = "TestDB-2";
       _gSetupTool.addResourceToCluster(CLUSTER_NAME, db2, NUM_PARTITIONS, "MasterSlave",
-          IdealState.RebalanceMode.FULL_AUTO.name());
+          IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db2, NUM_REPLICAS);
 
       // shutdown an instance

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureTaskNotStarted.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureTaskNotStarted.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixException;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.mock.statemodel.MockTaskStateModelFactory;
@@ -181,7 +182,7 @@ public class TestJobFailureTaskNotStarted extends TaskSynchronizedTestBase {
   private void setupUnbalancedDB() throws InterruptedException {
     // Start with Full-Auto mode to create the partitions, Semi-Auto won't create partitions.
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, UNBALANCED_DB_NAME, 50, MASTER_SLAVE_STATE_MODEL,
-        IdealState.RebalanceMode.FULL_AUTO.toString());
+        IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, UNBALANCED_DB_NAME, 1);
 
     // Set preference list to put all partitions to one instance.

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskThreadLeak.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskThreadLeak.java
@@ -22,6 +22,7 @@ package org.apache.helix.integration.task;
 import java.util.Set;
 
 import org.apache.helix.TestHelper;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.task.JobConfig;
 import org.apache.helix.task.JobQueue;
@@ -52,7 +53,7 @@ public class TestTaskThreadLeak extends TaskTestBase {
     for (int i = 0; i < 5; i++) {
       String db = TestHelper.getTestMethodName() + "_" + i;
       _gSetupTool.addResourceToCluster(CLUSTER_NAME, db, 20, MASTER_SLAVE_STATE_MODEL,
-          IdealState.RebalanceMode.FULL_AUTO.name());
+          IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, 1);
       JobConfig.Builder jobBuilder =
           new JobConfig.Builder().setCommand(MockTask.TASK_COMMAND).setTargetResource(db)

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestRebalancerMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestRebalancerMetrics.java
@@ -128,8 +128,10 @@ public class TestRebalancerMetrics extends BaseStageTest {
     event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
     setupLiveInstances(4);
 
-    runStage(event, new ReadClusterDataStage());
+
     ResourceControllerDataProvider cache = event.getAttribute(AttributeName.ControllerDataProvider.name());
+    cache.clearCachedResourceAssignments();
+    runStage(event, new ReadClusterDataStage());
     setupThrottleConfig(cache.getClusterConfig(),
         StateTransitionThrottleConfig.RebalanceType.LOAD_BALANCE, maxPending);
     runStage(event, new BestPossibleStateCalcStage());

--- a/helix-core/src/test/java/org/apache/helix/task/TaskSynchronizedTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TaskSynchronizedTestBase.java
@@ -29,6 +29,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.integration.task.MockTask;
@@ -101,14 +102,17 @@ public class TaskSynchronizedTestBase extends ZkTestBase {
         int varyNum = _partitionVary ? 10 * i : 0;
         String db = WorkflowGenerator.DEFAULT_TGT_DB + i;
         clusterSetup.addResourceToCluster(CLUSTER_NAME, db, _numPartitions + varyNum,
-            MASTER_SLAVE_STATE_MODEL, IdealState.RebalanceMode.FULL_AUTO.toString());
+            MASTER_SLAVE_STATE_MODEL, IdealState.RebalanceMode.FULL_AUTO.toString(),
+            CrushEdRebalanceStrategy.class.getName());
         clusterSetup.rebalanceStorageCluster(CLUSTER_NAME, db, _numReplicas);
         _testDbs.add(db);
       }
     } else {
       if (_instanceGroupTag) {
-        clusterSetup.addResourceToCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB,
-            _numPartitions, "OnlineOffline", IdealState.RebalanceMode.FULL_AUTO.name());
+        clusterSetup
+            .addResourceToCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, _numPartitions,
+                "OnlineOffline", IdealState.RebalanceMode.FULL_AUTO.name(),
+                CrushEdRebalanceStrategy.class.getName());
         IdealState idealState = clusterSetup.getClusterManagementTool()
             .getResourceIdealState(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB);
         idealState.setInstanceGroupTag("TESTTAG0");
@@ -116,7 +120,8 @@ public class TaskSynchronizedTestBase extends ZkTestBase {
             WorkflowGenerator.DEFAULT_TGT_DB, idealState);
       } else {
         clusterSetup.addResourceToCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB,
-            _numPartitions, MASTER_SLAVE_STATE_MODEL, IdealState.RebalanceMode.FULL_AUTO.name());
+            _numPartitions, MASTER_SLAVE_STATE_MODEL, IdealState.RebalanceMode.FULL_AUTO.name(),
+            CrushEdRebalanceStrategy.class.getName());
       }
       clusterSetup.rebalanceStorageCluster(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB,
           _numReplicas);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1349 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR depends on #1359 , please reviewing that PR first.

If no rebalancer class name is specified, use the DelayedAutoRebalancer instead of AutoRebalancer.
Note that DelayedAutoRebalancer is compatible with the AutoRebalanceStrategy. So the assignment would remain the same even after migration.
However, since DelayedAutoRebalancer keeps a cached rebalance result in the Controller cache, it causes a behavior change.
- We need to modify multiple test classes to use the CrushEd rebalance strategy for the correct test logic.
- This behavior change only impacts BestPossibleExternalViewVerifier if the resource was on the older AutoRebalancer (by DEFAULT setting) and AutoRebalanceStrategy.
- If any Helix client is using BestPossibleExternalViewVerifier with the described configuration, then changing the rebalancer class config in the IdealState explicitly to AutoRebalancer is required before the Helix version bump-up. Or the BestPossibleExternalViewVerifier may fail.

### Tests

- [X] The following tests are written for this issue:

Multiple related tests have been updated to cover the new change.

- [X] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures:
[ERROR]   TestP2PNoDuplicatedMessage.testP2PStateTransitionEnabled:174 expected:<2200> but was:<2187>
[INFO]
[ERROR] Tests run: 1200, Failures: 1, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:13 h
[INFO] Finished at: 2020-09-16T00:42:16-07:00
[INFO] ------------------------------------------------------------------------

Rerun

[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:01 min
[INFO] Finished at: 2020-09-16T11:10:08-07:00
[INFO] ------------------------------------------------------------------------


### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
