### PR TITLE
Trim strings in znrecord fields for REST json content

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/AbstractHelixResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/AbstractHelixResource.java
@@ -33,7 +33,7 @@ import org.apache.helix.tools.ClusterSetup;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
-
+import org.apache.helix.zookeeper.util.ZNRecordUtil;
 
 /**
  * This class provides methods to access Helix specific objects
@@ -83,7 +83,8 @@ public class AbstractHelixResource extends AbstractResource {
 
   protected static ZNRecord toZNRecord(String data)
       throws IOException {
-    return OBJECT_MAPPER.reader(ZNRecord.class).readValue(data);
+    ZNRecord record = OBJECT_MAPPER.readValue(data, ZNRecord.class);
+    return ZNRecordUtil.trimFields(record);
   }
 
   private ServerContext getServerContext() {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/ZNRecordUtil.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/ZNRecordUtil.java
@@ -19,6 +19,10 @@ package org.apache.helix.zookeeper.util;
  * under the License.
  */
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.helix.zookeeper.constant.ZkSystemPropertyKeys;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
@@ -61,5 +65,32 @@ public class ZNRecordUtil {
     }
 
     return writeSizeLimit;
+  }
+
+  /**
+   * Trims leading/trailing spaces for all strings in Simple/List/Map fields of a {@link ZNRecord}.
+   *
+   * @param record the {@link ZNRecord} to be trimmed.
+   * @return a {@link ZNRecord} that has been trimmed: strings in its fields are trimmed.
+   */
+  public static ZNRecord trimFields(ZNRecord record) {
+    Map<String, String> simpleFields = record.getSimpleFields().entrySet().stream()
+        .collect(Collectors.toMap(e -> e.getKey().trim(), e -> e.getValue().trim()));
+
+    Map<String, List<String>> listFields = record.getListFields().entrySet().stream()
+        .collect(Collectors.toMap(e -> e.getKey().trim(),
+            e -> e.getValue().stream().map(String::trim).collect(Collectors.toList())));
+
+    Map<String, Map<String, String>> mapFields = record.getMapFields().entrySet().stream()
+        .collect(Collectors.toMap(e1 -> e1.getKey().trim(),
+            e1 -> e1.getValue().entrySet().stream()
+                .collect(Collectors.toMap(e2 -> e2.getKey().trim(), e2 -> e2.getValue().trim()))));
+
+    ZNRecord trimmedRecord = new ZNRecord(record);
+    trimmedRecord.setSimpleFields(simpleFields);
+    trimmedRecord.setListFields(listFields);
+    trimmedRecord.setMapFields(mapFields);
+
+    return trimmedRecord;
   }
 }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestZNRecordUtil.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/util/TestZNRecordUtil.java
@@ -1,0 +1,46 @@
+package org.apache.helix.zookeeper.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestZNRecordUtil {
+  @Test
+  public void testTrimFields() {
+    ZNRecord record = new ZNRecord("test");
+    record.setSimpleFields(ImmutableMap.of(" simpleKey", " simpleValue"));
+    record.setListFields(ImmutableMap.of(" ListKey ", ImmutableList.of("  ListValue  ")));
+    record.setMapFields(ImmutableMap.of(" MapKey", ImmutableMap.of(" subMapKey ", "subMapValue")));
+
+    ZNRecord trimmedRecord = ZNRecordUtil.trimFields(record);
+
+    ZNRecord expectedRecord = new ZNRecord("expected");
+    expectedRecord.setSimpleFields(ImmutableMap.of("simpleKey", "simpleValue"));
+    expectedRecord.setListFields(ImmutableMap.of("ListKey", ImmutableList.of("ListValue")));
+    expectedRecord.setMapFields(ImmutableMap.of("MapKey", ImmutableMap.of("subMapKey", "subMapValue")));
+
+    Assert.assertEquals(trimmedRecord, expectedRecord);
+    Assert.assertFalse(record.equals(trimmedRecord));
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1498 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

If users accidentally put a leading space in the json payloads and call helix rest to update cluster configs, the leading space is not correctly handled and causes configs not to be appropriately parsed. Then it leads to some issues in helix that relies on the configs.

This PR trims strings in the znrecords fields after the REST API's json payloads are deserialized to a znrecord.

### Tests

- [x] The following tests are written for this issue:

TestZNRecordUtil#testTrimFields

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestClusterAccessor.testUpdateRESTConfig:718->AbstractTestClass.post:529 expected:<200> but was:<500>
[INFO]
[ERROR] Tests run: 170, Failures: 1, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:46 min
[INFO] Finished at: 2020-10-29T23:12:16-07:00
[INFO] ------------------------------------------------------------------------
```
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
