### PR TITLE
testUpdateConfigFields failure

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -226,7 +226,6 @@ public class TestClusterAccessor extends AbstractTestClass {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String cluster = _clusters.iterator().next();
     ClusterConfig oldConfig = getClusterConfigFromRest(cluster);
-    System.out.println("config at beginning of testAddConfig:" + oldConfig.toString());
 
     ClusterConfig configDelta = new ClusterConfig(cluster);
     configDelta.getRecord().setSimpleField("newField", "newValue");
@@ -244,7 +243,6 @@ public class TestClusterAccessor extends AbstractTestClass {
     oldConfig.getRecord().update(configDelta.getRecord());
     Assert.assertEquals(newConfig, oldConfig,
         "cluster config from response: " + newConfig + " vs cluster config actually: " + oldConfig);
-    System.out.println("config at end testAddConfig:" + newConfig.toString());
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
@@ -254,8 +252,6 @@ public class TestClusterAccessor extends AbstractTestClass {
     String cluster = _clusters.iterator().next();
     ClusterConfig config = getClusterConfigFromRest(cluster);
 
-    System.out.println("new config:" + config.toString());
-
     ZNRecord record = config.getRecord();
 
     String key = record.getSimpleFields().keySet().iterator().next();
@@ -263,7 +259,15 @@ public class TestClusterAccessor extends AbstractTestClass {
     record.getSimpleFields().clear();
     record.setSimpleField(key, value + "--updated");
 
-    key = record.getListFields().keySet().iterator().next();
+    // skip INSTANCE_CAPACITY_KEYS which can be added by waged rebalancer in global run
+    Iterator<String> itListField = record.getListFields().keySet().iterator();
+    while (itListField.hasNext()) {
+      key = itListField.next();
+      if (key.equals("ListField1")) {
+        break;
+      }
+    }
+
     List<String> list = record.getListField(key);
     list.remove(0);
     list.add("newValue--updated");
@@ -302,7 +306,16 @@ public class TestClusterAccessor extends AbstractTestClass {
     record.getSimpleFields().clear();
     record.setSimpleField(simpleKey, value);
 
-    String listKey = record.getListFields().keySet().iterator().next();
+    String listKey = null;
+    // skip INSTANCE_CAPACITY_KEYS which can be added by waged rebalancer in global run
+    Iterator<String> itListField = record.getListFields().keySet().iterator();
+    while (itListField.hasNext()) {
+      listKey = itListField.next();
+      if (listKey.equals("ListField1")) {
+        break;
+      }
+    }
+    Assert.assertTrue(listKey != null);
     List<String> list = record.getListField(listKey);
     record.getListFields().clear();
     record.setListField(listKey, list);

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -243,6 +243,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     oldConfig.getRecord().update(configDelta.getRecord());
     Assert.assertEquals(newConfig, oldConfig,
         "cluster config from response: " + newConfig + " vs cluster config actually: " + oldConfig);
+    System.out.println("new config:" + newConfig.toString());
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
@@ -251,6 +252,8 @@ public class TestClusterAccessor extends AbstractTestClass {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String cluster = _clusters.iterator().next();
     ClusterConfig config = getClusterConfigFromRest(cluster);
+    
+    System.out.println("new config:" + config.toString());
 
     ZNRecord record = config.getRecord();
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -226,6 +226,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String cluster = _clusters.iterator().next();
     ClusterConfig oldConfig = getClusterConfigFromRest(cluster);
+    System.out.println("config at beginning of testAddConfig:" + oldConfig.toString());
 
     ClusterConfig configDelta = new ClusterConfig(cluster);
     configDelta.getRecord().setSimpleField("newField", "newValue");
@@ -243,7 +244,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     oldConfig.getRecord().update(configDelta.getRecord());
     Assert.assertEquals(newConfig, oldConfig,
         "cluster config from response: " + newConfig + " vs cluster config actually: " + oldConfig);
-    System.out.println("new config:" + newConfig.toString());
+    System.out.println("config at end testAddConfig:" + newConfig.toString());
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
@@ -252,7 +253,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String cluster = _clusters.iterator().next();
     ClusterConfig config = getClusterConfigFromRest(cluster);
-    
+
     System.out.println("new config:" + config.toString());
 
     ZNRecord record = config.getRecord();


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

fix #1336 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

   The test becomes flaky due to waged rebalancer would add INSTANCE_CAPACITY_KEYS
    list field after global calculation. To the test, this means sometime a
    "magic" INSTANCE_CAPACITY_KEYS would appear, depend on timing. Here we fix this
    issue by skip this key for the failed test.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

https://github.com/apache/helix/runs/1246249153?check_suite_focus=true
This test now pass github run too.

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
