### PR TITLE
thread leakage checker and memory usage reporter #1226

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/ThreadLeakageChecker.java
+++ b/helix-core/src/test/java/org/apache/helix/ThreadLeakageChecker.java
@@ -176,6 +176,8 @@ public class ThreadLeakageChecker {
       });
     });
 
+    // todo: We should make the following System.out as LOG.INfO once we achieve 0 thread leakage.
+    // todo: also the calling point of this method would fail the test
     // step 3: enforce checking policy
     boolean checkStatus = true;
     for (ThreadCategory threadCategory : ThreadCategory.values()) {

--- a/helix-core/src/test/java/org/apache/helix/ThreadLeakageChecker.java
+++ b/helix-core/src/test/java/org/apache/helix/ThreadLeakageChecker.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.helix;
 
 import java.util.ArrayList;
@@ -33,20 +52,20 @@ public class ThreadLeakageChecker {
     return Arrays.asList(Arrays.copyOf(threads, count));
   }
 
-  private static final String[] ZkServerThrdPattern =
+  private static final String[] ZKSERVER_THRD_PATTERN =
       {"SessionTracker", "NIOServerCxn", "SyncThread:", "ProcessThread"};
-  private static final String[] ZkSessionThrdPattern =
+  private static final String[] ZKSESSION_THRD_PATTERN =
       new String[]{"ZkClient-EventThread", "ZkClient-AsyncCallback", "-EventThread", "-SendThread"};
-  private static final String[] ForkJoinThrdPattern = new String[]{"ForkJoinPool"};
-  private static final String[] TimerThrdPattern = new String[]{"time"};
-  private static final String[] TaskStateModelThrdPattern = new String[]{"TaskStateModel"};
+  private static final String[] FORKJOIN_THRD_PATTERN = new String[]{"ForkJoinPool"};
+  private static final String[] TIMER_THRD_PATTERN = new String[]{"time"};
+  private static final String[] TASKSTATEMODEL_THRD_PATTERN = new String[]{"TaskStateModel"};
 
   private static enum ThreadCategory {
-    ZkServer("zookeeper server threads", 4, 100, ZkServerThrdPattern),
-    ZkSession("zkclient/zooKeeper session threads", 12, 12, ZkSessionThrdPattern),
-    ForkJoin("fork join pool threads", 2, 100, ForkJoinThrdPattern),
-    Timer("timer threads", 0, 2, TimerThrdPattern),
-    TaskStateModel("TaskStateModel threads", 0, 0, TaskStateModelThrdPattern),
+    ZkServer("zookeeper server threads", 4, 100, ZKSERVER_THRD_PATTERN),
+    ZkSession("zkclient/zooKeeper session threads", 12, 12, ZKSESSION_THRD_PATTERN),
+    ForkJoin("fork join pool threads", 2, 100, FORKJOIN_THRD_PATTERN),
+    Timer("timer threads", 0, 2, TIMER_THRD_PATTERN),
+    TaskStateModel("TaskStateModel threads", 0, 0, TASKSTATEMODEL_THRD_PATTERN),
     Other("Other threads", 0, 2, new String[]{""});
 
     private String _description;

--- a/helix-core/src/test/java/org/apache/helix/ThreadLeakageChecker.java
+++ b/helix-core/src/test/java/org/apache/helix/ThreadLeakageChecker.java
@@ -44,10 +44,10 @@ public class ThreadLeakageChecker {
   private static enum ThreadCategory {
     ZkServer("zookeeper server threads", 4, 100, ZkServerThrdPattern),
     ZkSession("zkclient/zooKeeper session threads", 12, 12, ZkSessionThrdPattern),
-    ForkJoin("fork join pool threads", 2, 10, ForkJoinThrdPattern),
+    ForkJoin("fork join pool threads", 2, 100, ForkJoinThrdPattern),
     Timer("timer threads", 0, 2, TimerThrdPattern),
     TaskStateModel("TaskStateModel threads", 0, 0, TaskStateModelThrdPattern),
-    Other("Other threads", 0, 3, new String[]{""});
+    Other("Other threads", 0, 2, new String[]{""});
 
     private String _description;
     private List<String> _pattern;
@@ -145,25 +145,25 @@ public class ThreadLeakageChecker {
       int limit = threadCategory.getLimit();
       int warningLimit = threadCategory.getWarningLimit();
 
-      Integer catThreadCnt = threadByCnt.get(threadCategory);
-      if (catThreadCnt != null) {
+      Integer categoryThreadCnt = threadByCnt.get(threadCategory);
+      if (categoryThreadCnt != null) {
         boolean dumpThread = false;
-        if (catThreadCnt > limit) {
+        if (categoryThreadCnt > limit) {
           checkStatus = false;
           System.out.println(
-              "Failure " + threadCategory.getDescription() + " has " + catThreadCnt + " thread");
+              "Failure " + threadCategory.getDescription() + " has " + categoryThreadCnt + " thread");
           dumpThread = true;
-        } else if (catThreadCnt > warningLimit) {
+        } else if (categoryThreadCnt > warningLimit) {
           System.out.println(
-              "Warning " + threadCategory.getDescription() + " has " + catThreadCnt + " thread");
+              "Warning " + threadCategory.getDescription() + " has " + categoryThreadCnt + " thread");
           dumpThread = true;
         } else {
-          System.out.println(threadCategory.getDescription() + " has " + catThreadCnt + " thread");
+          System.out.println(threadCategory.getDescription() + " has " + categoryThreadCnt + " thread");
         }
         if (!dumpThread) {
           continue;
         }
-        // print first 10 thread names
+        // print first 100 thread names
         int i = 0;
         for (Thread t : threadByCat.get(threadCategory)) {
           System.out.println(i + " thread:" + t.getName());

--- a/helix-core/src/test/java/org/apache/helix/ThreadLeakageChecker.java
+++ b/helix-core/src/test/java/org/apache/helix/ThreadLeakageChecker.java
@@ -1,0 +1,181 @@
+package org.apache.helix;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.helix.common.ZkTestBase;
+
+
+public class ThreadLeakageChecker {
+  private static ThreadGroup getRootThreadGroup() {
+    ThreadGroup candidate = Thread.currentThread().getThreadGroup();
+    while (candidate.getParent() != null) {
+      candidate = candidate.getParent();
+    }
+    return candidate;
+  }
+
+  private static List<Thread> getAllThreads() {
+    ThreadGroup rootThreadGroup = getRootThreadGroup();
+    Thread[] threads = new Thread[32];
+    int count = rootThreadGroup.enumerate(threads);
+    while (count == threads.length) {
+      threads = new Thread[threads.length * 2];
+      count = rootThreadGroup.enumerate(threads);
+    }
+    return Arrays.asList(Arrays.copyOf(threads, count));
+  }
+
+  private static final String[] ZkServerThrdPattern =
+      {"SessionTracker", "NIOServerCxn", "SyncThread:", "ProcessThread"};
+  private static final String[] ZkSessionThrdPattern =
+      new String[]{"ZkClient-EventThread", "ZkClient-AsyncCallback", "-EventThread", "-SendThread"};
+  private static final String[] ForkJoinThrdPattern = new String[]{"ForkJoinPool"};
+  private static final String[] TimerThrdPattern = new String[]{"time"};
+  private static final String[] TaskStateModelThrdPattern = new String[]{"TaskStateModel"};
+
+  private static enum ThreadCategory {
+    ZkServer("zookeeper server threads", 4, 100, ZkServerThrdPattern),
+    ZkSession("zkclient/zooKeeper session threads", 12, 12, ZkSessionThrdPattern),
+    ForkJoin("fork join pool threads", 2, 10, ForkJoinThrdPattern),
+    Timer("timer threads", 0, 2, TimerThrdPattern),
+    TaskStateModel("TaskStateModel threads", 0, 0, TaskStateModelThrdPattern),
+    Other("Other threads", 0, 3, new String[]{""});
+
+    private String _description;
+    private List<String> _pattern;
+    private int _warningLimit;
+    private int _limit;
+
+    public String getDescription() {
+      return _description;
+    }
+
+    public Predicate<String> getMatchPred() {
+      if (this.name() != ThreadCategory.Other.name()) {
+        Predicate<String> pred = target -> {
+          for (String p : _pattern) {
+            if (target.toLowerCase().contains(p.toLowerCase())) {
+              return true;
+            }
+          }
+          return false;
+        };
+        return pred;
+      }
+
+      List<Predicate<String>> predicateList = new ArrayList<>();
+      for (ThreadCategory threadCategory : ThreadCategory.values()) {
+        if (threadCategory == ThreadCategory.Other) {
+          continue;
+        }
+        predicateList.add(threadCategory.getMatchPred());
+      }
+      Predicate<String> pred = target -> {
+        for (Predicate<String> p : predicateList) {
+          if (p.test(target)) {
+            return false;
+          }
+        }
+        return true;
+      };
+
+      return pred;
+    }
+
+    public int getWarningLimit() {
+      return _warningLimit;
+    }
+
+    public int getLimit() {
+      return _limit;
+    }
+
+    private ThreadCategory(String description, int warningLimit, int limit, String[] patterns) {
+      _description = description;
+      _pattern = Arrays.asList(patterns);
+      _warningLimit = warningLimit;
+      _limit = limit;
+    }
+  }
+
+  public static boolean afterClassCheck(String classname) {
+    ZkTestBase.reportPhysicalMemory();
+    // step 1: get all active threads
+    List<Thread> threads = getAllThreads();
+    System.out.println(classname + " has active threads cnt:" + threads.size());
+
+    // step 2: categorize threads
+    Map<String, List<Thread>> threadByName = null;
+    Map<ThreadCategory, Integer> threadByCnt = new HashMap<>();
+    Map<ThreadCategory, Set<Thread>> threadByCat = new HashMap<>();
+    try {
+      threadByName = threads.
+          stream().
+          filter(p -> p.getThreadGroup() != null && p.getThreadGroup().getName() != null
+              &&  ! "system".equals(p.getThreadGroup().getName())).
+          collect(Collectors.groupingBy(p -> p.getName()));
+    } catch (Exception e) {
+      System.out.println("filtering thread failure with exception:" + e.getStackTrace());
+    }
+
+    threadByName.entrySet().stream().forEach(entry -> {
+      String key = entry.getKey(); // thread name
+      Arrays.asList(ThreadCategory.values()).stream().forEach(category -> {
+        if (category.getMatchPred().test(key)) {
+          Integer count = threadByCnt.containsKey(category) ? threadByCnt.get(category) : 0;
+          threadByCnt.put(category, count + entry.getValue().size());
+          Set<Thread> thisSet = threadByCat.getOrDefault(category, new HashSet<>());
+          thisSet.addAll(entry.getValue());
+          threadByCat.put(category, thisSet);
+        }
+      });
+    });
+
+    // step 3: enforce checking policy
+    boolean checkStatus = true;
+    for (ThreadCategory threadCategory : ThreadCategory.values()) {
+      int limit = threadCategory.getLimit();
+      int warningLimit = threadCategory.getWarningLimit();
+
+      Integer catThreadCnt = threadByCnt.get(threadCategory);
+      if (catThreadCnt != null) {
+        boolean dumpThread = false;
+        if (catThreadCnt > limit) {
+          checkStatus = false;
+          System.out.println(
+              "Failure " + threadCategory.getDescription() + " has " + catThreadCnt + " thread");
+          dumpThread = true;
+        } else if (catThreadCnt > warningLimit) {
+          System.out.println(
+              "Warning " + threadCategory.getDescription() + " has " + catThreadCnt + " thread");
+          dumpThread = true;
+        } else {
+          System.out.println(threadCategory.getDescription() + " has " + catThreadCnt + " thread");
+        }
+        if (!dumpThread) {
+          continue;
+        }
+        // print first 10 thread names
+        int i = 0;
+        for (Thread t : threadByCat.get(threadCategory)) {
+          System.out.println(i + " thread:" + t.getName());
+          i++;
+          if (i == 100) {
+            System.out.println(" skipping the rest");
+            break;
+          }
+        }
+      }
+    }
+
+    return checkStatus;
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
@@ -727,7 +727,6 @@ public class ZkTestBase {
   @AfterClass
   public void cleanupLiveInstanceOwners() throws InterruptedException {
     String testClassName = this.getShortClassName();
-    System.out.println("AfterClass:" + testClassName + " afterclass of ZkTestBase called!");
     for (String cluster : _liveInstanceOwners.keySet()) {
       Map<String, HelixZkClient> clientMap = _liveInstanceOwners.get(cluster);
       for (HelixZkClient client : clientMap.values()) {
@@ -741,7 +740,7 @@ public class ZkTestBase {
     try {
       status = ThreadLeakageChecker.afterClassCheck(testClassName);
     } catch (Exception e) {
-      System.out.println("ThreadLeakageChecker exception:" + e.getStackTrace());
+      LOG.error("ThreadLeakageChecker exception:", e);
     }
     // Assert here does not work.
     if (!status) {

--- a/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
@@ -742,7 +742,7 @@ public class ZkTestBase {
     } catch (Exception e) {
       LOG.error("ThreadLeakageChecker exception:", e);
     }
-    // Assert here does not work.
+    // todo: We should fail test here once we achieved 0 leakage and remove the following System print
     if (!status) {
       System.out.println("---------- Test Class " + testClassName + " thread leakage detected! ---------------");
     }

--- a/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
@@ -33,7 +33,6 @@ import java.util.logging.Level;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
-import bsh.This;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;

--- a/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
@@ -135,7 +135,7 @@ public class ZkTestBase {
     long physicalMemorySize = os.getTotalPhysicalMemorySize();
     System.out.println("************ SYSTEM Physical Memory:"  + physicalMemorySize);
 
-    int MB = 1024 * 1024;
+    long MB = 1024 * 1024;
     Runtime runtime = Runtime.getRuntime();
     long free = runtime.freeMemory()/MB;
     long total = runtime.totalMemory()/MB;

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -45,6 +45,7 @@ import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ThreadLeakageChecker;
 import org.apache.helix.api.config.RebalanceConfig;
+import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
@@ -84,6 +85,8 @@ import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
 import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
 import org.apache.helix.zookeeper.routing.RoutingDataManager;
 import org.apache.helix.zookeeper.zkclient.ZkServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -96,6 +99,7 @@ import org.testng.annotations.Test;
  * This test verifies that all Helix Java APIs work as expected.
  */
 public class TestMultiZkHelixJavaApis {
+  private static Logger LOG = LoggerFactory.getLogger(TestMultiZkHelixJavaApis.class);
   private static final int NUM_ZK = 3;
   private static final Map<String, ZkServer> ZK_SERVER_MAP = new HashMap<>();
   private static final Map<String, HelixZkClient> ZK_CLIENT_MAP = new HashMap<>();
@@ -172,7 +176,7 @@ public class TestMultiZkHelixJavaApis {
   @AfterClass
   public void afterClass() throws Exception {
     String testClassName = getClass().getSimpleName();
-    
+
     try {
       // Kill all mock controllers and participants
       MOCK_CONTROLLERS.values().forEach(ClusterControllerManager::syncStop);
@@ -224,7 +228,7 @@ public class TestMultiZkHelixJavaApis {
     try {
       status = ThreadLeakageChecker.afterClassCheck(testClassName);
     } catch (Exception e) {
-      System.out.println("ThreadLeakageChecker exception:" + e.getStackTrace());
+      LOG.error("ThreadLeakageChecker exception:", e);
     }
     // Assert here does not work.
     if (!status) {

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -172,8 +172,7 @@ public class TestMultiZkHelixJavaApis {
   @AfterClass
   public void afterClass() throws Exception {
     String testClassName = getClass().getSimpleName();
-    System.out.println("AfterClass: " + testClassName + " of TestMultiZkHelixJavaApis called.");
-
+    
     try {
       // Kill all mock controllers and participants
       MOCK_CONTROLLERS.values().forEach(ClusterControllerManager::syncStop);

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -43,6 +43,7 @@ import org.apache.helix.HelixManagerProperty;
 import org.apache.helix.InstanceType;
 import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.TestHelper;
+import org.apache.helix.ThreadLeakageChecker;
 import org.apache.helix.api.config.RebalanceConfig;
 import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
@@ -170,6 +171,9 @@ public class TestMultiZkHelixJavaApis {
 
   @AfterClass
   public void afterClass() throws Exception {
+    String testClassName = getClass().getSimpleName();
+    System.out.println("AfterClass: " + testClassName + " of TestMultiZkHelixJavaApis called.");
+
     try {
       // Kill all mock controllers and participants
       MOCK_CONTROLLERS.values().forEach(ClusterControllerManager::syncStop);
@@ -215,6 +219,17 @@ public class TestMultiZkHelixJavaApis {
       } else {
         System.clearProperty(MetadataStoreRoutingConstants.MSDS_SERVER_ENDPOINT_KEY);
       }
+    }
+
+    boolean status = false;
+    try {
+      status = ThreadLeakageChecker.afterClassCheck(testClassName);
+    } catch (Exception e) {
+      System.out.println("ThreadLeakageChecker exception:" + e.getStackTrace());
+    }
+    // Assert here does not work.
+    if (!status) {
+      System.out.println("---------- Test Class " + testClassName + " thread leakage detected! ---------------");
     }
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -230,7 +230,7 @@ public class TestMultiZkHelixJavaApis {
     } catch (Exception e) {
       LOG.error("ThreadLeakageChecker exception:", e);
     }
-    // Assert here does not work.
+    // todo: We should fail test here once we achieved 0 leakage and remove the following System print
     if (!status) {
       System.out.println("---------- Test Class " + testClassName + " thread leakage detected! ---------------");
     }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

fix #1226

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add thread leakage checker and memory usage reporter. The two
utility would be invoke before and after test classes. The would
help to detect/monitor resource/memory usage of the unit test.
### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

2020-10-08T07:55:24.0931119Z 
2020-10-08T07:55:24.4922133Z [ERROR] Failures: 
2020-10-08T07:55:24.4923510Z [ERROR]   TestDisableCustomCodeRunner.test:236 expected:<false> but was:<true>
2020-10-08T07:55:24.4925729Z [ERROR]   TestClusterStatusMonitorLifecycle.testClusterStatusMonitorLifecycle:290 expected:<true> but was:<false>
2020-10-08T07:55:24.4928050Z [ERROR] Tests run: 1213, Failures: 2, Errors: 0, Skipped: 0
re-run would work.

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
