### PR TITLE
Add host name to the Participant History znode.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ParticipantHistory.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ParticipantHistory.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ParticipantHistory extends HelixProperty {
   private static Logger LOG = LoggerFactory.getLogger(ParticipantHistory.class);
-  private static final String UNKNOWN_HOST_NAME = "UnknownHostName";
+  private static final String UNKNOWN_HOST_NAME = "UnknownHostname";
 
   private final static int HISTORY_SIZE = 20;
   private enum ConfigProperty {
@@ -51,7 +51,7 @@ public class ParticipantHistory extends HelixProperty {
     OFFLINE,
     VERSION,
     LAST_OFFLINE_TIME,
-    HOST_NAME
+    HOST
   }
 
   public static long ONLINE = -1;
@@ -138,7 +138,7 @@ public class ParticipantHistory extends HelixProperty {
     String dateTime = df.format(new Date(timeMillis));
     sessionEntry.put(ConfigProperty.DATE.name(), dateTime);
     sessionEntry.put(ConfigProperty.VERSION.name(), version);
-    sessionEntry.put(ConfigProperty.HOST_NAME.name(), hostname);
+    sessionEntry.put(ConfigProperty.HOST.name(), hostname);
 
     list.add(sessionEntry.toString());
   }

--- a/helix-core/src/main/java/org/apache/helix/model/ParticipantHistory.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ParticipantHistory.java
@@ -19,6 +19,8 @@ package org.apache.helix.model;
  * under the License.
  */
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -38,6 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ParticipantHistory extends HelixProperty {
   private static Logger LOG = LoggerFactory.getLogger(ParticipantHistory.class);
+  private static final String UNKNOWN_HOST_NAME = "UnknownHostName";
 
   private final static int HISTORY_SIZE = 20;
   private enum ConfigProperty {
@@ -47,7 +50,8 @@ public class ParticipantHistory extends HelixProperty {
     HISTORY,
     OFFLINE,
     VERSION,
-    LAST_OFFLINE_TIME
+    LAST_OFFLINE_TIME,
+    HOST_NAME
   }
 
   public static long ONLINE = -1;
@@ -76,7 +80,15 @@ public class ParticipantHistory extends HelixProperty {
    * @return
    */
   public void reportOnline(String sessionId, String version) {
-    updateSessionHistory(sessionId, version);
+    String hostname;
+    try {
+      hostname = InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      LOG.error("Failed to get host name. Use {} for the participant history recording.",
+          UNKNOWN_HOST_NAME);
+      hostname = UNKNOWN_HOST_NAME;
+    }
+    updateSessionHistory(sessionId, version, hostname);
     _record.setSimpleField(ConfigProperty.LAST_OFFLINE_TIME.name(), String.valueOf(ONLINE));
   }
 
@@ -103,7 +115,7 @@ public class ParticipantHistory extends HelixProperty {
   /**
    * Add record to session online history list
    */
-  private void updateSessionHistory(String sessionId, String version) {
+  private void updateSessionHistory(String sessionId, String version, String hostname) {
     List<String> list = _record.getListField(ConfigProperty.HISTORY.name());
     if (list == null) {
       list = new ArrayList<>();
@@ -126,6 +138,7 @@ public class ParticipantHistory extends HelixProperty {
     String dateTime = df.format(new Date(timeMillis));
     sessionEntry.put(ConfigProperty.DATE.name(), dateTime);
     sessionEntry.put(ConfigProperty.VERSION.name(), version);
+    sessionEntry.put(ConfigProperty.HOST_NAME.name(), hostname);
 
     list.add(sessionEntry.toString());
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceHistory.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceHistory.java
@@ -20,6 +20,7 @@ package org.apache.helix.integration.paticipant;
  */
 
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 
 import org.apache.helix.HelixManager;
@@ -48,8 +49,16 @@ public class TestInstanceHistory extends ZkStandAloneCMTestBase {
 
     Assert.assertTrue(list.get(0).contains("SESSION=" + _participants[0].getSessionId()));
     Assert.assertTrue(list.get(0).contains("VERSION=" + _participants[0].getVersion()));
+
+    String hostname;
+    try {
+      hostname = InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException ex) {
+      hostname = "UnknownHostname";
+    }
     Assert
-        .assertTrue(list.get(0).contains("HOST_NAME=" + InetAddress.getLocalHost().getHostName()));
+        .assertTrue(list.get(0).contains("HOST=" + hostname));
+
     Assert.assertTrue(list.get(0).contains("TIME="));
     Assert.assertTrue(list.get(0).contains("DATE="));
 

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceHistory.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceHistory.java
@@ -19,6 +19,7 @@ package org.apache.helix.integration.paticipant;
  * under the License.
  */
 
+import java.net.InetAddress;
 import java.util.List;
 
 import org.apache.helix.HelixManager;
@@ -32,7 +33,8 @@ import org.testng.annotations.Test;
 
 public class TestInstanceHistory extends ZkStandAloneCMTestBase {
 
-  @Test() public void testInstanceHistory() throws Exception {
+  @Test()
+  public void testInstanceHistory() throws Exception {
     HelixManager manager = HelixManagerFactory
         .getZKHelixManager(CLUSTER_NAME, "admin", InstanceType.ADMINISTRATOR, ZK_ADDR);
     manager.connect();
@@ -43,6 +45,13 @@ public class TestInstanceHistory extends ZkStandAloneCMTestBase {
     Assert.assertNotNull(history);
     List<String> list = history.getRecord().getListField("HISTORY");
     Assert.assertEquals(list.size(), 1);
+
+    Assert.assertTrue(list.get(0).contains("SESSION=" + _participants[0].getSessionId()));
+    Assert.assertTrue(list.get(0).contains("VERSION=" + _participants[0].getVersion()));
+    Assert
+        .assertTrue(list.get(0).contains("HOST_NAME=" + InetAddress.getLocalHost().getHostName()));
+    Assert.assertTrue(list.get(0).contains("TIME="));
+    Assert.assertTrue(list.get(0).contains("DATE="));
 
     for (int i = 0; i <= 22; i++) {
       _participants[0].disconnect();


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1396 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Add hostname to the Participant History znode.
This is to ensure that we can track the participant instance allocation even the live instance node has been removed.

### Tests

- [X] The following tests are written for this issue:

TestInstanceHistory

- [X] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures: 
[ERROR]   TestP2PNoDuplicatedMessage.testP2PStateTransitionEnabled:174 expected:<2200> but was:<2174>
[ERROR]   TestDeleteJobFromJobQueue.testForceDeleteJobFromJobQueue:73 » Helix Failed to ...
[INFO] 
[ERROR] Tests run: 1210, Failures: 2, Errors: 0, Skipped: 0

[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:02 min
[INFO] Finished at: 2020-09-25T22:09:08-07:00
[INFO] ------------------------------------------------------------------------

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
