### PR TITLE
Make byte array data accessor use RealmAwareZkClient

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
@@ -52,6 +52,7 @@ import org.apache.helix.zookeeper.routing.RoutingDataManager;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.helix.zookeeper.zkclient.IZkStateListener;
+import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.apache.zookeeper.Watcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,7 +83,7 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
    */
   private ZkMetadataStoreDirectory _zkMetadataStoreDirectory;
   // Create a dedicated ZkClient for listening to data changes in routing data
-  private RealmAwareZkClient _zkClientForListener;
+  private RealmAwareZkClient _zkClientForRoutingDataListener;
 
   public ServerContext(String zkAddr) {
     this(zkAddr, false, null);
@@ -110,48 +111,15 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
     _zkMetadataStoreDirectory = ZkMetadataStoreDirectory.getInstance();
   }
 
+  /**
+   * Lazy initialization of RealmAwareZkClient used throughout the REST server.
+   * @return
+   */
   public RealmAwareZkClient getRealmAwareZkClient() {
     if (_zkClient == null) {
       synchronized (this) {
         if (_zkClient == null) {
-          // If the multi ZK config is enabled, use FederatedZkClient on multi-realm mode
-          if (_isMultiZkEnabled || Boolean
-              .parseBoolean(System.getProperty(SystemPropertyKeys.MULTI_ZK_ENABLED))) {
-            try {
-              // Make sure the ServerContext is subscribed to routing data change so that it knows
-              // when to reset ZkClient and Helix APIs
-              if (_zkClientForListener == null) {
-                _zkClientForListener = DedicatedZkClientFactory.getInstance()
-                    .buildZkClient(new HelixZkClient.ZkConnectionConfig(_zkAddr),
-                        new HelixZkClient.ZkClientConfig()
-                            .setZkSerializer(new ZNRecordSerializer()));
-              }
-              // Refresh data subscription
-              _zkClientForListener.unsubscribeAll();
-              _zkClientForListener.subscribeRoutingDataChanges(this, this);
-              LOG.info("ServerContext: subscribed to routing data in routing ZK at {}!", _zkAddr);
-
-              RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder connectionConfigBuilder =
-                  new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder();
-              // If MSDS endpoint is set for this namespace, use that instead.
-              if (_msdsEndpoint != null && !_msdsEndpoint.isEmpty()) {
-                connectionConfigBuilder.setRoutingDataSourceEndpoint(_msdsEndpoint)
-                    .setRoutingDataSourceType(RoutingDataReaderType.HTTP.name());
-              }
-              _zkClient = new FederatedZkClient(connectionConfigBuilder.build(),
-                  new RealmAwareZkClient.RealmAwareZkClientConfig()
-                      .setZkSerializer(new ZNRecordSerializer()));
-              LOG.info("ServerContext: FederatedZkClient created successfully!");
-            } catch (InvalidRoutingDataException | IllegalStateException e) {
-              throw new HelixException("Failed to create FederatedZkClient!", e);
-            }
-          } else {
-            // If multi ZK config is not set, just connect to the ZK address given
-            HelixZkClient.ZkClientConfig clientConfig = new HelixZkClient.ZkClientConfig();
-            clientConfig.setZkSerializer(new ZNRecordSerializer());
-            _zkClient = SharedZkClientFactory.getInstance()
-                .buildZkClient(new HelixZkClient.ZkConnectionConfig(_zkAddr), clientConfig);
-          }
+          _zkClient = createRealmAwareZkClient(_zkClient, true, new ZNRecordSerializer());
         }
       }
     }
@@ -168,38 +136,72 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
     if (_byteArrayZkClient == null) {
       synchronized (this) {
         if (_byteArrayZkClient == null) {
-          // If the multi ZK config is enabled, use FederatedZkClient on multi-realm mode
-          if (_isMultiZkEnabled || Boolean
-              .parseBoolean(System.getProperty(SystemPropertyKeys.MULTI_ZK_ENABLED))) {
-            try {
-              RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder connectionConfigBuilder =
-                  new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder();
-              // If MSDS endpoint is set for this namespace, use that instead.
-              if (_msdsEndpoint != null && !_msdsEndpoint.isEmpty()) {
-                connectionConfigBuilder.setRoutingDataSourceEndpoint(_msdsEndpoint)
-                    .setRoutingDataSourceType(RoutingDataReaderType.HTTP.name());
-              }
-              _byteArrayZkClient = new FederatedZkClient(connectionConfigBuilder.build(),
-                  new RealmAwareZkClient.RealmAwareZkClientConfig()
-                      .setZkSerializer(new ByteArraySerializer()));
-              LOG.info(
-                  "ServerContext::getByteArrayRealmAwareZkClient(): FederatedZkClient created successfully!");
-            } catch (InvalidRoutingDataException | IllegalStateException e) {
-              throw new HelixException(
-                  "ServerContext::getByteArrayRealmAwareZkClient(): Failed to create FederatedZkClient!",
-                  e);
-            }
-          } else {
-            // If multi ZK config is not set, just connect to the ZK address given
-            HelixZkClient.ZkClientConfig clientConfig = new HelixZkClient.ZkClientConfig();
-            clientConfig.setZkSerializer(new ByteArraySerializer());
-            _byteArrayZkClient = SharedZkClientFactory.getInstance()
-                .buildZkClient(new HelixZkClient.ZkConnectionConfig(_zkAddr), clientConfig);
-          }
+          _byteArrayZkClient =
+              createRealmAwareZkClient(_byteArrayZkClient, false, new ByteArraySerializer());
         }
       }
     }
     return _byteArrayZkClient;
+  }
+
+  /**
+   * Main creation logic for RealmAwareZkClient.
+   * @param realmAwareZkClient
+   * @param shouldSubscribeToRoutingDataChange if true, it will initialize zk client to listen on
+   *                                           routing data change and refresh change subscription
+   * @param zkSerializer the type of ZkSerializer to use
+   * @return
+   */
+  private RealmAwareZkClient createRealmAwareZkClient(RealmAwareZkClient realmAwareZkClient,
+      boolean shouldSubscribeToRoutingDataChange, ZkSerializer zkSerializer) {
+    // If the multi ZK config is enabled, use FederatedZkClient on multi-realm mode
+    if (_isMultiZkEnabled || Boolean
+        .parseBoolean(System.getProperty(SystemPropertyKeys.MULTI_ZK_ENABLED))) {
+      try {
+        if (shouldSubscribeToRoutingDataChange) {
+          initializeZkClientForRoutingData();
+        }
+        RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder connectionConfigBuilder =
+            new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder();
+        // If MSDS endpoint is set for this namespace, use that instead.
+        if (_msdsEndpoint != null && !_msdsEndpoint.isEmpty()) {
+          connectionConfigBuilder.setRoutingDataSourceEndpoint(_msdsEndpoint)
+              .setRoutingDataSourceType(RoutingDataReaderType.HTTP.name());
+        }
+        realmAwareZkClient = new FederatedZkClient(connectionConfigBuilder.build(),
+            new RealmAwareZkClient.RealmAwareZkClientConfig().setZkSerializer(zkSerializer));
+        LOG.info("ServerContext: FederatedZkClient created successfully!");
+      } catch (InvalidRoutingDataException | IllegalStateException e) {
+        throw new HelixException("Failed to create FederatedZkClient!", e);
+      }
+    } else {
+      // If multi ZK config is not set, just connect to the ZK address given
+      HelixZkClient.ZkClientConfig clientConfig = new HelixZkClient.ZkClientConfig();
+      clientConfig.setZkSerializer(zkSerializer);
+      realmAwareZkClient = SharedZkClientFactory.getInstance()
+          .buildZkClient(new HelixZkClient.ZkConnectionConfig(_zkAddr), clientConfig);
+    }
+    return realmAwareZkClient;
+  }
+
+  /**
+   * Initialization logic for ZkClient for routing data listener.
+   * NOTE: The initialization lifecycle of zkClientForRoutingDataListener is tied to the private
+   * volatile zkClient.
+   */
+  private void initializeZkClientForRoutingData() {
+    // Make sure the ServerContext is subscribed to routing data change so that it knows
+    // when to reset ZkClient and Helix APIs
+    if (_zkClientForRoutingDataListener == null) {
+      // Routing data is always in the ZNRecord format
+      _zkClientForRoutingDataListener = DedicatedZkClientFactory.getInstance()
+          .buildZkClient(new HelixZkClient.ZkConnectionConfig(_zkAddr),
+              new HelixZkClient.ZkClientConfig().setZkSerializer(new ZNRecordSerializer()));
+    }
+    // Refresh data subscription
+    _zkClientForRoutingDataListener.unsubscribeAll();
+    _zkClientForRoutingDataListener.subscribeRoutingDataChanges(this, this);
+    LOG.info("ServerContext: subscribed to routing data in routing ZK at {}!", _zkAddr);
   }
 
   @Deprecated
