### PR TITLE
add REST API for cluster topology

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -453,9 +453,6 @@ public class ClusterAccessor extends AbstractHelixResource {
       topologyMap = admin.getClusterTopology(clusterId).getTopologyMap();
     } catch (HelixException ex) {
       return badRequest(ex.getMessage());
-    } catch (Exception ex) {
-      LOG.error("Failed to get cluster topology map from cluster {}.", clusterId, ex);
-      return serverError(ex);
     }
     return JSONRepresentation(topologyMap);
   }
@@ -471,9 +468,6 @@ public class ClusterAccessor extends AbstractHelixResource {
       faultZoneMap = admin.getClusterTopology(clusterId).getFaultZoneMap();
     } catch (HelixException ex) {
       return badRequest(ex.getMessage());
-    } catch (Exception ex) {
-      LOG.error("Failed to get cluster fault zone map from cluster {}", clusterId, ex);
-      return serverError(ex);
     }
     return JSONRepresentation(faultZoneMap);
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -447,9 +447,6 @@ public class ClusterAccessor extends AbstractHelixResource {
   @GET
   @Path("{clusterId}/topologymap")
   public Response getClusterTopologyMap(@PathParam("clusterId") String clusterId) {
-    if (!doesClusterExist(clusterId)) {
-      return notFound(String.format("Cluster %s does not exist", clusterId));
-    }
     HelixAdmin admin = getHelixAdmin();
     Map<String, List<String>> topologyMap;
     try {
@@ -457,8 +454,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     } catch (HelixException ex) {
       return badRequest(ex.getMessage());
     } catch (Exception ex) {
-      LOG.error("Failed to get cluster topology map from cluster {}. Exception: " + "{}.",
-          clusterId, ex);
+      LOG.error("Failed to get cluster topology map from cluster {}.", clusterId, ex);
       return serverError(ex);
     }
     return JSONRepresentation(topologyMap);
@@ -476,8 +472,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     } catch (HelixException ex) {
       return badRequest(ex.getMessage());
     } catch (Exception ex) {
-      LOG.error("Failed to get cluster fault zone map from cluster {}. Exception: " + "{}.",
-          clusterId, ex);
+      LOG.error("Failed to get cluster fault zone map from cluster {}", clusterId, ex);
       return serverError(ex);
     }
     return JSONRepresentation(faultZoneMap);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -442,6 +442,26 @@ public class ClusterAccessor extends AbstractHelixResource {
     return OK(objectMapper.writeValueAsString(clusterTopology));
   }
 
+  @ResponseMetered(name = HttpConstants.READ_REQUEST)
+  @Timed(name = HttpConstants.READ_REQUEST)
+  @GET
+  @Path("{clusterId}/topologymap")
+  public Response getClusterTopologyMap(@PathParam("clusterId") String clusterId) {
+    HelixAdmin admin = getHelixAdmin();
+    Map<String, List<String>> topologyMap = admin.getClusterTopology(clusterId).getTopologyMap();
+    return JSONRepresentation(topologyMap);
+  }
+
+  @ResponseMetered(name = HttpConstants.READ_REQUEST)
+  @Timed(name = HttpConstants.READ_REQUEST)
+  @GET
+  @Path("{clusterId}/faultzonemap")
+  public Response getClusterFaultZoneMap(@PathParam("clusterId") String clusterId) {
+    HelixAdmin admin = getHelixAdmin();
+    Map<String, List<String>> topologyMap = admin.getClusterTopology(clusterId).getTopologyMap();
+    return JSONRepresentation(topologyMap);
+  }
+
   @ResponseMetered(name = HttpConstants.WRITE_REQUEST)
   @Timed(name = HttpConstants.WRITE_REQUEST)
   @POST

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -457,8 +457,8 @@ public class ClusterAccessor extends AbstractHelixResource {
     } catch (HelixException ex) {
       return badRequest(ex.getMessage());
     } catch (Exception ex) {
-      LOG.error("Failed to get cluster topology map fro cluster {}. Exception: " + "{}.", clusterId,
-          ex);
+      LOG.error("Failed to get cluster topology map from cluster {}. Exception: " + "{}.",
+          clusterId, ex);
       return serverError(ex);
     }
     return JSONRepresentation(topologyMap);
@@ -469,9 +469,6 @@ public class ClusterAccessor extends AbstractHelixResource {
   @GET
   @Path("{clusterId}/faultzonemap")
   public Response getClusterFaultZoneMap(@PathParam("clusterId") String clusterId) {
-    if (!doesClusterExist(clusterId)) {
-      return notFound(String.format("Cluster %s does not exist", clusterId));
-    }
     HelixAdmin admin = getHelixAdmin();
     Map<String, List<String>> faultZoneMap;
     try {
@@ -479,7 +476,7 @@ public class ClusterAccessor extends AbstractHelixResource {
     } catch (HelixException ex) {
       return badRequest(ex.getMessage());
     } catch (Exception ex) {
-      LOG.error("Failed to get cluster fault zone map fro cluster {}. Exception: " + "{}.",
+      LOG.error("Failed to get cluster fault zone map from cluster {}. Exception: " + "{}.",
           clusterId, ex);
       return serverError(ex);
     }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -461,8 +461,14 @@ public class ClusterAccessor extends AbstractHelixResource {
   @Path("{clusterId}/faultzonemap")
   public Response getClusterFaultZoneMap(@PathParam("clusterId") String clusterId) {
     HelixAdmin admin = getHelixAdmin();
-    Map<String, List<String>> topologyMap = admin.getClusterTopology(clusterId).getTopologyMap();
-    return JSONRepresentation(topologyMap);
+    Map<String, List<String>> faultZoneMap;
+    try {
+      faultZoneMap =
+          admin.getClusterTopology(clusterId).getFaultZoneMap();
+    } catch (IllegalArgumentException ex) {
+      return badRequest(ex.getMessage());
+    }
+    return JSONRepresentation(faultZoneMap);
   }
 
   @ResponseMetered(name = HttpConstants.WRITE_REQUEST)

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -451,7 +451,16 @@ public class ClusterAccessor extends AbstractHelixResource {
       return notFound(String.format("Cluster %s does not exist", clusterId));
     }
     HelixAdmin admin = getHelixAdmin();
-    Map<String, List<String>> topologyMap = admin.getClusterTopology(clusterId).getTopologyMap();
+    Map<String, List<String>> topologyMap;
+    try {
+      topologyMap = admin.getClusterTopology(clusterId).getTopologyMap();
+    } catch (HelixException ex) {
+      return badRequest(ex.getMessage());
+    } catch (Exception ex) {
+      LOG.error("Failed to get cluster topology map fro cluster {}. Exception: " + "{}.", clusterId,
+          ex);
+      return serverError(ex);
+    }
     return JSONRepresentation(topologyMap);
   }
 
@@ -460,13 +469,19 @@ public class ClusterAccessor extends AbstractHelixResource {
   @GET
   @Path("{clusterId}/faultzonemap")
   public Response getClusterFaultZoneMap(@PathParam("clusterId") String clusterId) {
+    if (!doesClusterExist(clusterId)) {
+      return notFound(String.format("Cluster %s does not exist", clusterId));
+    }
     HelixAdmin admin = getHelixAdmin();
     Map<String, List<String>> faultZoneMap;
     try {
-      faultZoneMap =
-          admin.getClusterTopology(clusterId).getFaultZoneMap();
-    } catch (IllegalArgumentException ex) {
+      faultZoneMap = admin.getClusterTopology(clusterId).getFaultZoneMap();
+    } catch (HelixException ex) {
       return badRequest(ex.getMessage());
+    } catch (Exception ex) {
+      LOG.error("Failed to get cluster fault zone map fro cluster {}. Exception: " + "{}.",
+          clusterId, ex);
+      return serverError(ex);
     }
     return JSONRepresentation(faultZoneMap);
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -447,6 +447,9 @@ public class ClusterAccessor extends AbstractHelixResource {
   @GET
   @Path("{clusterId}/topologymap")
   public Response getClusterTopologyMap(@PathParam("clusterId") String clusterId) {
+    if (!doesClusterExist(clusterId)) {
+      return notFound(String.format("Cluster %s does not exist", clusterId));
+    }
     HelixAdmin admin = getHelixAdmin();
     Map<String, List<String>> topologyMap = admin.getClusterTopology(clusterId).getTopologyMap();
     return JSONRepresentation(topologyMap);

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -162,10 +163,22 @@ public class TestClusterAccessor extends AbstractTestClass {
     Assert.assertTrue(topologyMap.get("/helixZoneId:zone0") instanceof List);
     List<String> instances = (List<String>) topologyMap.get("/helixZoneId:zone0");
     Assert.assertEquals(instances.size(), 5);
+    Assert.assertTrue(instances.containsAll(new HashSet<>(Arrays
+        .asList("/instance:TestCluster_1localhost_12918",
+            "/instance:TestCluster_1localhost_12919",
+            "/instance:TestCluster_1localhost_12920",
+            "/instance:TestCluster_1localhost_12921",
+            "/instance:TestCluster_1localhost_12922"))));
 
     Assert.assertTrue(topologyMap.get("/helixZoneId:zone1") instanceof List);
     instances = (List<String>) topologyMap.get("/helixZoneId:zone1");
     Assert.assertEquals(instances.size(), 5);
+    Assert.assertTrue(instances.containsAll(new HashSet<>(Arrays
+        .asList("/instance:TestCluster_1localhost_12923",
+            "/instance:TestCluster_1localhost_12924",
+            "/instance:TestCluster_1localhost_12925",
+            "/instance:TestCluster_1localhost_12926",
+            "/instance:TestCluster_1localhost_12927"))));
 
     configDelta = new ClusterConfig(cluster);
     configDelta.getRecord().setSimpleField("FAULT_ZONE_TYPE", "helixZoneId");
@@ -181,10 +194,22 @@ public class TestClusterAccessor extends AbstractTestClass {
     Assert.assertTrue(faultZoneMap.get("/helixZoneId:zone0") instanceof List);
     instances = (List<String>) faultZoneMap.get("/helixZoneId:zone0");
     Assert.assertEquals(instances.size(), 5);
+    Assert.assertTrue(instances.containsAll(new HashSet<>(Arrays
+        .asList("/instance:TestCluster_1localhost_12918",
+            "/instance:TestCluster_1localhost_12919",
+            "/instance:TestCluster_1localhost_12920",
+            "/instance:TestCluster_1localhost_12921",
+            "/instance:TestCluster_1localhost_12922"))));
 
     Assert.assertTrue(faultZoneMap.get("/helixZoneId:zone1") instanceof List);
     instances = (List<String>) faultZoneMap.get("/helixZoneId:zone1");
     Assert.assertEquals(instances.size(), 5);
+    Assert.assertTrue(instances.containsAll(new HashSet<>(Arrays
+        .asList("/instance:TestCluster_1localhost_12923",
+            "/instance:TestCluster_1localhost_12924",
+            "/instance:TestCluster_1localhost_12925",
+            "/instance:TestCluster_1localhost_12926",
+            "/instance:TestCluster_1localhost_12927"))));
   }
 
   @Test(dependsOnMethods = "testGetClusterTopologyAndFaultZoneMap")

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -128,6 +128,13 @@ public class TestClusterAccessor extends AbstractTestClass {
   @Test(dependsOnMethods = "testGetClusterTopology")
   public void testGetClusterTopologyAndFaultZoneMap() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String topologyMapUrlBase = "clusters/TestCluster_1/topologymap/";
+    String faultZoneUrlBase = "clusters/TestCluster_1/faultzonemap/";
+
+    // test invalid case where instance config and cluster topology have not been set.
+    get(topologyMapUrlBase, null, Response.Status.BAD_REQUEST.getStatusCode(), true);
+    get(faultZoneUrlBase, null, Response.Status.BAD_REQUEST.getStatusCode(), true);
+
     String cluster = "TestCluster_1";
     for (int i = 0; i < 5; i++) {
       String instance = cluster + "localhost_129" + String.valueOf(18 + i);
@@ -149,12 +156,15 @@ public class TestClusterAccessor extends AbstractTestClass {
           .setProperty(helixDataAccessor.keyBuilder().instanceConfig(instance), instanceConfig);
     }
 
+    // test invalid case where instance config is set, but cluster topology has not been set.
+    get(topologyMapUrlBase, null, Response.Status.BAD_REQUEST.getStatusCode(), true);
+    get(faultZoneUrlBase, null, Response.Status.BAD_REQUEST.getStatusCode(), true);
+
     ClusterConfig configDelta = new ClusterConfig(cluster);
     configDelta.getRecord().setSimpleField("TOPOLOGY", "/helixZoneId/instance");
     updateClusterConfigFromRest(cluster, configDelta, Command.update);
 
-    //get cluster topology map
-    String topologyMapUrlBase = "clusters/TestCluster_1/topologymap/";
+    //get valid cluster topology map
     String topologyMapDef = get(topologyMapUrlBase, null, Response.Status.OK.getStatusCode(), true);
     Map<String, Object> topologyMap =
         OBJECT_MAPPER.readValue(topologyMapDef, new TypeReference<HashMap<String, Object>>() {
@@ -184,8 +194,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     configDelta.getRecord().setSimpleField("FAULT_ZONE_TYPE", "helixZoneId");
     updateClusterConfigFromRest(cluster, configDelta, Command.update);
 
-    //get cluster fault zone map
-    String faultZoneUrlBase = "clusters/TestCluster_1/faultzonemap/";
+    //get valid cluster fault zone map
     String faultZoneMapDef = get(faultZoneUrlBase, null, Response.Status.OK.getStatusCode(), true);
     Map<String, Object> faultZoneMap =
         OBJECT_MAPPER.readValue(faultZoneMapDef, new TypeReference<HashMap<String, Object>>() {


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixed #1405 

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
This PR provide a few REST API for user to retrieve cluster topology information. The APIs are added in ClusterAccessor

### Tests

- [X] The following is the result of the "mvn test" command on the appropriate module:

helix-rest:
[INFO] Tests run: 170, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 139.365 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 170, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:23 min
[INFO] Finished at: 2020-10-06T21:37:18-07:00
[INFO] --------------------------------------------------------------------
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
