### PR TITLE
Add Zookeeper multi ops support in the Helix ZkClient.

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/MultiOp.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/MultiOp.java
@@ -1,0 +1,144 @@
+package org.apache.helix.zookeeper.api.client;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+
+import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Op;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
+
+
+/**
+ * A wrapper class of org.apache.zookeeper.Op to support Helix interfaces and monitoring
+ * functionality.
+ */
+public abstract class MultiOp {
+  private final String _path;
+
+  private MultiOp(String path) {
+    _path = path;
+  }
+
+  /**
+   * @return the target path of the operation.
+   */
+  public String getPath() {
+    return _path;
+  }
+
+  /**
+   * Build a new org.apache.zookeeper.Op object for Zookeeper.multi call.
+   * @param serializer
+   * @return org.apache.zookeeper.Op object corresponding to the MultiOp object.
+   */
+  public abstract Op buildZkOp(PathBasedZkSerializer serializer);
+
+  /**
+   * Return a create MultiOp object.
+   * @param path target Zookeeper path
+   * @param dataObj optional initial data content of the created node
+   * @param createMode CreateMode of the newly created node
+   * @return Create MultiOp
+   */
+  public static MultiOp create(String path, Object dataObj, CreateMode createMode) {
+    return new CreateOp(path, dataObj, ZooDefs.Ids.OPEN_ACL_UNSAFE, createMode);
+  }
+
+  /**
+   * Return a delete MultiOp object.
+   * @param path target Zookeeper path
+   * @param version optional target version of the deleting node
+   * @return Delete MultiOp
+   */
+  public static MultiOp delete(String path, int version) {
+    return new DeleteOp(path, version);
+  }
+
+  /**
+   * Return a setData MultiOp object.
+   * @param path target Zookeeper path
+   * @param dataObj data content to be written to the target node
+   * @param version optional target version of the modified node
+   * @return setData MultiOp
+   */
+  public static MultiOp setData(String path, Object dataObj, int version) {
+    return new SetDataOp(path, dataObj, version);
+  }
+
+  /**
+   * Create new node operation.
+   */
+  public static class CreateOp extends MultiOp {
+    private final Object _dataObj;
+    private final List<ACL> _acl;
+    private final CreateMode _createMode;
+
+    private CreateOp(String path, Object dataObj, List<ACL> acl, CreateMode createMode) {
+      super(path);
+      _dataObj = dataObj;
+      _acl = acl;
+      _createMode = createMode;
+    }
+
+    @Override
+    public Op buildZkOp(PathBasedZkSerializer serializer) {
+      return Op.create(getPath(), serializer.serialize(_dataObj, getPath()), _acl, _createMode);
+    }
+  }
+
+  /**
+   * Delete node operation.
+   */
+  public static class DeleteOp extends MultiOp {
+    private final int _version;
+
+    private DeleteOp(String path, int version) {
+      super(path);
+      _version = version;
+    }
+
+    @Override
+    public Op buildZkOp(PathBasedZkSerializer serializer) {
+      return Op.delete(getPath(), _version);
+    }
+  }
+
+  /**
+   * Modify exiting node operation.
+   */
+  public static class SetDataOp extends MultiOp {
+    private final Object _dataObj;
+    private final int _version;
+
+    private SetDataOp(String path, Object dataObj, int version) {
+      super(path);
+      _dataObj = dataObj;
+      _version = version;
+    }
+
+    @Override
+    public Op buildZkOp(PathBasedZkSerializer serializer) {
+      return Op.setData(getPath(), serializer.serialize(_dataObj, getPath()), _version);
+    }
+  }
+}

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -261,7 +261,10 @@ public interface RealmAwareZkClient {
 
   long getCreationTime(String path);
 
+  @Deprecated
   List<OpResult> multi(final Iterable<Op> ops);
+
+  List<OpResult> multiOps(final List<MultiOp> ops);
 
   // ZK state control
   boolean waitUntilConnected(long time, TimeUnit timeUnit);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
+import org.apache.helix.zookeeper.api.client.MultiOp;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
@@ -416,9 +417,15 @@ public class DedicatedZkClient implements RealmAwareZkClient {
     return _rawZkClient.getCreationTime(path);
   }
 
+  @Deprecated
   @Override
   public List<OpResult> multi(Iterable<Op> ops) {
     return _rawZkClient.multi(ops);
+  }
+
+  @Override
+  public List<OpResult> multiOps(final List<MultiOp> ops) {
+    return _rawZkClient.multiOps(ops);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
+import org.apache.helix.zookeeper.api.client.MultiOp;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.constant.RoutingDataConstants;
 import org.apache.helix.zookeeper.constant.RoutingSystemPropertyKeys;
@@ -401,8 +402,15 @@ public class FederatedZkClient implements RealmAwareZkClient {
     return getZkClient(path).getCreationTime(path);
   }
 
+  @Deprecated
   @Override
   public List<OpResult> multi(Iterable<Op> ops) {
+    throwUnsupportedOperationException();
+    return null;
+  }
+
+  @Override
+  public List<OpResult> multiOps(final List<MultiOp> ops) {
     throwUnsupportedOperationException();
     return null;
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -27,6 +27,7 @@ import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
+import org.apache.helix.zookeeper.api.client.MultiOp;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
@@ -452,9 +453,15 @@ public class SharedZkClient implements RealmAwareZkClient {
     return _innerSharedZkClient.getCreationTime(path);
   }
 
+  @Deprecated
   @Override
   public List<OpResult> multi(Iterable<Op> ops) {
     return _innerSharedZkClient.multi(ops);
+  }
+
+  @Override
+  public List<OpResult> multiOps(final List<MultiOp> ops) {
+    return _innerSharedZkClient.multiOps(ops);
   }
 
   @Override

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
@@ -33,6 +33,7 @@ import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
 import org.apache.helix.msdcommon.datamodel.MetadataStoreRoutingData;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.msdcommon.mock.MockMetadataStoreDirectoryServer;
+import org.apache.helix.zookeeper.api.client.MultiOp;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.constant.RoutingDataReaderType;
 import org.apache.helix.zookeeper.constant.RoutingSystemPropertyKeys;
@@ -109,6 +110,16 @@ public class TestFederatedZkClient extends RealmAwareZkClientTestBase {
     try {
       _realmAwareZkClient.multi(ops);
       Assert.fail("multi() should not be supported.");
+    } catch (UnsupportedOperationException ex) {
+      Assert.assertTrue(ex.getMessage().startsWith(UNSUPPORTED_OPERATION_MESSAGE));
+    }
+
+    List<MultiOp> multiOps = Arrays
+        .asList(MultiOp.create(TEST_REALM_ONE_VALID_PATH, "test", CreateMode.PERSISTENT),
+            MultiOp.delete(TEST_REALM_ONE_VALID_PATH, -1));
+    try {
+      _realmAwareZkClient.multiOps(multiOps);
+      Assert.fail("multiOps() should not be supported.");
     } catch (UnsupportedOperationException ex) {
       Assert.assertTrue(ex.getMessage().startsWith(UNSUPPORTED_OPERATION_MESSAGE));
     }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1428 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

The Helix ZkClient multi ops interfaces can be used in the same way as the native Zookeeper multi ops method. But the users are required to construct Helix MultiOp Objects for the additional Helix support such as monitoring, validation, and auto compress, etc.

### Tests

- [X] The following tests are written for this issue:

TestRawZkClient.testMultiOps 

- [X] The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 47, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
