### PR TITLE
Add Builder to ZKDistributedNonblockingLock to enable ZooScalability use

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/GenericZkHelixApiBuilder.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/GenericZkHelixApiBuilder.java
@@ -24,11 +24,9 @@ import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
-import org.apache.helix.zookeeper.constant.RoutingDataReaderType;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.apache.helix.zookeeper.impl.client.FederatedZkClient;
 import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
-import org.apache.helix.zookeeper.routing.RoutingDataManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
@@ -68,6 +68,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock {
    * @param timeout the timeout period of the lock
    * @param lockMsg the reason for having this lock
    * @param userId a universal unique userId for lock owner identity
+   * @param baseDataAccessor baseDataAccessor instance to do I/O against ZK with
    */
   private ZKDistributedNonblockingLock(String lockPath, Long timeout, String lockMsg, String userId,
       BaseDataAccessor<ZNRecord> baseDataAccessor) {

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
@@ -161,7 +161,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock {
    * Builder class to use with ZKDistributedNonblockingLock.
    */
   public static class Builder extends GenericZkHelixApiBuilder<Builder> {
-    private String _lockPath;
+    private LockScope _lockScope;
     private String _userId;
     private long _timeout;
     private String _lockMsg;
@@ -169,8 +169,8 @@ public class ZKDistributedNonblockingLock implements DistributedLock {
     public Builder() {
     }
 
-    public void setLockPath(String lockPath) {
-      _lockPath = lockPath;
+    public void setLockScope(LockScope lockScope) {
+      _lockScope = lockScope;
     }
 
     public void setUserId(String userId) {
@@ -200,7 +200,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock {
       }
 
       // Return a ZKDistributedNonblockingLock instance
-      return new ZKDistributedNonblockingLock(_lockPath, _timeout, _lockMsg, _userId,
+      return new ZKDistributedNonblockingLock(_lockScope.getPath(), _timeout, _lockMsg, _userId,
           baseDataAccessor);
     }
   }

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
@@ -169,20 +169,24 @@ public class ZKDistributedNonblockingLock implements DistributedLock {
     public Builder() {
     }
 
-    public void setLockScope(LockScope lockScope) {
+    public Builder setLockScope(LockScope lockScope) {
       _lockScope = lockScope;
+      return this;
     }
 
-    public void setUserId(String userId) {
+    public Builder setUserId(String userId) {
       _userId = userId;
+      return this;
     }
 
-    public void setTimeout(long timeout) {
+    public Builder setTimeout(long timeout) {
       _timeout = timeout;
+      return this;
     }
 
-    public void setLockMsg(String lockMsg) {
+    public Builder setLockMsg(String lockMsg) {
       _lockMsg = lockMsg;
+      return this;
     }
 
     public ZKDistributedNonblockingLock build() {


### PR DESCRIPTION


### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1408

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

ZKDistributedNonblockingLock and its related helix-lock API were not ZooScalability-compliant, meaning they could not be used in a multi-ZK environment. This PR updates the said APIs so that we could use them in multi-ZK environment by adding a Builder that allows users to set multi-ZK parameters.

### Tests

- [x] The following tests are written for this issue:

No logic change.

- [x] The following is the result of the "mvn test" command on the appropriate module:

helix-lock:
```
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.565 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```



### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
