### PR TITLE
Fix task related flaky test due to phantom read (WIP)

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/task/TaskTestUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TaskTestUtil.java
@@ -239,15 +239,15 @@ public class TaskTestUtil {
 
   public static JobQueue.Builder buildJobQueue(String jobQueueName, int delayStart,
       int failureThreshold, int capacity) {
-    return buildJobQueue(jobQueueName, delayStart, failureThreshold, capacity, false);
+    return buildJobQueue(jobQueueName, delayStart, failureThreshold, capacity, true);
   }
 
   public static JobQueue.Builder buildJobQueue(String jobQueueName, int delayStart,
-      int failureThreshold, int capacity, boolean disablePurge) {
+      int failureThreshold, int capacity, boolean doPurge) {
     WorkflowConfig.Builder workflowCfgBuilder = new WorkflowConfig.Builder(jobQueueName);
     workflowCfgBuilder.setExpiry(120000);
     workflowCfgBuilder.setCapacity(capacity);
-    if (disablePurge) {
+    if (!doPurge) {
       workflowCfgBuilder.setJobPurgeInterval(-1);
     }
 
@@ -264,8 +264,8 @@ public class TaskTestUtil {
   }
 
   public static JobQueue.Builder buildJobQueue(String jobQueueName, int delayStart,
-      int failureThreshold, boolean disablePurge) {
-    return buildJobQueue(jobQueueName, delayStart, failureThreshold, 500, disablePurge);
+      int failureThreshold, boolean doPurge) {
+    return buildJobQueue(jobQueueName, delayStart, failureThreshold, 500, doPurge);
   }
 
   public static JobQueue.Builder buildJobQueue(String jobQueueName, int delayStart,

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TaskTestUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TaskTestUtil.java
@@ -68,7 +68,7 @@ import org.testng.Assert;
  * Static test utility methods.
  */
 public class TaskTestUtil {
-  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(TaskTestUtil.class);
+  private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(TaskTestUtil.class);
   public static final String JOB_KW = "JOB";
   private final static int _default_timeout = 2 * 60 * 1000; /* 2 mins */
 
@@ -178,7 +178,7 @@ public class TaskTestUtil {
     boolean retVal =  maxRunningCount > 1 && (workflowConfig.isJobQueue() ? maxRunningCount <= workflowConfig
         .getParallelJobs() : true);
     if (!retVal) {
-      logger.error("maxRunningCount={}, workflowConfig.isJobQueue()={}, maxRunningCount={}, workflowConfig.getParallelJobs()={}, workFlowConfig={}, stack trace {}",
+      LOG.error("maxRunningCount={}, workflowConfig.isJobQueue()={}, maxRunningCount={}, workflowConfig.getParallelJobs()={}, workFlowConfig={}, stack trace {}",
           maxRunningCount, workflowConfig.isJobQueue(), maxRunningCount, workflowConfig.getParallelJobs(),
           workflowConfig);
     }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestBatchAddJobs.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestBatchAddJobs.java
@@ -87,7 +87,7 @@ public class TestBatchAddJobs extends ZkTestBase {
   @AfterClass
   public void afterClass() {
     String testClassName = this.getShortClassName();
-    System.out.println("AfterClass: " + testClassName + " of TestBachAddJobs called.");
+    System.out.println("AfterClass: " + testClassName + " called.");
 
     for (SubmitJobTask submitJobTask : _submitJobTasks) {
       submitJobTask.interrupt();

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestBatchAddJobs.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestBatchAddJobs.java
@@ -86,6 +86,9 @@ public class TestBatchAddJobs extends ZkTestBase {
 
   @AfterClass
   public void afterClass() {
+    String testClassName = this.getShortClassName();
+    System.out.println("AfterClass: " + testClassName + " of TestBachAddJobs called.");
+
     for (SubmitJobTask submitJobTask : _submitJobTasks) {
       submitJobTask.interrupt();
       submitJobTask.cleanup();

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestDeleteJobFromJobQueue.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestDeleteJobFromJobQueue.java
@@ -69,11 +69,18 @@ public class TestDeleteJobFromJobQueue extends TaskTestBase {
     Assert
         .assertNotNull(_driver.getJobContext(TaskUtil.getNamespacedJobName(jobQueueName, "job2")));
 
-    // The following force delete for the job should go through without getting an exception
+    // force deletion can have Exception thrown as controller is writing to propertystore path too.
+    // https://github.com/apache/helix/issues/1406
+
+    // Thus, we stop pipeline to make sure there is not such race condition.
+    _gSetupTool.getClusterManagementTool().enableCluster(CLUSTER_NAME, false);
+    Thread.sleep(3000); // note this sleep is critical as it would take time for controller to stop
+
     _driver.deleteJob(jobQueueName, "job2", true);
 
     // Check that the job has been force-deleted (fully gone from ZK)
     Assert.assertNull(_driver.getJobConfig(TaskUtil.getNamespacedJobName(jobQueueName, "job2")));
     Assert.assertNull(_driver.getJobContext(TaskUtil.getNamespacedJobName(jobQueueName, "job2")));
+
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestEnqueueJobs.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestEnqueueJobs.java
@@ -19,10 +19,8 @@ package org.apache.helix.integration.task;
  * under the License.
  */
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import org.apache.helix.TestHelper;
 import org.apache.helix.integration.manager.ClusterControllerManager;
@@ -34,14 +32,16 @@ import org.apache.helix.task.TaskUtil;
 import org.apache.helix.task.Workflow;
 import org.apache.helix.task.WorkflowConfig;
 import org.testng.Assert;
-import org.testng.ITestContext;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class TestEnqueueJobs extends TaskTestBase {
+  
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    setSingleTestEnvironment();
+    super.beforeClass();
+  }
 
   @Test
   public void testJobQueueAddingJobsOneByOne() throws InterruptedException {

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestEnqueueJobs.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestEnqueueJobs.java
@@ -47,13 +47,11 @@ public class TestEnqueueJobs extends TaskTestBase {
   public void beforeClass() throws Exception {
     setSingleTestEnvironment();
     super.beforeClass();
-    //WorkflowConfig.disableJobPurge();
   }
 
   @AfterClass
   @Override
   public void afterClass() throws Exception {
-    //WorkflowConfig.enableJobPurge();
     super.afterClass();
   }
 
@@ -97,7 +95,7 @@ public class TestEnqueueJobs extends TaskTestBase {
         TaskState.COMPLETED);
   }
 
-  @Test()
+  @Test
   public void testJobQueueAddingJobsAtSametime() throws InterruptedException {
     String queueName = TestHelper.getTestMethodName();
     JobQueue.Builder builder = TaskTestUtil.buildJobQueue(queueName);
@@ -165,7 +163,7 @@ public class TestEnqueueJobs extends TaskTestBase {
     _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
   }
 
-  @Test()
+  @Test
   public void testQueueParallelJobs() throws InterruptedException {
     final int parallelJobs = 3;
     final int numberOfJobsAddedBeforeControllerSwitch = 4;
@@ -237,7 +235,7 @@ public class TestEnqueueJobs extends TaskTestBase {
     Assert.assertTrue(minFinishTime > maxStartTime);
   }
 
-  @Test()
+  @Test
   public void testQueueJobsMaxCapacity() throws InterruptedException {
     final int numberOfJobsAddedInitially = 4;
     final int queueCapacity = 5;

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestEnqueueJobs.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestEnqueueJobs.java
@@ -43,33 +43,6 @@ import org.testng.annotations.Test;
 
 public class TestEnqueueJobs extends TaskTestBase {
 
-  @BeforeClass
-  public void beforeClass() throws Exception {
-    setSingleTestEnvironment();
-    super.beforeClass();
-  }
-
-  @AfterClass
-  @Override
-  public void afterClass() throws Exception {
-    super.afterClass();
-  }
-
-  @BeforeMethod
-  public void beforeTest(Method testMethod, ITestContext testContext) {
-    long startTime = System.currentTimeMillis();
-    System.out.println("START " + testMethod.getName() + " at " + new Date(startTime));
-    testContext.setAttribute("StartTime", System.currentTimeMillis());
-  }
-
-  @AfterMethod
-  public void endTest(Method testMethod, ITestContext testContext) {
-    Long startTime = (Long) testContext.getAttribute("StartTime");
-    long endTime = System.currentTimeMillis();
-    System.out.println("END " + testMethod.getName() + " at " + new Date(endTime) + ", took: "
-        + (endTime - startTime) + "ms.");
-  }
-
   @Test
   public void testJobQueueAddingJobsOneByOne() throws InterruptedException {
     String queueName = TestHelper.getTestMethodName();

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureDependence.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureDependence.java
@@ -48,7 +48,7 @@ public class TestJobFailureDependence extends TaskTestBase {
 
     // Create a queue
     LOG.info("Starting job-queue: " + queueName);
-    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 100);
+    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 100, true);
     // Create and Enqueue jobs
     List<String> currentJobNames = new ArrayList<String>();
     for (int i = 0; i < _numDbs; i++) {
@@ -101,7 +101,7 @@ public class TestJobFailureDependence extends TaskTestBase {
 
     // Create a queue
     LOG.info("Starting job-queue: " + queueName);
-    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 100);
+    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 100, true);
     // Create and Enqueue jobs
     List<String> currentJobNames = new ArrayList<String>();
     for (int i = 0; i < _numDbs; i++) {
@@ -131,7 +131,7 @@ public class TestJobFailureDependence extends TaskTestBase {
 
     // Create a queue
     LOG.info("Starting job-queue: " + queueName);
-    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 3);
+    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 3, true);
     // Create and Enqueue jobs
     List<String> currentJobNames = new ArrayList<String>();
     for (int i = 0; i < _numDbs; i++) {
@@ -161,15 +161,18 @@ public class TestJobFailureDependence extends TaskTestBase {
     _driver.updateWorkflow(queueName, configBuilder.build());
     _driver.stop(queueName);
 
+    List<String> jobNames = new ArrayList<>();
+    List<JobConfig.Builder> jobBuilders = new ArrayList<>();
     for (int i = 0; i < _numDbs; i++) {
       JobConfig.Builder jobConfig =
           new JobConfig.Builder().setCommand(MockTask.TASK_COMMAND).setTargetResource(_testDbs.get(i))
               .setTargetPartitionStates(Sets.newHashSet("SLAVE")).setIgnoreDependentJobFailure(true);
       String jobName = "job" + _testDbs.get(i);
       queueBuilder.enqueueJob(jobName, jobConfig);
-      _driver.enqueueJob(queueName, jobName, jobConfig);
+      jobNames.add(jobName);
+      jobBuilders.add(jobConfig);
     }
-
+    _driver.enqueueJobs(queueName, jobNames, jobBuilders);
     _driver.resume(queueName);
 
     namedSpaceJob1 = String.format("%s_%s", queueName, currentJobNames.get(1));

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureDependence.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureDependence.java
@@ -48,7 +48,7 @@ public class TestJobFailureDependence extends TaskTestBase {
 
     // Create a queue
     LOG.info("Starting job-queue: " + queueName);
-    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 100, true);
+    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 100, false);
     // Create and Enqueue jobs
     List<String> currentJobNames = new ArrayList<String>();
     for (int i = 0; i < _numDbs; i++) {
@@ -101,7 +101,7 @@ public class TestJobFailureDependence extends TaskTestBase {
 
     // Create a queue
     LOG.info("Starting job-queue: " + queueName);
-    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 100, true);
+    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 100, false);
     // Create and Enqueue jobs
     List<String> currentJobNames = new ArrayList<String>();
     for (int i = 0; i < _numDbs; i++) {
@@ -131,7 +131,7 @@ public class TestJobFailureDependence extends TaskTestBase {
 
     // Create a queue
     LOG.info("Starting job-queue: " + queueName);
-    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 3, true);
+    JobQueue.Builder queueBuilder = TaskTestUtil.buildJobQueue(queueName, 0, 3, false);
     // Create and Enqueue jobs
     List<String> currentJobNames = new ArrayList<String>();
     for (int i = 0; i < _numDbs; i++) {

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestMaxNumberOfAttemptsMasterSwitch.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestMaxNumberOfAttemptsMasterSwitch.java
@@ -33,7 +33,6 @@ import org.apache.helix.task.TaskDriver;
 import org.apache.helix.task.TaskState;
 import org.apache.helix.task.TaskUtil;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableMap;
@@ -67,14 +66,6 @@ public class TestMaxNumberOfAttemptsMasterSwitch extends TaskTestBase {
     _assignmentList2.add(PARTICIPANT_PREFIX + "_" + (_startPort + 1));
     _assignmentList2.add(PARTICIPANT_PREFIX + "_" + (_startPort + 0));
     _assignmentList2.add(PARTICIPANT_PREFIX + "_" + (_startPort + 2));
-  }
-
-  @AfterClass
-  public void afterClass() throws Exception {
-    String testClassName = this.getShortClassName();
-    System.out.println("AfterClass: " + TestHelper.getTestClassName() + ":" + TestHelper.getTestMethodName()  + "invoked.");
-
-    super.afterClass();
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestMaxNumberOfAttemptsMasterSwitch.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestMaxNumberOfAttemptsMasterSwitch.java
@@ -71,6 +71,9 @@ public class TestMaxNumberOfAttemptsMasterSwitch extends TaskTestBase {
 
   @AfterClass
   public void afterClass() throws Exception {
+    String testClassName = this.getShortClassName();
+    System.out.println("AfterClass: " + TestHelper.getTestClassName() + ":" + TestHelper.getTestMethodName()  + "invoked.");
+
     super.afterClass();
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestQuotaBasedScheduling.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestQuotaBasedScheduling.java
@@ -50,7 +50,6 @@ import org.apache.helix.task.WorkflowConfig;
 import org.apache.helix.task.assigner.AssignableInstance;
 import org.apache.helix.tools.ClusterSetup;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -117,10 +116,6 @@ public class TestQuotaBasedScheduling extends TaskTestBase {
     _jobCommandMap = Maps.newHashMap();
   }
 
-  @AfterClass
-  public void afterClass() throws Exception {
-    super.afterClass();
-  }
 
   @BeforeMethod
   public void beforeMethod() {

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestQuotaBasedScheduling.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestQuotaBasedScheduling.java
@@ -502,7 +502,7 @@ public class TestQuotaBasedScheduling extends TaskTestBase {
    * Tests quota-based scheduling for a job queue with different quota types.
    * @throws InterruptedException
    */
-  @Test(dependsOnMethods = "testSchedulingWithoutQuota", enabled = true)
+  @Test(dependsOnMethods = "testSchedulingWithoutQuota")
   public void testJobQueueScheduling() throws InterruptedException {
     // First define quota config
     ClusterConfig clusterConfig = _manager.getConfigAccessor().getClusterConfig(CLUSTER_NAME);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestStuckTaskQuota.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestStuckTaskQuota.java
@@ -35,7 +35,6 @@ import org.apache.helix.task.TaskStateModelFactory;
 import org.apache.helix.task.TaskUtil;
 import org.apache.helix.task.Workflow;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -59,14 +58,6 @@ public class TestStuckTaskQuota extends TaskTestBase {
 
     // Start first participant
     startParticipantAndRegisterNewMockTask(0);
-  }
-
-  @AfterClass
-  public void afterClass() throws Exception {
-    String testClassName = this.getShortClassName();
-    System.out.println("AfterClass: " + TestHelper.getTestClassName() + ":" + TestHelper.getTestMethodName()  + "invoked.");
-
-    super.afterClass();
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestStuckTaskQuota.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestStuckTaskQuota.java
@@ -63,6 +63,9 @@ public class TestStuckTaskQuota extends TaskTestBase {
 
   @AfterClass
   public void afterClass() throws Exception {
+    String testClassName = this.getShortClassName();
+    System.out.println("AfterClass: " + TestHelper.getTestClassName() + ":" + TestHelper.getTestMethodName()  + "invoked.");
+
     super.afterClass();
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskAssignmentCalculator.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskAssignmentCalculator.java
@@ -19,6 +19,8 @@ package org.apache.helix.integration.task;
  * under the License.
  */
 
+import java.lang.reflect.Method;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +46,11 @@ import org.apache.helix.task.TaskStateModelFactory;
 import org.apache.helix.task.Workflow;
 import org.apache.helix.task.WorkflowConfig;
 import org.testng.Assert;
+import org.testng.ITestContext;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.collections.Sets;
 
@@ -102,6 +108,26 @@ public class TestTaskAssignmentCalculator extends TaskTestBase {
     _jobCommandMap = Maps.newHashMap();
   }
 
+  @AfterClass
+  public void afterClass() throws Exception {
+    super.afterClass();
+  }
+
+  @BeforeMethod
+  public void beforeTest(Method testMethod, ITestContext testContext) {
+    long startTime = System.currentTimeMillis();
+    System.out.println("START " + testMethod.getName() + " at " + new Date(startTime));
+    testContext.setAttribute("StartTime", System.currentTimeMillis());
+  }
+
+  @AfterMethod
+  public void endTest(Method testMethod, ITestContext testContext) {
+    Long startTime = (Long) testContext.getAttribute("StartTime");
+    long endTime = System.currentTimeMillis();
+    System.out.println("END " + testMethod.getName() + " at " + new Date(endTime) + ", took: "
+        + (endTime - startTime) + "ms.");
+  }
+
   /**
    * This test does NOT allow multiple jobs being assigned to an instance.
    * @throws InterruptedException
@@ -111,7 +137,9 @@ public class TestTaskAssignmentCalculator extends TaskTestBase {
     _runCounts.clear();
     failTask = false;
     String workflowName = TestHelper.getTestMethodName();
-    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder wfgBuilder = new WorkflowConfig.Builder().setJobPurgeInterval(-1);
+    WorkflowConfig wfg = wfgBuilder.build();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName).setWorkflowConfig(wfg);
 
     for (int i = 0; i < 20; i++) {
       List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(1);
@@ -140,6 +168,7 @@ public class TestTaskAssignmentCalculator extends TaskTestBase {
     Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
     WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
     configBuilder.setAllowOverlapJobAssignment(true);
+    configBuilder.setJobPurgeInterval(-1);
     workflowBuilder.setWorkflowConfig(configBuilder.build());
 
     for (int i = 0; i < 40; i++) {
@@ -161,7 +190,9 @@ public class TestTaskAssignmentCalculator extends TaskTestBase {
     _runCounts.clear();
     failTask = false;
     String workflowName = TestHelper.getTestMethodName();
-    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder wfgBuilder = new WorkflowConfig.Builder().setJobPurgeInterval(-1);
+    WorkflowConfig wfg = wfgBuilder.build();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName).setWorkflowConfig(wfg);
 
     List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(20);
     for (int i = 0; i < 20; i++) {
@@ -180,9 +211,12 @@ public class TestTaskAssignmentCalculator extends TaskTestBase {
 
   @Test
   public void testAbortTaskForWorkflowFail() throws InterruptedException {
+    _runCounts.clear();
     failTask = true;
     String workflowName = TestHelper.getTestMethodName();
-    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder wfgBuilder = new WorkflowConfig.Builder().setJobPurgeInterval(-1);
+    WorkflowConfig wfg = wfgBuilder.build();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName).setWorkflowConfig(wfg);
 
     for (int i = 0; i < 5; i++) {
       List<TaskConfig> taskConfigs = Lists.newArrayListWithCapacity(1);
@@ -203,7 +237,11 @@ public class TestTaskAssignmentCalculator extends TaskTestBase {
       }
     }
 
-    Assert.assertEquals(abortedTask, 4);
+    // Note, the starting tasks messages are send out at the same time.
+    // There is no guarante only one task would fail. In fact 5 tasks run in parallel in
+    // 5 instances. There can be multiple task failing.
+    Assert.assertTrue(abortedTask <= 4);
+    Assert.assertEquals(_runCounts.size(), 5);
   }
 
   private class TaskOne extends MockTask {
@@ -213,16 +251,24 @@ public class TestTaskAssignmentCalculator extends TaskTestBase {
       super(context);
 
       // Initialize the count for this instance if not already done
-      if (!_runCounts.containsKey(instanceName)) {
-        _runCounts.put(instanceName, 0);
-      }
+      _runCounts.putIfAbsent(instanceName, 0);
       _instanceName = instanceName;
     }
 
     @Override
     public TaskResult run() {
-      _invokedClasses.add(getClass().getName());
-      _runCounts.put(_instanceName, _runCounts.get(_instanceName) + 1);
+      // make sure concurrent run task won't lose updates.
+      // in fact, each instance update its own slot, should have not confict. Still this is right way.
+      synchronized (_runCounts) {
+        _invokedClasses.add(getClass().getName());
+        _runCounts.put(_instanceName, _runCounts.get(_instanceName) + 1);
+      }
+      // this is to make sure task don't finish too quick
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        // ignore
+      }
       if (failTask) {
         return new TaskResult(TaskResult.Status.FAILED, "");
       }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskAssignmentCalculator.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskAssignmentCalculator.java
@@ -19,8 +19,6 @@ package org.apache.helix.integration.task;
  * under the License.
  */
 
-import java.lang.reflect.Method;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,11 +44,7 @@ import org.apache.helix.task.TaskStateModelFactory;
 import org.apache.helix.task.Workflow;
 import org.apache.helix.task.WorkflowConfig;
 import org.testng.Assert;
-import org.testng.ITestContext;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.collections.Sets;
 
@@ -106,26 +100,6 @@ public class TestTaskAssignmentCalculator extends TaskTestBase {
     _driver = new TaskDriver(_manager);
 
     _jobCommandMap = Maps.newHashMap();
-  }
-
-  @AfterClass
-  public void afterClass() throws Exception {
-    super.afterClass();
-  }
-
-  @BeforeMethod
-  public void beforeTest(Method testMethod, ITestContext testContext) {
-    long startTime = System.currentTimeMillis();
-    System.out.println("START " + testMethod.getName() + " at " + new Date(startTime));
-    testContext.setAttribute("StartTime", System.currentTimeMillis());
-  }
-
-  @AfterMethod
-  public void endTest(Method testMethod, ITestContext testContext) {
-    Long startTime = (Long) testContext.getAttribute("StartTime");
-    long endTime = System.currentTimeMillis();
-    System.out.println("END " + testMethod.getName() + " at " + new Date(endTime) + ", took: "
-        + (endTime - startTime) + "ms.");
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancer.java
@@ -50,15 +50,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class TestTaskRebalancer extends TaskTestBase {
-  @BeforeClass
-  public void beforeClass() throws Exception {
-    super.beforeClass();
-  }
-
-  @AfterClass
-  public void afterClass() throws Exception {
-    super.afterClass();
-  }
 
   @Test
   public void basic() throws Exception {

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerParallel.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerParallel.java
@@ -30,7 +30,6 @@ import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.WorkflowConfig;
 import org.apache.helix.tools.ClusterVerifiers.ClusterLiveNodesVerifier;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -43,11 +42,6 @@ public class TestTaskRebalancerParallel extends TaskTestBase {
     _numDbs = 4;
     _partitionVary = false;
     super.beforeClass();
-  }
-
-  @AfterClass
-  public void afterClass() throws Exception {
-    super.afterClass();
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerParallel.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerParallel.java
@@ -30,6 +30,7 @@ import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.WorkflowConfig;
 import org.apache.helix.tools.ClusterVerifiers.ClusterLiveNodesVerifier;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -44,6 +45,11 @@ public class TestTaskRebalancerParallel extends TaskTestBase {
     super.beforeClass();
   }
 
+  @AfterClass
+  public void afterClass() throws Exception {
+    super.afterClass();
+  }
+
   /**
    * This test starts 4 jobs in job queue, the job all stuck, and verify that
    * (1) the number of running job does not exceed configured max allowed parallel jobs
@@ -56,6 +62,7 @@ public class TestTaskRebalancerParallel extends TaskTestBase {
     WorkflowConfig.Builder cfgBuilder = new WorkflowConfig.Builder(queueName);
     cfgBuilder.setParallelJobs(PARALLEL_COUNT);
     cfgBuilder.setAllowOverlapJobAssignment(false);
+    cfgBuilder.setJobPurgeInterval(-1);
 
     JobQueue.Builder queueBuild =
         new JobQueue.Builder(queueName).setWorkflowConfig(cfgBuilder.build());
@@ -99,6 +106,7 @@ public class TestTaskRebalancerParallel extends TaskTestBase {
     WorkflowConfig.Builder cfgBuilder = new WorkflowConfig.Builder(queueName);
     cfgBuilder.setParallelJobs(PARALLEL_COUNT);
     cfgBuilder.setAllowOverlapJobAssignment(true);
+    cfgBuilder.setJobPurgeInterval(-1);
 
     JobQueue.Builder queueBuild = new JobQueue.Builder(queueName).setWorkflowConfig(cfgBuilder.build());
     JobQueue queue = queueBuild.build();
@@ -109,16 +117,21 @@ public class TestTaskRebalancerParallel extends TaskTestBase {
     for (int i = 0; i < PARALLEL_COUNT; i++) {
       List<TaskConfig> taskConfigs = new ArrayList<TaskConfig>();
       for (int j = 0; j < TASK_COUNT; j++) {
-        taskConfigs.add(new TaskConfig.Builder().setTaskId("job_" + (i + 1) + "_task_" + j)
-            .setCommand(MockTask.TASK_COMMAND).build());
+        taskConfigs.add(new TaskConfig.Builder()
+            .setTaskId("job_" + (i + 1) + "_task_" + j)
+            .setCommand(MockTask.TASK_COMMAND)
+            .addConfig(MockTask.JOB_DELAY, "2000")
+            .build());
       }
       jobConfigBuilders.add(new JobConfig.Builder().addTaskConfigs(taskConfigs));
     }
 
     _driver.stop(queueName);
+    List<String> jobNames = new ArrayList<>();
     for (int i = 0; i < jobConfigBuilders.size(); ++i) {
-      _driver.enqueueJob(queueName, "job_" + (i + 1), jobConfigBuilders.get(i));
+      jobNames.add("job_" + (i + 1));
     }
+    _driver.enqueueJobs(queueName, jobNames, jobConfigBuilders);
     _driver.resume(queueName);
     Thread.sleep(2000);
     Assert.assertTrue(TaskTestUtil.pollForWorkflowParallelState(_driver, queueName));

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerStopResume.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerStopResume.java
@@ -32,7 +32,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.sun.corba.se.spi.orbutil.threadpool.Work;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyPathBuilder;
@@ -190,7 +189,7 @@ public class TestTaskRebalancerStopResume extends TaskTestBase {
     verifyJobNotInQueue(queueName, namespacedJob2);
   }
 
-  @Test(enabled = true)
+  @Test
   public void stopDeleteJobAndResumeNamedQueue() throws Exception {
     String queueName = TestHelper.getTestMethodName();
 
@@ -476,9 +475,7 @@ public class TestTaskRebalancerStopResume extends TaskTestBase {
     jobNames.add(job2Name);
     jobBuilders.add(job2);
     _driver.enqueueJob(queueName, job2Name, job2);
-
-    //_driver.enqueueJobs(queueName, jobNames, jobBuilders);
-
+    
     String namespacedJob1 = String.format("%s_%s", queueName, job1Name);
     _driver.pollForJobState(queueName, namespacedJob1, TaskState.COMPLETED);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerStopResume.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskRebalancerStopResume.java
@@ -51,23 +51,11 @@ import org.apache.helix.tools.ClusterStateVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class TestTaskRebalancerStopResume extends TaskTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(TestTaskRebalancerStopResume.class);
   private static final String JOB_RESOURCE = "SomeJob";
-
-  @BeforeClass
-  public void BeforeClass() throws Exception {
-    super.beforeClass();
-  }
-
-  @AfterClass
-  public void afterClass() throws Exception {
-    super.afterClass();
-  }
 
   @Test
   public void stopAndResume() throws Exception {
@@ -475,7 +463,7 @@ public class TestTaskRebalancerStopResume extends TaskTestBase {
     jobNames.add(job2Name);
     jobBuilders.add(job2);
     _driver.enqueueJob(queueName, job2Name, job2);
-    
+
     String namespacedJob1 = String.format("%s_%s", queueName, job1Name);
     _driver.pollForJobState(queueName, namespacedJob1, TaskState.COMPLETED);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
@@ -48,7 +48,6 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableMap;
@@ -89,13 +88,6 @@ public class TestTaskSchedulingTwoCurrentStates extends TaskTestBase {
           new TaskStateModelFactory(_participants[i], taskFactoryReg));
       _participants[i].syncStart();
     }
-  }
-
-  @AfterClass()
-  public void afterClass() throws Exception {
-    String testClassName = this.getShortClassName();
-    System.out.println("AfterClass: " + TestHelper.getTestClassName() + ":" + TestHelper.getTestMethodName() + "called.");
-    super.afterClass();
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskSchedulingTwoCurrentStates.java
@@ -93,6 +93,8 @@ public class TestTaskSchedulingTwoCurrentStates extends TaskTestBase {
 
   @AfterClass()
   public void afterClass() throws Exception {
+    String testClassName = this.getShortClassName();
+    System.out.println("AfterClass: " + TestHelper.getTestClassName() + ":" + TestHelper.getTestMethodName() + "called.");
     super.afterClass();
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskThrottling.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskThrottling.java
@@ -37,7 +37,9 @@ import org.apache.helix.task.TaskPartitionState;
 import org.apache.helix.task.TaskState;
 import org.apache.helix.task.TaskUtil;
 import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -50,6 +52,10 @@ public class TestTaskThrottling extends TaskTestBase {
     super.beforeClass();
   }
 
+  @AfterClass
+  public void afterClass() throws Exception {
+    super.afterClass();
+  }
   /**
    * This test has been disabled/deprecated because Task Framework 2.0 uses quotas that are meant to
    * throttle tasks.
@@ -63,8 +69,12 @@ public class TestTaskThrottling extends TaskTestBase {
     JobConfig.Builder jobConfig = generateLongRunJobConfig(numTasks);
 
     // 1. Job executed in the participants with no limitation
+    WorkflowConfig.Builder wfgBuilder = new WorkflowConfig.Builder().setJobPurgeInterval(-1);
+    WorkflowConfig wfg = wfgBuilder.build();
     String jobName1 = "Job1";
-    Workflow flow1 = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName1, jobConfig).build();
+    Workflow flow1 = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName1, jobConfig)
+        .setWorkflowConfig(wfg)
+        .build();
     _driver.start(flow1);
     _driver.pollForJobState(flow1.getName(), TaskUtil.getNamespacedJobName(flow1.getName(), jobName1),
         TaskState.IN_PROGRESS);
@@ -87,7 +97,9 @@ public class TestTaskThrottling extends TaskTestBase {
     _gSetupTool.getClusterManagementTool().setConfig(scope, properties);
 
     String jobName2 = "Job2";
-    Workflow flow2 = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName2, jobConfig).build();
+    Workflow flow2 = WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName2, jobConfig)
+        .setWorkflowConfig(wfg)
+        .build();
     _driver.start(flow2);
     _driver.pollForJobState(flow2.getName(), TaskUtil.getNamespacedJobName(flow2.getName(), jobName2),
         TaskState.IN_PROGRESS);
@@ -123,9 +135,14 @@ public class TestTaskThrottling extends TaskTestBase {
     setParticipantsCapacity(perNodeTaskLimitation);
 
     // schedule job1
+    WorkflowConfig.Builder wfgBuilder = new WorkflowConfig.Builder().setJobPurgeInterval(-1);
+    WorkflowConfig wfg = wfgBuilder.build();
+
     String jobName1 = "PriorityJob1";
     Workflow flow1 =
-        WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName1, jobConfig).build();
+        WorkflowGenerator.generateSingleJobWorkflowBuilder(jobName1, jobConfig)
+            .setWorkflowConfig(wfg)
+            .build();
     _driver.start(flow1);
     _driver.pollForJobState(flow1.getName(),
         TaskUtil.getNamespacedJobName(flow1.getName(), jobName1), TaskState.IN_PROGRESS);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskThrottling.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskThrottling.java
@@ -39,7 +39,6 @@ import org.apache.helix.task.TaskUtil;
 import org.apache.helix.task.Workflow;
 import org.apache.helix.task.WorkflowConfig;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -52,10 +51,6 @@ public class TestTaskThrottling extends TaskTestBase {
     super.beforeClass();
   }
 
-  @AfterClass
-  public void afterClass() throws Exception {
-    super.afterClass();
-  }
   /**
    * This test has been disabled/deprecated because Task Framework 2.0 uses quotas that are meant to
    * throttle tasks.

--- a/helix-core/src/test/java/org/apache/helix/task/TaskSynchronizedTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TaskSynchronizedTestBase.java
@@ -28,6 +28,7 @@ import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
@@ -89,6 +90,7 @@ public class TaskSynchronizedTestBase extends ZkTestBase {
     }
     stopParticipants();
     deleteCluster(CLUSTER_NAME);
+    System.out.println("AfterClass: " + TestHelper.getTestClassName() + ":" + TestHelper.getTestMethodName()  + "invoked.");
   }
 
   protected void setupDBs() {


### PR DESCRIPTION

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

fix #1454 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently selective update can result in "phantom read". For
example, when job1 cfg is added and then workflow cfg
containing job 1 is updated. The selective update may only
see updated workflow cfg but not job 1 cfg. This would cause
job1 cfg and ctx removed. THus hanging tests.

Currently we work around this issue by setting purge interval
to -1 and enhance logging in task to make test stable.


### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

running

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
