### PR TITLE
HelixClusterVerifier verify() with default waitTillVerify time -- part one

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/TestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/TestHelper.java
@@ -77,7 +77,7 @@ import org.testng.Assert;
 public class TestHelper {
   private static final Logger LOG = LoggerFactory.getLogger(TestHelper.class);
   public static final long WAIT_DURATION = 20 * 1000L; // 20 seconds
-
+  public static final int DEFAULT_REBALANCE_PROCESSING_WAIT_TIME = 1500;
   /**
    * Returns a unused random port.
    */

--- a/helix-core/src/test/java/org/apache/helix/controller/changedetector/TestResourceChangeDetector.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/changedetector/TestResourceChangeDetector.java
@@ -415,6 +415,8 @@ public class TestResourceChangeDetector extends ZkTestBase {
               .getChangesByType(ChangeType.INSTANCE_CONFIG).size() + changeDetector
               .getRemovalsByType(ChangeType.INSTANCE_CONFIG).size(), 0);
     } finally {
+      // remove newly added resource/ideastate
+      _gSetupTool.getClusterManagementTool().dropResource(CLUSTER_NAME, resourceName);
       instanceConfig.setInstanceEnabled(true);
       _dataAccessor.updateProperty(_keyBuilder.instanceConfig(instanceName), instanceConfig);
     }
@@ -424,9 +426,10 @@ public class TestResourceChangeDetector extends ZkTestBase {
   public void testResetSnapshots() {
     // ensure the cluster converged before the test to ensure IS is not modified unexpectedly
     HelixClusterVerifier _clusterVerifier =
-        new StrictMatchExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddress(ZK_ADDR)
+        new StrictMatchExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
             .setDeactivatedNodeAwareness(true)
             .setResources(new HashSet<>(_dataAccessor.getChildNames(_keyBuilder.idealStates())))
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
             .build();
     Assert.assertTrue(_clusterVerifier.verify());
 
@@ -438,7 +441,7 @@ public class TestResourceChangeDetector extends ZkTestBase {
     Assert.assertEquals(
         changeDetector.getAdditionsByType(ChangeType.IDEAL_STATE).size() + changeDetector
             .getChangesByType(ChangeType.IDEAL_STATE).size() + changeDetector
-            .getRemovalsByType(ChangeType.IDEAL_STATE).size(), 2);
+            .getRemovalsByType(ChangeType.IDEAL_STATE).size(), 1);
 
     // Update the detector with old data, since nothing changed, the result shall be empty.
     _dataProvider.notifyDataChange(ChangeType.IDEAL_STATE);
@@ -458,7 +461,7 @@ public class TestResourceChangeDetector extends ZkTestBase {
     Assert.assertEquals(
         changeDetector.getAdditionsByType(ChangeType.IDEAL_STATE).size() + changeDetector
             .getChangesByType(ChangeType.IDEAL_STATE).size() + changeDetector
-            .getRemovalsByType(ChangeType.IDEAL_STATE).size(), 2);
+            .getRemovalsByType(ChangeType.IDEAL_STATE).size(), 1);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/integration/TestAddClusterV2.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestAddClusterV2.java
@@ -21,6 +21,7 @@ package org.apache.helix.integration;
 
 import java.util.Date;
 
+import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.integration.manager.ClusterDistributedController;
 import org.apache.helix.integration.manager.MockParticipantManager;
@@ -136,11 +137,13 @@ public class TestAddClusterV2 extends ZkTestBase {
   private void verifyClusters() {
     ZkHelixClusterVerifier _clusterVerifier =
         new BestPossibleExternalViewVerifier.Builder(CONTROLLER_CLUSTER).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
             .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     _clusterVerifier =
         new BestPossibleExternalViewVerifier.Builder(CLUSTER_PREFIX + "_" + CLASS_NAME + "_0")
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
             .setZkClient(_gZkClient).build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/TestAddNodeAfterControllerStart.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestAddNodeAfterControllerStart.java
@@ -110,8 +110,10 @@ public class TestAddNodeAfterControllerStart extends ZkTestBase {
     _gSetupTool.activateCluster(clusterName, "GRAND_" + clusterName, true); // addCluster2
 
     BestPossibleExternalViewVerifier verifier =
-        new BestPossibleExternalViewVerifier.Builder(grandClusterName).setZkAddr(ZK_ADDR)
-            .setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(grandClusterName)
+            .setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier.verifyByPolling());
 
     // add node/resource, and do rebalance
@@ -124,8 +126,10 @@ public class TestAddNodeAfterControllerStart extends ZkTestBase {
     _gSetupTool.addResourceToCluster(clusterName, "TestDB0", 1, "LeaderStandby");
     _gSetupTool.rebalanceStorageCluster(clusterName, "TestDB0", 1);
     BestPossibleExternalViewVerifier verifier2 =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkAddr(ZK_ADDR)
-            .setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName)
+            .setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier2.verifyByPolling());
 
     MockParticipantManager[] participants = new MockParticipantManager[nodeNr];

--- a/helix-core/src/test/java/org/apache/helix/integration/TestAlertingRebalancerFailure.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestAlertingRebalancerFailure.java
@@ -109,7 +109,10 @@ public class TestAlertingRebalancerFailure extends ZkStandAloneCMTestBase {
     errorNodeKey = accessor.keyBuilder().controllerTaskError(RebalanceResourceFailure.name());
 
     _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
+            .setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
   }
 
   @BeforeMethod
@@ -132,7 +135,9 @@ public class TestAlertingRebalancerFailure extends ZkStandAloneCMTestBase {
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, testDb, 3);
     ZkHelixClusterVerifier verifier =
         new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
-            .setResources(new HashSet<>(Collections.singleton(testDb))).build();
+            .setResources(new HashSet<>(Collections.singleton(testDb)))
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier.verifyByPolling());
 
     // disable then enable the resource to ensure no rebalancing error is generated during this
@@ -173,7 +178,9 @@ public class TestAlertingRebalancerFailure extends ZkStandAloneCMTestBase {
         BuiltInStateModelDefinitions.MasterSlave.name(), RebalanceMode.FULL_AUTO.name(),
         CrushEdRebalanceStrategy.class.getName());
     ZkHelixClusterVerifier verifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
-        .setZkClient(_gZkClient).setResources(new HashSet<>(Collections.singleton(testDb))).build();
+        .setZkClient(_gZkClient).setResources(new HashSet<>(Collections.singleton(testDb)))
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
     _gSetupTool.getClusterManagementTool().rebalance(CLUSTER_NAME, testDb, 3);
     Assert.assertTrue(verifier.verifyByPolling());
 
@@ -230,7 +237,9 @@ public class TestAlertingRebalancerFailure extends ZkStandAloneCMTestBase {
         CrushRebalanceStrategy.class.getName());
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, testDb, replicas);
     ZkHelixClusterVerifier verifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
-        .setZkClient(_gZkClient).setResources(new HashSet<>(Collections.singleton(testDb))).build();
+        .setZkClient(_gZkClient).setResources(new HashSet<>(Collections.singleton(testDb)))
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
     Assert.assertTrue(verifier.verifyByPolling());
     // Verify there is no rebalance error logged
     Assert.assertNull(accessor.getProperty(errorNodeKey));

--- a/helix-core/src/test/java/org/apache/helix/integration/TestBucketizedResource.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestBucketizedResource.java
@@ -95,7 +95,10 @@ public class TestBucketizedResource extends ZkTestBase {
     PropertyKey evKey = accessor.keyBuilder().externalView(dbName);
 
     BestPossibleExternalViewVerifier _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkAddr(ZK_ADDR).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName)
+            .setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     ExternalView ev = accessor.getProperty(evKey);
@@ -148,7 +151,9 @@ public class TestBucketizedResource extends ZkTestBase {
     }
 
     ZkHelixClusterVerifier _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // bounce
@@ -184,7 +189,7 @@ public class TestBucketizedResource extends ZkTestBase {
         public boolean verify() {
           return !_baseAccessor.exists(evPath, 0);
         }
-      }, 3000);
+      }, TestHelper.WAIT_DURATION);
 
     boolean result = _baseAccessor.exists(evPath, 0);
     Assert.assertFalse(result);
