### PR TITLE
Mark AutoRebalancer as deprecated and convert the default test logic to not use AutoRebalancer.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
  * The output is a preference list and a mapping based on that preference list, i.e. partition p
  * has a replica on node k with state s.
  */
+@Deprecated // Use the DelayedAutoRebalancer instead
 public class AutoRebalancer extends AbstractRebalancer<ResourceControllerDataProvider> {
   private static final Logger LOG = LoggerFactory.getLogger(AutoRebalancer.class);
 

--- a/helix-core/src/test/java/org/apache/helix/TestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/TestHelper.java
@@ -40,15 +40,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.PropertyKey.Builder;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
+import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
 import org.apache.helix.integration.manager.ZkTestManager;
 import org.apache.helix.manager.zk.CallbackHandler;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.zookeeper.api.client.HelixZkClient;
-import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
-import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState.RebalanceMode;
@@ -59,13 +58,16 @@ import org.apache.helix.model.StateModelDefinition.StateModelDefinitionProperty;
 import org.apache.helix.store.zk.ZNode;
 import org.apache.helix.tools.ClusterSetup;
 import org.apache.helix.util.ZKClientPool;
+import org.apache.helix.zookeeper.api.client.HelixZkClient;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
 import org.apache.helix.zookeeper.zkclient.IDefaultNameSpace;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.helix.zookeeper.zkclient.ZkClient;
 import org.apache.helix.zookeeper.zkclient.ZkServer;
 import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -287,7 +289,10 @@ public class TestHelper {
 
       for (int i = 0; i < resourceNb; i++) {
         String resourceName = resourceNamePrefix + i;
-        setupTool.addResourceToCluster(clusterName, resourceName, partitionNb, stateModelDef, mode.toString());
+        setupTool.addResourceToCluster(clusterName, resourceName, partitionNb, stateModelDef,
+            mode.name(),
+            mode == RebalanceMode.FULL_AUTO ? CrushEdRebalanceStrategy.class.getName()
+                : RebalanceStrategy.DEFAULT_REBALANCE_STRATEGY);
         if (doRebalance) {
           setupTool.rebalanceStorageCluster(clusterName, resourceName, replica);
         }

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey.Builder;
 import org.apache.helix.TestHelper;
@@ -236,13 +237,12 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
   }
 
   private void setupAutoRebalancer() {
+    HelixAdmin admin = _gSetupTool.getClusterManagementTool();
     for (String resourceName : _gSetupTool.getClusterManagementTool()
         .getResourcesInCluster(CLUSTER_NAME)) {
-      IdealState idealState =
-          _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, resourceName);
+      IdealState idealState = admin.getResourceIdealState(CLUSTER_NAME, resourceName);
       idealState.setRebalancerClassName(AutoRebalancer.class.getName());
-      _gSetupTool.getClusterManagementTool()
-          .setResourceIdealState(CLUSTER_NAME, resourceName, idealState);
+      admin.setResourceIdealState(CLUSTER_NAME, resourceName, idealState);
     }
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
@@ -236,6 +236,7 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
     return partitionCount == totalCount;
   }
 
+  // Ensure that we are testing the AutoRebalancer.
   private void setupAutoRebalancer() {
     HelixAdmin admin = _gSetupTool.getClusterManagementTool();
     for (String resourceName : _gSetupTool.getClusterManagementTool()

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
@@ -28,21 +28,22 @@ import java.util.Set;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey.Builder;
 import org.apache.helix.TestHelper;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.rebalancer.AutoRebalancer;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.zookeeper.impl.client.ZkClient;
-import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.IdealState.RebalanceMode;
 import org.apache.helix.tools.ClusterSetup;
 import org.apache.helix.tools.ClusterStateVerifier;
 import org.apache.helix.tools.ClusterStateVerifier.ZkVerifier;
+import org.apache.helix.zookeeper.api.client.HelixZkClient;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -64,10 +65,11 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
     // setup storage cluster
     _gSetupTool.addCluster(CLUSTER_NAME, true);
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, TEST_DB, _PARTITIONS, STATE_MODEL,
-        RebalanceMode.FULL_AUTO + "");
-
+        RebalanceMode.FULL_AUTO.name());
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, db2, _PARTITIONS, "OnlineOffline",
-        RebalanceMode.FULL_AUTO + "");
+        RebalanceMode.FULL_AUTO.name());
+
+    setupAutoRebalancer();
 
     for (int i = 0; i < NODE_NR; i++) {
       String storageNodeName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
@@ -117,7 +119,9 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
   public void testDropResourceAutoRebalance() throws Exception {
     // add a resource to be dropped
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, "MyDB", _PARTITIONS, "OnlineOffline",
-        RebalanceMode.FULL_AUTO + "");
+        RebalanceMode.FULL_AUTO.name());
+
+    setupAutoRebalancer();
 
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, "MyDB", 1);
 
@@ -135,7 +139,9 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
 
     // add a resource to be dropped
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, "MyDB2", _PARTITIONS, "MasterSlave",
-        RebalanceMode.FULL_AUTO + "");
+        RebalanceMode.FULL_AUTO.name());
+
+    setupAutoRebalancer();
 
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, "MyDB2", 1);
 
@@ -227,6 +233,17 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
       }
     }
     return partitionCount == totalCount;
