### PR TITLE
Add getResourceCustomized View REST API

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -458,7 +458,8 @@ public interface HelixAdmin {
    * @param resourceName
    * @return customized for the resource
    */
-  CustomizedView getResourceCustomizedView(String clusterName, String resourceName);
+  CustomizedView getResourceCustomizedView(String clusterName, String resourceName,
+      String customizedStateType);
 
   /**
    * Drop a cluster

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1087,11 +1087,12 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   @Override
-  public CustomizedView getResourceCustomizedView(String clusterName, String resourceName) {
+  public CustomizedView getResourceCustomizedView(String clusterName, String resourceName,
+      String customizedStateType) {
     HelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<ZNRecord>(_zkClient));
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
-    return accessor.getProperty(keyBuilder.customizedView(resourceName));
+    return accessor.getProperty(keyBuilder.customizedView(customizedStateType, resourceName));
   }
 
   @Override

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -299,7 +299,8 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     ExternalView resourceExternalView = tool.getResourceExternalView(clusterName, "resource");
     AssertJUnit.assertNull(resourceExternalView);
 
-    CustomizedView resourceCustomizedView = tool.getResourceCustomizedView(clusterName, "resource");
+    CustomizedView resourceCustomizedView = tool.getResourceCustomizedView(clusterName,"resource"
+        , "customizedStateType");
     AssertJUnit.assertNull(resourceCustomizedView);
 
     // test config support

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -375,7 +375,7 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   @Override public CustomizedView getResourceCustomizedView(String clusterName,
-      String resourceName) {
+      String resourceName, String customizedStateType) {
     return null;
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAccessor.java
@@ -47,6 +47,7 @@ import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixException;
 import org.apache.helix.PropertyPathBuilder;
+import org.apache.helix.model.CustomizedView;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState;
@@ -522,6 +523,21 @@ public class ResourceAccessor extends AbstractHelixResource {
     ExternalView externalView = admin.getResourceExternalView(clusterId, resourceName);
     if (externalView != null) {
       return JSONRepresentation(externalView.getRecord());
+    }
+
+    return notFound();
+  }
+
+  @ResponseMetered(name = HttpConstants.READ_REQUEST)
+  @Timed(name = HttpConstants.READ_REQUEST)
+  @GET
+  @Path("{resourceName}/customizedView")
+  public Response getResourceCustomizedView(@PathParam("clusterId") String clusterId,
+      @PathParam("resourceName") String resourceName) {
+    HelixAdmin admin = getHelixAdmin();
+    CustomizedView customizedView = admin.getResourceCustomizedView(clusterId, resourceName);
+    if (customizedView != null) {
+      return JSONRepresentation(customizedView.getRecord());
     }
 
     return notFound();

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAccessor.java
@@ -531,11 +531,13 @@ public class ResourceAccessor extends AbstractHelixResource {
   @ResponseMetered(name = HttpConstants.READ_REQUEST)
   @Timed(name = HttpConstants.READ_REQUEST)
   @GET
-  @Path("{resourceName}/customizedView")
+  @Path("{resourceName}/{customizedStateType}/customizedView")
   public Response getResourceCustomizedView(@PathParam("clusterId") String clusterId,
-      @PathParam("resourceName") String resourceName) {
+      @PathParam("resourceName") String resourceName,
+      @PathParam("customizedStateType") String customizedStateType) {
     HelixAdmin admin = getHelixAdmin();
-    CustomizedView customizedView = admin.getResourceCustomizedView(clusterId, resourceName);
+    CustomizedView customizedView =
+        admin.getResourceCustomizedView(clusterId, resourceName, customizedStateType);
     if (customizedView != null) {
       return JSONRepresentation(customizedView.getRecord());
     }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
@@ -163,6 +163,13 @@ public class TestResourceAccessor extends AbstractTestClass {
   }
 
   @Test(dependsOnMethods = "testExternalView")
+  public void testCustomizedView() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    get("clusters/" + CLUSTER_NAME + "/resources/" + RESOURCE_NAME + "/customizedView", null,
+        Response.Status.NOT_FOUND.getStatusCode(), true);
+  }
+
+  @Test(dependsOnMethods = "testExternalView")
   public void testPartitionHealth() throws Exception {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
@@ -44,6 +44,7 @@ import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.TestHelper;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.CustomizedView;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
@@ -58,6 +59,7 @@ public class TestResourceAccessor extends AbstractTestClass {
   private final static String CLUSTER_NAME = "TestCluster_0";
   private final static String RESOURCE_NAME = CLUSTER_NAME + "_db_0";
   private final static String ANY_INSTANCE = "ANY_LIVEINSTANCE";
+  private final static String CUSTOMIZED_STATE_TYPE = "Customized_state_type_0";
 
   @Test
   public void testGetResources() throws IOException {
@@ -163,10 +165,19 @@ public class TestResourceAccessor extends AbstractTestClass {
   }
 
   @Test(dependsOnMethods = "testExternalView")
-  public void testCustomizedView() {
+  public void testCustomizedView() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
-    get("clusters/" + CLUSTER_NAME + "/resources/" + RESOURCE_NAME + "/customizedView", null,
-        Response.Status.NOT_FOUND.getStatusCode(), true);
+    ZNRecord znRecord = new ZNRecord("test_customizedView");
+    _baseAccessor
+        .set(PropertyPathBuilder.customizedView(CLUSTER_NAME, CUSTOMIZED_STATE_TYPE, RESOURCE_NAME),
+            znRecord, 1);
+    String body =
+        get("clusters/" + CLUSTER_NAME + "/resources/" + RESOURCE_NAME + "/" + CUSTOMIZED_STATE_TYPE
+            + "/customizedView", null, Response.Status.OK.getStatusCode(), true);
+    CustomizedView customizedView = new CustomizedView(toZNRecord(body));
+    Assert.assertEquals(customizedView, _gSetupTool.getClusterManagementTool()
+        .getResourceCustomizedView(CLUSTER_NAME, RESOURCE_NAME, CUSTOMIZED_STATE_TYPE));
+    System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
   @Test(dependsOnMethods = "testExternalView")


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fixed #1425 
### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

We need a REST API for getting resource customized view for our users. This PR adds one in resource accessor.

### Tests

- [X] The following is the result of the "mvn test" command on the appropriate module:

helix-core
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 1210, Failures: 0, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:07 h
[INFO] Finished at: 2020-10-02T14:57:53-07:00
[INFO] -----------------------------------------

helix-rest
[INFO] Tests run: 169, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 122.996 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 169, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:09 min
[INFO] Finished at: 2020-10-02T09:20:49-07:00
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
