### PR TITLE
Stabilize the TestJobTimeout

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobTimeout.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobTimeout.java
@@ -74,7 +74,7 @@ public final class TestJobTimeout extends TaskSynchronizedTestBase {
             .setTargetPartitionStates(Sets.newHashSet(MasterSlaveSMD.States.MASTER.name()))
             .setCommand(MockTask.TASK_COMMAND)
             .setJobCommandConfigMap(ImmutableMap.of(MockTask.JOB_DELAY, "99999999")) // task stuck
-            .setTimeout(10);
+            .setTimeout(2000L);
 
     JobConfig.Builder secondJobBuilder =
         new JobConfig.Builder().setWorkflow(WORKFLOW_NAME).setTargetResource(DB_NAME)


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixes #1397 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
In this PR, TestJobTimeout has been stabilized by increasing the job's timeout time. The tasks will be aborted if the job is timing_out and the tasks have already been started. Since 10ms is very short, it is possible that the job goes to a timeout state without tasks being even started on the participant. Hence, a longer timeout time will stabilize the test.


### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:
```
[INFO] Tests run: 1199, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4,326.057 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1199, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:12 h
[INFO] Finished at: 2020-09-23T12:57:11-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)