### PR TITLE
Restore deprecated constructor of bestpossibleverifier to make it backward compatible

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -82,6 +82,7 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
     this(zkAddr, clusterName, resources, errStates, expectLiveInstances, 0);
   }
 
+  @Deprecated
   public BestPossibleExternalViewVerifier(String zkAddr, String clusterName, Set<String> resources,
       Map<String, Map<String, String>> errStates, Set<String> expectLiveInstances, int waitTillVerify) {
     super(zkAddr, clusterName, waitTillVerify);
@@ -105,7 +106,8 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
       Set<String> expectLiveInstances) {
     this(zkClient, clusterName, resources, errStates, expectLiveInstances, 0);
   }
-  
+
+  @Deprecated
   public BestPossibleExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Set<String> resources, Map<String, Map<String, String>> errStates,
       Set<String> expectLiveInstances, int waitTillVerify) {

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -78,6 +78,11 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
    */
   @Deprecated
   public BestPossibleExternalViewVerifier(String zkAddr, String clusterName, Set<String> resources,
+      Map<String, Map<String, String>> errStates, Set<String> expectLiveInstances) {
+    this(zkAddr, clusterName, resources, errStates, expectLiveInstances, 0);
+  }
+
+  public BestPossibleExternalViewVerifier(String zkAddr, String clusterName, Set<String> resources,
       Map<String, Map<String, String>> errStates, Set<String> expectLiveInstances, int waitTillVerify) {
     super(zkAddr, clusterName, waitTillVerify);
     _errStates = errStates;
@@ -95,6 +100,12 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
    * @param expectLiveInstances
    */
   @Deprecated
+  public BestPossibleExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
+      Set<String> resources, Map<String, Map<String, String>> errStates,
+      Set<String> expectLiveInstances) {
+    this(zkClient, clusterName, resources, errStates, expectLiveInstances, 0);
+  }
+  
   public BestPossibleExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Set<String> resources, Map<String, Map<String, String>> errStates,
       Set<String> expectLiveInstances, int waitTillVerify) {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

fix #1495 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

make BestPossibleExternalViewVerifier deprecated constructor backward
compatible. Otherwise, it breaks partner's build.
### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [x] The following is the result of the "mvn test" command on the appropriate module:

build against partner's repo and it eliminates the previous backward compatibility issue.
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