@@ -236,7 +241,9 @@ public class TestBucketizedResource extends ZkTestBase {
     }
 
     ZkHelixClusterVerifier _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // add an external view listener
@@ -252,7 +259,7 @@ public class TestBucketizedResource extends ZkTestBase {
       @Override public boolean verify() throws Exception {
         return listener.cbCnt > 0;
       }
-    }, 20000);
+    }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(listener.cbCnt > 0);
 
     listener.cbCnt = 0;
@@ -276,7 +283,7 @@ public class TestBucketizedResource extends ZkTestBase {
       @Override public boolean verify() throws Exception {
         return listener.cbCnt > 0;
       }
-    }, 20000);
+    }, TestHelper.WAIT_DURATION);
 
     Assert.assertTrue(listener.cbCnt > 0);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestDisable.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestDisable.java
@@ -88,7 +88,9 @@ public class TestDisable extends ZkTestBase {
     }
 
     ZkHelixClusterVerifier _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // disable localhost_12918
@@ -162,7 +164,9 @@ public class TestDisable extends ZkTestBase {
     }
 
     ZkHelixClusterVerifier _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // disable localhost_12919
@@ -245,8 +249,10 @@ public class TestDisable extends ZkTestBase {
     }
 
     BestPossibleExternalViewVerifier _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkAddr(ZK_ADDR)
-            .setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName)
+            .setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // disable [TestDB0_0, TestDB0_5] on localhost_12919
@@ -325,7 +331,9 @@ public class TestDisable extends ZkTestBase {
     }
 
     ZkHelixClusterVerifier _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // disable [TestDB0_0, TestDB0_5] on localhost_12919

--- a/helix-core/src/test/java/org/apache/helix/integration/TestDriver.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestDriver.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.helix.HelixManager;
 import org.apache.helix.PropertyPathBuilder;
+import org.apache.helix.TestHelper;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
@@ -245,7 +246,10 @@ public class TestDriver {
     String clusterName = testInfo._clusterName;
 
     ZkHelixClusterVerifier verifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkAddr(ZK_ADDR).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName)
+            .setZkAddr(ZK_ADDR)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     try {
       Assert.assertTrue(verifier.verifyByPolling());
     } finally {

--- a/helix-core/src/test/java/org/apache/helix/integration/TestDrop.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestDrop.java
@@ -110,7 +110,9 @@ public class TestDrop extends ZkTestBase {
     }
 
     ZkHelixClusterVerifier verifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier.verifyByPolling());
 
     // Drop TestDB0
