### PR TITLE
Enhancement of ClusterVerifier and TaskDriver

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -177,7 +177,7 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
     _lock = new Object();
     _statusUpdateUtil = new StatusUpdateUtil();
 
-    _timer = new Timer("HelixTaskExecutor_timer", true); // created as a daemon timer thread to handle task timeout
+    _timer = new Timer("HelixTaskExecutor_Timer", true); // created as a daemon timer thread to handle task timeout
 
     _isShuttingDown = false;
 
@@ -622,6 +622,8 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
         item.factory().reset();
       }
     }
+    // threads pool specific to STATE_TRANSITION.Key specific pool are not shut down.
+    // this is a potential area to improve. https://github.com/apache/helix/issues/1245
 
     StringBuilder sb = new StringBuilder();
     // Log all tasks that fail to terminate

--- a/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskDriver.java
@@ -941,9 +941,15 @@ public class TaskDriver {
         && System.currentTimeMillis() < st + timeout);
 
     if (ctx == null || !allowedStates.contains(ctx.getJobState(jobName))) {
+      WorkflowConfig wfcfg = getWorkflowConfig(workflowName);
+      JobConfig jobConfig = getJobConfig(jobName);
+      JobContext jbCtx = getJobContext(jobName);
       throw new HelixException(
-          String.format("Workflow \"%s\" context is null or job \"%s\" is not in states: %s",
-              workflowName, jobName, allowedStates));
+          String.format("Workflow \"%s\" context is null or job \"%s\" is not in states: %s; ctx is %s, jobState is %s, wf cfg %s, jobcfg %s, jbctx %s",
+              workflowName, jobName, allowedStates,
+              ctx == null ? "null" : ctx, ctx != null ? ctx.getJobState(jobName) : "null",
+              wfcfg, jobConfig, jbCtx));
+
     }
 
     return ctx.getJobState(jobName);

--- a/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
@@ -952,6 +952,7 @@ public class TaskUtil {
         return false;
       }
     }
+    LOG.info("removed job context {}.", path);
     return true;
   }
 
@@ -971,7 +972,7 @@ public class TaskUtil {
         return false;
       }
     }
-
+    LOG.info("removed job config {}.", cfgKey.getPath());
     return true;
   }
 

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -78,8 +78,8 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
    */
   @Deprecated
   public BestPossibleExternalViewVerifier(String zkAddr, String clusterName, Set<String> resources,
-      Map<String, Map<String, String>> errStates, Set<String> expectLiveInstances) {
-    super(zkAddr, clusterName);
+      Map<String, Map<String, String>> errStates, Set<String> expectLiveInstances, int waitTillVerify) {
+    super(zkAddr, clusterName, waitTillVerify);
     _errStates = errStates;
     _resources = resources;
     _expectLiveInstances = expectLiveInstances;
@@ -97,8 +97,8 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
   @Deprecated
   public BestPossibleExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Set<String> resources, Map<String, Map<String, String>> errStates,
-      Set<String> expectLiveInstances) {
-    super(zkClient, clusterName, 0);
+      Set<String> expectLiveInstances, int waitTillVerify) {
+    super(zkClient, clusterName, waitTillVerify);
     _errStates = errStates;
     _resources = resources;
     _expectLiveInstances = expectLiveInstances;
@@ -138,13 +138,13 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
 
       if (_zkClient != null) {
         return new BestPossibleExternalViewVerifier(_zkClient, _clusterName, _resources, _errStates,
-            _expectLiveInstances);
+            _expectLiveInstances, _waitPeriodTillVerify);
       }
 
       if (_realmAwareZkConnectionConfig == null || _realmAwareZkClientConfig == null) {
         // For backward-compatibility
         return new BestPossibleExternalViewVerifier(_zkAddress, _clusterName, _resources,
-            _errStates, _expectLiveInstances);
+            _errStates, _expectLiveInstances, _waitPeriodTillVerify);
       }
 
       validate();

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
@@ -60,7 +60,7 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
   @Deprecated
   public StrictMatchExternalViewVerifier(String zkAddr, String clusterName, Set<String> resources,
       Set<String> expectLiveInstances) {
-    this(zkAddr, clusterName, resources, expectLiveInstances, false);
+    this(zkAddr, clusterName, resources, expectLiveInstances, false,0);
   }
 
   @Deprecated
