### PR TITLE
Fix wrong logging for instance validation

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
@@ -114,7 +114,7 @@ public class InstanceValidationUtil {
       }
     }
 
-    _logger.warn(String.format("The instance %s is not active", instanceName));
+    _logger.warn(String.format("The instance %s does not have resource assigned on it.", instanceName));
     return false;
   }
 
@@ -196,12 +196,12 @@ public class InstanceValidationUtil {
         CurrentState currentState = dataAccessor.getProperty(key);
         if (currentState != null
             && currentState.getPartitionStateMap().containsValue(HelixDefinedState.ERROR.name())) {
+          _logger.warn(String.format("The instance %s has error partitions on it.", instanceName));
           return true;
         }
       }
     }
 
-    _logger.warn(String.format("The instance %s is not active", instanceName));
     return false;
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
fixes #1491 
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fixes wrong logging in Instance validation for :
1. Error partition.
2. Resource assigned.

### Tests

- [ ] The following tests are written for this issue:

- [x] The following is the result of the "mvn test" command on the appropriate module:

[ERROR] Failures:
[ERROR]   TestCleanupExternalView.test:122 external-view for TestDB0 should be removed, but was: ZnRecord=TestDB0, {BUCKET_SIZE=0, IDEAL_STATE_MODE=AUTO, NUM_PARTITIONS=2, REBALANCE_MODE=SEMI_AUTO, REBALANCE_STRATEGY=DEFAULT, REPLICAS=2, STATE_MODEL_DEF_REF=MasterSlave, STATE_MODEL_FACTORY_NAME=DEFAULT}{TestDB0_0={localhost_12918=SLAVE, localhost_12919=MASTER}, TestDB0_1={localhost_12918=MASTER, localhost_12919=SLAVE}}{}, Stat=Stat {_version=5, _creationTime=1603838409203, _modifiedTime=1603838409642, _ephemeralOwner=0} expected:<true> but was:<false>
[ERROR]   TestRoutingTableProviderPeriodicRefresh.testPeriodicRefresh:214 expected:<4> but was:<3>
[INFO]
[ERROR] Tests run: 1234, Failures: 2, Errors: 0, Skipped: 0

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.981 s - in org.apache.helix.integration.TestCleanupExternalView
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0


### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
