### PR TITLE
Move ST message to state validation from executing phase to scheduling phase.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -112,7 +112,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
     // Set start time right before invoke client logic
     _currentStateDelta.setStartTime(_message.getPartitionName(), System.currentTimeMillis());
 
-    Exception err = isMessageStaled(false /*inSchedulerCheck*/);
+    Exception err = validateStaleMessage(false /*inSchedulerCheck*/);
 
     if (err != null) {
       _statusUpdateUtil
@@ -443,7 +443,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
   }
 
   // Verify the fromState and current state of the stateModel.
-  public Exception isMessageStaled(boolean inSchedulerCheck) {
+  public Exception validateStaleMessage(boolean inSchedulerCheck) {
     String fromState = _message.getFromState();
     String toState = _message.getToState();
     String partitionName = _message.getPartitionName();

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -107,17 +107,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
         + _message.getToState() + ", relayedFrom: " + _message.getRelaySrcHost());
 
     HelixDataAccessor accessor = _manager.getHelixDataAccessor();
-
     String partitionName = _message.getPartitionName();
-    String fromState = _message.getFromState();
-    String toState = _message.getToState();
-
-    // Verify the fromState and current state of the stateModel
-    // getting current state from state model will provide most up-to-date
-    // current state. In case current state is null, partition is in initial
-    // state and we are setting it in current state
-    String state = _stateModel.getCurrentState() != null ? _stateModel.getCurrentState()
-        : _currentStateDelta.getState(partitionName);
 
     // Set start time right before invoke client logic
     _currentStateDelta.setStartTime(_message.getPartitionName(), System.currentTimeMillis());
@@ -452,12 +442,19 @@ public class HelixStateTransitionHandler extends MessageHandler {
 
   }
 
+  // Verify the fromState and current state of the stateModel.
   public Exception isMessageStaled() {
-    String state = _stateModel.getCurrentState() != null ? _stateModel.getCurrentState()
-        : _currentStateDelta.getState(_message.getPartitionName());
     String fromState = _message.getFromState();
     String toState = _message.getToState();
     String partitionName = _message.getPartitionName();
+
+
+    // state in _currentStateDelta uses current state from state model. It has the
+    // most up-to-date. current state. In case currentState in stateModel is null,
+    // partition is in initial state and we using it as current state.
+    // Defined in HelixStateMachineEngine.
+    String state =  _currentStateDelta.getState(partitionName);
+
 
     //String err = null;
 

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -113,7 +113,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
     _currentStateDelta.setStartTime(_message.getPartitionName(), System.currentTimeMillis());
 
     try {
-      validateStaleMessage(false /*isPreCheck*/);
+      validateStaleMessage();
     } catch (Exception err) {
       _statusUpdateUtil
           .logError(_message, HelixStateTransitionHandler.class, err.getMessage(), _manager);
@@ -443,7 +443,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
   }
 
   // Verify the fromState and current state of the stateModel.
-  private void validateStaleMessage (boolean isPreCheck) throws Exception {
+  public void validateStaleMessage() throws Exception {
     String fromState = _message.getFromState();
     String toState = _message.getToState();
     String partitionName = _message.getPartitionName();
@@ -459,7 +459,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
       throw new HelixDuplicatedStateTransitionException(String
           .format("Partition %s current state is same as toState (%s->%s) from message.",
               partitionName, fromState, toState));
-    } else if (!isPreCheck && fromState != null && !fromState.equals("*") && !fromState
+    } else if (fromState != null && !fromState.equals("*") && !fromState
         .equalsIgnoreCase(state)) {
       // If current state is neither toState nor fromState in message, there is a problem
       throw new HelixStateMismatchException(String.format(
@@ -468,9 +468,6 @@ public class HelixStateTransitionHandler extends MessageHandler {
     }
   }
 
-  public void precheckForStaleMessage() throws Exception {
-    validateStaleMessage(true /*isPreCheck*/);
-  }
 
   @Override
   public void onTimeout() {

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -303,6 +303,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
 
       _statusUpdateUtil.logInfo(message, HelixStateTransitionHandler.class,
           "Message handling task begin execute", manager);
+      System.out.println("[Xyy], Message handling task begin execute");
       message.setExecuteStartTimeStamp(System.currentTimeMillis());
 
       try {
@@ -457,6 +458,12 @@ public class HelixStateTransitionHandler extends MessageHandler {
 
 
     //String err = null;
+
+    System.out.println(String.format(
+        "[Xyy] CurrentState: %s, Message: %s: %s->%s, Partition: %s, from: %s, to: %s",
+        _message.getMsgId(), state, fromState, toState, partitionName, _message.getMsgSrc(), _message.getTgtName()));
+
+
 
     Exception err = null;
     if (toState.equalsIgnoreCase(state)) {

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -303,7 +303,6 @@ public class HelixStateTransitionHandler extends MessageHandler {
 
       _statusUpdateUtil.logInfo(message, HelixStateTransitionHandler.class,
           "Message handling task begin execute", manager);
-      System.out.println("[Xyy], Message handling task begin execute");
       message.setExecuteStartTimeStamp(System.currentTimeMillis());
 
       try {
@@ -459,10 +458,10 @@ public class HelixStateTransitionHandler extends MessageHandler {
 
     //String err = null;
 
-    System.out.println(String.format(
+   /* System.out.println(String.format(
         "[Xyy] CurrentState: %s, Message: %s: %s->%s, Partition: %s, from: %s, to: %s",
         _message.getMsgId(), state, fromState, toState, partitionName, _message.getMsgSrc(), _message.getTgtName()));
-
+*/
 
 
     Exception err = null;

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -112,7 +112,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
     // Set start time right before invoke client logic
     _currentStateDelta.setStartTime(_message.getPartitionName(), System.currentTimeMillis());
 
-    Exception err = validateStaleMessageHelper();
+    Exception err = staleMessageValidator();
     if (err != null) {
       _statusUpdateUtil
           .logError(_message, HelixStateTransitionHandler.class, err.getMessage(), _manager);
@@ -441,7 +441,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
   }
 
   // Verify the fromState and current state of the stateModel.
-  private Exception validateStaleMessageHelper() {
+  public Exception staleMessageValidator() {
     String fromState = _message.getFromState();
     String toState = _message.getToState();
     String partitionName = _message.getPartitionName();
@@ -465,13 +465,6 @@ public class HelixStateTransitionHandler extends MessageHandler {
           state, fromState, toState, partitionName, _message.getMsgSrc(), _message.getTgtName()));
     }
     return err;
-  }
-
-  public void validateStaleMessage() throws Exception {
-    Exception err = validateStaleMessageHelper();
-    if (err != null) {
-      throw err;
-    }
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -112,7 +112,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
     // Set start time right before invoke client logic
     _currentStateDelta.setStartTime(_message.getPartitionName(), System.currentTimeMillis());
 
-    Exception err = isMessageStaled();
+    Exception err = isMessageStaled(false);
 
     if (err != null) {
       _statusUpdateUtil.logError(_message, HelixStateTransitionHandler.class, err.getMessage(),
@@ -444,7 +444,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
   }
 
   // Verify the fromState and current state of the stateModel.
-  public Exception isMessageStaled() {
+  public Exception isMessageStaled(boolean inSchedularCheck) {
     String fromState = _message.getFromState();
     String toState = _message.getToState();
     String partitionName = _message.getPartitionName();
@@ -471,7 +471,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
       err = new HelixDuplicatedStateTransitionException(
           String.format("Partition %s current state is same as toState (%s->%s) from message.",
               partitionName, fromState, toState));
-    } else if (fromState != null && !fromState.equals("*") && !fromState.equalsIgnoreCase(state)) {
+    } else if (!inSchedularCheck && fromState != null && !fromState.equals("*") && !fromState.equalsIgnoreCase(state)) {
       // If current state is neither toState nor fromState in message, there is a problem
       err = new HelixStateMismatchException(String.format(
           "Current state of stateModel does not match the fromState in Message, CurrentState: %s, Message: %s->%s, Partition: %s, from: %s, to: %s",

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -69,6 +69,7 @@ import org.apache.helix.monitoring.mbeans.ParticipantStatusMonitor;
 import org.apache.helix.participant.HelixStateMachineEngine;
 import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelFactory;
+import org.apache.helix.participant.statemachine.StateTransitionError;
 import org.apache.helix.util.HelixUtil;
 import org.apache.helix.util.StatusUpdateUtil;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -921,7 +922,10 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
           if (createHandler instanceof HelixStateTransitionHandler) {
             // We only check from/to state if there is no ST task scheduled/executing.
             // if (createHandler instanceof HelixStateTransitionHandler) {
-            Exception err = ((HelixStateTransitionHandler) createHandler).isMessageStaled();
+            Exception err = ((HelixStateTransitionHandler) createHandler).isMessageStaled(true);
+            /*StateTransitionError error =
+                new StateTransitionError(MessageHandler.ErrorType.FRAMEWORK, MessageHandler.ErrorCode.ERROR, err);
+            _stateModel.rollbackOnError(_message, _notificationContext, error);*/
             if (err != null) {
               throw err;
             }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -923,11 +923,11 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
           }
           if (createHandler instanceof HelixStateTransitionHandler) {
             // We only check to state if there is no ST task scheduled/executing.
-            Exception err =
+            HelixStateTransitionHandler.StaleMessageValidateResult result =
                 ((HelixStateTransitionHandler) createHandler).staleMessageValidator();
-            if (err != null) {
-              handleUnprocessableMessage(message, null /* exception */, err.getMessage(), accessor,
-                  instanceName, manager);
+            if (!result.isValid) {
+              handleUnprocessableMessage(message, null /* exception */,
+                  result.exception.getMessage(), accessor, instanceName, manager);
               continue;
             }
           }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -920,7 +920,7 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
           }
           if (createHandler instanceof HelixStateTransitionHandler) {
             // We only check to state if there is no ST task scheduled/executing.
-            Exception err = ((HelixStateTransitionHandler) createHandler).isMessageStaled(true /*inSchedulerCheck*/);
+            Exception err = ((HelixStateTransitionHandler) createHandler).validateStaleMessage(true /*inSchedulerCheck*/);
             if (err != null) {
               throw err;
             }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -69,7 +69,6 @@ import org.apache.helix.monitoring.mbeans.ParticipantStatusMonitor;
 import org.apache.helix.participant.HelixStateMachineEngine;
 import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelFactory;
-import org.apache.helix.participant.statemachine.StateTransitionError;
 import org.apache.helix.util.HelixUtil;
 import org.apache.helix.util.StatusUpdateUtil;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -920,12 +919,8 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
                 System.currentTimeMillis(), message.getFromState(), message.getToState()));
           }
           if (createHandler instanceof HelixStateTransitionHandler) {
-            // We only check from/to state if there is no ST task scheduled/executing.
-            // if (createHandler instanceof HelixStateTransitionHandler) {
-            Exception err = ((HelixStateTransitionHandler) createHandler).isMessageStaled(true);
-            /*StateTransitionError error =
-                new StateTransitionError(MessageHandler.ErrorType.FRAMEWORK, MessageHandler.ErrorCode.ERROR, err);
-            _stateModel.rollbackOnError(_message, _notificationContext, error);*/
+            // We only check to state if there is no ST task scheduled/executing.
+            Exception err = ((HelixStateTransitionHandler) createHandler).isMessageStaled(true /*inSchedulerCheck*/);
             if (err != null) {
               throw err;
             }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -943,16 +943,15 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
           nonStateTransitionContexts.add(msgWorkingContext);
         }
       } catch (Exception e) {
-        LOG.error("Message " + message.getMsgId() + " cannot be processed: " + message.getRecord(),
-            e);
         String error =
-            "Failed to create message handler for " + message.getMsgId() + ", exception: " + e;
-
+            "Message " + message.getMsgId() + " cannot be processed: " + message.getRecord();
+        LOG.error(error, e);
         _statusUpdateUtil.logError(message, HelixStateMachineEngine.class, e, error, manager);
 
         message.setMsgState(MessageState.UNPROCESSABLE);
         removeMessageFromZK(accessor, message, instanceName);
-        _monitor.reportProcessedMessage(message, ParticipantMessageMonitor.ProcessedMessageState.DISCARDED);
+        _monitor.reportProcessedMessage(message,
+            ParticipantMessageMonitor.ProcessedMessageState.DISCARDED);
         continue;
       }
 

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -920,7 +920,7 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
           }
           if (createHandler instanceof HelixStateTransitionHandler) {
             // We only check to state if there is no ST task scheduled/executing.
-            ((HelixStateTransitionHandler) createHandler).precheckForStaleMessage();
+            ((HelixStateTransitionHandler) createHandler).validateStaleMessage();
           }
           if (stateTransitionHandlers.containsKey(messageTarget)) {
             // If there are 2 messages in same batch about same partition's state transition,

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -921,10 +921,17 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
             // discard the message. Controller will resend if this is a valid message
             throw new HelixException(String.format(
                 "Another state transition for %s:%s is in progress with msg: %s, p2p: %s, read: %d, current:%d. Discarding %s->%s message",
-                message.getResourceName(), message.getPartitionName(), msg.getMsgId(), String.valueOf(msg.isRelayMessage()),
-                msg.getReadTimeStamp(), System.currentTimeMillis(), message.getFromState(),
-                message.getToState()));
+                message.getResourceName(), message.getPartitionName(), msg.getMsgId(),
+                String.valueOf(msg.isRelayMessage()), msg.getReadTimeStamp(),
+                System.currentTimeMillis(), message.getFromState(), message.getToState()));
+          } else if (message.getMsgType().equals(MessageType.STATE_TRANSITION.name())) {
+            //if (createHandler instanceof HelixStateTransitionHandler) {
+            Exception err = ((HelixStateTransitionHandler) createHandler).isMessageStaled();
+            if (err !=null) {
+              throw err;
+            }
           }
+           // }
 
           stateTransitionHandlers
               .put(getMessageTarget(message.getResourceName(), message.getPartitionName()),

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureTaskNotStarted.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureTaskNotStarted.java
@@ -158,9 +158,15 @@ public class TestJobFailureTaskNotStarted extends TaskSynchronizedTestBase {
 
     _driver.start(failWorkflowBuilder.build());
 
+   // _driver.pollForJobState(FAIL_WORKFLOW_NAME,
+   //     TaskUtil.getNamespacedJobName(FAIL_WORKFLOW_NAME, FAIL_JOB_NAME), TaskState.NOT_STARTED);
+    //Assert.assertTrue(_driver.getWorkflowContext(FAIL_WORKFLOW_NAME) == null);
+
+    Thread.sleep(100);
     _driver.pollForJobState(FAIL_WORKFLOW_NAME,
-        TaskUtil.getNamespacedJobName(FAIL_WORKFLOW_NAME, FAIL_JOB_NAME), TaskState.FAILED);
+               TaskUtil.getNamespacedJobName(FAIL_WORKFLOW_NAME, FAIL_JOB_NAME), TaskState.FAILED);
     _driver.pollForWorkflowState(FAIL_WORKFLOW_NAME, TaskState.FAILED);
+
 
     JobContext jobContext =
         _driver.getJobContext(TaskUtil.getNamespacedJobName(FAIL_WORKFLOW_NAME, FAIL_JOB_NAME));

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureTaskNotStarted.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureTaskNotStarted.java
@@ -158,15 +158,9 @@ public class TestJobFailureTaskNotStarted extends TaskSynchronizedTestBase {
 
     _driver.start(failWorkflowBuilder.build());
 
-   // _driver.pollForJobState(FAIL_WORKFLOW_NAME,
-   //     TaskUtil.getNamespacedJobName(FAIL_WORKFLOW_NAME, FAIL_JOB_NAME), TaskState.NOT_STARTED);
-    //Assert.assertTrue(_driver.getWorkflowContext(FAIL_WORKFLOW_NAME) == null);
-
-    Thread.sleep(100);
     _driver.pollForJobState(FAIL_WORKFLOW_NAME,
-               TaskUtil.getNamespacedJobName(FAIL_WORKFLOW_NAME, FAIL_JOB_NAME), TaskState.FAILED);
+        TaskUtil.getNamespacedJobName(FAIL_WORKFLOW_NAME, FAIL_JOB_NAME), TaskState.FAILED);
     _driver.pollForWorkflowState(FAIL_WORKFLOW_NAME, TaskState.FAILED);
-
 
     JobContext jobContext =
         _driver.getJobContext(TaskUtil.getNamespacedJobName(FAIL_WORKFLOW_NAME, FAIL_JOB_NAME));

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
@@ -250,11 +250,11 @@ public class TestHelixTaskExecutor {
       }
 
       @Override
-      public Exception isMessageStaled(boolean b) {
+      public Exception validateStaleMessage(boolean b) {
         if (!_testIsMessageStaled) {
           return null;
         } else {
-          return super.isMessageStaled(true);
+          return super.validateStaleMessage(true);
         }
 
       }
@@ -460,7 +460,7 @@ public class TestHelixTaskExecutor {
     Assert.assertEquals(dataAccessor.getChildValues(keyBuilder.messages(instanceName), true).size(),
         0);
 
-    System.out.println("END TestHelixTaskExecutor.testDuplicatedMessage()");
+    System.out.println("END TestHelixTaskExecutor.testStaledMessage()");
   }
 
   @Test()

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
@@ -250,13 +250,10 @@ public class TestHelixTaskExecutor {
       }
 
       @Override
-      public Exception validateStaleMessage(boolean b) {
-        if (!_testIsMessageStaled) {
-          return null;
-        } else {
-          return super.validateStaleMessage(true);
+      public void precheckForStaleMessage() throws Exception {
+        if (_testIsMessageStaled) {
+          super.precheckForStaleMessage();
         }
-
       }
     }
 

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
@@ -251,11 +251,11 @@ public class TestHelixTaskExecutor {
       }
 
       @Override
-      public Exception isMessageStaled() {
+      public Exception isMessageStaled(boolean b) {
         if (!_testIsMessageStaled) {
           return null;
         } else {
-          return super.isMessageStaled();
+          return super.isMessageStaled(true);
         }
 
       }

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
@@ -225,8 +225,6 @@ public class TestHelixTaskExecutor {
           CurrentState currentStateDelta) {
         super(null, null, message, context, currentStateDelta);
         _testIsMessageStaled = true;
-
-
       }
 
       @Override
@@ -235,7 +233,7 @@ public class TestHelixTaskExecutor {
         _processedMsgIds.put(_message.getMsgId(), _message.getMsgId());
         if (_delay > 0) {
           System.out.println("Sleeping..." + _delay);
-          try{
+          try {
             Thread.sleep(_delay);
           } catch (Exception e) {
             assert (false);
@@ -446,7 +444,7 @@ public class TestHelixTaskExecutor {
     }
 
     Assert.assertEquals(dataAccessor.getChildValues(keyBuilder.messages(instanceName), true).size(),
-            nMsgs);
+        nMsgs);
 
     changeContext.setChangeType(HelixConstants.ChangeType.MESSAGE);
     executor.onMessage(instanceName, msgList, changeContext);

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
@@ -37,6 +37,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.mock.MockManager;
+import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Message.MessageState;
 import org.testng.Assert;
@@ -203,6 +204,7 @@ public class TestHelixTaskExecutor {
     ConcurrentHashMap<String, String> _processedMsgIds = new ConcurrentHashMap<String, String>();
     private final String _msgType;
     private final long _delay;
+
     public TestStateTransitionHandlerFactory(String msgType) {
       this(msgType, -1);
     }
@@ -212,18 +214,33 @@ public class TestHelixTaskExecutor {
       _delay = delay;
     }
 
-    class TestStateTransitionMessageHandler extends MessageHandler {
+    class TestStateTransitionMessageHandler extends HelixStateTransitionHandler {
+      boolean _testIsMessageStaled;
+
       public TestStateTransitionMessageHandler(Message message, NotificationContext context) {
-        super(message, context);
+        super(null, null, message, context, null);
+        _testIsMessageStaled = false;
+      }
+
+      public TestStateTransitionMessageHandler(Message message, NotificationContext context,
+          CurrentState currentStateDelta) {
+        super(null, null, message, context, currentStateDelta);
+        _testIsMessageStaled = true;
+
+
       }
 
       @Override
-      public HelixTaskResult handleMessage() throws InterruptedException {
+      public HelixTaskResult handleMessage() {
         HelixTaskResult result = new HelixTaskResult();
         _processedMsgIds.put(_message.getMsgId(), _message.getMsgId());
         if (_delay > 0) {
           System.out.println("Sleeping..." + _delay);
-          Thread.sleep(_delay);
+          try {
+            Thread.sleep(_delay);
+          } catch (Exception ex) {
+            assert (false);
+          }
         }
         result.setSuccess(true);
         return result;
@@ -232,11 +249,32 @@ public class TestHelixTaskExecutor {
       @Override
       public void onError(Exception e, ErrorCode code, ErrorType type) {
       }
+
+      @Override
+      public Exception isMessageStaled() {
+        if (!_testIsMessageStaled) {
+          return null;
+        } else {
+          return super.isMessageStaled();
+        }
+
+      }
     }
 
     @Override
     public MessageHandler createHandler(Message message, NotificationContext context) {
-      return new TestStateTransitionMessageHandler(message, context);
+      if (message.getResourceName()!="testStaledMessageResource") {
+        return new TestStateTransitionMessageHandler(message, context);
+      } else {
+        CurrentState currentStateDelta = new CurrentState(message.getResourceName());
+        currentStateDelta.setSessionId(message.getTgtSessionId());
+        currentStateDelta.setStateModelDefRef(message.getStateModelDef());
+        currentStateDelta.setStateModelFactoryName(message.getStateModelFactoryName());
+        currentStateDelta.setBucketSize(message.getBucketSize());
+
+        currentStateDelta.setState(message.getPartitionName(), "MASTER");
+        return new TestStateTransitionMessageHandler(message, context, currentStateDelta);
+      }
     }
 
     @Override
@@ -374,6 +412,56 @@ public class TestHelixTaskExecutor {
     Thread.sleep(1000);
     Assert.assertEquals(dataAccessor.getChildValues(keyBuilder.messages(instanceName), true).size(),
         0);
+    System.out.println("END TestHelixTaskExecutor.testDuplicatedMessage()");
+  }
+
+  @Test()
+  public void testStaledMessage() throws InterruptedException {
+    System.out.println("START TestHelixTaskExecutor.testStaledMessage()");
+    HelixTaskExecutor executor = new HelixTaskExecutor();
+    HelixManager manager = new MockClusterManager();
+    HelixDataAccessor dataAccessor = manager.getHelixDataAccessor();
+    PropertyKey.Builder keyBuilder = dataAccessor.keyBuilder();
+
+    TestStateTransitionHandlerFactory stateTransitionFactory =
+        new TestStateTransitionHandlerFactory(Message.MessageType.STATE_TRANSITION.name(), 1000);
+    executor.registerMessageHandlerFactory(Message.MessageType.STATE_TRANSITION.name(),
+        stateTransitionFactory);
+
+    NotificationContext changeContext = new NotificationContext(manager);
+    List<Message> msgList = new ArrayList<Message>();
+
+    int nMsgs = 1;
+    String instanceName = manager.getInstanceName();
+    for (int i = 0; i < nMsgs; i++) {
+      Message msg =
+          new Message(Message.MessageType.STATE_TRANSITION.name(), UUID.randomUUID().toString());
+      msg.setTgtSessionId(manager.getSessionId());
+      msg.setCreateTimeStamp((long) i);
+      msg.setTgtName("Localhost_1123");
+      msg.setSrcName("127.101.1.23_2234");
+      msg.setPartitionName("Partition");
+      msg.setResourceName("testStaledMessageResource");
+      msg.setStateModelDef("DummyMasterSlave");
+      msg.setFromState("SLAVE");
+      msg.setToState("MASTER");
+      dataAccessor.setProperty(msg.getKey(keyBuilder, instanceName), msg);
+      msgList.add(msg);
+    }
+
+    AssertJUnit
+        .assertEquals(dataAccessor.getChildValues(keyBuilder.messages(instanceName), true).size(),
+            nMsgs);
+
+    changeContext.setChangeType(HelixConstants.ChangeType.MESSAGE);
+    executor.onMessage(instanceName, msgList, changeContext);
+
+    Thread.sleep(200);
+
+    // The message should be ignored since toState is the same as current state.
+    Assert.assertEquals(dataAccessor.getChildValues(keyBuilder.messages(instanceName), true).size(),
+        0);
+
     System.out.println("END TestHelixTaskExecutor.testDuplicatedMessage()");
   }
 

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
@@ -204,7 +204,6 @@ public class TestHelixTaskExecutor {
     ConcurrentHashMap<String, String> _processedMsgIds = new ConcurrentHashMap<String, String>();
     private final String _msgType;
     private final long _delay;
-
     public TestStateTransitionHandlerFactory(String msgType) {
       this(msgType, -1);
     }
@@ -236,9 +235,9 @@ public class TestHelixTaskExecutor {
         _processedMsgIds.put(_message.getMsgId(), _message.getMsgId());
         if (_delay > 0) {
           System.out.println("Sleeping..." + _delay);
-          try {
+          try{
             Thread.sleep(_delay);
-          } catch (Exception ex) {
+          } catch (Exception e) {
             assert (false);
           }
         }
@@ -271,7 +270,7 @@ public class TestHelixTaskExecutor {
         currentStateDelta.setStateModelDefRef(message.getStateModelDef());
         currentStateDelta.setStateModelFactoryName(message.getStateModelFactoryName());
         currentStateDelta.setBucketSize(message.getBucketSize());
-
+        // set the current state same as to state in the message in test testStaledMessage.
         currentStateDelta.setState(message.getPartitionName(), "MASTER");
         return new TestStateTransitionMessageHandler(message, context, currentStateDelta);
       }
@@ -449,8 +448,7 @@ public class TestHelixTaskExecutor {
       msgList.add(msg);
     }
 
-    AssertJUnit
-        .assertEquals(dataAccessor.getChildValues(keyBuilder.messages(instanceName), true).size(),
+    Assert.assertEquals(dataAccessor.getChildValues(keyBuilder.messages(instanceName), true).size(),
             nMsgs);
 
     changeContext.setChangeType(HelixConstants.ChangeType.MESSAGE);

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
@@ -241,7 +241,7 @@ public class TestHelixTaskExecutor {
       }
 
       @Override
-      public Exception staleMessageValidator() {
+      public StaleMessageValidateResult staleMessageValidator() {
         return super.staleMessageValidator();
       }
     }

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
@@ -250,9 +250,9 @@ public class TestHelixTaskExecutor {
       }
 
       @Override
-      public void precheckForStaleMessage() throws Exception {
+      public void validateStaleMessage() throws Exception {
         if (_testIsMessageStaled) {
-          super.precheckForStaleMessage();
+          super.validateStaleMessage();
         }
       }
     }

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
@@ -259,7 +259,7 @@ public class TestHelixTaskExecutor {
 
     @Override
     public MessageHandler createHandler(Message message, NotificationContext context) {
-      if (message.getResourceName()!="testStaledMessageResource") {
+      if (!message.getResourceName().equals("testStaledMessageResource")) {
         return new TestStateTransitionMessageHandler(message, context);
       } else {
         CurrentState currentStateDelta = new CurrentState(message.getResourceName());


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolve #1361

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Currently we do all the state validation (the from state should be same current state and to state should be different to current state) for state transition message when the message is being executed in HelixStateTransitionHandler.

We should move the to state validation to the scheduling stage because of the following reasons:
1. It is a no-op operation, thus we should not create a thread to execute it.
2. The lag between scheduling and executing could add additional latency for controller and eventually application latency.

### Tests

- [X] The following tests are written for this issue:

TestStateTransitionHandlerFactory.testStaledMessage

- [X] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Results:                                                                                                                                                                                                                                                                                        
[INFO]                                                                                                                                                                                                                                                                                                 
[ERROR] Failures:                                                                                                                                                                                                                                                                                      
[ERROR]   TestPauseSignal.testPauseSignal:106 expected:<true> but was:<false>                                                                                                                                                                                                                          
[ERROR]   TestHelixAdminCli.testDeactivateCluster:604 » ZkClient Failed to delete /TestH...                                                                                                                                                                                                            
[INFO]                                                                                                                                                                                                                                                                                                 
[ERROR] Tests run: 1213, Failures: 2, Errors: 0, Skipped: 2                                                                                                                                                                                                                                            
[INFO]                                                                                                                                                                                                                                                                                                 
[INFO] ------------------------------------------------------------------------                                                                                                                                                                                                                        
[INFO] BUILD FAILURE                                                                                                                                                                                                                                                                                   
[INFO] ------------------------------------------------------------------------                                                                                                                                                                                                                        
[INFO] Total time:  01:07 h                                                                                                                                                                                                                                                                            
[INFO] Finished at: 2020-10-06T21:42:24-07:00                                                                                                                                                                                                                                                          
[INFO] ------------------------------------------------------------------------                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                           
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 28.41 s - in org.apache.helix.tools.TestHelixAdminCli
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 60.272 s - in org.apache.helix.integration.TestPauseSignal


```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
