### PR TITLE
Add Metrics for External Custom Health Check Requests

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/common/HelixDataAccessorWrapper.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/common/HelixDataAccessorWrapper.java
@@ -60,12 +60,10 @@ public class HelixDataAccessorWrapper extends ZKHelixDataAccessor {
   public static final String EXPIRY_KEY = "EXPIRE";
 
   // Metric names for custom partition check
-  private static final String CUSTOM_PARTITION_CHECK_HTTP_REQUESTS_TOTAL =
-      MetricRegistry.name(InstanceService.class, "custom_partition_check_http_requests_total");
   private static final String CUSTOM_PARTITION_CHECK_HTTP_REQUESTS_ERROR_TOTAL = MetricRegistry
       .name(InstanceService.class, "custom_partition_check_http_requests_error_total");
-  private static final String CUSTOM_PARTITION_CHECK_HTTP_REQUEST_DURATION =
-      MetricRegistry.name(InstanceService.class, "custom_partition_check_http_request_duration");
+  private static final String CUSTOM_PARTITION_CHECK_HTTP_REQUESTS_DURATION =
+      MetricRegistry.name(InstanceService.class, "custom_partition_check_http_requests_duration");
 
   private final Map<PropertyKey, HelixProperty> _propertyCache = new HashMap<>();
   private final Map<PropertyKey, List<String>> _batchNameCache = new HashMap<>();
@@ -82,16 +80,13 @@ public class HelixDataAccessorWrapper extends ZKHelixDataAccessor {
     this(dataAccessor, CustomRestClientFactory.get(), HelixRestNamespace.DEFAULT_NAMESPACE_NAME);
   }
 
-  public HelixDataAccessorWrapper(ZKHelixDataAccessor dataAccessor, String namespace) {
-    this(dataAccessor, CustomRestClientFactory.get(), namespace);
-  }
-
+  @Deprecated
   public HelixDataAccessorWrapper(ZKHelixDataAccessor dataAccessor,
       CustomRestClient customRestClient) {
     this(dataAccessor, customRestClient, HelixRestNamespace.DEFAULT_NAMESPACE_NAME);
   }
 
-  private HelixDataAccessorWrapper(ZKHelixDataAccessor dataAccessor,
+  public HelixDataAccessorWrapper(ZKHelixDataAccessor dataAccessor,
       CustomRestClient customRestClient, String namespace) {
     super(dataAccessor);
     _restClient = customRestClient;
@@ -197,9 +192,9 @@ public class HelixDataAccessorWrapper extends ZKHelixDataAccessor {
   private Map<String, Boolean> getHealthStatusFromRest(String instance, List<String> partitions,
       RESTConfig restConfig, Map<String, String> customPayLoads) {
     MetricRegistry metrics = SharedMetricRegistries.getOrCreate(_namespace);
-    try (final Timer.Context timer = metrics.timer(CUSTOM_PARTITION_CHECK_HTTP_REQUEST_DURATION)
+    // Total requests metric is included as an attribute(Count) in timers
+    try (final Timer.Context timer = metrics.timer(CUSTOM_PARTITION_CHECK_HTTP_REQUESTS_DURATION)
         .time()) {
-      metrics.counter(CUSTOM_PARTITION_CHECK_HTTP_REQUESTS_TOTAL).inc();
       return _restClient.getPartitionStoppableCheck(restConfig.getBaseUrl(instance), partitions,
           customPayLoads);
     } catch (IOException e) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
@@ -213,7 +213,7 @@ public class HelixRestServer {
     }
   }
 
-  public void shutdown() {
+  public synchronized void shutdown() {
     if (_server != null) {
       try {
         _server.stop();

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
@@ -222,7 +222,6 @@ public class HelixRestServer {
       }
     }
     _jmxReporterList.forEach(JmxReporter::stop);
-    _jmxReporterList.clear();
     cleanupResourceConfigs();
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -34,6 +34,8 @@ import javax.ws.rs.core.Response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.helix.HelixException;
+import org.apache.helix.rest.common.ContextPropertyKeys;
+import org.apache.helix.rest.common.HelixRestNamespace;
 import org.apache.helix.rest.server.auditlog.AuditLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -176,5 +178,11 @@ public class AbstractResource {
     } catch (IllegalArgumentException ex) {
       throw new HelixException("Unknown command: " + commandStr);
     }
+  }
+
+  protected String getNamespace() {
+    HelixRestNamespace namespace =
+        (HelixRestNamespace) _application.getProperties().get(ContextPropertyKeys.METADATA.name());
+    return namespace.getName();
   }
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -223,9 +223,9 @@ public class InstancesAccessor extends AbstractHelixResource {
           result.putArray(InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name());
       ObjectNode failedStoppableInstances = result.putObject(
           InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
-      InstanceService instanceService =
-          new InstanceServiceImpl(new HelixDataAccessorWrapper((ZKHelixDataAccessor) getDataAccssor(clusterId)),
-              getConfigAccessor(), skipZKRead);
+      InstanceService instanceService = new InstanceServiceImpl(
+          new HelixDataAccessorWrapper((ZKHelixDataAccessor) getDataAccssor(clusterId), getNamespace()),
+          getConfigAccessor(), skipZKRead, getNamespace());
       ClusterService clusterService = new ClusterServiceImpl(getDataAccssor(clusterId), getConfigAccessor());
       ClusterTopology clusterTopology = clusterService.getClusterTopology(clusterId);
       switch (selectionBase) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -48,7 +48,6 @@ import org.apache.helix.HelixException;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.InstanceConfig;
-import org.apache.helix.rest.common.HelixDataAccessorWrapper;
 import org.apache.helix.rest.common.HttpConstants;
 import org.apache.helix.rest.server.json.cluster.ClusterTopology;
 import org.apache.helix.rest.server.json.instance.StoppableCheck;
@@ -223,9 +222,9 @@ public class InstancesAccessor extends AbstractHelixResource {
           result.putArray(InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name());
       ObjectNode failedStoppableInstances = result.putObject(
           InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
-      InstanceService instanceService = new InstanceServiceImpl(
-          new HelixDataAccessorWrapper((ZKHelixDataAccessor) getDataAccssor(clusterId), getNamespace()),
-          getConfigAccessor(), skipZKRead, getNamespace());
+      InstanceService instanceService =
+          new InstanceServiceImpl((ZKHelixDataAccessor) getDataAccssor(clusterId),
+              getConfigAccessor(), skipZKRead, getNamespace());
       ClusterService clusterService = new ClusterServiceImpl(getDataAccssor(clusterId), getConfigAccessor());
       ClusterTopology clusterTopology = clusterService.getClusterTopology(clusterId);
       switch (selectionBase) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -143,9 +143,9 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       @PathParam("instanceName") String instanceName, @QueryParam("skipZKRead") String skipZKRead) throws IOException {
     ObjectMapper objectMapper = new ObjectMapper();
     HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
-    InstanceService instanceService =
-        new InstanceServiceImpl(new HelixDataAccessorWrapper((ZKHelixDataAccessor) dataAccessor), getConfigAccessor(),
-            Boolean.valueOf(skipZKRead));
+    InstanceService instanceService = new InstanceServiceImpl(
+        new HelixDataAccessorWrapper((ZKHelixDataAccessor) dataAccessor, getNamespace()),
+        getConfigAccessor(), Boolean.valueOf(skipZKRead));
     StoppableCheck stoppableCheck = null;
     try {
       stoppableCheck =

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -56,7 +56,6 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.ParticipantHistory;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
-import org.apache.helix.rest.common.HelixDataAccessorWrapper;
 import org.apache.helix.rest.common.HttpConstants;
 import org.apache.helix.rest.server.json.instance.InstanceInfo;
 import org.apache.helix.rest.server.json.instance.StoppableCheck;
@@ -105,9 +104,9 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       ObjectMapper objectMapper = new ObjectMapper();
       HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
       // TODO reduce GC by dependency injection
-      InstanceService instanceService = new InstanceServiceImpl(
-          new HelixDataAccessorWrapper((ZKHelixDataAccessor) dataAccessor, getNamespace()),
-          getConfigAccessor(), Boolean.valueOf(skipZKRead), getNamespace());
+      InstanceService instanceService =
+          new InstanceServiceImpl((ZKHelixDataAccessor) dataAccessor, getConfigAccessor(),
+              Boolean.parseBoolean(skipZKRead), getNamespace());
       InstanceInfo instanceInfo = instanceService.getInstanceInfo(clusterId, instanceName,
           InstanceService.HealthCheck.STARTED_AND_HEALTH_CHECK_LIST);
       String instanceInfoString;
@@ -143,9 +142,9 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       @PathParam("instanceName") String instanceName, @QueryParam("skipZKRead") String skipZKRead) throws IOException {
     ObjectMapper objectMapper = new ObjectMapper();
     HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
-    InstanceService instanceService = new InstanceServiceImpl(
-        new HelixDataAccessorWrapper((ZKHelixDataAccessor) dataAccessor, getNamespace()),
-        getConfigAccessor(), Boolean.valueOf(skipZKRead), getNamespace());
+    InstanceService instanceService =
+        new InstanceServiceImpl((ZKHelixDataAccessor) dataAccessor, getConfigAccessor(),
+            Boolean.parseBoolean(skipZKRead), getNamespace());
     StoppableCheck stoppableCheck = null;
     try {
       stoppableCheck =

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -105,9 +105,9 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       ObjectMapper objectMapper = new ObjectMapper();
       HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
       // TODO reduce GC by dependency injection
-      InstanceService instanceService =
-          new InstanceServiceImpl(new HelixDataAccessorWrapper((ZKHelixDataAccessor) dataAccessor), getConfigAccessor(),
-              Boolean.valueOf(skipZKRead));
+      InstanceService instanceService = new InstanceServiceImpl(
+          new HelixDataAccessorWrapper((ZKHelixDataAccessor) dataAccessor, getNamespace()),
+          getConfigAccessor(), Boolean.valueOf(skipZKRead), getNamespace());
       InstanceInfo instanceInfo = instanceService.getInstanceInfo(clusterId, instanceName,
           InstanceService.HealthCheck.STARTED_AND_HEALTH_CHECK_LIST);
       String instanceInfoString;
@@ -145,7 +145,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
     HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
     InstanceService instanceService = new InstanceServiceImpl(
         new HelixDataAccessorWrapper((ZKHelixDataAccessor) dataAccessor, getNamespace()),
-        getConfigAccessor(), Boolean.valueOf(skipZKRead));
+        getConfigAccessor(), Boolean.valueOf(skipZKRead), getNamespace());
     StoppableCheck stoppableCheck = null;
     try {
       stoppableCheck =

--- a/helix-rest/src/test/java/org/apache/helix/rest/common/TestHelixDataAccessorWrapper.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/common/TestHelixDataAccessorWrapper.java
@@ -71,6 +71,10 @@ public class TestHelixDataAccessorWrapper {
     void setRestClient(CustomRestClient restClient) {
       _restClient = restClient;
     }
+
+    void setNamespace(String namespace) {
+      _namespace = namespace;
+    }
   }
 
   @BeforeMethod
@@ -80,6 +84,7 @@ public class TestHelixDataAccessorWrapper {
     when(_restConfig.getBaseUrl(anyString())).thenReturn("http://localhost:1000");
     _restClient = mock(CustomRestClient.class);
     _dataAccessor.setRestClient(_restClient);
+    _dataAccessor.setNamespace("test");
 
     when(_restClient.getPartitionStoppableCheck(anyString(), anyList(), anyMap()))
         .thenAnswer((invocationOnMock) -> {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
@@ -211,16 +211,14 @@ public class TestInstanceService {
 
     // Valid data only from ZK, pass the check
     InstanceService instanceServiceReadZK =
-        new MockInstanceServiceImpl(new HelixDataAccessorWrapper(zkHelixDataAccessor, _customRestClient),
-            _configAccessor, _customRestClient, false);
+        new MockInstanceServiceImpl(zkHelixDataAccessor, _configAccessor, _customRestClient, false);
     StoppableCheck stoppableCheck =
         instanceServiceReadZK.getInstanceStoppableCheck(TEST_CLUSTER, TEST_INSTANCE, jsonContent);
     Assert.assertTrue(stoppableCheck.isStoppable());
 
     // Even ZK data is valid. Skip ZK read should fail the test.
     InstanceService instanceServiceWithoutReadZK =
-        new MockInstanceServiceImpl(new HelixDataAccessorWrapper(zkHelixDataAccessor, _customRestClient),
-            _configAccessor, _customRestClient, true);
+        new MockInstanceServiceImpl(zkHelixDataAccessor, _configAccessor, _customRestClient, true);
     stoppableCheck = instanceServiceWithoutReadZK.getInstanceStoppableCheck(TEST_CLUSTER, TEST_INSTANCE, jsonContent);
     Assert.assertFalse(stoppableCheck.isStoppable());
   }
@@ -250,7 +248,7 @@ public class TestInstanceService {
   }
 
   class MockInstanceServiceImpl extends InstanceServiceImpl {
-    MockInstanceServiceImpl(HelixDataAccessorWrapper dataAccessor, ConfigAccessor configAccessor,
+    MockInstanceServiceImpl(ZKHelixDataAccessor dataAccessor, ConfigAccessor configAccessor,
         CustomRestClient customRestClient, boolean skipZKRead) {
       super(dataAccessor, configAccessor, customRestClient, skipZKRead,
           HelixRestNamespace.DEFAULT_NAMESPACE_NAME);

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
@@ -40,6 +40,7 @@ import org.apache.helix.model.MasterSlaveSMD;
 import org.apache.helix.model.RESTConfig;
 import org.apache.helix.rest.client.CustomRestClient;
 import org.apache.helix.rest.common.HelixDataAccessorWrapper;
+import org.apache.helix.rest.common.HelixRestNamespace;
 import org.apache.helix.rest.server.json.instance.StoppableCheck;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.zookeeper.data.Stat;
@@ -82,7 +83,8 @@ public class TestInstanceService {
   public void testGetInstanceStoppableCheckWhenHelixOwnCheckFail() throws IOException {
     Map<String, Boolean> failedCheck = ImmutableMap.of("FailCheck", false);
     InstanceService service =
-        new InstanceServiceImpl(_dataAccessor, _configAccessor, _customRestClient, false) {
+        new InstanceServiceImpl(_dataAccessor, _configAccessor, _customRestClient, false,
+            HelixRestNamespace.DEFAULT_NAMESPACE_NAME) {
           @Override
           protected Map<String, Boolean> getInstanceHealthStatus(String clusterId,
               String instanceName, List<HealthCheck> healthChecks) {
@@ -103,7 +105,8 @@ public class TestInstanceService {
   @Test
   public void testGetInstanceStoppableCheckWhenCustomInstanceCheckFail() throws IOException {
     InstanceService service =
-        new InstanceServiceImpl(_dataAccessor, _configAccessor, _customRestClient, false) {
+        new InstanceServiceImpl(_dataAccessor, _configAccessor, _customRestClient, false,
+            HelixRestNamespace.DEFAULT_NAMESPACE_NAME) {
           @Override
           protected Map<String, Boolean> getInstanceHealthStatus(String clusterId,
               String instanceName, List<HealthCheck> healthChecks) {
@@ -127,7 +130,8 @@ public class TestInstanceService {
   @Test
   public void testGetInstanceStoppableCheckConnectionRefused() throws IOException {
     InstanceService service =
-        new InstanceServiceImpl(_dataAccessor, _configAccessor, _customRestClient, false) {
+        new InstanceServiceImpl(_dataAccessor, _configAccessor, _customRestClient, false,
+            HelixRestNamespace.DEFAULT_NAMESPACE_NAME) {
           @Override
           protected Map<String, Boolean> getInstanceHealthStatus(String clusterId,
               String instanceName, List<HealthCheck> healthChecks) {
@@ -225,7 +229,8 @@ public class TestInstanceService {
   @Test(enabled = false)
   public void testGetInstanceStoppableCheckWhenPartitionsCheckFail() throws IOException {
     InstanceService service =
-        new InstanceServiceImpl(_dataAccessor, _configAccessor, _customRestClient, false) {
+        new InstanceServiceImpl(_dataAccessor, _configAccessor, _customRestClient, false,
+            HelixRestNamespace.DEFAULT_NAMESPACE_NAME) {
           @Override
           protected Map<String, Boolean> getInstanceHealthStatus(String clusterId,
               String instanceName, List<HealthCheck> healthChecks) {
@@ -247,7 +252,8 @@ public class TestInstanceService {
   class MockInstanceServiceImpl extends InstanceServiceImpl {
     MockInstanceServiceImpl(HelixDataAccessorWrapper dataAccessor, ConfigAccessor configAccessor,
         CustomRestClient customRestClient, boolean skipZKRead) {
-      super(dataAccessor, configAccessor, customRestClient, skipZKRead);
+      super(dataAccessor, configAccessor, customRestClient, skipZKRead,
+          HelixRestNamespace.DEFAULT_NAMESPACE_NAME);
     }
 
     @Override


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1382 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Custom rest client interacts with participant side to query for its health checks. Currently there is no metrics for the query requests. We'd like to have metrics for the requests.

Here's a design trade-off:

1) Add a new API `getInstanceStoppableCheck(baseUrl, customPayloads, namespace)` in interface `CustomRestClient`. We need the namespace name when recording metrics in `CustomRestClient`. Since CustomRestClient is a singleton instance, we can not inject the namespace to the class. Having the namespace as a parameter in the API is an option. The benefit is we can accurately record the http request latency, and it is more scalable if we have more places calling the API, we don't need to do anything. Cons: change existing interface to add the new API. Though it is an interface, we may not expect external users to use it. So it should be fine to change the interface.
2) Record the metrics in the upstream caller outside `CustomRestClient`, eg.  `InstanceService` where `getInstanceStoppableCheck()` is called, we record the metrics. Pros: we don't need to change existing interface `CustomRestClient`. Cons: Latency of http request is more than the actual number because other stuff like json response parsing is also involved in `CustomRestClient`; and it is not scalable because we have to record metrics in each place where `CustomRestClient. getInstanceStoppableCheck()` is called.

This PR implements option 2), because there are not many places that call `CustomRestClient` APIs, and it doesn't look good that pass the namespace as a parameter just for metrics rather than logic related.

<img width="680" alt="image" src="https://user-images.githubusercontent.com/5187721/93721478-6be97a80-fb45-11ea-838f-85851f9088fd.png">


### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 168, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 59.766 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 168, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:05 min
[INFO] Finished at: 2020-09-28T17:43:10-07:00
[INFO] ------------------------------------------------------------------------
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
