### PR TITLE
Helix Issue 1319: Fix Maven builds failing on on Java 11 and above

### DIFF
--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -152,6 +152,11 @@
       <artifactId>httpclient</artifactId>
       <version>4.5.8</version>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.1</version>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -94,6 +94,11 @@
       <version>1.7.14</version>
     </dependency>
     <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

(Fixes #1319  )

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

A small addition of Maven dependencies to make Apache Helix build successfully on Java 11 and above out-of-the-box.  The core issue is that, as of Java 11, some legacy J2EE-related packages such as javax.annotation.* and javax.xml.bind.* have been removed from the JDK, but the helix/zookeeper-api and helix-core sub-builds of the project still require these libraries.  For Java 11 and beyond, these packages need to be fetched from Maven Central. 

See the following for more details: http://openjdk.java.net/jeps/320

### Tests

- [x] The following tests are written for this issue:

n/a

- [x] The following is the result of the "mvn test" command on the appropriate module:

I ran "mvn test" on OpenJDK v1.8.0_265 and OpenJDK v11.0.8 on Ubuntu 18.04.  Per the discussion on https://github.com/apache/helix/issues/1319, I ran tests individually (i.e. "mvn clean install package") for the following modules:  /helix-core, /zookeeper-api, /helix-rest, /helix-common

This is a summary of the results:

```
/helix-core
- Java 8: OK
[ERROR]   TestDelayedWagedRebalanceWithDisabledInstance.testPartitionMovementAfterDelayTime:82->TestDelayedAutoRebalanceWithDisabledInstance.testPartitionMovementAfterDelayTime:204->ZkTestBase.validateMinActiveAndTopStateReplica:518 Test-DB-createTestDBs0_0 has less active replica 2 then required 3 expected:<true> but was:<false>
OK - Ran successfully standalone
[ERROR]   TestJobFailureDependence.testWorkflowFailureJobThreshold ? ThreadTimeout Metho...
OK - Ran successfully in IntelliJ
[ERROR]   TestScheduleDelayTask.testDeplayTimeAndStartTime ? ThreadTimeout Method org.te...
[ERROR]   TestScheduleDelayTask.testJobQueueDelay ? ThreadTimeout Method org.testng.inte...
OK - Ran successfully standalone
[ERROR]   TestWorkflowTermination.testWorkflowPausedTimeout:168 ? Helix Workflow "testWo...
OK - Ran successfully standalone
- Java 11: OK
[ERROR]   TestDelayedWagedRebalanceWithDisabledInstance.testPartitionMovementAfterDelayTime:82->TestDelayedAutoRebalanceWithDisabledInstance.testPartitionMovementAfterDelayTime:204->ZkTestBase.validateMinActiveAndTopStateReplica:518 Test-DB-createTestDBs0_0 has less active replica 2 then required 3 expected:<true> but was:<false>
OK - Ran successfully standalone
[ERROR]   TestScheduleDelayTask.testDeplayTimeAndStartTime ? ThreadTimeout Method org.te...
[ERROR]   TestScheduleDelayTask.testScheduleDelayTaskWithDelayTime ? ThreadTimeout Metho...
[ERROR]   TestScheduleDelayTask.testScheduleDelayTaskWithStartTime ? ThreadTimeout Metho...
OK - Ran successfully standalone
[ERROR]   TestTaskNumAttempts.testTaskNumAttemptsWithDelay:76 expected:<3> but was:<2>
OK - Ran successfully standalone

/zookeeper-api
- Java 8: OK
- Java 11: OK

/helix-rest
- Java 8: OK
- Java 11: OK

/helix-common
- Java 8: OK
- Java 11: OK
```
In both Java versions there were failures in /helix-core, but when I ran the failing tests by themselves, they passed (again, per discussion in the linked issue).

### Documentation (Optional)

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

New pages:
* https://github.com/apache/helix/wiki/Pull-Request-Testing

Updated pages:
* https://github.com/apache/helix/wiki/Pull-Request-Guidelines (added link to testing page on second bullet point)
* https://github.com/apache/helix/wiki (added link to testing page on sidebar under "Resources for Contributors")

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

Helix Issue 1319: Fix Maven builds failing on on Java 11 and above

The helix-zookeeper and helix-core subprojects fail to build on later
versions of Java due to changes in the structure of the JDK starting
in Java 11. These dependencies on older J2EE packages are no longer
in the JDK and must now be pulled from Maven directly.

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)

I verified that pom.xml formatting matches existings pom.xml formatting (including tabs vs. spaces).