+  }
+
+  private void setupAutoRebalancer() {
+    for (String resourceName : _gSetupTool.getClusterManagementTool()
+        .getResourcesInCluster(CLUSTER_NAME)) {
+      IdealState idealState =
+          _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, resourceName);
+      idealState.setRebalancerClassName(AutoRebalancer.class.getName());
+      _gSetupTool.getClusterManagementTool()
+          .setResourceIdealState(CLUSTER_NAME, resourceName, idealState);
+    }
   }
 
   public static class ExternalViewBalancedVerifier implements ZkVerifier {

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalancePartitionLimit.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalancePartitionLimit.java
@@ -41,11 +41,14 @@ import org.apache.helix.tools.ClusterStateVerifier.ZkVerifier;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class TestAutoRebalancePartitionLimit extends ZkStandAloneCMTestBase {
+  private static Logger LOG = LoggerFactory.getLogger(TestAutoRebalancePartitionLimit.class);
 
   @Override
   @BeforeClass
@@ -58,6 +61,7 @@ public class TestAutoRebalancePartitionLimit extends ZkStandAloneCMTestBase {
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, TEST_DB, 100, "OnlineOffline",
         RebalanceMode.FULL_AUTO.name(), 0, 25);
 
+    // Ensure that we are testing the AutoRebalancer.
     IdealState idealState =
         _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, TEST_DB);
     idealState.setRebalancerClassName(AutoRebalancer.class.getName());
@@ -221,6 +225,7 @@ public class TestAutoRebalancePartitionLimit extends ZkStandAloneCMTestBase {
             numberOfPartitions, masterValue, replicas, cache.getLiveInstances().size(),
             cache.getIdealState(_resourceName).getMaxPartitionsPerInstance());
       } catch (Exception e) {
+        LOG.debug("Verify failed due to {}", e.getStackTrace());
         return false;
       }
     }

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalanceWithDisabledInstance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalanceWithDisabledInstance.java
@@ -146,6 +146,7 @@ public class TestAutoRebalanceWithDisabledInstance extends ZkStandAloneCMTestBas
     return partitionSet;
   }
 
+  // Ensure that we are testing the AutoRebalancer.
   private void setupAutoRebalancer() {
     HelixAdmin admin = _gSetupTool.getClusterManagementTool();
     for (String resourceName : _gSetupTool.getClusterManagementTool()

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalanceWithDisabledInstance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalanceWithDisabledInstance.java
@@ -147,13 +147,12 @@ public class TestAutoRebalanceWithDisabledInstance extends ZkStandAloneCMTestBas
   }
 
   private void setupAutoRebalancer() {
+    HelixAdmin admin = _gSetupTool.getClusterManagementTool();
     for (String resourceName : _gSetupTool.getClusterManagementTool()
         .getResourcesInCluster(CLUSTER_NAME)) {
-      IdealState idealState =
-          _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, resourceName);
+      IdealState idealState = admin.getResourceIdealState(CLUSTER_NAME, resourceName);
       idealState.setRebalancerClassName(AutoRebalancer.class.getName());
-      _gSetupTool.getClusterManagementTool()
-          .setResourceIdealState(CLUSTER_NAME, resourceName, idealState);
+      admin.setResourceIdealState(CLUSTER_NAME, resourceName, idealState);
     }
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/tools/TestClusterVerifier.java
+++ b/helix-core/src/test/java/org/apache/helix/tools/TestClusterVerifier.java
@@ -27,6 +27,7 @@ import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZkUnitTestBase;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.mock.participant.SleepTransition;
@@ -75,9 +76,11 @@ public class TestClusterVerifier extends ZkUnitTestBase {
         BuiltInStateModelDefinitions.OnlineOffline.name(), RebalanceMode.SEMI_AUTO.toString());
 
     _setupTool.addResourceToCluster(_clusterName, RESOURCES[2], NUM_PARTITIONS,
-        BuiltInStateModelDefinitions.MasterSlave.name(), RebalanceMode.FULL_AUTO.toString());
+        BuiltInStateModelDefinitions.MasterSlave.name(), RebalanceMode.FULL_AUTO.toString(),
+        CrushEdRebalanceStrategy.class.getName());
     _setupTool.addResourceToCluster(_clusterName, RESOURCES[3], NUM_PARTITIONS,
-        BuiltInStateModelDefinitions.OnlineOffline.name(), RebalanceMode.FULL_AUTO.toString());
+        BuiltInStateModelDefinitions.OnlineOffline.name(), RebalanceMode.FULL_AUTO.toString(),
+        CrushEdRebalanceStrategy.class.getName());
 
     // Enable persist best possible assignment
     ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);


### PR DESCRIPTION
# Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1392, #1393, #1374.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Mark AutoRebalancer as deprecated and convert the default test logic to not use AutoRebalancer.
The only remaining AutoRebalancer tests should be the ones that are specifically testing the AutoRebalancer class.

### Tests

- [X] The following tests are written for this issue:

This PR is a pure test change.

- [X] The following is the result of the "mvn test" command on the appropriate module:

[ERROR]   TestDeleteJobFromJobQueue.testForceDeleteJobFromJobQueue:73 » Helix Failed to ...
[INFO] 
[ERROR] Tests run: 1200, Failures: 1, Errors: 0, Skipped: 0

Rerun

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.284 s - in org.apache.helix.integration.task.TestDeleteJobFromJobQueue
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------


### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
