### PR TITLE
Add a configuration option to allow enable/disable writing error log to ZK

### DIFF
--- a/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
+++ b/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
@@ -83,5 +83,5 @@ public class SystemPropertyKeys {
   public static final String MSDS_SERVER_ENDPOINT_KEY =
       MetadataStoreRoutingConstants.MSDS_SERVER_ENDPOINT_KEY;
 
-  public static final String STATEUPDATEUTIL_ERROR_LOG_ENABLED = "helix.StateUpdateUtil.errorLog.enabled";
+  public static final String STATEUPDATEUTIL_ERROR_LOG2ZK_ENABLED = "helix.StateUpdateUtil.errorLog.enabled";
 }

--- a/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
+++ b/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
@@ -82,4 +82,6 @@ public class SystemPropertyKeys {
   // System Property Metadata Store Directory Server endpoint key
   public static final String MSDS_SERVER_ENDPOINT_KEY =
       MetadataStoreRoutingConstants.MSDS_SERVER_ENDPOINT_KEY;
+
+  public static final String STATEUPDATEUTIL_ERROR_LOG_ENABLED = "helix.StateUpdateUtil.errorLog.enabled";
 }

--- a/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
+++ b/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
@@ -83,5 +83,5 @@ public class SystemPropertyKeys {
   public static final String MSDS_SERVER_ENDPOINT_KEY =
       MetadataStoreRoutingConstants.MSDS_SERVER_ENDPOINT_KEY;
 
-  public static final String STATEUPDATEUTIL_ERROR_LOG2ZK_ENABLED = "helix.StateUpdateUtil.errorLog.enabled";
+  public static final String STATEUPDATEUTIL_ERROR_PERSISTENCY_ENABLED = "helix.StateUpdateUtil.errorLog.enabled";
 }

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -469,12 +469,12 @@ public final class HelixUtil {
     return propertyDefaultValue;
   }
 
