### PR TITLE
Disable TestRoutingTableProviderPeriodicRefresh #1250

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderPeriodicRefresh.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderPeriodicRefresh.java
@@ -201,7 +201,8 @@ public class TestRoutingTableProviderPeriodicRefresh extends ZkTestBase {
     }
   }
 
-  @Test
+  // The test needs to be re-write. Waiting for timer triggerng is source of flakiness.
+  @Test(enabled = false)
   public void testPeriodicRefresh() throws InterruptedException {
     // Wait so that initial refreshes finish (not triggered by periodic refresh timer)
     Thread.sleep(1000L);

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderPeriodicRefresh.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderPeriodicRefresh.java
@@ -202,6 +202,7 @@ public class TestRoutingTableProviderPeriodicRefresh extends ZkTestBase {
   }
 
   // The test needs to be re-write. Waiting for timer triggerng is source of flakiness.
+  // todo: re-write the test, tracked by https://github.com/apache/helix/issues/1250
   @Test(enabled = false)
   public void testPeriodicRefresh() throws InterruptedException {
     // Wait so that initial refreshes finish (not triggered by periodic refresh timer)


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Disable #1250 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

TestRoutingTableProviderPeriodicRefresh use sleep() waiting for timers
to trigger. This is the source of frequent failure. This test needs a
re-write. Current state is hard to fix.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

github running
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
