### PR TITLE
Silence Stacktrace from Stale Reply Messages

### DIFF
--- a/helix-common/src/main/java/org/apache/helix/HelixException.java
+++ b/helix-common/src/main/java/org/apache/helix/HelixException.java
@@ -30,6 +30,16 @@ public class HelixException extends RuntimeException {
     super(message);
   }
 
+  /**
+   * Create a HelixException that can optionally turn off stack trace. Its other characteristics are
+   * the same as a HelixException with a message.
+   * @param message the detail message
+   * @param writableStackTrace whether or not the stack trace should be writable
+   */
+  public HelixException(String message, boolean writableStackTrace) {
+    super(message, null, false, writableStackTrace);
+  }
+
   public HelixException(Throwable cause) {
     super(cause);
   }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/AsyncCallbackService.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/AsyncCallbackService.java
@@ -69,7 +69,7 @@ public class AsyncCallbackService implements MultiTypeMessageHandlerFactory {
               + " does not have correponding callback. Probably timed out already. Correlation id: "
               + correlationId;
       _logger.error(errorMsg);
-      throw new HelixException(errorMsg);
+      throw new HelixException(errorMsg, false);
     }
     _logger.info("Verified reply message " + message.getMsgId() + " correlation:" + correlationId);
   }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1459 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

If a reply message doesn't have a corresponding callback, AsyncCallbackService will raise an exception when creating a handler for it. Since stale reply messages may happen during participant reconnects, some customers prefer not seeing too verbose error messages since they don't require any actions of debugging. 

This PR adds a less verbose (no stacktrace) HelixException and raises it for this specific case. It may also be used in other occasions if necessary.  

### Tests

- [x] The following tests are written for this issue:

```
[ERROR] Tests run: 1213, Failures: 1, Errors: 0, Skipped: 1, Time elapsed: 4,830.531 s <<< FAILURE! - in TestSuite
[ERROR] testPeriodicRefresh(org.apache.helix.integration.spectator.TestRoutingTableProviderPeriodicRefresh)  Time elapsed: 2.031 s  <<< FAILURE!
java.lang.AssertionError: expected:<4> but was:<3>
        at org.apache.helix.integration.spectator.TestRoutingTableProviderPeriodicRefresh.testPeriodicRefresh(TestRoutingTableProviderPeriodicRefresh.java:214)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestRoutingTableProviderPeriodicRefresh.testPeriodicRefresh:214 expected:<4> but was:<3>
[INFO] 
[ERROR] Tests run: 1213, Failures: 1, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:20 h
[INFO] Finished at: 2020-10-12T16:36:07-07:00
[INFO] ------------------------------------------------------------------------
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
