### PR TITLE
Fix TaskGarbageCollectionStage rebalance trigger when job purge interval is negative

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TaskGarbageCollectionStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TaskGarbageCollectionStage.java
@@ -73,9 +73,12 @@ public class TaskGarbageCollectionStage extends AbstractAsyncBaseStage {
           continue;
         }
         long purgeInterval = workflowConfig.getJobPurgeInterval();
+        if (purgeInterval <= 0) {
+          continue;
+        }
         long currentTime = System.currentTimeMillis();
         long nextPurgeTime = workflowContext.getLastJobPurgeTime() + purgeInterval;
-        if (purgeInterval > 0 && nextPurgeTime <= currentTime) {
+        if (nextPurgeTime <= currentTime) {
           nextPurgeTime = currentTime + purgeInterval;
           // Find jobs that are ready to be purged
           Set<String> expiredJobs =


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1353 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Since we allow negative delay in `scheduleRebalance`, which leads to immediate rebalance (on-demand), the current logic is incorrect. When job purge interval is non-positive, a rebalance is always triggered immediately. 

Adding a check earlier to disable the rebalance triggering when job purge interval is non-positive. 

### Tests
- [x] The following is the result of the "mvn test" command on the appropriate module:

[WARNING] Tests run: 1210, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 4,007.762 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 1210, Failures: 0, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:06 h
[INFO] Finished at: 2020-10-05T17:04:49-07:00
[INFO] ------------------------------------------------------------------------
### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
