### PR TITLE
 Remove resource from customized state if all partitions are gone

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
@@ -117,5 +117,11 @@ public class CustomizedStateProvider {
         return current;
       }
     }, existingState);
+    // remove the resource from customized state if all partitions are gone
+    if (_helixDataAccessor
+        .getProperty(keyBuilder.customizedState(_instanceName, customizedStateName, resourceName))
+        .getRecord().getMapFields().isEmpty()) {
+      _helixDataAccessor.removeProperty(propertyKey);
+    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixDataAccessor.java
@@ -185,17 +185,18 @@ public class ZKHelixDataAccessor implements HelixDataAccessor {
 
     boolean success = false;
     switch (type) {
-    case CURRENTSTATES:
-      success = _groupCommit.commit(_baseDataAccessor, options, path, value.getRecord(), true);
-      break;
-    case STATUSUPDATES:
-      if (LOG.isTraceEnabled()) {
-        LOG.trace("Update status. path: " + key.getPath() + ", record: " + value.getRecord());
-      }
-      break;
-    default:
-      success = _baseDataAccessor.update(path, updater, options);
-      break;
+      case CURRENTSTATES:
+      case CUSTOMIZEDSTATES:
+        success = _groupCommit.commit(_baseDataAccessor, options, path, value.getRecord(), true);
+        break;
+      case STATUSUPDATES:
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Update status. path: " + key.getPath() + ", record: " + value.getRecord());
+        }
+        break;
+      default:
+        success = _baseDataAccessor.update(path, updater, options);
+        break;
     }
     return success;
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestCustomizedStateUpdate.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestCustomizedStateUpdate.java
@@ -161,6 +161,11 @@ public class TestCustomizedStateUpdate extends ZkStandAloneCMTestBase {
     mapView = customizedState.getRecord().getMapFields();
     Assert.assertEquals(mapView.keySet().size(), 1);
     Assert.assertEquals(mapView.keySet().iterator().next(), PARTITION_NAME2);
+
+    _mockProvider
+        .deletePerPartitionCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME, PARTITION_NAME2);
+    customizedState = _mockProvider.getCustomizedState(CUSTOMIZE_STATE_NAME, RESOURCE_NAME);
+    Assert.assertNull(customizedState);
   }
 
   @Test


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixes #1410 
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Currently if all partitions of a resource in customized state are gone, the znode itself is still there. This is not optimal, we should delete the znode once the map fields are empty. This PR fixed this issue.

### Tests

- [X] The following is the result of the "mvn test" command on the appropriate module:
helix-core

[WARNING] Tests run: 1208, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 3,965.426 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 1208, Failures: 0, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:06 h
[INFO] Finished at: 2020-09-28T12:01:49-07:00
[INFO] ------------------------------------------------------------------------
                                                                                  

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