@@ -71,8 +71,8 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
 
   @Deprecated
   private StrictMatchExternalViewVerifier(String zkAddr, String clusterName, Set<String> resources,
-      Set<String> expectLiveInstances, boolean isDeactivatedNodeAware) {
-    super(zkAddr, clusterName);
+      Set<String> expectLiveInstances, boolean isDeactivatedNodeAware, int waitTillVerify) {
+    super(zkAddr, clusterName, waitTillVerify);
     _resources = resources;
     _expectLiveInstances = expectLiveInstances;
     _isDeactivatedNodeAware = isDeactivatedNodeAware;
@@ -108,7 +108,7 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
       if (_realmAwareZkConnectionConfig == null || _realmAwareZkClientConfig == null) {
         // For backward-compatibility
         return new StrictMatchExternalViewVerifier(_zkAddress, _clusterName, _resources,
-            _expectLiveInstances, _isDeactivatedNodeAware);
+            _expectLiveInstances, _isDeactivatedNodeAware, _waitPeriodTillVerify);
       }
 
       validate();

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
@@ -60,7 +60,7 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
   @Deprecated
   public StrictMatchExternalViewVerifier(String zkAddr, String clusterName, Set<String> resources,
       Set<String> expectLiveInstances) {
-    this(zkAddr, clusterName, resources, expectLiveInstances, false,0);
+    this(zkAddr, clusterName, resources, expectLiveInstances, false, 0);
   }
 
   @Deprecated

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
@@ -355,6 +355,15 @@ public abstract class ZkHelixClusterVerifier
       return setZkAddress(zkAddress);
     }
 
+    /**
+     * The class of verify() methods in this class and its subclass such as
+     * BestPossibleExternalViewVerifier is intend to wait for the cluster converging to a stable
+     * state after changes in the cluster. However, after making changes, it would take some time
+     * till controller taking the changes in. Thus, if we verify() too early, before controller
+     * taking the changes, the class may mistake the previous stable cluster state as new (expected)
+     * stable state. This would cause various issues. Thus, we supply a waitPeriod before starting
+     * to validate next expected state to avoid this pre-mature stable state validation.
+     */
     public B setWaitTillVerify(int waitPeriod) {
       _waitPeriodTillVerify = waitPeriod;
       return (B) this;

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
@@ -107,7 +107,7 @@ public abstract class ZkHelixClusterVerifier
   }
 
   @Deprecated
-  public ZkHelixClusterVerifier(String zkAddr, String clusterName) {
+  public ZkHelixClusterVerifier(String zkAddr, String clusterName, int waitPeriodTillVerify) {
     if (clusterName == null || clusterName.isEmpty()) {
       throw new IllegalArgumentException("ZkHelixClusterVerifier: clusterName is null or empty!");
     }
@@ -138,7 +138,7 @@ public abstract class ZkHelixClusterVerifier
     _clusterName = clusterName;
     _accessor = new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_zkClient));
     _keyBuilder = _accessor.keyBuilder();
-    _waitPeriodTillVerify = 0;
+    _waitPeriodTillVerify = waitPeriodTillVerify;
   }
 
   /**


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fix #1431 

fix clusterVerifier to take waitTillVeriy and also enhance
logging of TaskDriver and TaskUtil to make sure the job
adding and selective update race condition would have a
log

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Running

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

All test passed. See this link from github https://github.com/apache/helix/runs/1201249679?check_suite_focus=true
The following is the last part of the result of mvn test
>testCluster-823c9bca-693f-4b04-8e28-687f0c392cdf, STATEMODELDEFS]
2020-10-03T00:11:06.9787433Z 4254322 [TestNGInvoker-testP2PWithInstanceOffline()] ERROR org.apache.helix.common.caches.InstanceMessagesCache  - Target state for partition testDB_0 matches the hosted message's target state, set relay message 377cd66d-5166-47e3-9a59-a3c9e2ae19b6 to be expired.
2020-10-03T00:11:07.0293029Z keySplit:[, testCluster-823c9bca-693f-4b04-8e28-687f0c392cdf, INSTANCES, localhost_0, MESSAGES]
2020-10-03T00:11:07.0305557Z pathSplit:[, testCluster-823c9bca-693f-4b04-8e28-687f0c392cdf, INSTANCES, localhost_0, MESSAGES]
2020-10-03T00:11:07.0307510Z END testP2PWithInstanceOffline at Sat Oct 03 00:11:07 UTC 2020, took: 960ms.
2020-10-03T00:11:07.0308546Z END TestP2PMessages at Sat Oct 03 00:11:07 UTC 2020
2020-10-03T00:11:07.0309791Z START TestP2PWithStateCancellationMessage at Sat Oct 03 00:11:07 UTC 2020
2020-10-03T00:11:07.0311509Z START testP2PWithStateCancellationMessage at Sat Oct 03 00:11:07 UTC 2020
2020-10-03T00:11:07.8645832Z END testP2PWithStateCancellationMessage at Sat Oct 03 00:11:07 UTC 2020, took: 833ms.
2020-10-03T00:11:07.8647681Z END TestP2PWithStateCancellationMessage at Sat Oct 03 00:11:07 UTC 2020
2020-10-03T00:11:08.1968465Z Shut down zookeeper at port 2183 in thread main

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
