### PR TITLE
Not to cache data accessor in Helix customized state provider

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/GroupCommit.java
+++ b/helix-core/src/main/java/org/apache/helix/GroupCommit.java
@@ -145,6 +145,7 @@ public class GroupCommit {
               try {
                 success = accessor.remove(mergedKey, options);
               } catch (Exception e) {
+                LOG.error("Fails to remove " + mergedKey + " from ZK due to ZK issue.", e);
                 success = false;
               }
               if (!success) {
@@ -156,6 +157,7 @@ public class GroupCommit {
               try {
                 success = accessor.set(mergedKey, merged, options);
               } catch (Exception e) {
+                LOG.error("Fails to update " + mergedKey + " to ZK due to ZK issue.", e);
                 success = false;
               }
               if (!success) {

--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
@@ -74,9 +74,9 @@ public class CustomizedStateProvider {
         String.valueOf(System.currentTimeMillis()));
     record.setMapField(partitionName, customizedStateMap);
     if (!accessor.updateProperty(propertyKey, new CustomizedState(record))) {
-      throw new HelixException(String
-          .format("Failed to persist customized state %s to zk for instance %s, resource %s",
-              customizedStateName, _instanceName, record.getId()));
+      throw new HelixException(String.format(
+          "Failed to persist customized state %s to zk for instance %s, resource %s, "
+              + "partition %s", customizedStateName, _instanceName, resourceName, partitionName));
     }
   }
 
@@ -119,6 +119,10 @@ public class CustomizedStateProvider {
     List<ZNRecordDelta> deltaList = new ArrayList<ZNRecordDelta>();
     deltaList.add(delta);
     existingState.setDeltaList(deltaList);
-    accessor.updateProperty(propertyKey, existingState);
+    if (!accessor.updateProperty(propertyKey, existingState)) {
+      throw new HelixException(String.format(
+          "Failed to delete customized state %s to zk for instance %s, resource %s, "
+              + "partition %s", customizedStateName, _instanceName, resourceName, partitionName));
+    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/customizedstate/CustomizedStateProvider.java
@@ -40,13 +40,11 @@ import org.slf4j.LoggerFactory;
 public class CustomizedStateProvider {
   private static final Logger LOG = LoggerFactory.getLogger(CustomizedStateProvider.class);
   private final HelixManager _helixManager;
-  private final HelixDataAccessor _helixDataAccessor;
   private String _instanceName;
 
   public CustomizedStateProvider(HelixManager helixManager, String instanceName) {
     _helixManager = helixManager;
     _instanceName = instanceName;
-    _helixDataAccessor = _helixManager.getHelixDataAccessor();
   }
 
   /**
@@ -66,7 +64,8 @@ public class CustomizedStateProvider {
    */
   public void updateCustomizedState(String customizedStateName, String resourceName,
       String partitionName, Map<String, String> customizedStateMap) {
-    PropertyKey.Builder keyBuilder = _helixDataAccessor.keyBuilder();
+    HelixDataAccessor accessor = _helixManager.getHelixDataAccessor();
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
     PropertyKey propertyKey =
         keyBuilder.customizedState(_instanceName, customizedStateName, resourceName);
     ZNRecord record = new ZNRecord(resourceName);
@@ -74,7 +73,7 @@ public class CustomizedStateProvider {
     customizedStateMap.put(CustomizedState.CustomizedStateProperty.START_TIME.name(),
         String.valueOf(System.currentTimeMillis()));
     record.setMapField(partitionName, customizedStateMap);
-    if (!_helixDataAccessor.updateProperty(propertyKey, new CustomizedState(record))) {
+    if (!accessor.updateProperty(propertyKey, new CustomizedState(record))) {
       throw new HelixException(String
           .format("Failed to persist customized state %s to zk for instance %s, resource %s",
               customizedStateName, _instanceName, record.getId()));
@@ -96,8 +95,9 @@ public class CustomizedStateProvider {
    */
   public Map<String, String> getPerPartitionCustomizedState(String customizedStateName,
       String resourceName, String partitionName) {
-    PropertyKey.Builder keyBuilder = _helixDataAccessor.keyBuilder();
-    Map<String, Map<String, String>> mapView = _helixDataAccessor
+    HelixDataAccessor accessor = _helixManager.getHelixDataAccessor();
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    Map<String, Map<String, String>> mapView = accessor
         .getProperty(keyBuilder.customizedState(_instanceName, customizedStateName, resourceName))
         .getRecord().getMapFields();
     return mapView.get(partitionName);
@@ -108,7 +108,8 @@ public class CustomizedStateProvider {
    */
   public void deletePerPartitionCustomizedState(String customizedStateName, String resourceName,
       String partitionName) {
-    PropertyKey.Builder keyBuilder = _helixDataAccessor.keyBuilder();
+    HelixDataAccessor accessor = _helixManager.getHelixDataAccessor();
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
     PropertyKey propertyKey =
         keyBuilder.customizedState(_instanceName, customizedStateName, resourceName);
     CustomizedState existingState = getCustomizedState(customizedStateName, resourceName);
@@ -118,6 +119,6 @@ public class CustomizedStateProvider {
     List<ZNRecordDelta> deltaList = new ArrayList<ZNRecordDelta>();
     deltaList.add(delta);
     existingState.setDeltaList(deltaList);
-    _helixDataAccessor.updateProperty(propertyKey, existingState);
+    accessor.updateProperty(propertyKey, existingState);
   }
 }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fixed #1435 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

In customized state provider, there is a local variable of Helix data accessor, which is get from Helix manager. When Helix manager disconnect and reconnect, the data accessor is actually stale. 
The reason is that when a Helix manager reconnects, it instantiates a new data accessor, but the data accessor in state provider still points to the old object, whose zkclient is already closed. So we should explicitly get the data accessor from Helix manager each time we need to use it in customized state provider.

Another change is in group commit, currently it throws an exception when zkclinet is closed, and this is different from other updateProperty calls, which returns an error code. We change it to have the same behavior. 

### Tests


- [X] The following is the result of the "mvn test" command on the appropriate module:

helix-core
[WARNING] Tests run: 1210, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 3,972.81 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 1210, Failures: 0, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:06 h
[INFO] Finished at: 2020-10-05T18:53:46-07:00


### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
