### PR TITLE
Fix MaxCapacityUsageGauge value not updated

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/WagedValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/WagedValidationUtil.java
@@ -24,7 +24,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.helix.HelixException;
+import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.ResourceConfig;
 
@@ -87,5 +89,17 @@ public class WagedValidationUtil {
           partitionCapacity.toString()));
     }
     return partitionCapacity;
+  }
+
+  /**
+   * Checks whether or not a resource has enabled WAGED rebalancer.
+   *
+   * @param idealState {@code IdealState} of the resource being checked.
+   * @return {@code true} if WAGED is enabled; otherwise, {@code false}.
+   */
+  public static boolean isWagedEnabled(IdealState idealState) {
+    return idealState != null
+        && idealState.getRebalanceMode().equals(IdealState.RebalanceMode.FULL_AUTO)
+        && WagedRebalancer.class.getName().equals(idealState.getRebalancerClassName());
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -41,6 +41,7 @@ import org.apache.helix.controller.rebalancer.MaintenanceRebalancer;
 import org.apache.helix.controller.rebalancer.Rebalancer;
 import org.apache.helix.controller.rebalancer.SemiAutoRebalancer;
 import org.apache.helix.controller.rebalancer.internal.MappingCalculator;
+import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.IdealState;
@@ -253,13 +254,10 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     }
 
     // Find the compatible resources: 1. FULL_AUTO 2. Configured to use the WAGED rebalancer
-    Map<String, Resource> wagedRebalancedResourceMap =
-        resourceMap.entrySet().stream().filter(resourceEntry -> {
-          IdealState is = cache.getIdealState(resourceEntry.getKey());
-          return is != null && is.getRebalanceMode().equals(IdealState.RebalanceMode.FULL_AUTO)
-              && WagedRebalancer.class.getName().equals(is.getRebalancerClassName());
-        }).collect(Collectors.toMap(resourceEntry -> resourceEntry.getKey(),
-            resourceEntry -> resourceEntry.getValue()));
+    Map<String, Resource> wagedRebalancedResourceMap = resourceMap.entrySet().stream()
+        .filter(resourceEntry ->
+            WagedValidationUtil.isWagedEnabled(cache.getIdealState(resourceEntry.getKey())))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     Map<String, IdealState> newIdealStates = new HashMap<>();
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -34,6 +34,7 @@ import org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider;
 import org.apache.helix.controller.pipeline.AbstractBaseStage;
 import org.apache.helix.controller.pipeline.StageException;
 import org.apache.helix.controller.rebalancer.util.ResourceUsageCalculator;
+import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModelProvider;
@@ -283,10 +284,10 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
     asyncExecute(dataProvider.getAsyncTasksThreadPool(), () -> {
       try {
         // ResourceToRebalance map also has resources from current states.
-        // Only use the resources in ideal states to parse all replicas.
+        // Only use the resources in ideal states that enable WAGED to parse all replicas.
         Map<String, IdealState> idealStateMap = dataProvider.getIdealStates();
         Map<String, Resource> resourceToMonitorMap = resourceMap.entrySet().stream()
-            .filter(idealStateMap::containsKey)
+            .filter(entry -> WagedValidationUtil.isWagedEnabled(idealStateMap.get(entry.getKey())))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         Map<String, ResourceAssignment> currentStateAssignment =

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
@@ -201,14 +201,13 @@ public class TestWagedRebalancerMetrics extends AbstractTestClusterModel {
         String capacityKey = capacityEntry.getKey();
         String attributeName = capacityKey + "Gauge";
         Assert.assertTrue(TestHelper.verify(() -> {
-              try {
-                return (long) mBeanServer.getAttribute(instanceObjectName, attributeName)
-                    == _capacityDataMap.get(capacityKey);
-              } catch (AttributeNotFoundException e) {
-                return false;
-              }
-            }, TestHelper.WAIT_DURATION),
-            "Instance capacity gauge metric is not found or incorrect!");
+          try {
+            return (long) mBeanServer.getAttribute(instanceObjectName, attributeName)
+                == _capacityDataMap.get(capacityKey);
+          } catch (AttributeNotFoundException e) {
+            return false;
+          }
+        }, TestHelper.WAIT_DURATION), "Instance capacity gauge metric is not found or incorrect!");
         Assert.assertEquals((long) mBeanServer.getAttribute(instanceObjectName, attributeName),
             (long) _capacityDataMap.get(capacityKey));
       }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
