### PR TITLE
Add a system config to disable bucketized feature

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -400,7 +400,7 @@ public class ParticipantManager {
           }
 
         } else {
-          _dataAccessor.getBaseDataAccessor().update(curStatePath,
+          baseAccessor.update(curStatePath,
               new CurStateCarryOverUpdater(_sessionId, initState, lastCurState),
               AccessOption.PERSISTENT);
         }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixDataAccessor.java
@@ -61,8 +61,8 @@ public class ZKHelixDataAccessor implements HelixDataAccessor {
   private final Builder _propertyKeyBuilder;
   private final GroupCommit _groupCommit = new GroupCommit();
 
-  private static final boolean BUCKETIZE_ZNRECORD_ENABLED = Boolean
-      .parseBoolean(System.getProperty(ZkSystemPropertyKeys.ZK_BUCKETIZE_ZNRECORD_ENABLED, "true"));
+  private static final boolean ZNRECORD_BUCKETIZE_ENABLED = Boolean
+      .parseBoolean(System.getProperty(ZkSystemPropertyKeys.ZK_ZNRECORD_BUCKETIZE_ENABLED, "true"));
 
   public ZKHelixDataAccessor(String clusterName, BaseDataAccessor<ZNRecord> baseDataAccessor) {
     this(clusterName, null, baseDataAccessor);
@@ -613,10 +613,11 @@ public class ZKHelixDataAccessor implements HelixDataAccessor {
   }
 
   private void validateBucketizedEnabled(String path, boolean isRead) {
-    if (!BUCKETIZE_ZNRECORD_ENABLED) {
+    if (!ZNRECORD_BUCKETIZE_ENABLED) {
       throw new HelixMetaDataAccessException(
           "Can't " + (isRead ? "read" : "write") + " bucktized ZNode " + path
-              + " because Bucktize feature is not enabled. Please check ZK system property 'zk.bucketize.znrecord.enabled' .");
+              + " because Bucktize feature is not enabled. Please check ZK system property: "
+              + ZkSystemPropertyKeys.ZK_ZNRECORD_BUCKETIZE_ENABLED);
     }
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
@@ -37,7 +37,11 @@ public class ZkSystemPropertyKeys {
       "zk.serializer.znrecord.auto-compress.enabled";
 
   /**
-   * Setting this property to true enables ZNode bucketization.
+   * Setting this property to true enables ZNode bucketization, an operation to divide a ZNRecord
+   * into specified buckets. This property applies to
+   * {@link org.apache.helix.zookeeper.datamodel.ZNRecordBucketizer}.
+   * <p>
+   * The default value is "true" (enabled).
    */
   public static final String ZK_BUCKETIZE_ZNRECORD_ENABLED =
       "zk.bucketize.znrecord.enabled";

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
@@ -43,8 +43,8 @@ public class ZkSystemPropertyKeys {
    * <p>
    * The default value is "true" (enabled).
    */
-  public static final String ZK_BUCKETIZE_ZNRECORD_ENABLED =
-      "zk.bucketize.znrecord.enabled";
+  public static final String ZK_ZNRECORD_BUCKETIZE_ENABLED =
+      "zk.znrecord.bucketize.enabled";
 
   /**
    * This is property that defines the maximum write size in bytes for ZKRecord's two serializers

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
@@ -37,6 +37,12 @@ public class ZkSystemPropertyKeys {
       "zk.serializer.znrecord.auto-compress.enabled";
 
   /**
+   * Setting this property to true enables ZNode bucketization.
+   */
+  public static final String ZK_BUCKETIZE_ZNRECORD_ENABLED =
+      "zk.bucketize.znrecord.enabled";
+
+  /**
    * This is property that defines the maximum write size in bytes for ZKRecord's two serializers
    * before serialized data is ready to be written to ZK. This property applies to
    * 1. {@link org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer}


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
 #1414
Add a system config to disable bucketized feature.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

As mentioned in issue #1291 and #401, doing getChildren() in subscribeForChanges() to determine if a node is bucketized or not takes a lot time. It would be useful to have a system config to disable the feature for performance boost.

### Tests

- [X] The following tests are written for this issue:

NA

- [X] The following is the result of the "mvn test" command on the appropriate module:

```
[WARNING] Tests run: 1210, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 4,076.809 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 1210, Failures: 0, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:08 h
[INFO] Finished at: 2020-09-25T16:28:06-07:00
[INFO] ------------------------------------------------------------------------
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
