### PR TITLE
Add offline node purge timeout in cluster config

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -128,7 +128,9 @@ public class ClusterConfig extends HelixProperty {
     // offline for more than this specified time period, it's treated as offline for the rest of
     // the maintenance mode's duration even when it comes online.
     // The unit is milliseconds.
-    OFFLINE_NODE_TIME_OUT_FOR_MAINTENANCE_MODE
+    OFFLINE_NODE_TIME_OUT_FOR_MAINTENANCE_MODE,
+
+    OFFLINE_NODE_TIME_OUT_FOR_PURGE
   }
 
   public enum GlobalRebalancePreferenceKey {
@@ -158,6 +160,7 @@ public class ClusterConfig extends HelixProperty {
   public final static boolean DEFAULT_GLOBAL_REBALANCE_ASYNC_MODE_ENABLED = true;
   private static final int GLOBAL_TARGET_TASK_THREAD_POOL_SIZE_NOT_SET = -1;
   private static final long OFFLINE_NODE_TIME_OUT_FOR_MAINTENANCE_MODE_NOT_SET = -1;
+  private static final long OFFLINE_NODE_TIME_OUT_FOR_PURGE_NOT_SET = -1;
 
   /**
    * Instantiate for a specific cluster
@@ -935,6 +938,27 @@ public class ClusterConfig extends HelixProperty {
     return _record
         .getLongField(ClusterConfigProperty.OFFLINE_NODE_TIME_OUT_FOR_MAINTENANCE_MODE.name(),
             OFFLINE_NODE_TIME_OUT_FOR_MAINTENANCE_MODE_NOT_SET);
+  }
+
+  /**
+   * Set the default time out window for offline nodes to be purged. If an offline node has been
+   * offline for more than this specified time period, when users call purge participants API,
+   * the node will be dropped.
+   * @param timeOut timeout window in milliseconds.
+   */
+  public void setOfflineNodeTimeOutForPurge(long timeOut) {
+    _record.setLongField(ClusterConfigProperty.OFFLINE_NODE_TIME_OUT_FOR_PURGE.name(),
+        timeOut);
+  }
+
+  /**
+   * Get the default time out window for offline nodes to be purged. I
+   * @return timeout window in milliseconds
+   */
+  public long getOfflineNodeTimeOutForPurge() {
+    return _record
+        .getLongField(ClusterConfigProperty.OFFLINE_NODE_TIME_OUT_FOR_PURGE.name(),
+            OFFLINE_NODE_TIME_OUT_FOR_PURGE_NOT_SET);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -130,6 +130,10 @@ public class ClusterConfig extends HelixProperty {
     // The unit is milliseconds.
     OFFLINE_NODE_TIME_OUT_FOR_MAINTENANCE_MODE,
 
+    // The time out window for offline nodes to be purged; if an offline node has been
+    // offline for more than this specified time period, and users call purge participant API,
+    // then the node will be removed.
+    // The unit is milliseconds.
     OFFLINE_NODE_TIME_OUT_FOR_PURGE
   }
 
@@ -159,8 +163,7 @@ public class ClusterConfig extends HelixProperty {
   private final static int MIN_REBALANCE_PREFERENCE = 0;
   public final static boolean DEFAULT_GLOBAL_REBALANCE_ASYNC_MODE_ENABLED = true;
   private static final int GLOBAL_TARGET_TASK_THREAD_POOL_SIZE_NOT_SET = -1;
-  private static final long OFFLINE_NODE_TIME_OUT_FOR_MAINTENANCE_MODE_NOT_SET = -1;
-  private static final long OFFLINE_NODE_TIME_OUT_FOR_PURGE_NOT_SET = -1;
+  private static final long VALUE_NOT_SET = -1;
 
   /**
    * Instantiate for a specific cluster
@@ -937,7 +940,7 @@ public class ClusterConfig extends HelixProperty {
   public long getOfflineNodeTimeOutForMaintenanceMode() {
     return _record
         .getLongField(ClusterConfigProperty.OFFLINE_NODE_TIME_OUT_FOR_MAINTENANCE_MODE.name(),
-            OFFLINE_NODE_TIME_OUT_FOR_MAINTENANCE_MODE_NOT_SET);
+            VALUE_NOT_SET);
   }
 
   /**
@@ -952,13 +955,13 @@ public class ClusterConfig extends HelixProperty {
   }
 
   /**
-   * Get the default time out window for offline nodes to be purged. I
+   * Get the default time out window for offline nodes to be purged.
    * @return timeout window in milliseconds
    */
   public long getOfflineNodeTimeOutForPurge() {
     return _record
         .getLongField(ClusterConfigProperty.OFFLINE_NODE_TIME_OUT_FOR_PURGE.name(),
-            OFFLINE_NODE_TIME_OUT_FOR_PURGE_NOT_SET);
+            VALUE_NOT_SET);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
@@ -320,6 +320,29 @@ public class TestClusterConfig {
             -1), 10000L);
   }
 
+
+  @Test
+  public void testGetOfflineNodeTimeOutForPurge() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    Assert.assertEquals(testConfig.getOfflineNodeTimeOutForPurge(), -1);
+
+    testConfig.getRecord()
+        .setLongField(ClusterConfig.ClusterConfigProperty.OFFLINE_NODE_TIME_OUT_FOR_PURGE
+                .name(),
+            10000L);
+    Assert.assertEquals(testConfig.getOfflineNodeTimeOutForPurge(), 10000L);
+  }
+
+  @Test
+  public void testSetOfflineNodeTimeOutForPurge() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    testConfig.setOfflineNodeTimeOutForPurge(10000L);
+    Assert.assertEquals(testConfig.getRecord()
+        .getLongField(ClusterConfig.ClusterConfigProperty.OFFLINE_NODE_TIME_OUT_FOR_PURGE
+                .name(),
+            -1), 10000L);
+  }
+
   @Test
   public void testAbnormalStatesResolverConfig() {
     ClusterConfig testConfig = new ClusterConfig("testConfig");


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fixed #1484 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Helix plans to support the purge of offline nodes that have passed the timeout defined by users. As a prerequisite, we need to provide a simple field in cluster config for users to define the default timeout. This PR add one more field in cluster config for offline nodes timeout to be purged.

### Tests

- [X] The following tests are written for this issue:

TestClusterConfig

- [X] The following is the result of the "mvn test" command on the appropriate module:
helix-core:
[ERROR] Failures:
[ERROR]   TestRoutingTableProviderPeriodicRefresh.testPeriodicRefresh:214 expected:<4> but was:<3>
[ERROR]   TestDeleteJobFromJobQueue.testForceDeleteJobFromJobQueue:73 » Helix Failed to ...
[INFO]
[ERROR] Tests run: 1236, Failures: 2, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:22 h
[INFO] Finished at: 2020-10-27T13:12:36-07:00


### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
