### PR TITLE
ExpiredJob Workaround for Selective Update Race Conditions

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TaskGarbageCollectionStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TaskGarbageCollectionStage.java
@@ -81,8 +81,8 @@ public class TaskGarbageCollectionStage extends AbstractAsyncBaseStage {
         if (nextPurgeTime <= currentTime) {
           nextPurgeTime = currentTime + purgeInterval;
           // Find jobs that are ready to be purged
-          Set<String> expiredJobs =
-              TaskUtil.getExpiredJobsFromCache(dataProvider, workflowConfig, workflowContext);
+          Set<String> expiredJobs = TaskUtil
+              .getExpiredJobsFromCache(dataProvider, workflowConfig, workflowContext, manager);
           if (!expiredJobs.isEmpty()) {
             expiredJobsMap.put(workflowConfig.getWorkflowId(), expiredJobs);
           }

--- a/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskUtil.java
@@ -789,7 +789,7 @@ public class TaskUtil {
    */
   public static Set<String> getExpiredJobsFromCache(
       WorkflowControllerDataProvider workflowControllerDataProvider, WorkflowConfig workflowConfig,
-      WorkflowContext workflowContext) {
+      WorkflowContext workflowContext, HelixManager manager) {
     Set<String> expiredJobs = new HashSet<>();
     Map<String, TaskState> jobStates = workflowContext.getJobStates();
     for (String job : workflowConfig.getJobDag().getAllNodes()) {
@@ -797,6 +797,11 @@ public class TaskUtil {
         continue;
       }
       JobConfig jobConfig = workflowControllerDataProvider.getJobConfig(job);
+      // TODO: Temporary solution for cache selective update race conditions
+      if (jobConfig == null) {
+        jobConfig = TaskUtil.getJobConfig(manager, job);
+      }
+
       JobContext jobContext = workflowControllerDataProvider.getJobContext(job);
       TaskState jobState = jobStates.get(job);
       if (isJobExpired(job, jobConfig, jobContext, jobState)) {

--- a/helix-core/src/test/java/org/apache/helix/task/TestTaskUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestTaskUtil.java
@@ -98,7 +98,7 @@ public class TestTaskUtil extends TaskTestBase {
     expectedJobs.add(workflowName + "_Job_3");
     Assert.assertEquals(TaskUtil
         .getExpiredJobsFromCache(workflowControllerDataProvider, jobQueue.getWorkflowConfig(),
-            workflowContext), expectedJobs);
+            workflowContext, _manager), expectedJobs);
   }
 
   @Test
@@ -188,7 +188,7 @@ public class TestTaskUtil extends TaskTestBase {
     expectedJobs.add(workflowName + "_Job_8");
     Assert.assertEquals(TaskUtil
         .getExpiredJobsFromCache(workflowControllerDataProvider, workflow.getWorkflowConfig(),
-            workflowContext), expectedJobs);
+            workflowContext, _manager), expectedJobs);
   }
 
   @Test


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1469 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Cache selective update is a two step procedure. It first "lists", which gets all the ZNodes, and then it "updates" by comparing ZNode metadata to determine which ZNodes have been changed. Job enqueue is also a two step procedure, where it adds all JobConfigs one by one, and update WorkflowConfig's DAG in the end.  

If selective update "lists" before all JobConfigs are added, and "updates" after the WorkflowConfig is done updating, it's possible to read in a DAG containing more jobs than JobConfigs that are seen by selective update. This causes TaskGarbageCollection to remove the jobs that are "missing" JobConfigs, even though their JobConfigs actually exist. This PR implements a workaround for determining expired jobs while avoiding this case of cache "phantom read": if JobConfig doesn't exist in the cache, check ZK directly.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[ERROR] Tests run: 1234, Failures: 1, Errors: 0, Skipped: 1, Time elapsed: 4,885.942 s <<< FAILURE! - in TestSuite
[ERROR] testPeriodicRefresh(org.apache.helix.integration.spectator.TestRoutingTableProviderPeriodicRefresh)  Time elapsed: 2.022 s  <<< FAILURE!
java.lang.AssertionError: expected:<4> but was:<3>
        at org.apache.helix.integration.spectator.TestRoutingTableProviderPeriodicRefresh.testPeriodicRefresh(TestRoutingTableProviderPeriodicRefresh.java:214)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestRoutingTableProviderPeriodicRefresh.testPeriodicRefresh:214 expected:<4> but was:<3>
[INFO] 
[ERROR] Tests run: 1234, Failures: 1, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:21 h
[INFO] Finished at: 2020-10-21T12:14:46-07:00
[INFO] ------------------------------------------------------------------------
```
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
