### PR TITLE
fixed bug #1517: Controller tutorial doc page compilation errors

### DIFF
--- a/website/0.9.8/src/site/markdown/tutorial_controller.md
+++ b/website/0.9.8/src/site/markdown/tutorial_controller.md
@@ -119,11 +119,12 @@ If you need additional functionality, see GenericHelixController on how to confi
                                                           zkConnectString);
      manager.connect();
      GenericHelixController controller = new GenericHelixController();
-     manager.addConfigChangeListener(controller);
+     manager.addControllerListener(controller);
+     manager.addInstanceConfigChangeListener(controller);
+     manager.addResourceConfigChangeListener(controller);
+     manager.addClusterfigChangeListener(controller);
      manager.addLiveInstanceChangeListener(controller);
      manager.addIdealStateChangeListener(controller);
-     manager.addExternalViewChangeListener(controller);
-     manager.addControllerListener(controller);
 ```
 The snippet above shows how the controller is started. You can also start the controller using command line interface.
 

--- a/website/1.0.1/src/site/markdown/tutorial_controller.md
+++ b/website/1.0.1/src/site/markdown/tutorial_controller.md
@@ -119,11 +119,13 @@ If you need additional functionality, see GenericHelixController on how to confi
                                                           zkConnectString);
      manager.connect();
      GenericHelixController controller = new GenericHelixController();
-     manager.addConfigChangeListener(controller);
+     manager.addControllerListener(controller);
+     manager.addInstanceConfigChangeListener(controller);
+     manager.addResourceConfigChangeListener(controller);
+     manager.addClusterfigChangeListener(controller);
+     manager.addCustomizedStateConfigChangeListener(controller);
      manager.addLiveInstanceChangeListener(controller);
      manager.addIdealStateChangeListener(controller);
-     manager.addExternalViewChangeListener(controller);
-     manager.addControllerListener(controller);
 ```
 The snippet above shows how the controller is started. You can also start the controller using command line interface.
 


### PR DESCRIPTION


### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1517 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

I fixed them by doing the same thing as the ``addListenersToController`` method of ``org.apache.helix.manager.zk.ControllerManagerHelper``.
As the code is different between 0.9.8 and 1.0.1, the documentation fix also differs accordingly (0.9.8 and 1.0.1 docs).
