### PR TITLE
Make ClusterStateVerifier closable

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterStateVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterStateVerifier.java
@@ -181,6 +181,12 @@ public class ClusterStateVerifier {
       this.resources = resources;
     }
 
+    public void close() {
+      if (zkClient != null) {
+        zkClient.close();
+      }
+    }
+
     @Override
     public boolean verify() {
       try {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

fix #1444 


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
ClusterStateVerifier need to be closable. Otherwise, we may leak
ZooKeeper client session together with ZkClient. That is thread
leakage with memory leakage and potentially Zookeeper server
resource hogging.

Address comments in #1227 

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

>TestSuite
2020-10-06T23:33:30.7406510Z [ERROR] testDropCurrentStateRunningTask(org.apache.helix.integration.task.TestDropCurrentStateRunningTask)  Time elapsed: 20.403 s  <<< FAILURE!
2020-10-06T23:33:30.7410020Z org.apache.helix.HelixException: Fail to stop the workflow/queue testDropCurrentStateRunningTask with in 20000 milliseconds.
2020-10-06T23:33:30.7414218Z 	at org.apache.helix.integration.task.TestDropCurrentStateRunningTask.testDropCurrentStateRunningTask(TestDropCurrentStateRunningTask.java:152)
2020-10-06T23:33:30.7417525Z 
2020-10-06T23:33:30.7419462Z [ERROR] testResetSnapshots(org.apache.helix.controller.changedetector.TestResourceChangeDetector)  Time elapsed: 300.009 s  <<< FAILURE!
2020-10-06T23:33:30.7423453Z org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testResetSnapshots() didn't finish within the time-out 300000
2020-10-06T23:33:30.7428437Z 	at org.apache.helix.controller.changedetector.TestResourceChangeDetector.testResetSnapshots(TestResourceChangeDetector.java:431)
2020-10-06T23:33:30.7431160Z 
2020-10-06T23:33:30.7432867Z [ERROR] testWorkflowFailureJobThreshold(org.apache.helix.integration.task.TestJobFailureDependence)  Time elapsed: 300.007 s  <<< FAILURE!
2020-10-06T23:33:30.7436858Z org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testWorkflowFailureJobThreshold() didn't finish within the time-out 300000
2020-10-06T23:33:30.7441600Z 	at org.apache.helix.integration.task.TestJobFailureDependence.testWorkflowFailureJobThreshold(TestJobFailureDependence.java:176)
2020-10-06T23:33:30.7444447Z 
2020-10-06T23:33:31.1409397Z [ERROR] Failures: 
2020-10-06T23:33:31.1428396Z [ERROR]   TestResourceChangeDetector.testResetSnapshots:431 » ThreadTimeout Method org.t...
2020-10-06T23:33:31.1430782Z [ERROR]   TestDropCurrentStateRunningTask.testDropCurrentStateRunningTask:152 » Helix Fa...
2020-10-06T23:33:31.1433339Z [ERROR]   TestJobFailureDependence.testWorkflowFailureJobThreshold:176 » ThreadTimeout M...
2020-10-06T23:33:31.1434896Z [ERROR] Tests run: 1211, Failures: 3, Errors: 0, Skipped: 2
2020-10-06T23:33:31.1542965Z [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
2020-10-06T23:33:31.1546109Z [ERROR] 

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
