### PR TITLE
Replace the system.out.printlns in the ThreadLeakageChecker with debug log or error log to avoid verbose output.

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/ThreadLeakageChecker.java
+++ b/helix-core/src/test/java/org/apache/helix/ThreadLeakageChecker.java
@@ -30,9 +30,13 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.helix.common.ZkTestBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ThreadLeakageChecker {
+  private final static Logger LOG = LoggerFactory.getLogger(ThreadLeakageChecker.class);
+
   private static ThreadGroup getRootThreadGroup() {
     ThreadGroup candidate = Thread.currentThread().getThreadGroup();
     while (candidate.getParent() != null) {
@@ -147,7 +151,7 @@ public class ThreadLeakageChecker {
     ZkTestBase.reportPhysicalMemory();
     // step 1: get all active threads
     List<Thread> threads = getAllThreads();
-    System.out.println(classname + " has active threads cnt:" + threads.size());
+    LOG.info(classname + " has active threads cnt:" + threads.size());
 
     // step 2: categorize threads
     Map<String, List<Thread>> threadByName = null;
@@ -160,7 +164,7 @@ public class ThreadLeakageChecker {
               &&  ! "system".equals(p.getThreadGroup().getName())).
           collect(Collectors.groupingBy(p -> p.getName()));
     } catch (Exception e) {
-      System.out.println("filtering thread failure with exception:" + e.getStackTrace());
+      LOG.error("Filtering thread failure with exception:" + e.getStackTrace());
     }
 
     threadByName.entrySet().stream().forEach(entry -> {
@@ -189,15 +193,15 @@ public class ThreadLeakageChecker {
         boolean dumpThread = false;
         if (categoryThreadCnt > limit) {
           checkStatus = false;
-          System.out.println(
+          LOG.info(
               "Failure " + threadCategory.getDescription() + " has " + categoryThreadCnt + " thread");
           dumpThread = true;
         } else if (categoryThreadCnt > warningLimit) {
-          System.out.println(
+          LOG.info(
               "Warning " + threadCategory.getDescription() + " has " + categoryThreadCnt + " thread");
           dumpThread = true;
         } else {
-          System.out.println(threadCategory.getDescription() + " has " + categoryThreadCnt + " thread");
+          LOG.info(threadCategory.getDescription() + " has " + categoryThreadCnt + " thread");
         }
         if (!dumpThread) {
           continue;
@@ -205,10 +209,10 @@ public class ThreadLeakageChecker {
         // print first 100 thread names
         int i = 0;
         for (Thread t : threadByCat.get(threadCategory)) {
-          System.out.println(i + " thread:" + t.getName());
+          LOG.debug(i + " thread:" + t.getName());
           i++;
           if (i == 100) {
-            System.out.println(" skipping the rest");
+            LOG.debug(" skipping the rest");
             break;
           }
         }

--- a/helix-core/src/test/java/org/apache/helix/ThreadLeakageChecker.java
+++ b/helix-core/src/test/java/org/apache/helix/ThreadLeakageChecker.java
@@ -164,7 +164,7 @@ public class ThreadLeakageChecker {
               &&  ! "system".equals(p.getThreadGroup().getName())).
           collect(Collectors.groupingBy(p -> p.getName()));
     } catch (Exception e) {
-      LOG.error("Filtering thread failure with exception:" + e.getStackTrace());
+      LOG.error("Filtering thread failure with exception:", e);
     }
 
     threadByName.entrySet().stream().forEach(entry -> {


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1482 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Replace the system.out.printlns in the ThreadLeakageChecker with debug log or error log to avoid verbose output.
This is a pure test code change. No logic change.

### Tests

- [X] The following tests are written for this issue:

NA

- [X] The following is the result of the "mvn test" command on the appropriate module:

NA

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