-    /**
-     * Get the value of system property
-     * @param propertyKey
-     * @param propertyDefaultValue
-     * @return
-     */
+  /**
+   * Get the value of system property
+   * @param propertyKey
+   * @param propertyDefaultValue
+   * @return
+   */
   public static long getSystemPropertyAsLong(String propertyKey, long propertyDefaultValue) {
     String valueString = System.getProperty(propertyKey, "" + propertyDefaultValue);
 

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -62,6 +62,7 @@ import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
+import org.apache.helix.tools.ClusterVerifiers.StrictMatchExternalViewVerifier;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -470,11 +471,26 @@ public final class HelixUtil {
   }
 
   /**
-   * Get the value of system property
+   * Get the boolean value of system property
    * @param propertyKey
    * @param propertyDefaultValue
    * @return
    */
+  public static boolean getSystemPropertyAsBoolean(String propertyKey, String propertyDefaultValue) {
+    String valueString = System.getProperty(propertyKey, "" + propertyDefaultValue);
+    if (valueString.toLowerCase().equals("true")) {
+      return true;
+    }
+    return false;
+  }
+
+
+    /**
+     * Get the value of system property
+     * @param propertyKey
+     * @param propertyDefaultValue
+     * @return
+     */
   public static long getSystemPropertyAsLong(String propertyKey, long propertyDefaultValue) {
     String valueString = System.getProperty(propertyKey, "" + propertyDefaultValue);
 

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -62,7 +62,6 @@ import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
-import org.apache.helix.tools.ClusterVerifiers.StrictMatchExternalViewVerifier;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -469,21 +468,6 @@ public final class HelixUtil {
 
     return propertyDefaultValue;
   }
-
-  /**
-   * Get the boolean value of system property
-   * @param propertyKey
-   * @param propertyDefaultValue
-   * @return
-   */
-  public static boolean getSystemPropertyAsBoolean(String propertyKey, String propertyDefaultValue) {
-    String valueString = System.getProperty(propertyKey, "" + propertyDefaultValue);
-    if (valueString.toLowerCase().equals("true")) {
-      return true;
-    }
-    return false;
-  }
-
 
     /**
      * Get the value of system property

--- a/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
@@ -57,7 +57,7 @@ public class StatusUpdateUtil {
   static Logger _logger = LoggerFactory.getLogger(StatusUpdateUtil.class);
 
   public static final boolean ERROR_LOG_TO_ZK_ENABLED =
-      Boolean.getBoolean(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG2ZK_ENABLED);
+      Boolean.getBoolean(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_PERSISTENCY_ENABLED);
 
   public static class Transition implements Comparable<Transition> {
     private final String _msgID;
@@ -501,13 +501,12 @@ public class StatusUpdateUtil {
 
       if (isController) {
         propertyKey = keyBuilder.controllerTaskStatus(statusUpdateSubPath, statusUpdateKey);
-        accessor.updateProperty(propertyKey, new StatusUpdate(statusUpdateRecord));
       } else {
         propertyKey =
             keyBuilder.stateTransitionStatus(instanceName, sessionId, statusUpdateSubPath,
                 statusUpdateKey);
-        accessor.updateProperty(propertyKey, new StatusUpdate(statusUpdateRecord));
       }
+      accessor.updateProperty(propertyKey, new StatusUpdate(statusUpdateRecord));
 
       if (_logger.isTraceEnabled()) {
         _logger.trace("StatusUpdate path:" + propertyKey.getPath() + ", updates:"
@@ -519,13 +518,13 @@ public class StatusUpdateUtil {
     PropertyKey propertyKey;
     if (isController) {
       propertyKey = keyBuilder.controllerTaskStatus(statusUpdateSubPath, statusUpdateKey);
-      accessor.updateProperty(propertyKey, new StatusUpdate(record));
     } else {
       propertyKey =
           keyBuilder.stateTransitionStatus(instanceName, sessionId, statusUpdateSubPath,
               statusUpdateKey);
-      accessor.updateProperty(propertyKey, new StatusUpdate(record));
     }
+    accessor.updateProperty(propertyKey, new StatusUpdate(record));
+
     if (_logger.isTraceEnabled()) {
       _logger.trace("StatusUpdate path:" + propertyKey.getPath() + ", updates:" + record);
     }

--- a/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
 public class StatusUpdateUtil {
   static Logger _logger = LoggerFactory.getLogger(StatusUpdateUtil.class);
 
-  public static boolean ERROR_LOG_TO_ZK_ENABLED;
+  public static final boolean ERROR_LOG_TO_ZK_ENABLED;
   static {
     String valueString = System.getProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG_ENABLED, "");
     ERROR_LOG_TO_ZK_ENABLED = valueString.equals("enabled") ? true : false;

--- a/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
@@ -496,46 +496,38 @@ public class StatusUpdateUtil {
 
     Builder keyBuilder = accessor.keyBuilder();
     if (!_recordedMessages.containsKey(message.getMsgId())) {
+      ZNRecord statusUpdateRecord = createMessageLogRecord(message);
+      PropertyKey propertyKey;
+
       if (isController) {
-        accessor
-            .updateProperty(keyBuilder.controllerTaskStatus(statusUpdateSubPath, statusUpdateKey),
-                new StatusUpdate(createMessageLogRecord(message)));
-
+        propertyKey = keyBuilder.controllerTaskStatus(statusUpdateSubPath, statusUpdateKey);
+        accessor.updateProperty(propertyKey, new StatusUpdate(statusUpdateRecord));
       } else {
-
-        PropertyKey propertyKey =
+        propertyKey =
             keyBuilder.stateTransitionStatus(instanceName, sessionId, statusUpdateSubPath,
                 statusUpdateKey);
-
-        ZNRecord statusUpdateRecord = createMessageLogRecord(message);
-
-        // For now write participant StatusUpdates to log4j.
-        // we are using restlet as another data channel to report to controller.
-        if (_logger.isTraceEnabled()) {
-          _logger.trace("StatusUpdate path:" + propertyKey.getPath() + ", updates:"
-              + statusUpdateRecord);
-        }
         accessor.updateProperty(propertyKey, new StatusUpdate(statusUpdateRecord));
+      }
 
+      if (_logger.isTraceEnabled()) {
+        _logger.trace("StatusUpdate path:" + propertyKey.getPath() + ", updates:"
+            + statusUpdateRecord);
       }
       _recordedMessages.put(message.getMsgId(), message.getMsgId());
     }
 
+    PropertyKey propertyKey;
     if (isController) {
-      accessor.updateProperty(
-          keyBuilder.controllerTaskStatus(statusUpdateSubPath, statusUpdateKey), new StatusUpdate(
-              record));
+      propertyKey = keyBuilder.controllerTaskStatus(statusUpdateSubPath, statusUpdateKey);
+      accessor.updateProperty(propertyKey, new StatusUpdate(record));
     } else {
-
-      PropertyKey propertyKey =
+      propertyKey =
           keyBuilder.stateTransitionStatus(instanceName, sessionId, statusUpdateSubPath,
               statusUpdateKey);
-      // For now write participant StatusUpdates to log4j.
-      // we are using restlet as another data channel to report to controller.
-      if (_logger.isTraceEnabled()) {
-        _logger.trace("StatusUpdate path:" + propertyKey.getPath() + ", updates:" + record);
-      }
       accessor.updateProperty(propertyKey, new StatusUpdate(record));
+    }
+    if (_logger.isTraceEnabled()) {
+      _logger.trace("StatusUpdate path:" + propertyKey.getPath() + ", updates:" + record);
     }
 
     // If the error level is ERROR, also write the record to "ERROR" ZNode

--- a/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
@@ -57,8 +57,7 @@ public class StatusUpdateUtil {
   static Logger _logger = LoggerFactory.getLogger(StatusUpdateUtil.class);
 
   public static final boolean ERROR_LOG_TO_ZK_ENABLED =
-      HelixUtil.getSystemPropertyAsBoolean(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG_ENABLED, "false");
-
+      Boolean.getBoolean(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG2ZK_ENABLED);
 
   public static class Transition implements Comparable<Transition> {
     private final String _msgID;
@@ -565,7 +564,7 @@ public class StatusUpdateUtil {
    */
   void publishErrorRecord(ZNRecord record, String instanceName, String updateSubPath,
       String updateKey, String sessionId, HelixDataAccessor accessor, boolean isController) {
-    _logger.error("StatusUpdate Error record: {}", record.toString());
+    _logger.error("StatusUpdate Error record: {}", record);
     if (!ERROR_LOG_TO_ZK_ENABLED) {
       return;
     }

--- a/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
@@ -39,6 +39,7 @@ import org.apache.helix.HelixProperty;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyKey.Builder;
+import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.model.Error;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Message.MessageType;
@@ -54,6 +55,12 @@ import org.slf4j.LoggerFactory;
  */
 public class StatusUpdateUtil {
   static Logger _logger = LoggerFactory.getLogger(StatusUpdateUtil.class);
+
+  public static boolean ERROR_LOG_TO_ZK_ENABLED;
+  static {
+    String valueString = System.getProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG_ENABLED, "");
+    ERROR_LOG_TO_ZK_ENABLED = valueString.equals("enabled") ? true : false;
+  }
 
   public static class Transition implements Comparable<Transition> {
     private final String _msgID;
@@ -560,6 +567,9 @@ public class StatusUpdateUtil {
    */
   void publishErrorRecord(ZNRecord record, String instanceName, String updateSubPath,
       String updateKey, String sessionId, HelixDataAccessor accessor, boolean isController) {
+    if (!ERROR_LOG_TO_ZK_ENABLED) {
+      return;
+    }
     Builder keyBuilder = accessor.keyBuilder();
     if (isController) {
       // TODO need to fix: ERRORS_CONTROLLER doesn't have a form of

--- a/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
@@ -56,11 +56,9 @@ import org.slf4j.LoggerFactory;
 public class StatusUpdateUtil {
   static Logger _logger = LoggerFactory.getLogger(StatusUpdateUtil.class);
 
-  public static final boolean ERROR_LOG_TO_ZK_ENABLED;
-  static {
-    String valueString = System.getProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG_ENABLED, "");
-    ERROR_LOG_TO_ZK_ENABLED = valueString.equals("enabled") ? true : false;
-  }
+  public static final boolean ERROR_LOG_TO_ZK_ENABLED =
+      HelixUtil.getSystemPropertyAsBoolean(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG_ENABLED, "false");
+
 
   public static class Transition implements Comparable<Transition> {
     private final String _msgID;
@@ -567,6 +565,7 @@ public class StatusUpdateUtil {
    */
   void publishErrorRecord(ZNRecord record, String instanceName, String updateSubPath,
       String updateKey, String sessionId, HelixDataAccessor accessor, boolean isController) {
+    _logger.error("StatusUpdate Error record: {}", record.toString());
     if (!ERROR_LOG_TO_ZK_ENABLED) {
       return;
     }

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
@@ -66,6 +66,9 @@ import org.testng.annotations.Test;
 public class TestParticipantManager extends ZkTestBase {
   private MBeanServer _server = ManagementFactory.getPlatformMBeanServer();
   private String clusterName = TestHelper.getTestClassName();
+  static {
+    System.setProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG_ENABLED, "enabled");
+  }
 
   @AfterMethod
   public void afterMethod(Method testMethod, ITestContext testContext) {

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
@@ -67,7 +67,7 @@ public class TestParticipantManager extends ZkTestBase {
   private MBeanServer _server = ManagementFactory.getPlatformMBeanServer();
   private String clusterName = TestHelper.getTestClassName();
   static {
-    System.setProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG_ENABLED, "true");
+    System.setProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG2ZK_ENABLED, "true");
   }
 
   @AfterMethod

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
@@ -67,7 +67,7 @@ public class TestParticipantManager extends ZkTestBase {
   private MBeanServer _server = ManagementFactory.getPlatformMBeanServer();
   private String clusterName = TestHelper.getTestClassName();
   static {
-    System.setProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG2ZK_ENABLED, "true");
+    System.setProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_PERSISTENCY_ENABLED, "true");
   }
 
   @AfterMethod

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
@@ -67,7 +67,7 @@ public class TestParticipantManager extends ZkTestBase {
   private MBeanServer _server = ManagementFactory.getPlatformMBeanServer();
   private String clusterName = TestHelper.getTestClassName();
   static {
-    System.setProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG_ENABLED, "enabled");
+    System.setProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG_ENABLED, "true");
   }
 
   @AfterMethod

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
@@ -60,6 +60,7 @@ import org.apache.helix.monitoring.mbeans.ZkClientPathMonitor;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.testng.Assert;
 import org.testng.ITestContext;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
@@ -74,6 +75,11 @@ public class TestParticipantManager extends ZkTestBase {
   public void afterMethod(Method testMethod, ITestContext testContext) {
     deleteCluster(clusterName);
     super.endTest(testMethod, testContext);
+  }
+
+  @AfterClass
+  public void afterClass() {
+    System.clearProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_PERSISTENCY_ENABLED);
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/util/TestStatusUpdateUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestStatusUpdateUtil.java
@@ -1,5 +1,27 @@
 package org.apache.helix.util;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
 import org.apache.helix.HelixConstants;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.SystemPropertyKeys;
@@ -8,24 +30,42 @@ import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.messaging.handling.HelixStateTransitionHandler;
 import org.apache.helix.model.Message;
+import org.apache.helix.model.StatusUpdate;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.zkclient.exception.ZkException;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
 public class TestStatusUpdateUtil extends ZkTestBase {
   private String clusterName = TestHelper.getTestClassName();
-  static {
-    System.clearProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG_ENABLED);
+  private int n = 1;
+  private Message message = new Message(Message.MessageType.STATE_TRANSITION, "Some unique id");
+  private MockParticipantManager[] participants = new MockParticipantManager[n];
+
+
+  static void setFinalStatic(Field field, Object newValue) throws Exception {
+    field.setAccessible(true);
+
+    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    modifiersField.setAccessible(true);
+    modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+    field.set(null, newValue);
   }
 
-  @Test
-  public void testDisableErrorLogByDefault() throws Exception {
-    StatusUpdateUtil _statusUpdateUtil = new StatusUpdateUtil();
-    int n = 1;
+  @AfterClass
+  public void afterClass() {
+    for (int i = 0; i < n; i++) {
+      participants[i].syncStop();
+    }
+  }
 
-    Exception e = new RuntimeException("test exception");
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    super.beforeClass();
 
     TestHelper.setupCluster(clusterName, ZK_ADDR, 12918, // participant port
         "localhost", // participant name prefix
@@ -36,15 +76,12 @@ public class TestStatusUpdateUtil extends ZkTestBase {
         1, // replicas
         "MasterSlave", true);
 
-    MockParticipantManager[] participants = new MockParticipantManager[n];
-
     for (int i = 0; i < n; i++) {
       String instanceName = "localhost_" + (12918 + i);
       participants[i] = new MockParticipantManager(ZK_ADDR, clusterName, instanceName);
       participants[i].syncStart();
     }
 
-    Message message = new Message(Message.MessageType.STATE_TRANSITION, "Some unique id");
     message.setSrcName("cm-instance-0");
     message.setTgtSessionId(participants[0].getSessionId());
     message.setFromState("Offline");
@@ -55,22 +92,47 @@ public class TestStatusUpdateUtil extends ZkTestBase {
     message.setTgtName("localhost_12918");
     message.setStateModelDef("MasterSlave");
     message.setStateModelFactoryName(HelixConstants.DEFAULT_STATE_MODEL_FACTORY);
-    _statusUpdateUtil.logError(message, HelixStateTransitionHandler.class, e,
+
+  }
+
+  @Test(dependsOnMethods = "testDisableErrorLogByDefault")
+  public void testEnableErrorLog() throws Exception {
+    StatusUpdateUtil statusUpdateUtil = new StatusUpdateUtil();
+    setFinalStatic(StatusUpdateUtil.class.getField("ERROR_LOG_TO_ZK_ENABLED"), true);
+
+    Exception e = new RuntimeException("test exception");
+    statusUpdateUtil.logError(message, HelixStateTransitionHandler.class, e,
+        "test status update", participants[0]);
+    // logged to Zookeeper
+    String errPath = PropertyPathBuilder
+        .instanceError(clusterName, "localhost_12918", participants[0].getSessionId(), "TestDB",
+            "TestDB_0");
+
+    try {
+      ZNRecord error = _gZkClient.readData(errPath);
+    } catch (ZkException zke) {
+      Assert.fail("expecting being able to send error logs to ZK.", zke);
+    }
+  }
+
+  @Test
+  public void testDisableErrorLogByDefault() throws Exception {
+    StatusUpdateUtil statusUpdateUtil = new StatusUpdateUtil();
+    setFinalStatic(StatusUpdateUtil.class.getField("ERROR_LOG_TO_ZK_ENABLED"), false);
+
+    Exception e = new RuntimeException("test exception");
+    statusUpdateUtil.logError(message, HelixStateTransitionHandler.class, e,
         "test status update", participants[0]);
 
     // assert by default, not logged to Zookeeper
-    String errPath = PropertyPathBuilder.instanceError(clusterName, "localhost_12918",
-        participants[0].getSessionId(),
-        "TestDB", "TestDB_0");
+    String errPath = PropertyPathBuilder
+        .instanceError(clusterName, "localhost_12918", participants[0].getSessionId(), "TestDB",
+            "TestDB_0");
     try {
       ZNRecord error = _gZkClient.readData(errPath);
       Assert.fail("not expecting being able to send error logs to ZK by default.");
     } catch (ZkException zke) {
-      Assert.assertTrue(true);
-    }
-
-    for (int i = 0; i < n; i++) {
-      participants[i].syncStop();
+      // expected
     }
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/util/TestStatusUpdateUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestStatusUpdateUtil.java
@@ -1,0 +1,76 @@
+package org.apache.helix.util;
+
+import org.apache.helix.HelixConstants;
+import org.apache.helix.PropertyPathBuilder;
+import org.apache.helix.SystemPropertyKeys;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.messaging.handling.HelixStateTransitionHandler;
+import org.apache.helix.model.Message;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.zkclient.exception.ZkException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestStatusUpdateUtil extends ZkTestBase {
+  private String clusterName = TestHelper.getTestClassName();
+  static {
+    System.clearProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_LOG_ENABLED);
+  }
+
+  @Test
+  public void testDisableErrorLogByDefault() throws Exception {
+    StatusUpdateUtil _statusUpdateUtil = new StatusUpdateUtil();
+    int n = 1;
+
+    Exception e = new RuntimeException("test exception");
+
+    TestHelper.setupCluster(clusterName, ZK_ADDR, 12918, // participant port
+        "localhost", // participant name prefix
+        "TestDB", // resource name prefix
+        1, // resources
+        1, // partitions per resource
+        n, // number of nodes
+        1, // replicas
+        "MasterSlave", true);
+
+    MockParticipantManager[] participants = new MockParticipantManager[n];
+
+    for (int i = 0; i < n; i++) {
+      String instanceName = "localhost_" + (12918 + i);
+      participants[i] = new MockParticipantManager(ZK_ADDR, clusterName, instanceName);
+      participants[i].syncStart();
+    }
+
+    Message message = new Message(Message.MessageType.STATE_TRANSITION, "Some unique id");
+    message.setSrcName("cm-instance-0");
+    message.setTgtSessionId(participants[0].getSessionId());
+    message.setFromState("Offline");
+    message.setToState("Slave");
+    message.setPartitionName("TestDB_0");
+    message.setMsgId("Some unique message id");
+    message.setResourceName("TestDB");
+    message.setTgtName("localhost_12918");
+    message.setStateModelDef("MasterSlave");
+    message.setStateModelFactoryName(HelixConstants.DEFAULT_STATE_MODEL_FACTORY);
+    _statusUpdateUtil.logError(message, HelixStateTransitionHandler.class, e,
+        "test status update", participants[0]);
+
+    // assert by default, not logged to Zookeeper
+    String errPath = PropertyPathBuilder.instanceError(clusterName, "localhost_12918",
+        participants[0].getSessionId(),
+        "TestDB", "TestDB_0");
+    try {
+      ZNRecord error = _gZkClient.readData(errPath);
+      Assert.fail("not expecting being able to send error logs to ZK by default.");
+    } catch (ZkException zke) {
+      Assert.assertTrue(true);
+    }
+
+    for (int i = 0; i < n; i++) {
+      participants[i].syncStop();
+    }
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

    fix #1486

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

    Improve statusUpdateUtil log error to ZK by adding an option to enabled
    it. By default, it would not log error to ZK. This is to avoid some
    error code path that keep flooding ZK sever which cause DoS to Zk.
    Such as HelixTaskExecutor onMessage creation messageHandler exception.

### Tests

- [x] The following tests are written for this issue:
  TestStatusUpdateUtil

- [x] The following is the result of the "mvn test" command on the appropriate module:

github passed.
https://github.com/apache/helix/runs/1344486165?check_suite_focus=true

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