@@ -291,25 +293,25 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
     if (_zkMetadataStoreDirectory != null) {
       _zkMetadataStoreDirectory.close();
     }
-    if (_zkClientForListener != null) {
-      _zkClientForListener.close();
+    if (_zkClientForRoutingDataListener != null) {
+      _zkClientForRoutingDataListener.close();
     }
   }
 
   @Override
   public void handleChildChange(String parentPath, List<String> currentChilds) {
-    if (_zkClientForListener == null || _zkClientForListener.isClosed()) {
+    if (_zkClientForRoutingDataListener == null || _zkClientForRoutingDataListener.isClosed()) {
       return;
     }
     // Resubscribe
-    _zkClientForListener.unsubscribeAll();
-    _zkClientForListener.subscribeRoutingDataChanges(this, this);
+    _zkClientForRoutingDataListener.unsubscribeAll();
+    _zkClientForRoutingDataListener.subscribeRoutingDataChanges(this, this);
     resetZkResources();
   }
 
   @Override
   public void handleDataChange(String dataPath, Object data) {
-    if (_zkClientForListener == null || _zkClientForListener.isClosed()) {
+    if (_zkClientForRoutingDataListener == null || _zkClientForRoutingDataListener.isClosed()) {
       return;
     }
     resetZkResources();
@@ -317,45 +319,45 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
 
   @Override
   public void handleDataDeleted(String dataPath) {
-    if (_zkClientForListener == null || _zkClientForListener.isClosed()) {
+    if (_zkClientForRoutingDataListener == null || _zkClientForRoutingDataListener.isClosed()) {
       return;
     }
     // Resubscribe
-    _zkClientForListener.unsubscribeAll();
-    _zkClientForListener.subscribeRoutingDataChanges(this, this);
+    _zkClientForRoutingDataListener.unsubscribeAll();
+    _zkClientForRoutingDataListener.subscribeRoutingDataChanges(this, this);
     resetZkResources();
   }
 
   @Override
   public void handleStateChanged(Watcher.Event.KeeperState state) {
-    if (_zkClientForListener == null || _zkClientForListener.isClosed()) {
+    if (_zkClientForRoutingDataListener == null || _zkClientForRoutingDataListener.isClosed()) {
       return;
     }
     // Resubscribe
-    _zkClientForListener.unsubscribeAll();
-    _zkClientForListener.subscribeRoutingDataChanges(this, this);
+    _zkClientForRoutingDataListener.unsubscribeAll();
+    _zkClientForRoutingDataListener.subscribeRoutingDataChanges(this, this);
     resetZkResources();
   }
 
   @Override
   public void handleNewSession(String sessionId) {
-    if (_zkClientForListener == null || _zkClientForListener.isClosed()) {
+    if (_zkClientForRoutingDataListener == null || _zkClientForRoutingDataListener.isClosed()) {
       return;
     }
     // Resubscribe
-    _zkClientForListener.unsubscribeAll();
-    _zkClientForListener.subscribeRoutingDataChanges(this, this);
+    _zkClientForRoutingDataListener.unsubscribeAll();
+    _zkClientForRoutingDataListener.subscribeRoutingDataChanges(this, this);
     resetZkResources();
   }
 
   @Override
   public void handleSessionEstablishmentError(Throwable error) {
-    if (_zkClientForListener == null || _zkClientForListener.isClosed()) {
+    if (_zkClientForRoutingDataListener == null || _zkClientForRoutingDataListener.isClosed()) {
       return;
     }
     // Resubscribe
-    _zkClientForListener.unsubscribeAll();
-    _zkClientForListener.subscribeRoutingDataChanges(this, this);
+    _zkClientForRoutingDataListener.unsubscribeAll();
+    _zkClientForRoutingDataListener.subscribeRoutingDataChanges(this, this);
     resetZkResources();
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
@@ -233,7 +233,7 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
       synchronized (this) {
         if (_byteArrayZkBaseDataAccessor == null) {
           _byteArrayZkBaseDataAccessor =
-              new ZkBaseDataAccessor<>(_zkAddr, new ByteArraySerializer());
+              new ZkBaseDataAccessor<>(getRealmAwareZkClient());
         }
       }
     }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1479

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This change was left out of the ZooScalability migration of helix-rest, making ZooKeeperAccessor endpoints fail in a multi-zk setting. This change fixes this.

### Tests

- [x] The following tests are written for this issue:

Tests already exist for this part of the code.

- [x] The following is the result of the "mvn test" command on the appropriate module:

helix-rest module:
```

[INFO] Tests run: 168, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.257 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 168, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  38.829 s
[INFO] Finished at: 2020-10-21T17:08:58-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