@@ -176,8 +178,9 @@ public class TestDrop extends ZkTestBase {
     errStateMap.get("TestDB0").put("TestDB0_8", "localhost_12918");
 
     ZkHelixClusterVerifier verifier = new BestPossibleExternalViewVerifier.Builder(clusterName)
-        .setZkClient(_gZkClient).setErrStates(errStateMap).build();
-    Assert.assertTrue(verifier.verifyByPolling());
+        .setZkClient(_gZkClient).setErrStates(errStateMap)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();    Assert.assertTrue(verifier.verifyByPolling());
 
     // drop resource containing error partitions should drop the partition successfully
     ClusterSetup.processCommandLineArgs(new String[] {
@@ -185,7 +188,10 @@ public class TestDrop extends ZkTestBase {
     });
 
     // make sure TestDB0_4 and TestDB0_8 partitions are dropped
-    verifier = new BestPossibleExternalViewVerifier.Builder(clusterName).setZkAddr(ZK_ADDR).build();
+    verifier = new BestPossibleExternalViewVerifier.Builder(clusterName)
+        .setZkClient(_gZkClient)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
     Assert.assertTrue(verifier.verifyByPolling());
 
     Thread.sleep(400);
@@ -249,7 +255,9 @@ public class TestDrop extends ZkTestBase {
     errStateMap.get("TestDB0").put("TestDB0_4", "localhost_12918");
 
     ZkHelixClusterVerifier verifier = new BestPossibleExternalViewVerifier.Builder(clusterName)
-        .setZkClient(_gZkClient).setErrStates(errStateMap).build();
+        .setZkClient(_gZkClient).setErrStates(errStateMap)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
     Assert.assertTrue(verifier.verifyByPolling());
 
     // drop resource containing error partitions should invoke error->dropped transition
@@ -258,7 +266,6 @@ public class TestDrop extends ZkTestBase {
         "--zkSvr", ZK_ADDR, "--dropResource", clusterName, "TestDB0"
     });
 
-    Thread.sleep(100L);
     // make sure TestDB0_4 stay in ERROR state and is disabled
     Assert.assertTrue(verifier.verifyByPolling());
 
@@ -372,7 +379,9 @@ public class TestDrop extends ZkTestBase {
     errStateMap.get("TestDB0").put("TestDB0_0", "localhost_12918");
 
     ZkHelixClusterVerifier verifier = new BestPossibleExternalViewVerifier.Builder(clusterName)
-        .setZkClient(_gZkClient).setErrStates(errStateMap).build();
+        .setZkClient(_gZkClient).setErrStates(errStateMap)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
     Assert.assertTrue(verifier.verifyByPolling());
 
     // drop resource containing error partitions should drop the partition successfully
@@ -381,7 +390,9 @@ public class TestDrop extends ZkTestBase {
     });
 
     // make sure TestDB0_0 partition is dropped
-    verifier = new BestPossibleExternalViewVerifier.Builder(clusterName).setZkAddr(ZK_ADDR).build();
+    verifier = new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
     Assert.assertTrue(verifier.verifyByPolling(), "Should be empty exeternal-view");
     Thread.sleep(400);
 
@@ -432,7 +443,9 @@ public class TestDrop extends ZkTestBase {
     }
 
     ZkHelixClusterVerifier verifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier.verifyByPolling());
 
     // add schemata resource group

--- a/helix-core/src/test/java/org/apache/helix/integration/TestEnableCompression.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestEnableCompression.java
@@ -47,6 +47,9 @@ import org.testng.annotations.Test;
  * idealstate of the resource. Generally this is used when the number of partitions is large
  */
 public class TestEnableCompression extends ZkTestBase {
+  private static final int ENABLE_COMPRESSION_WAIT = 20 * 60 * 1000;
+  private static final int ENABLE_COMPRESSION_POLL_INTERVAL = 2000;
+
   @Test()
   public void testEnableCompressionResource() throws Exception {
     String className = TestHelper.getTestClassName();
@@ -116,8 +119,7 @@ public class TestEnableCompression extends ZkTestBase {
             .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
             .build();
 
-    System.out.println("before TestEnableCompression verify by polling");
-    boolean reuslt = verifier.verifyByPolling(20 * 60 * 1000, 2000);
+    boolean reuslt = verifier.verifyByPolling(ENABLE_COMPRESSION_WAIT, ENABLE_COMPRESSION_POLL_INTERVAL);
     Assert.assertTrue((reuslt));
 
     List<String> compressedPaths = new ArrayList<>();

--- a/helix-core/src/test/java/org/apache/helix/integration/TestEnableCompression.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestEnableCompression.java
@@ -111,10 +111,14 @@ public class TestEnableCompression extends ZkTestBase {
     }
 
     BestPossibleExternalViewVerifier verifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkAddr(ZK_ADDR)
-            .setExpectLiveInstances(expectedLiveInstances).setResources(expectedResources).build();
-    boolean result = verifier.verify(120000L);
-    Assert.assertTrue(result);
+        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+            .setExpectLiveInstances(expectedLiveInstances).setResources(expectedResources)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+
+    System.out.println("before TestEnableCompression verify by polling");
+    boolean reuslt = verifier.verifyByPolling(20 * 60 * 1000, 2000);
+    Assert.assertTrue((reuslt));
 
     List<String> compressedPaths = new ArrayList<>();
     findCompressedZNodes(zkClient, "/" + clusterName, compressedPaths);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestErrorReplicaPersist.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestErrorReplicaPersist.java
@@ -23,6 +23,7 @@ import java.util.Date;
 
 import org.apache.helix.HelixRollbackException;
 import org.apache.helix.NotificationContext;
+import org.apache.helix.TestHelper;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
@@ -109,7 +110,9 @@ public class TestErrorReplicaPersist extends ZkStandAloneCMTestBase {
       _participants[i] = participant;
     }
     HelixClusterVerifier verifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(((BestPossibleExternalViewVerifier) verifier).verifyByPolling());
     for (int i = 0; i < (NODE_NR + 1) / 2; i++) {
       _gSetupTool.getClusterManagementTool()

--- a/helix-core/src/test/java/org/apache/helix/integration/TestNoThrottleDisabledPartitions.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestNoThrottleDisabledPartitions.java
@@ -330,7 +330,9 @@ public class TestNoThrottleDisabledPartitions extends ZkTestBase {
         new ClusterControllerManager(ZK_ADDR, _clusterName, "controller_0");
     controller.syncStart();
     BestPossibleExternalViewVerifier verifier =
-        new BestPossibleExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier.verify(3000));
 
     // Pause the controller

--- a/helix-core/src/test/java/org/apache/helix/integration/TestPartitionMovementThrottle.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestPartitionMovementThrottle.java
@@ -93,7 +93,10 @@ public class TestPartitionMovementThrottle extends ZkStandAloneCMTestBase {
     setupThrottleConfig();
 
     _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
+            .setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestRebalancerPersistAssignments.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestRebalancerPersistAssignments.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.helix.TestHelper;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
@@ -93,8 +94,9 @@ public class TestRebalancerPersistAssignments extends ZkStandAloneCMTestBase {
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, testDb, 3);
 
     BestPossibleExternalViewVerifier.Builder verifierBuilder =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
-            .setResources(new HashSet<>(Collections.singleton(testDb)));
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setResources(new HashSet<>(Collections.singleton(testDb)))
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME);
 
     Assert.assertTrue(verifierBuilder.build().verifyByPolling());
 
@@ -134,8 +136,9 @@ public class TestRebalancerPersistAssignments extends ZkStandAloneCMTestBase {
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, testDb, 3);
 
     BestPossibleExternalViewVerifier.Builder verifierBuilder =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
-            .setResources(new HashSet<>(Collections.singleton(testDb)));
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setResources(new HashSet<>(Collections.singleton(testDb)))
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME);
 
     Assert.assertTrue(verifierBuilder.build().verifyByPolling());
 
@@ -181,8 +184,9 @@ public class TestRebalancerPersistAssignments extends ZkStandAloneCMTestBase {
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, testDb, 3);
 
     BestPossibleExternalViewVerifier.Builder verifierBuilder =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
-            .setResources(new HashSet<>(Collections.singleton(testDb)));
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setResources(new HashSet<>(Collections.singleton(testDb)))
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME);
 
     Assert.assertTrue(verifierBuilder.build().verifyByPolling());
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestStateTransitionCancellation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestStateTransitionCancellation.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixRollbackException;
 import org.apache.helix.NotificationContext;
+import org.apache.helix.TestHelper;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.integration.task.MockTask;
@@ -64,7 +65,9 @@ public class TestStateTransitionCancellation extends TaskTestBase {
     _numNodes = 2;
     _numReplicas = 2;
     _verifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
 
     _gSetupTool.addCluster(CLUSTER_NAME, true);
     setupParticipants();

--- a/helix-core/src/test/java/org/apache/helix/integration/TestZkConnectionLost.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestZkConnectionLost.java
@@ -86,7 +86,9 @@ public class TestZkConnectionLost extends TaskTestBase {
     _controller.syncStart();
 
     ZkHelixClusterVerifier clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(_zkAddr).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(_zkAddr)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     try {
       Assert.assertTrue(clusterVerifier.verifyByPolling());
     } finally {

--- a/helix-core/src/test/java/org/apache/helix/integration/common/ZkStandAloneCMTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/common/ZkStandAloneCMTestBase.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
@@ -80,9 +81,10 @@ public class ZkStandAloneCMTestBase extends ZkTestBase {
     String controllerName = CONTROLLER_PREFIX + "_0";
     _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
     _controller.syncStart();
-    
-    _clusterVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    _clusterVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // create cluster manager
     _manager = HelixManagerFactory

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestControllerLeadershipChange.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestControllerLeadershipChange.java
@@ -30,6 +30,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyPathBuilder;
+import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
@@ -197,7 +198,9 @@ public class TestControllerLeadershipChange extends ZkTestBase {
 
     // Create cluster verifier
     ZkHelixClusterVerifier clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
 
     // Create participant
     _gSetupTool.addInstanceToCluster(clusterName, instanceName);

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestTargetExternalView.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestTargetExternalView.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.TestHelper;
 import org.apache.helix.integration.task.TaskTestBase;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ExternalView;
@@ -61,7 +62,9 @@ public class TestTargetExternalView extends TaskTestBase {
     _gSetupTool.getClusterManagementTool().rebalance(CLUSTER_NAME, _testDbs.get(0), 3);
 
     ZkHelixClusterVerifier verifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier.verifyByPolling());
 
     Assert.assertEquals(

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestWatcherLeakageOnController.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestWatcherLeakageOnController.java
@@ -22,6 +22,7 @@ package org.apache.helix.integration.controller;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.helix.TestHelper;
 import org.apache.helix.ZkTestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
@@ -43,7 +44,9 @@ public class TestWatcherLeakageOnController extends ZkTestBase {
   public void beforeClass() throws Exception {
     super.beforeClass();
     _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     _gSetupTool.addCluster(CLUSTER_NAME, true);
     _gSetupTool.addInstanceToCluster(CLUSTER_NAME, "TestInstance");
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, TEST_RESOURCE, 10, "MasterSlave");

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
@@ -103,7 +103,8 @@ public class TestParticipantManager extends ZkTestBase {
 
     BestPossibleExternalViewVerifier verifier =
         new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
-            .setZkAddr(ZK_ADDR).build();
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier.verifyByPolling());
 
     // cleanup
@@ -275,8 +276,8 @@ public class TestParticipantManager extends ZkTestBase {
 
     BestPossibleExternalViewVerifier verifier =
         new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
-            .setZkAddr(ZK_ADDR).build();
-    Assert.assertTrue(verifier.verifyByPolling());
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();    Assert.assertTrue(verifier.verifyByPolling());
     String oldSessionId = participants[0].getSessionId();
 
     // expire zk-connection on localhost_12918
@@ -357,7 +358,8 @@ public class TestParticipantManager extends ZkTestBase {
 
     BestPossibleExternalViewVerifier verifier =
         new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
-            .setZkAddr(ZK_ADDR).build();
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier.verifyByPolling());
 
     String newSessionId = participants[0].getSessionId();

--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestBatchMessageWrapper.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestBatchMessageWrapper.java
@@ -112,7 +112,9 @@ public class TestBatchMessageWrapper extends ZkUnitTestBase {
 
       // wait for each participant to complete state transitions, so we have deterministic results
       ZkHelixClusterVerifier _clusterVerifier =
-          new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient).build();
+          new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+              .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+              .build();
       Assert.assertTrue(_clusterVerifier.verifyByPolling(),
           "participant: " + instanceName + " fails to complete all transitions");
     }

--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestCrossClusterMessagingService.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestCrossClusterMessagingService.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import org.apache.helix.Criteria;
 import org.apache.helix.Criteria.DataSource;
 import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.messaging.AsyncCallback;
 import org.apache.helix.model.Message;
@@ -57,7 +58,9 @@ public class TestCrossClusterMessagingService extends TestMessagingService {
     _adminController.syncStart();
 
     ZkHelixClusterVerifier adminClusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(ADMIN_CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(ADMIN_CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(adminClusterVerifier.verifyByPolling());
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PMessageSemiAuto.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PMessageSemiAuto.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.integration.DelayedTransitionBase;
@@ -99,7 +100,9 @@ public class TestP2PMessageSemiAuto extends ZkTestBase {
     _controller.syncStart();
 
     _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     _configAccessor = new ConfigAccessor(_gZkClient);

--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PNoDuplicatedMessage.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PNoDuplicatedMessage.java
@@ -31,6 +31,7 @@ import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
@@ -116,7 +117,9 @@ public class TestP2PNoDuplicatedMessage extends ZkTestBase {
     _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, _controllerName);
     _controller.syncStart();
 
-    _clusterVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+    _clusterVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     _configAccessor = new ConfigAccessor(_gZkClient);

--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PSingleTopState.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PSingleTopState.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.NotificationContext;
+import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.DelayedTransitionBase;
@@ -113,7 +114,9 @@ public class TestP2PSingleTopState extends ZkTestBase {
     }
 
     _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
   }
 
@@ -133,11 +136,9 @@ public class TestP2PSingleTopState extends ZkTestBase {
     for (String ins : _instances) {
       System.out.println("Disable " + ins);
       _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, ins, false);
-      Thread.sleep(1000L);
       Assert.assertTrue(_clusterVerifier.verifyByPolling());
       System.out.println("Enable " + ins);
       _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, ins, true);
-      Thread.sleep(1000L);
       Assert.assertTrue(_clusterVerifier.verifyByPolling());
     }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -466,7 +466,9 @@ public class TestMultiZkHelixJavaApis {
       // Create a verifier to make sure all resources have been rebalanced
       ZkHelixClusterVerifier verifier =
           new BestPossibleExternalViewVerifier.Builder(cluster).setResources(resourceNames)
-              .setExpectLiveInstances(liveInstancesNames).build();
+              .setExpectLiveInstances(liveInstancesNames)
+              .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+              .build();
       try {
         Assert.assertTrue(verifier.verifyByPolling());
       } finally {

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/CrushRebalancers/TestCrushAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/CrushRebalancers/TestCrushAutoRebalance.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.strategy.CrushRebalanceStrategy;
@@ -128,11 +129,12 @@ public class TestCrushAutoRebalance extends ZkTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(300);
 
     ZkHelixClusterVerifier _clusterVerifier =
         new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
-            .setResources(_allDBs).build();
+            .setResources(_allDBs)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     for (String db : _allDBs) {
@@ -161,11 +163,12 @@ public class TestCrushAutoRebalance extends ZkTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(300);
 
     ZkHelixClusterVerifier _clusterVerifier =
         new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
-            .setResources(_allDBs).build();
+            .setResources(_allDBs)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     for (String db : _allDBs) {
@@ -201,10 +204,11 @@ public class TestCrushAutoRebalance extends ZkTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(100);
     ZkHelixClusterVerifier _clusterVerifier =
         new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
-            .setResources(_allDBs).build();
+            .setResources(_allDBs)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     for (String db : _allDBs) {
@@ -244,11 +248,12 @@ public class TestCrushAutoRebalance extends ZkTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(1000);
 
     ZkHelixClusterVerifier _clusterVerifier =
         new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
-            .setResources(_allDBs).build();
+            .setResources(_allDBs)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     for (String db : _allDBs) {

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/CrushRebalancers/TestCrushAutoRebalanceNonRack.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/CrushRebalancers/TestCrushAutoRebalanceNonRack.java
@@ -151,12 +151,17 @@ public class TestCrushAutoRebalanceNonRack extends ZkStandAloneCMTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(300);
 
     HelixClusterVerifier _clusterVerifier =
         new StrictMatchExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
-            .setDeactivatedNodeAwareness(true).setResources(_allDBs).build();
-    Assert.assertTrue(_clusterVerifier.verify(5000));
+            .setDeactivatedNodeAwareness(true).setResources(_allDBs)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    try {
+      Assert.assertTrue(_clusterVerifier.verify(5000));
+    } finally {
+      _clusterVerifier.close();
+    }
     for (String db : _allDBs) {
       IdealState is =
           _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
@@ -183,12 +188,17 @@ public class TestCrushAutoRebalanceNonRack extends ZkStandAloneCMTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(300);
 
     HelixClusterVerifier _clusterVerifier =
         new StrictMatchExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
-            .setDeactivatedNodeAwareness(true).setResources(_allDBs).build();
-    Assert.assertTrue(_clusterVerifier.verify(5000));
+            .setDeactivatedNodeAwareness(true).setResources(_allDBs)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    try {
+      Assert.assertTrue(_clusterVerifier.verify(5000));
+    } finally {
+      _clusterVerifier.close();
+    }
     for (String db : _allDBs) {
       IdealState is =
           _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
@@ -219,12 +229,17 @@ public class TestCrushAutoRebalanceNonRack extends ZkStandAloneCMTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(300);
 
     HelixClusterVerifier _clusterVerifier =
         new StrictMatchExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
-            .setDeactivatedNodeAwareness(true).setResources(_allDBs).build();
-    Assert.assertTrue(_clusterVerifier.verify(5000));
+            .setDeactivatedNodeAwareness(true).setResources(_allDBs)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    try {
+      Assert.assertTrue(_clusterVerifier.verify(5000));
+    } finally {
+      _clusterVerifier.close();
+    }
     for (String db : _allDBs) {
       IdealState is =
           _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
@@ -234,8 +249,11 @@ public class TestCrushAutoRebalanceNonRack extends ZkStandAloneCMTestBase {
     }
 
     for (int i = 2; i < _participants.size(); i++) {
-      _participants.get(i).syncStart();
-    }
+      MockParticipantManager p = _participants.get(i);
+      MockParticipantManager newNode =
+          new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, p.getInstanceName());
+      _participants.set(i, newNode);
+      newNode.syncStart();    }
   }
 
   @Test(dataProvider = "rebalanceStrategies", enabled = true, dependsOnMethods = {
@@ -271,10 +289,12 @@ public class TestCrushAutoRebalanceNonRack extends ZkStandAloneCMTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(300);
+
     ZkHelixClusterVerifier _clusterVerifier =
         new StrictMatchExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
-            .setDeactivatedNodeAwareness(true).setResources(_allDBs).build();
+            .setDeactivatedNodeAwareness(true).setResources(_allDBs)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     try {
       Assert.assertTrue(_clusterVerifier.verifyByPolling());
     } finally {

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalanceWithRackaware.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalanceWithRackaware.java
@@ -21,6 +21,7 @@ package org.apache.helix.integration.rebalancer.DelayedAutoRebalancer;
 
 import java.util.Date;
 
+import org.apache.helix.TestHelper;
 import org.apache.helix.controller.rebalancer.strategy.CrushRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
@@ -60,8 +61,9 @@ public class TestDelayedAutoRebalanceWithRackaware extends TestDelayedAutoRebala
     _controller.syncStart();
 
     _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR).build();
-  }
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();  }
 
   @Override
   protected IdealState createResourceWithDelayedRebalance(String clusterName, String db,

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/PartitionMigration/TestPartitionMigrationBase.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/PartitionMigration/TestPartitionMigrationBase.java
@@ -31,6 +31,7 @@ import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.PropertyKey;
+import org.apache.helix.TestHelper;
 import org.apache.helix.api.listeners.ExternalViewChangeListener;
 import org.apache.helix.api.listeners.IdealStateChangeListener;
 import org.apache.helix.common.ZkTestBase;
@@ -86,7 +87,9 @@ public class TestPartitionMigrationBase extends ZkTestBase {
     _controller.syncStart();
 
     _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
 
     enablePersistIntermediateAssignment(_gZkClient, CLUSTER_NAME, true);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/PartitionMigration/TestWagedRebalancerMigration.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/PartitionMigration/TestWagedRebalancerMigration.java
@@ -22,6 +22,7 @@ package org.apache.helix.integration.rebalancer.PartitionMigration;
 import java.util.Collections;
 
 import org.apache.helix.ConfigAccessor;
+import org.apache.helix.TestHelper;
 import org.apache.helix.controller.rebalancer.strategy.CrushRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.integration.manager.MockParticipantManager;
@@ -84,9 +85,11 @@ public class TestWagedRebalancerMigration extends TestPartitionMigrationBase {
       _participants.add(participant);
       Thread.sleep(100);
     }
-    Thread.sleep(2000);
+
     ZkHelixClusterVerifier clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(clusterVerifier.verifyByPolling());
 
     _migrationVerifier =
@@ -100,7 +103,7 @@ public class TestWagedRebalancerMigration extends TestPartitionMigrationBase {
     currentIdealState.setRebalancerClassName(WagedRebalancer.class.getName());
     _gSetupTool.getClusterManagementTool()
         .setResourceIdealState(CLUSTER_NAME, db, currentIdealState);
-    Thread.sleep(2000);
+
     Assert.assertTrue(clusterVerifier.verifyByPolling());
 
     Assert.assertFalse(_migrationVerifier.hasLessReplica());

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAbnormalStatesResolver.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAbnormalStatesResolver.java
@@ -89,7 +89,9 @@ public class TestAbnormalStatesResolver extends ZkStandAloneCMTestBase {
   @Test(dependsOnMethods = "testConfigureResolver")
   public void testExcessiveTopStateResolver() throws InterruptedException {
     BestPossibleExternalViewVerifier verifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier.verify());
 
     // 1. Find a partition with a MASTER replica and a SLAVE replica
@@ -135,10 +137,11 @@ public class TestAbnormalStatesResolver extends ZkStandAloneCMTestBase {
     // 2.A. Without resolver, the fixing is not completely done by the default rebalancer logic.
     _controller.getMessagingService()
         .sendAndWait(cr, msg, callback, (int) TestHelper.WAIT_DURATION);
-    Thread.sleep(DEFAULT_REBALANCE_PROCESSING_WAIT_TIME);
     // Wait until the partition status is fixed, verify if the result is as expected
     verifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier.verifyByPolling());
     ev = admin.getResourceExternalView(CLUSTER_NAME, TEST_DB);
     Assert.assertEquals(ev.getStateMap(targetPartition).values().stream()
@@ -158,7 +161,6 @@ public class TestAbnormalStatesResolver extends ZkStandAloneCMTestBase {
 
     _controller.getMessagingService()
         .sendAndWait(cr, msg, callback, (int) TestHelper.WAIT_DURATION);
-    Thread.sleep(DEFAULT_REBALANCE_PROCESSING_WAIT_TIME);
     // Wait until the partition status is fixed, verify if the result is as expected
     Assert.assertTrue(verifier.verifyByPolling());
     ev = admin.getResourceExternalView(CLUSTER_NAME, TEST_DB);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
@@ -169,19 +169,19 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
     // kill 1 node
     _participants[0].syncStop();
 
-    ZkHelixClusterVerifier verifierTestDb = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
+    ZkHelixClusterVerifier verifierClusterTestDb = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
         .setResources(new HashSet<>(Collections.singleton(TEST_DB)))
         .setZkClient(_gZkClient)
         .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
         .build();
-    Assert.assertTrue(verifierTestDb.verifyByPolling());
+    Assert.assertTrue(verifierClusterTestDb.verifyByPolling());
 
-    ZkHelixClusterVerifier verifierDb2 = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
+    ZkHelixClusterVerifier verifierClusterDb2 = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
         .setResources(new HashSet<>(Collections.singleton(db2)))
         .setZkClient(_gZkClient)
         .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
         .build();
-    Assert.assertTrue(verifierDb2.verifyByPolling());
+    Assert.assertTrue(verifierClusterDb2.verifyByPolling());
 
     // add 2 nodes
     for (int i = 0; i < 2; i++) {
@@ -193,8 +193,8 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
       _extraParticipants.add(participant);
       participant.syncStart();
     }
-    Assert.assertTrue(verifierTestDb.verifyByPolling());
-    Assert.assertTrue(verifierDb2.verifyByPolling());
+    Assert.assertTrue(verifierClusterTestDb.verifyByPolling());
+    Assert.assertTrue(verifierClusterDb2.verifyByPolling());
 
     HelixDataAccessor accessor =
         new ZKHelixDataAccessor(CLUSTER_NAME, new ZkBaseDataAccessor<>(_gZkClient));

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
@@ -19,6 +19,7 @@ package org.apache.helix.integration.rebalancer;
  * under the License.
  */
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,6 +43,8 @@ import org.apache.helix.model.IdealState.RebalanceMode;
 import org.apache.helix.tools.ClusterSetup;
 import org.apache.helix.tools.ClusterStateVerifier;
 import org.apache.helix.tools.ClusterStateVerifier.ZkVerifier;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
@@ -100,6 +103,7 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
     _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
     _controller.syncStart();
 
+    Thread.sleep(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME);
     boolean result = ClusterStateVerifier
         .verifyByZkCallback(new ExternalViewBalancedVerifier(_gZkClient, CLUSTER_NAME, TEST_DB));
 
@@ -126,6 +130,7 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
 
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, "MyDB", 1);
 
+    Thread.sleep(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME);
     boolean result = ClusterStateVerifier
         .verifyByZkCallback(new ExternalViewBalancedVerifier(_gZkClient, CLUSTER_NAME, "MyDB"));
     Assert.assertTrue(result);
@@ -164,9 +169,19 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
     // kill 1 node
     _participants[0].syncStop();
 
-    boolean result = ClusterStateVerifier
-        .verifyByZkCallback(new ExternalViewBalancedVerifier(_gZkClient, CLUSTER_NAME, TEST_DB));
-    Assert.assertTrue(result);
+    ZkHelixClusterVerifier verifierTestDb = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
+        .setResources(new HashSet<>(Collections.singleton(TEST_DB)))
+        .setZkClient(_gZkClient)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
+    Assert.assertTrue(verifierTestDb.verifyByPolling());
+
+    ZkHelixClusterVerifier verifierDb2 = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
+        .setResources(new HashSet<>(Collections.singleton(db2)))
+        .setZkClient(_gZkClient)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
+    Assert.assertTrue(verifierDb2.verifyByPolling());
 
     // add 2 nodes
     for (int i = 0; i < 2; i++) {
@@ -178,14 +193,9 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
       _extraParticipants.add(participant);
       participant.syncStart();
     }
-    Thread.sleep(100);
-    result = ClusterStateVerifier.verifyByPolling(
-        new ExternalViewBalancedVerifier(_gZkClient, CLUSTER_NAME, TEST_DB), 10000, 100);
-    Assert.assertTrue(result);
+    Assert.assertTrue(verifierTestDb.verifyByPolling());
+    Assert.assertTrue(verifierDb2.verifyByPolling());
 
-    result = ClusterStateVerifier
-        .verifyByZkCallback(new ExternalViewBalancedVerifier(_gZkClient, CLUSTER_NAME, db2));
-    Assert.assertTrue(result);
     HelixDataAccessor accessor =
         new ZKHelixDataAccessor(CLUSTER_NAME, new ZkBaseDataAccessor<>(_gZkClient));
     Builder keyBuilder = accessor.keyBuilder();

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingMaxPartition.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingMaxPartition.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
@@ -76,7 +77,9 @@ public class TestClusterInMaintenanceModeWhenReachingMaxPartition extends ZkTest
     _controller.syncStart();
 
     _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
 
     enablePersistBestPossibleAssignment(_gZkClient, CLUSTER_NAME, true);
     _dataAccessor = new ZKHelixDataAccessor(CLUSTER_NAME, _baseAccessor);
@@ -103,7 +106,7 @@ public class TestClusterInMaintenanceModeWhenReachingMaxPartition extends ZkTest
           replica, -1);
       _testDBs.add(db);
     }
-    Thread.sleep(100L);
+
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     MaintenanceSignal maintenanceSignal =

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestMixedModeAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestMixedModeAutoRebalance.java
@@ -52,7 +52,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class TestMixedModeAutoRebalance extends ZkTestBase {
+  public class TestMixedModeAutoRebalance extends ZkTestBase {
   private final int NUM_NODE = 5;
   private static final int START_PORT = 12918;
   private static final int _PARTITIONS = 5;
@@ -89,7 +89,9 @@ public class TestMixedModeAutoRebalance extends ZkTestBase {
     _controller.syncStart();
 
     _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
 
     enablePersistBestPossibleAssignment(_gZkClient, CLUSTER_NAME, true);
 
@@ -145,9 +147,6 @@ public class TestMixedModeAutoRebalance extends ZkTestBase {
           new ResourceConfig.Builder(dbName).setPreferenceLists(userDefinedPreferenceLists).build();
       _configAccessor.setResourceConfig(CLUSTER_NAME, dbName, resourceConfig);
 
-      // TODO remove this sleep after fix https://github.com/apache/helix/issues/526
-      Thread.sleep(500);
-
       Assert.assertTrue(_clusterVerifier.verify(3000));
       verifyUserDefinedPreferenceLists(dbName, userDefinedPreferenceLists,
           userDefinedPartitions);
@@ -160,7 +159,7 @@ public class TestMixedModeAutoRebalance extends ZkTestBase {
 
         removePartitionFromUserDefinedList(dbName, userDefinedPartitions);
         // TODO: Remove wait once we enable the BestPossibleExternalViewVerifier for the WAGED rebalancer.
-        Thread.sleep(1000);
+
         Assert.assertTrue(_clusterVerifier.verify(3000));
         verifyUserDefinedPreferenceLists(dbName, userDefinedPreferenceLists,
             userDefinedPartitions);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestZeroReplicaAvoidance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestZeroReplicaAvoidance.java
@@ -30,6 +30,7 @@ import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.IdealStateChangeListener;
 import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
+import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
@@ -78,7 +79,9 @@ public class TestZeroReplicaAvoidance extends ZkTestBase
     _controller.syncStart();
 
     _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
   }
 
   @AfterMethod
@@ -165,8 +168,7 @@ public class TestZeroReplicaAvoidance extends ZkTestBase
       String db = "Test-DB-" + stateModel;
       createResourceWithWagedRebalance(CLUSTER_NAME, db, stateModel, partition, replica, replica);
     }
-    // TODO remove this sleep after fix https://github.com/apache/helix/issues/526
-    Thread.sleep(1000);
+
     Assert.assertTrue(_clusterVerifier.verifyByPolling(50000L, 100L));
 
     _startListen = true;


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

fix #1448 part 1

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

    HelixClusterVerifier verify() and related method may return
    pre-maturely. The reason is that the verify the converging stable
    condition too early before controller has a chance to make
    change. Basically the previous stable state is mistaken as the
    expected next stable state.
    
    We fix this issue by adding waitTillVerify() timeout in
    construction time of verifier.

### Tests

- [ ] The following tests are written for this issue:

github run https://github.com/apache/helix/runs/1222609480?check_suite_focus=true
- [x] The following is the result of the "mvn test" command on the appropriate module:

2020-10-07T21:51:30.9005474Z 
2020-10-07T21:51:31.3163346Z [ERROR] Failures: 
2020-10-07T21:51:31.3164350Z [ERROR]   TestDisableCustomCodeRunner.test:236 expected:<false> but was:<true>
2020-10-07T21:51:31.3187463Z [ERROR]   TestTaskRebalancer.testNamedQueue » ThreadTimeout Method org.testng.internal.T...
2020-10-07T21:51:31.3189714Z [ERROR]   TestHelixAdminCli.testInstanceOperations:469 » Helix Failed to drop instance: ...
2020-10-07T21:51:31.3190815Z [ERROR] Tests run: 1212, Failures: 3, Errors: 0, Skipped: 4
2020-10-07T21:51:31.3310693Z [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.
2020-10-07T21:51:31.3311431Z [ERROR] 
2020-10-07T21:51:31.3312114Z [ERROR] Please refer to /home/runner/work/helix/helix/helix-core/target/surefire-reports for the individual test results.
2020-10-07T21:51:31.3312933Z [ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
2020-10-07T21:51:31.3313549Z [ERROR] -> [Help 1]
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
