### PR TITLE
Fix Periodic rebalancer Timer leak

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -172,12 +173,15 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
   private boolean _inMaintenanceMode;
 
   /**
-   * The timer that can periodically run the rebalancing pipeline. The timer will start if there is
-   * one resource group has the config to use the timer.
+   * The executors that can periodically run the rebalancing pipeline. A
+   * SingleThreadScheduledExecutor will start if there is one resource group has the config to do
+   * periodically rebalance.
    */
-  Timer _periodicalRebalanceTimer = null;
+  private static final ScheduledExecutorService _periodicalRebalanceExecutor =
+      Executors.newSingleThreadScheduledExecutor();
+  private ScheduledFuture _periodicRebalancerFutureTasks = null;
   long _timerPeriod = Long.MAX_VALUE;
-
+  private final Object _lock = new Object();
 
   /**
    * The timer that triggers the on-demand rebalance pipeline.
@@ -333,15 +337,19 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
   void startPeriodRebalance(long period, HelixManager manager) {
     if (period != _timerPeriod) {
       logger.info("Controller starting periodical rebalance timer at period " + period);
-      if (_periodicalRebalanceTimer != null) {
-        _periodicalRebalanceTimer.cancel();
+      ScheduledFuture lastScheduledFuture = null;
+      synchronized (_lock) {
+        if (_periodicRebalancerFutureTasks!=null && !_periodicRebalancerFutureTasks.isCancelled()) {
+          lastScheduledFuture = _periodicRebalancerFutureTasks;
+        }
+        _timerPeriod = period;
+        _periodicRebalancerFutureTasks = _periodicalRebalanceExecutor
+            .scheduleAtFixedRate(new RebalanceTask(manager, ClusterEventType.PeriodicalRebalance),
+                _timerPeriod, _timerPeriod, TimeUnit.MILLISECONDS);
       }
-      _periodicalRebalanceTimer =
-          new Timer("GenericHelixController_" + _clusterName + "_periodical_Timer", true);
-      _timerPeriod = period;
-      _periodicalRebalanceTimer
-          .scheduleAtFixedRate(new RebalanceTask(manager, ClusterEventType.PeriodicalRebalance),
-              _timerPeriod, _timerPeriod);
+      if (lastScheduledFuture != null) {
+        lastScheduledFuture.cancel(true /* mayInterruptIfRunning */);
+      }
     } else {
       logger.info("Controller already has periodical rebalance timer at period " + _timerPeriod);
     }
@@ -352,11 +360,11 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
    */
   void stopPeriodRebalance() {
     logger.info("Controller stopping periodical rebalance timer at period " + _timerPeriod);
-    if (_periodicalRebalanceTimer != null) {
-      _periodicalRebalanceTimer.cancel();
-      _periodicalRebalanceTimer = null;
-      _timerPeriod = Long.MAX_VALUE;
-      logger.info("Controller stopped periodical rebalance timer at period " + _timerPeriod);
+    synchronized (_lock) {
+      if (_periodicRebalancerFutureTasks != null && !_periodicRebalancerFutureTasks.isCancelled()) {
+        _periodicRebalancerFutureTasks.cancel(true /* mayInterruptIfRunning */);
+        _timerPeriod = Long.MAX_VALUE;
+      }
     }
   }
 
@@ -1299,6 +1307,10 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
   }
 
   public void shutdown() throws InterruptedException {
+    if (_periodicRebalancerFutureTasks != null) {
+      _periodicRebalancerFutureTasks.cancel(false);
+    }
+    _periodicalRebalanceExecutor.shutdown();
     stopPeriodRebalance();
     shutdownOnDemandTimer();
     logger.info("Shutting down {} pipeline", Pipeline.Type.DEFAULT.name());

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -1306,19 +1306,19 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
   }
 
   public void shutdown() throws InterruptedException {
-    _periodicalRebalanceExecutor.shutdown();
     stopPeriodRebalance();
+    _periodicalRebalanceExecutor.shutdown();
+    if (!_periodicalRebalanceExecutor
+        .awaitTermination(EVENT_THREAD_JOIN_TIMEOUT, TimeUnit.MILLISECONDS)) {
+      _periodicalRebalanceExecutor.shutdownNow();
+    }
+
     shutdownOnDemandTimer();
     logger.info("Shutting down {} pipeline", Pipeline.Type.DEFAULT.name());
     shutdownPipeline(_eventThread, _eventQueue);
 
     logger.info("Shutting down {} pipeline", Pipeline.Type.TASK.name());
     shutdownPipeline(_taskEventThread, _taskEventQueue);
-
-    if (!_periodicalRebalanceExecutor
-        .awaitTermination(EVENT_THREAD_JOIN_TIMEOUT, TimeUnit.MILLISECONDS)) {
-      _periodicalRebalanceExecutor.shutdownNow();
-    }
 
     // shutdown asycTasksThreadpool and wait for terminate.
     _asyncTasksThreadPool.shutdownNow();


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
#1453 Race condition cause Timer leak in GenericHelixController

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
We found a periodic rebalance's Timer leakage issue during log analysis. In current startPeriodRebalance, two thread may interference with each other. This may result in one timer got canceled twice, two timers are created with one timer leaked. 

```
  void startPeriodRebalance(long period, HelixManager manager) {
    if (period != _timerPeriod) {
      logger.info("Controller starting periodical rebalance timer at period " + period);
      if (_periodicalRebalanceTimer != null) {
        _periodicalRebalanceTimer.cancel();                  <<<------ 
      } 
      _periodicalRebalanceTimer =
          new Timer("GenericHelixController_" + _clusterName + "_periodical_Timer", true);     <<<-----
     ......
  }
```
This PR changes Timer to use a SingleThreadScheduledExecutor and adds a synchronized block in start/stop PeriodRebalance.


### Tests

- [X] The following tests are written for this issue:

NA

- [X] The following is the result of the "mvn test" command on the appropriate module:
```
[ERROR] Failures: 
[ERROR]   TestRoutingTableProviderPeriodicRefresh.testPeriodicRefresh:214 expected:<4> but was:<3>
[INFO]
[ERROR] Tests run: 1234, Failures: 1, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:23 h

```

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [X] In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)