@@ -20,6 +20,7 @@ package org.apache.helix.controller.rebalancer.waged;
  */
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -28,19 +29,31 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
+import javax.management.AttributeNotFoundException;
 import javax.management.JMException;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
 
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.TestHelper;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.pipeline.Pipeline;
 import org.apache.helix.controller.rebalancer.waged.constraints.MockRebalanceAlgorithm;
 import org.apache.helix.controller.rebalancer.waged.model.AbstractTestClusterModel;
+import org.apache.helix.controller.stages.AttributeName;
+import org.apache.helix.controller.stages.ClusterEvent;
+import org.apache.helix.controller.stages.ClusterEventType;
+import org.apache.helix.controller.stages.CurrentStateComputationStage;
 import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.controller.stages.ReadClusterDataStage;
+import org.apache.helix.mock.MockManager;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Resource;
+import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
+import org.apache.helix.monitoring.mbeans.InstanceMonitor;
 import org.apache.helix.monitoring.metrics.MetricCollector;
 import org.apache.helix.monitoring.metrics.WagedRebalancerMetricCollector;
 import org.apache.helix.monitoring.metrics.model.CountMetric;
@@ -142,6 +155,78 @@ public class TestWagedRebalancerMetrics extends AbstractTestClusterModel {
     Assert.assertTrue(TestHelper.verify(() -> (double) metricCollector.getMetric(
         WagedRebalancerMetricCollector.WagedRebalancerMetricNames.BaselineDivergenceGauge.name(),
         RatioMetric.class).getLastEmittedMetricValue() == 0.0d, TestHelper.WAIT_DURATION));
+  }
+
+  /*
+   * Integration test for WAGED instance capacity metrics.
+   */
+  @Test
+  public void testInstanceCapacityMetrics() throws Exception {
+    final String clusterName = TestHelper.getTestMethodName();
+    final ClusterStatusMonitor monitor = new ClusterStatusMonitor(clusterName);
+    ClusterEvent event = new ClusterEvent(ClusterEventType.Unknown);
+
+    ResourceControllerDataProvider cache = setupClusterDataCache();
+    Map<String, Resource> resourceMap = cache.getIdealStates().entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+          Resource resource = new Resource(entry.getKey());
+          entry.getValue().getPartitionSet().forEach(resource::addPartition);
+          return resource;
+        }));
+
+    event.addAttribute(AttributeName.helixmanager.name(), new MockManager());
+    event.addAttribute(AttributeName.ControllerDataProvider.name(), cache);
+    event.addAttribute(AttributeName.RESOURCES.name(), resourceMap);
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), resourceMap);
+    event.addAttribute(AttributeName.clusterStatusMonitor.name(), monitor);
+
+    Pipeline rebalancePipeline = new Pipeline();
+    rebalancePipeline.addStage(new ReadClusterDataStage());
+    rebalancePipeline.addStage(new CurrentStateComputationStage());
+    rebalancePipeline.handle(event);
+
+    final MBeanServerConnection mBeanServer = ManagementFactory.getPlatformMBeanServer();
+
+    for (String instance : _instances) {
+      String instanceBeanName = String.format("%s=%s,instanceName=%s",
+          ClusterStatusMonitor.CLUSTER_DN_KEY, clusterName, instance);
+      ObjectName instanceObjectName = monitor.getObjectName(instanceBeanName);
+
+      Assert.assertTrue(TestHelper
+          .verify(() -> mBeanServer.isRegistered(instanceObjectName),
+              TestHelper.WAIT_DURATION));
+
+      // Verify capacity gauge metrics
+      for (Map.Entry<String, Integer> capacityEntry : _capacityDataMap.entrySet()) {
+        String capacityKey = capacityEntry.getKey();
+        String attributeName = capacityKey + "Gauge";
+        Assert.assertTrue(TestHelper.verify(() -> {
+              try {
+                return (long) mBeanServer.getAttribute(instanceObjectName, attributeName)
+                    == _capacityDataMap.get(capacityKey);
+              } catch (AttributeNotFoundException e) {
+                return false;
+              }
+            }, TestHelper.WAIT_DURATION),
+            "Instance capacity gauge metric is not found or incorrect!");
+        Assert.assertEquals((long) mBeanServer.getAttribute(instanceObjectName, attributeName),
+            (long) _capacityDataMap.get(capacityKey));
+      }
+
+      // Verify MaxCapacityUsageGauge
+      Assert.assertTrue(TestHelper.verify(() -> {
+        try {
+          double actualMaxUsage = (double) mBeanServer.getAttribute(instanceObjectName,
+              InstanceMonitor.InstanceMonitorMetric.MAX_CAPACITY_USAGE_GAUGE.metricName());
+          // The values are manually calculated from the capacity configs, to make the code simple.
+          double expectedMaxUsage = instance.equals(_testInstanceId) ? 0.4 : 0.0;
+
+          return Math.abs(actualMaxUsage - expectedMaxUsage) < 0.000001d;
+        } catch (AttributeNotFoundException e) {
+          return false;
+        }
+      }, TestHelper.WAIT_DURATION), "MaxCapacityUsageGauge is not found or incorrect");
+    }
   }
 
   @Override

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
@@ -137,6 +137,8 @@ public abstract class AbstractTestClusterModel {
     when(testCurrentStateResource1.getStateModelDefRef()).thenReturn("MasterSlave");
     when(testCurrentStateResource1.getState(_partitionNames.get(0))).thenReturn("MASTER");
     when(testCurrentStateResource1.getState(_partitionNames.get(1))).thenReturn("SLAVE");
+    when(testCurrentStateResource1.getSessionId()).thenReturn(_sessionId);
+
     CurrentState testCurrentStateResource2 = Mockito.mock(CurrentState.class);
     Map<String, String> partitionStateMap2 = new HashMap<>();
     partitionStateMap2.put(_partitionNames.get(2), "MASTER");
@@ -146,6 +148,8 @@ public abstract class AbstractTestClusterModel {
     when(testCurrentStateResource2.getStateModelDefRef()).thenReturn("MasterSlave");
     when(testCurrentStateResource2.getState(_partitionNames.get(2))).thenReturn("MASTER");
     when(testCurrentStateResource2.getState(_partitionNames.get(3))).thenReturn("SLAVE");
+    when(testCurrentStateResource2.getSessionId()).thenReturn(_sessionId);
+
     Map<String, CurrentState> currentStatemap = new HashMap<>();
     currentStatemap.put(_resourceNames.get(0), testCurrentStateResource1);
     currentStatemap.put(_resourceNames.get(1), testCurrentStateResource2);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1463 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

MaxCapacityUsageGauge value not updated because the resourcesToMonitor map is empty.

This PR fixes the bug and also add an integration test to protect the metrics reporting logic.

<img width="743" alt="image" src="https://user-images.githubusercontent.com/5187721/95827599-c9a65800-0ce8-11eb-854e-2d919e3b0bbd.png">


### Tests

- [x] The following tests are written for this issue:

testInstanceCapacityMetrics()

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestRoutingTableProviderPeriodicRefresh.testPeriodicRefresh:214 expected:<4> but was:<3>
[INFO]
[ERROR] Tests run: 1214, Failures: 1, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:23 h
[INFO] Finished at: 2020-10-13T01:54:46-07:00
[INFO] ------------------------------------------------------------------------
```

The failed test is a known one: https://github.com/apache/helix/issues/1250
@kaisun2000 is working on it.

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
