### PR TITLE
Fix ondemand rebalance flooding and log flooding caused by dangling jobs

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/common/caches/TaskDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/common/caches/TaskDataCache.java
@@ -116,9 +116,7 @@ public class TaskDataCache extends AbstractDataCache {
       }
     }
 
-    // This block makes sure that the workflow config has been changed.
-    // This avoid the race condition where job config has been purged but job has not been deleted
-    // from JobDag yet
+    // If the workflow config has been updated, it's possible that the dag has been changed.
     for (String workflowName : _workflowConfigMap.keySet()) {
       if (_runtimeJobDagMap.containsKey(workflowName)) {
         if (_workflowConfigMap.get(workflowName).getRecord().getVersion() != _runtimeJobDagMap

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ResourceComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ResourceComputationStage.java
@@ -164,7 +164,8 @@ public class ResourceComputationStage extends AbstractBaseStage {
       if (numPartitions == 0 && idealStates != null) {
         IdealState targetIs = idealStates.get(jobConfig.getTargetResource());
         if (targetIs == null) {
-          LOG.warn("Target resource " + jobConfig.getTargetResource() + " does not exist for job " + resourceName);
+          LOG.debug("Target resource " + jobConfig.getTargetResource() + " does not exist for job "
+              + resourceName);
         } else {
           numPartitions = targetIs.getPartitionSet().size();
         }

--- a/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestWorkflowControllerDataProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestWorkflowControllerDataProvider.java
@@ -19,10 +19,20 @@ package org.apache.helix.controller.dataproviders;
  * under the License.
  */
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.apache.helix.AccessOption;
+import org.apache.helix.PropertyKey;
 import org.apache.helix.TestHelper;
 import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.integration.task.TaskTestUtil;
 import org.apache.helix.integration.task.WorkflowGenerator;
 import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.JobQueue;
+import org.apache.helix.task.RuntimeJobDag;
+import org.apache.helix.task.TaskUtil;
 import org.apache.helix.task.Workflow;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -69,5 +79,61 @@ public class TestWorkflowControllerDataProvider extends TaskTestBase {
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(expectedValuesAchieved);
 
+  }
+
+  @Test (dependsOnMethods = "testResourceConfigRefresh")
+  public void testRuntimeDagRefresh() throws Exception {
+    String jobQueueName = TestHelper.getTestMethodName();
+    JobQueue.Builder builder = TaskTestUtil.buildJobQueue(jobQueueName);
+    JobConfig.Builder jobBuilder = JobConfig.Builder.fromMap(WorkflowGenerator.DEFAULT_JOB_CONFIG);
+    builder.enqueueJob(WorkflowGenerator.JOB_NAME_1, jobBuilder);
+    String jobName1 = TaskUtil.getNamespacedJobName(jobQueueName, WorkflowGenerator.JOB_NAME_1);
+    _driver.start(builder.build());
+
+    WorkflowControllerDataProvider cache =
+        new WorkflowControllerDataProvider("CLUSTER_" + TestHelper.getTestClassName());
+
+    Assert.assertTrue(TestHelper.verify(() -> {
+      cache.requireFullRefresh();
+      cache.refresh(_manager.getHelixDataAccessor());
+      return cache.getTaskDataCache().getJobConfig(jobName1) != null;
+    }, TestHelper.WAIT_DURATION));
+    RuntimeJobDag runtimeJobDag = cache.getTaskDataCache().getRuntimeJobDag(jobQueueName);
+    Assert.assertEquals(Collections.singleton(jobName1), runtimeJobDag.getAllNodes());
+
+    // Mimic job running
+    runtimeJobDag.getNextJob();
+
+    // Add job config without adding it to the dag
+    String danglingJobName = TaskUtil.getNamespacedJobName(jobQueueName, "DanglingJob");
+    JobConfig danglingJobConfig = new JobConfig(danglingJobName, jobBuilder.build());
+    PropertyKey.Builder keyBuilder = _manager.getHelixDataAccessor().keyBuilder();
+    _baseAccessor
+        .create(keyBuilder.resourceConfig(danglingJobName).getPath(), danglingJobConfig.getRecord(),
+            AccessOption.PERSISTENT);
+
+    // There shouldn't be a refresh to runtime dag. The dag should only contain one job and the job is inflight.
+    Assert.assertTrue(TestHelper.verify(() -> {
+      cache.requireFullRefresh();
+      cache.refresh(_manager.getHelixDataAccessor());
+      return cache.getTaskDataCache().getJobConfig(danglingJobName) != null;
+    }, TestHelper.WAIT_DURATION));
+    runtimeJobDag = cache.getTaskDataCache().getRuntimeJobDag(jobQueueName);
+    Assert.assertEquals(Collections.singleton(jobName1), runtimeJobDag.getAllNodes());
+    Assert.assertEquals(Collections.singleton(jobName1), runtimeJobDag.getInflightJobList());
+
+    _driver.enqueueJob(jobQueueName, WorkflowGenerator.JOB_NAME_2, jobBuilder);
+    String jobName2 = TaskUtil.getNamespacedJobName(jobQueueName, WorkflowGenerator.JOB_NAME_2);
+
+    // There should be a refresh to runtime dag.
+    Assert.assertTrue(TestHelper.verify(() -> {
+      cache.requireFullRefresh();
+      cache.refresh(_manager.getHelixDataAccessor());
+      return cache.getTaskDataCache().getJobConfig(jobName2) != null;
+    }, TestHelper.WAIT_DURATION));
+    runtimeJobDag = cache.getTaskDataCache().getRuntimeJobDag(jobQueueName);
+    Assert.assertEquals(new HashSet<>(Arrays.asList(jobName1, jobName2)),
+        runtimeJobDag.getAllNodes());
+    Assert.assertEquals(Collections.emptyList(), runtimeJobDag.getInflightJobList());
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1506, #1507

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR fixes 2 issues:
1. Ondemand rebalance flooding after TF IS removal. This is caused by an old problem. A jobConfig can exist for the previous iterations of a workflow, but the job doesn't exist in the job DAG. Because of runtime DAG refresh logic, such a jobConfig will cause the runtime DAG to be refreshed every time the pipeline runs. A new runtime DAG causes all the jobs to be reprocessed, and during processing, the cleanup logic is run for every job that has already completed. Before IS removal, the cleanup logic attempts to delete the IS again, which has no effect; in the new code, an onDemand rebalance is triggered instead. 
This "dangling job" will not be removed, so the job dag refresh keeps on happening, which causes the ondemand rebalances to keep on firing. 
2. Log flooding for jobs that miss target resources after TF IS removal. Similarly, "dangling jobs" can have missing target resources once their target resources are deleted. Before IS removal, this is not a problem because this log is only triggered when the job is first processed; now, the processing logic happens every pipeline (since it's config based, instead of IS based), so the log could keep on firing. 

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 1237, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4,907.142 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1237, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:21 h
[INFO] Finished at: 2020-11-03T13:22:54-08:00
[INFO] ------------------------------------------------------------------------
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
