### PR TITLE
Replace Thread.sleep() with TestHelper.verify() to fix the flaky unit tests

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/TestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/TestHelper.java
@@ -76,8 +76,10 @@ import org.testng.Assert;
 
 public class TestHelper {
   private static final Logger LOG = LoggerFactory.getLogger(TestHelper.class);
-  public static final long WAIT_DURATION = 20 * 1000L; // 20 seconds
+
+  public static final long WAIT_DURATION = 60 * 1000L; // 60 seconds
   public static final int DEFAULT_REBALANCE_PROCESSING_WAIT_TIME = 1500;
+
   /**
    * Returns a unused random port.
    */
@@ -799,7 +801,12 @@ public class TestHelper {
     long start = System.currentTimeMillis();
     do {
       boolean result = verifier.verify();
-      if (result || (System.currentTimeMillis() - start) > timeout) {
+      boolean isTimedout = (System.currentTimeMillis() - start) > timeout;
+      if (result || isTimedout) {
+        if (isTimedout && !result) {
+          LOG.error("verifier time out, consider try longer timeout, stack trace{}",
+              Arrays.asList(Thread.currentThread().getStackTrace()));
+        }
         return result;
       }
       Thread.sleep(50);

--- a/helix-core/src/test/java/org/apache/helix/TestListenerCallback.java
+++ b/helix-core/src/test/java/org/apache/helix/TestListenerCallback.java
@@ -132,7 +132,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     _manager.addInstanceConfigChangeListener(listener);
     boolean result = TestHelper.verify(()-> {
-      return listener._instanceConfigChanged == true;
+      return listener._instanceConfigChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result, "Should get initial instanceConfig callback invoked");
     Assert.assertEquals(listener._instanceConfigs.size(), _numNodes,
@@ -141,7 +141,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     _manager.addClusterfigChangeListener(listener);
     result = TestHelper.verify(()-> {
-      return listener._clusterConfigChanged == true;
+      return listener._clusterConfigChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result, "Should get initial clusterConfig callback invoked");
     Assert.assertNotNull(listener._clusterConfig, "Cluster Config size should not be null");
@@ -149,7 +149,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     _manager.addResourceConfigChangeListener(listener);
     result = TestHelper.verify(()-> {
-      return listener._resourceConfigChanged == true;
+      return listener._resourceConfigChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result, "Should get initial resourceConfig callback invoked");
     Assert.assertEquals(listener._resourceConfigs.size(), 0, "resource config size does not match");
@@ -163,7 +163,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     accessor.setProperty(keyBuilder.instanceConfig(instanceName), value);
     result = TestHelper.verify(()-> {
-      return listener._instanceConfigChanged == true;
+      return listener._instanceConfigChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result, "Should get instanceConfig callback invoked since we change instanceConfig");
     Assert.assertEquals(listener._instanceConfigs.size(), _numNodes,
@@ -174,7 +174,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     accessor.setProperty(keyBuilder.clusterConfig(), value);
     result = TestHelper.verify(()-> {
-      return listener._clusterConfigChanged == true;
+      return listener._clusterConfigChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result, "Should get clusterConfig callback invoked since we change clusterConfig");
     Assert.assertNotNull(listener._clusterConfig, "Cluster Config size should not be null");
@@ -185,7 +185,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     accessor.setProperty(keyBuilder.resourceConfig(resourceName), value);
     result = TestHelper.verify(()-> {
-      return listener._resourceConfigChanged == true;
+      return listener._resourceConfigChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result, "Should get resourceConfig callback invoked since we add resourceConfig");
     Assert.assertEquals(listener._resourceConfigs.size(), 1, "Resource config size does not match");
@@ -193,7 +193,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     accessor.removeProperty(keyBuilder.resourceConfig(resourceName));
     result = TestHelper.verify(()-> {
-      return listener._resourceConfigChanged == true;
+      return listener._resourceConfigChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result, "Should get resourceConfig callback invoked since we add resourceConfig");
     Assert.assertEquals(listener._resourceConfigs.size(), 0, "Instance Config size does not match");
@@ -206,13 +206,16 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     _manager.addConfigChangeListener(listener, ConfigScopeProperty.CLUSTER);
     boolean result = TestHelper.verify(()-> {
-      return listener._configChanged == true;
+      return listener._configChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result,"Should get initial clusterConfig callback invoked");
     Assert.assertEquals(listener._configSize, 1, "Cluster Config size should be 1");
 
     listener.reset();
     _manager.addConfigChangeListener(listener, ConfigScopeProperty.RESOURCE);
+    result = TestHelper.verify(()-> {
+      return listener._configChanged;
+    }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(listener._configChanged,
         "Should get initial resourceConfig callback invoked");
     Assert.assertEquals(listener._configSize, 0, "Resource Config size does not match");
@@ -220,7 +223,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     _manager.addConfigChangeListener(listener, ConfigScopeProperty.PARTICIPANT);
     result = TestHelper.verify(()-> {
-      return listener._configChanged == true;
+      return listener._configChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result,"Should get initial resourceConfig callback invoked");
     Assert.assertEquals(listener._configSize, _numNodes, "Instance Config size does not match");
@@ -234,7 +237,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     accessor.setProperty(keyBuilder.instanceConfig(instanceName), value);
     result = TestHelper.verify(()-> {
-      return listener._configChanged == true;
+      return listener._configChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result,
         "Should get instanceConfig callback invoked since we change instanceConfig");
@@ -245,7 +248,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     accessor.setProperty(keyBuilder.clusterConfig(), value);
     result = TestHelper.verify(()-> {
-      return listener._configChanged == true;
+      return listener._configChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result,
         "Should get clusterConfig callback invoked since we change clusterConfig");
@@ -257,7 +260,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     accessor.setProperty(keyBuilder.resourceConfig(resourceName), value);
     result = TestHelper.verify(()-> {
-      return listener._configChanged == true;
+      return listener._configChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result,
         "Should get resourceConfig callback invoked since we add resourceConfig");
@@ -266,7 +269,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     listener.reset();
     accessor.removeProperty(keyBuilder.resourceConfig(resourceName));
     result = TestHelper.verify(()-> {
-      return listener._configChanged == true;
+      return listener._configChanged;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result,
         "Should get resourceConfig callback invoked since we add resourceConfig");

--- a/helix-core/src/test/java/org/apache/helix/TestListenerCallback.java
+++ b/helix-core/src/test/java/org/apache/helix/TestListenerCallback.java
@@ -131,22 +131,28 @@ public class TestListenerCallback extends ZkUnitTestBase {
     TestConfigListener listener = new TestConfigListener();
     listener.reset();
     _manager.addInstanceConfigChangeListener(listener);
-    Assert.assertTrue(listener._instanceConfigChanged,
-        "Should get initial instanceConfig callback invoked");
+    boolean result = TestHelper.verify(()-> {
+      return listener._instanceConfigChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result, "Should get initial instanceConfig callback invoked");
     Assert.assertEquals(listener._instanceConfigs.size(), _numNodes,
         "Instance Config size does not match");
 
     listener.reset();
     _manager.addClusterfigChangeListener(listener);
-    Assert.assertTrue(listener._clusterConfigChanged,
-        "Should get initial clusterConfig callback invoked");
+    result = TestHelper.verify(()-> {
+      return listener._clusterConfigChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result, "Should get initial clusterConfig callback invoked");
     Assert.assertNotNull(listener._clusterConfig, "Cluster Config size should not be null");
 
     listener.reset();
     _manager.addResourceConfigChangeListener(listener);
-    Assert.assertTrue(listener._resourceConfigChanged,
-        "Should get initial resourceConfig callback invoked");
-    Assert.assertEquals(listener._resourceConfigs.size(), 0, "Instance Config size does not match");
+    result = TestHelper.verify(()-> {
+      return listener._resourceConfigChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result, "Should get initial resourceConfig callback invoked");
+    Assert.assertEquals(listener._resourceConfigs.size(), 0, "resource config size does not match");
 
     // test change content
     HelixDataAccessor accessor = _manager.getHelixDataAccessor();
@@ -156,9 +162,10 @@ public class TestListenerCallback extends ZkUnitTestBase {
     value._record.setSimpleField("" + System.currentTimeMillis(), "newValue");
     listener.reset();
     accessor.setProperty(keyBuilder.instanceConfig(instanceName), value);
-    Thread.sleep(500); // wait zk callback
-    Assert.assertTrue(listener._instanceConfigChanged,
-        "Should get instanceConfig callback invoked since we change instanceConfig");
+    result = TestHelper.verify(()-> {
+      return listener._instanceConfigChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result, "Should get instanceConfig callback invoked since we change instanceConfig");
     Assert.assertEquals(listener._instanceConfigs.size(), _numNodes,
         "Instance Config size does not match");
 
@@ -166,9 +173,10 @@ public class TestListenerCallback extends ZkUnitTestBase {
     value._record.setSimpleField("" + System.currentTimeMillis(), "newValue");
     listener.reset();
     accessor.setProperty(keyBuilder.clusterConfig(), value);
-    Thread.sleep(500); // wait zk callback
-    Assert.assertTrue(listener._clusterConfigChanged,
-        "Should get clusterConfig callback invoked since we change clusterConfig");
+    result = TestHelper.verify(()-> {
+      return listener._clusterConfigChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result, "Should get clusterConfig callback invoked since we change clusterConfig");
     Assert.assertNotNull(listener._clusterConfig, "Cluster Config size should not be null");
 
     String resourceName = "TestDB_0";
@@ -176,16 +184,18 @@ public class TestListenerCallback extends ZkUnitTestBase {
     value._record.setSimpleField("" + System.currentTimeMillis(), "newValue");
     listener.reset();
     accessor.setProperty(keyBuilder.resourceConfig(resourceName), value);
-    Thread.sleep(500); // wait zk callback
-    Assert.assertTrue(listener._resourceConfigChanged,
-        "Should get resourceConfig callback invoked since we add resourceConfig");
+    result = TestHelper.verify(()-> {
+      return listener._resourceConfigChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result, "Should get resourceConfig callback invoked since we add resourceConfig");
     Assert.assertEquals(listener._resourceConfigs.size(), 1, "Resource config size does not match");
 
     listener.reset();
     accessor.removeProperty(keyBuilder.resourceConfig(resourceName));
-    Thread.sleep(500); // wait zk callback
-    Assert.assertTrue(listener._resourceConfigChanged,
-        "Should get resourceConfig callback invoked since we add resourceConfig");
+    result = TestHelper.verify(()-> {
+      return listener._resourceConfigChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result, "Should get resourceConfig callback invoked since we add resourceConfig");
     Assert.assertEquals(listener._resourceConfigs.size(), 0, "Instance Config size does not match");
   }
 
@@ -195,7 +205,10 @@ public class TestListenerCallback extends ZkUnitTestBase {
 
     listener.reset();
     _manager.addConfigChangeListener(listener, ConfigScopeProperty.CLUSTER);
-    Assert.assertTrue(listener._configChanged, "Should get initial clusterConfig callback invoked");
+    boolean result = TestHelper.verify(()-> {
+      return listener._configChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result,"Should get initial clusterConfig callback invoked");
     Assert.assertEquals(listener._configSize, 1, "Cluster Config size should be 1");
 
     listener.reset();
@@ -206,8 +219,10 @@ public class TestListenerCallback extends ZkUnitTestBase {
 
     listener.reset();
     _manager.addConfigChangeListener(listener, ConfigScopeProperty.PARTICIPANT);
-    Assert.assertTrue(listener._configChanged,
-        "Should get initial instanceConfig callback invoked");
+    result = TestHelper.verify(()-> {
+      return listener._configChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result,"Should get initial resourceConfig callback invoked");
     Assert.assertEquals(listener._configSize, _numNodes, "Instance Config size does not match");
 
     // test change content
@@ -218,8 +233,10 @@ public class TestListenerCallback extends ZkUnitTestBase {
     value._record.setSimpleField("" + System.currentTimeMillis(), "newValue");
     listener.reset();
     accessor.setProperty(keyBuilder.instanceConfig(instanceName), value);
-    Thread.sleep(500); // wait zk callback
-    Assert.assertTrue(listener._configChanged,
+    result = TestHelper.verify(()-> {
+      return listener._configChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result,
         "Should get instanceConfig callback invoked since we change instanceConfig");
     Assert.assertEquals(listener._configSize, _numNodes, "Instance Config size does not match");
 
@@ -227,8 +244,10 @@ public class TestListenerCallback extends ZkUnitTestBase {
     value._record.setSimpleField("" + System.currentTimeMillis(), "newClusterValue");
     listener.reset();
     accessor.setProperty(keyBuilder.clusterConfig(), value);
-    Thread.sleep(500); // wait zk callback
-    Assert.assertTrue(listener._configChanged,
+    result = TestHelper.verify(()-> {
+      return listener._configChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result,
         "Should get clusterConfig callback invoked since we change clusterConfig");
     Assert.assertEquals(listener._configSize, 1, "Cluster Config size does not match");
 
@@ -237,15 +256,19 @@ public class TestListenerCallback extends ZkUnitTestBase {
     value._record.setSimpleField("" + System.currentTimeMillis(), "newValue");
     listener.reset();
     accessor.setProperty(keyBuilder.resourceConfig(resourceName), value);
-    Thread.sleep(500); // wait zk callback
-    Assert.assertTrue(listener._configChanged,
+    result = TestHelper.verify(()-> {
+      return listener._configChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result,
         "Should get resourceConfig callback invoked since we add resourceConfig");
     Assert.assertEquals(listener._configSize, 1, "Resource Config size does not match");
 
     listener.reset();
     accessor.removeProperty(keyBuilder.resourceConfig(resourceName));
-    Thread.sleep(500); // wait zk callback
-    Assert.assertTrue(listener._configChanged,
+    result = TestHelper.verify(()-> {
+      return listener._configChanged == true;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result,
         "Should get resourceConfig callback invoked since we add resourceConfig");
     Assert.assertEquals(listener._configSize, 0, "Resource Config size does not match");
   }

--- a/helix-core/src/test/java/org/apache/helix/TestListenerCallback.java
+++ b/helix-core/src/test/java/org/apache/helix/TestListenerCallback.java
@@ -216,7 +216,7 @@ public class TestListenerCallback extends ZkUnitTestBase {
     result = TestHelper.verify(()-> {
       return listener._configChanged;
     }, TestHelper.WAIT_DURATION);
-    Assert.assertTrue(listener._configChanged,
+    Assert.assertTrue(result,
         "Should get initial resourceConfig callback invoked");
     Assert.assertEquals(listener._configSize, 0, "Resource Config size does not match");
 

--- a/helix-core/src/test/java/org/apache/helix/TestZKCallback.java
+++ b/helix-core/src/test/java/org/apache/helix/TestZKCallback.java
@@ -167,7 +167,7 @@ public class TestZKCallback extends ZkUnitTestBase {
       ExternalView extView = new ExternalView("db-12345");
       accessor.setProperty(keyBuilder.externalView("db-12345"), extView);
       boolean result = TestHelper.verify(() -> {
-        return testListener.externalViewChangeReceived == true;
+        return testListener.externalViewChangeReceived;
       }, TestHelper.WAIT_DURATION);
       Assert.assertTrue(result);
       testListener.Reset();
@@ -179,7 +179,7 @@ public class TestZKCallback extends ZkUnitTestBase {
               .currentState("localhost_8900", testHelixManager.getSessionId(), curState.getId()),
           curState);
       result = TestHelper.verify(() -> {
-        return testListener.currentStateChangeReceived == true;
+        return testListener.currentStateChangeReceived;
       }, TestHelper.WAIT_DURATION);
       Assert.assertTrue(result);
       testListener.Reset();
@@ -190,7 +190,7 @@ public class TestZKCallback extends ZkUnitTestBase {
       idealState.setStateModelDefRef("StateModeldef");
       accessor.setProperty(keyBuilder.idealStates("db-1234"), idealState);
       result = TestHelper.verify(() -> {
-        return testListener.idealStateChangeReceived == true;
+        return testListener.idealStateChangeReceived;
       }, TestHelper.WAIT_DURATION);
       Assert.assertTrue(result);
       testListener.Reset();
@@ -219,7 +219,7 @@ public class TestZKCallback extends ZkUnitTestBase {
 
       accessor.setProperty(keyBuilder.message("localhost_8900", message.getId()), message);
       result = TestHelper.verify(() -> {
-        return testListener.messageChangeReceived == true;
+        return testListener.messageChangeReceived;
       }, TestHelper.WAIT_DURATION);
       Assert.assertTrue(result);
       testListener.Reset();
@@ -230,7 +230,7 @@ public class TestZKCallback extends ZkUnitTestBase {
       liveInstance.setHelixVersion(UUID.randomUUID().toString());
       accessor.setProperty(keyBuilder.liveInstance("localhost_9801"), liveInstance);
       result = TestHelper.verify(() -> {
-        return testListener.liveInstanceChangeReceived == true;
+        return testListener.liveInstanceChangeReceived;
       }, TestHelper.WAIT_DURATION);
       Assert.assertTrue(result);
       testListener.Reset();

--- a/helix-core/src/test/java/org/apache/helix/TestZKCallback.java
+++ b/helix-core/src/test/java/org/apache/helix/TestZKCallback.java
@@ -41,6 +41,7 @@ import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Message.MessageType;
 import org.apache.helix.tools.ClusterSetup;
+import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -165,8 +166,10 @@ public class TestZKCallback extends ZkUnitTestBase {
 
       ExternalView extView = new ExternalView("db-12345");
       accessor.setProperty(keyBuilder.externalView("db-12345"), extView);
-      Thread.sleep(100);
-      AssertJUnit.assertTrue(testListener.externalViewChangeReceived);
+      boolean result = TestHelper.verify(() -> {
+        return testListener.externalViewChangeReceived == true;
+      }, TestHelper.WAIT_DURATION);
+      Assert.assertTrue(result);
       testListener.Reset();
 
       CurrentState curState = new CurrentState("db-12345");
@@ -175,8 +178,10 @@ public class TestZKCallback extends ZkUnitTestBase {
       accessor.setProperty(keyBuilder
               .currentState("localhost_8900", testHelixManager.getSessionId(), curState.getId()),
           curState);
-      Thread.sleep(100);
-      AssertJUnit.assertTrue(testListener.currentStateChangeReceived);
+      result = TestHelper.verify(() -> {
+        return testListener.currentStateChangeReceived == true;
+      }, TestHelper.WAIT_DURATION);
+      Assert.assertTrue(result);
       testListener.Reset();
 
       IdealState idealState = new IdealState("db-1234");
@@ -184,8 +189,10 @@ public class TestZKCallback extends ZkUnitTestBase {
       idealState.setReplicas(Integer.toString(2));
       idealState.setStateModelDefRef("StateModeldef");
       accessor.setProperty(keyBuilder.idealStates("db-1234"), idealState);
-      Thread.sleep(100);
-      AssertJUnit.assertTrue(testListener.idealStateChangeReceived);
+      result = TestHelper.verify(() -> {
+        return testListener.idealStateChangeReceived == true;
+      }, TestHelper.WAIT_DURATION);
+      Assert.assertTrue(result);
       testListener.Reset();
 
       // dummyRecord = new ZNRecord("db-12345");
@@ -211,16 +218,21 @@ public class TestZKCallback extends ZkUnitTestBase {
       message.setStateModelFactoryName(HelixConstants.DEFAULT_STATE_MODEL_FACTORY);
 
       accessor.setProperty(keyBuilder.message("localhost_8900", message.getId()), message);
-      Thread.sleep(500);
-      AssertJUnit.assertTrue(testListener.messageChangeReceived);
+      result = TestHelper.verify(() -> {
+        return testListener.messageChangeReceived == true;
+      }, TestHelper.WAIT_DURATION);
+      Assert.assertTrue(result);
+      testListener.Reset();
 
       // dummyRecord = new ZNRecord("localhost_9801");
       LiveInstance liveInstance = new LiveInstance("localhost_9801");
       liveInstance.setSessionId(UUID.randomUUID().toString());
       liveInstance.setHelixVersion(UUID.randomUUID().toString());
       accessor.setProperty(keyBuilder.liveInstance("localhost_9801"), liveInstance);
-      Thread.sleep(500);
-      AssertJUnit.assertTrue(testListener.liveInstanceChangeReceived);
+      result = TestHelper.verify(() -> {
+        return testListener.liveInstanceChangeReceived == true;
+      }, TestHelper.WAIT_DURATION);
+      Assert.assertTrue(result);
       testListener.Reset();
 
       // dataAccessor.setNodeConfigs(recList); Thread.sleep(100);

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
@@ -155,15 +155,15 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     Assert.assertTrue(messages.get(0).getFromState().equalsIgnoreCase("SLAVE"));
     Assert.assertTrue(messages.get(0).getToState().equalsIgnoreCase("MASTER"));
 
-    runPipeline(event, dataRefresh, false);
 
-    // Verify the stale message should be deleted
+    Thread.sleep(2 * MessageGenerationPhase.DEFAULT_OBSELETE_MSG_PURGE_DELAY);
+    runPipeline(event, dataRefresh, false);
     Assert.assertTrue(TestHelper.verify(() -> {
       if (dataCache.getStaleMessages().size() != 0) {
         return false;
       }
       return true;
-    }, 2000));
+    }, TestHelper.WAIT_DURATION));
 
     deleteLiveInstances(clusterName);
     deleteCluster(clusterName);
@@ -216,7 +216,7 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
         }
       }
       return true;
-    }, 2000));
+    }, TestHelper.WAIT_DURATION));
 
     // round2: node0 and node1 update current states but not removing messages
     // Since controller's rebalancer pipeline will GC pending messages after timeout, and both hosts
@@ -238,7 +238,7 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
         }
       }
       return true;
-    }, 1000));
+    }, TestHelper.WAIT_DURATION));
 
     // After another purge delay, controller should cleanup messages and continue to rebalance
     Thread.sleep(msgPurgeDelay);
@@ -257,7 +257,7 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
         return false;
       }
       return true;
-    }, 2000));
+    }, TestHelper.WAIT_DURATION));
 
     // round3: node0 changes state to master, but failed to delete message,
     // controller will clean it up

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
@@ -155,9 +155,9 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     Assert.assertTrue(messages.get(0).getFromState().equalsIgnoreCase("SLAVE"));
     Assert.assertTrue(messages.get(0).getToState().equalsIgnoreCase("MASTER"));
 
-
     Thread.sleep(2 * MessageGenerationPhase.DEFAULT_OBSELETE_MSG_PURGE_DELAY);
     runPipeline(event, dataRefresh, false);
+    
     Assert.assertTrue(TestHelper.verify(() -> {
       if (dataCache.getStaleMessages().size() != 0) {
         return false;

--- a/helix-core/src/test/java/org/apache/helix/integration/TestDisableCustomCodeRunner.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestDisableCustomCodeRunner.java
@@ -180,7 +180,7 @@ public class TestDisableCustomCodeRunner extends ZkUnitTestBase {
         }
       }
       return true;
-    }, 10 * 1000);
+    }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result);
 
     // Change live-instance should not invoke any custom-code runner

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingMaxPartition.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingMaxPartition.java
@@ -121,6 +121,7 @@ public class TestClusterInMaintenanceModeWhenReachingMaxPartition extends ZkTest
       MaintenanceSignal ms = _dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
       return ms != null && ms.getReason() != null;
     }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result);
   }
 
   @AfterClass

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingMaxPartition.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingMaxPartition.java
@@ -117,10 +117,10 @@ public class TestClusterInMaintenanceModeWhenReachingMaxPartition extends ZkTest
       _participants.get(i).syncStop();
     }
 
-    Thread.sleep(1000L);
-    maintenanceSignal = _dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
-    Assert.assertNotNull(maintenanceSignal);
-    Assert.assertNotNull(maintenanceSignal.getReason());
+    boolean result = TestHelper.verify(() -> {
+      MaintenanceSignal ms = _dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
+      return ms != null && ms.getReason() != null;
+    }, TestHelper.WAIT_DURATION);
   }
 
   @AfterClass

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit.java
@@ -151,6 +151,7 @@ public class TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit exten
       MaintenanceSignal ms =_dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
       return ms != null && ms.getReason() != null;
     }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result);
 
     checkForRebalanceError(true);
 
@@ -176,17 +177,18 @@ public class TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit exten
       _participants.get(i).syncStop();
     }
 
-    Thread.sleep(500);
-
-    maintenanceSignal = _dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
-    Assert.assertNull(maintenanceSignal);
+    boolean result = TestHelper.verify(() -> {
+      MaintenanceSignal ms = _dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
+      return ms == null;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result);
 
     _participants.get(i).syncStop();
 
-    Thread.sleep(500);
-    maintenanceSignal = _dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
-    Assert.assertNotNull(maintenanceSignal);
-    Assert.assertNotNull(maintenanceSignal.getReason());
+    result = TestHelper.verify(() -> {
+      MaintenanceSignal ms =_dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
+      return ms != null && ms.getReason() != null;
+    }, TestHelper.WAIT_DURATION);
 
     // Verify there is rebalance error logged
     checkForRebalanceError(true);
@@ -217,7 +219,7 @@ public class TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit exten
       Long value =
           (Long) _server.getAttribute(getClusterMbeanName(CLUSTER_NAME), "RebalanceFailureGauge");
       return expectError == (value != null && value > 0);
-    }, 5000);
+    }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result);
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit.java
@@ -189,7 +189,8 @@ public class TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit exten
       MaintenanceSignal ms =_dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
       return ms != null && ms.getReason() != null;
     }, TestHelper.WAIT_DURATION);
-
+    Assert.assertTrue(result);
+    
     // Verify there is rebalance error logged
     checkForRebalanceError(true);
   }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/TestClusterStatusMonitorLifecycle.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/TestClusterStatusMonitorLifecycle.java
@@ -196,7 +196,7 @@ public class TestClusterStatusMonitorLifecycle extends ZkTestBase {
       mbeans.clear();
       mbeans.addAll(newMbeans);
       return newMbeans.size() == (previousMBeanCount - 2);
-    }, 3000));
+    }, TestHelper.WAIT_DURATION));
 
     HelixDataAccessor accessor = _participants[n - 1].getHelixDataAccessor();
     String firstControllerName =
@@ -226,7 +226,7 @@ public class TestClusterStatusMonitorLifecycle extends ZkTestBase {
       mbeans.clear();
       mbeans.addAll(newMbeans);
       return newMbeans.size() == (previousMBeanCount2 - 3);
-    }, 5000));
+    }, TestHelper.WAIT_DURATION));
 
     String instanceName = "localhost0_" + (12918);
     _participants[0] = new MockParticipantManager(ZK_ADDR, _firstClusterName, instanceName);
@@ -242,7 +242,7 @@ public class TestClusterStatusMonitorLifecycle extends ZkTestBase {
       mbeans.clear();
       mbeans.addAll(newMbeans);
       return newMbeans.size() == (previousMBeanCount3 + 2);
-    }, 3000));
+    }, TestHelper.WAIT_DURATION));
 
     // Add a resource
     // Register 1 resource mbean
@@ -263,7 +263,7 @@ public class TestClusterStatusMonitorLifecycle extends ZkTestBase {
       mbeans.clear();
       mbeans.addAll(newMbeans);
       return newMbeans.size() == (previousMBeanCount4 + _participants.length + 1);
-    }, 3000));
+    }, TestHelper.WAIT_DURATION));
 
     // Remove a resource
     // No change in instance/resource mbean
@@ -277,7 +277,7 @@ public class TestClusterStatusMonitorLifecycle extends ZkTestBase {
       mbeans.clear();
       mbeans.addAll(newMbeans);
       return newMbeans.size() == (previousMBeanCount5 - (_participants.length + 1));
-    }, 3000));
+    }, TestHelper.WAIT_DURATION));
 
     // Cleanup controllers then MBeans should all be removed.
     cleanupControllers();


### PR DESCRIPTION

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

fix #1446 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Quite some unit test still use Thread.sleep(xxx) to wait for a
condition to happen. This is a source of falkiness of test. This
may also make the test running unnecessarily long. We address
this issue with TestHelper.verify() method.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

https://github.com/apache/helix/runs/1218717184?check_suite_focus=true
See above link. All test passed.
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
