### PR TITLE
Stabilizing several tests by giving a starting up waiting periods 

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/TestDrop.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestDrop.java
@@ -180,7 +180,8 @@ public class TestDrop extends ZkTestBase {
     ZkHelixClusterVerifier verifier = new BestPossibleExternalViewVerifier.Builder(clusterName)
         .setZkClient(_gZkClient).setErrStates(errStateMap)
         .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
-        .build();    Assert.assertTrue(verifier.verifyByPolling());
+        .build();
+    Assert.assertTrue(verifier.verifyByPolling());
 
     // drop resource containing error partitions should drop the partition successfully
     ClusterSetup.processCommandLineArgs(new String[] {

--- a/helix-core/src/test/java/org/apache/helix/integration/TestStateTransitionThrottle.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestStateTransitionThrottle.java
@@ -86,7 +86,9 @@ public class TestStateTransitionThrottle extends ZkTestBase {
         new ClusterControllerManager(ZK_ADDR, clusterName, "controller_0");
     controller.syncStart();
     BestPossibleExternalViewVerifier verifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     // Won't match, since there is pending transition
     Assert.assertFalse(verifier.verify(3000));
 
@@ -158,7 +160,9 @@ public class TestStateTransitionThrottle extends ZkTestBase {
     controller.syncStart();
 
     BestPossibleExternalViewVerifier verifier =
-        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier.verify(3000));
 
     // Adding one more participant.

--- a/helix-core/src/test/java/org/apache/helix/integration/common/ZkStandAloneCMTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/common/ZkStandAloneCMTestBase.java
@@ -84,7 +84,8 @@ public class ZkStandAloneCMTestBase extends ZkTestBase {
 
     _clusterVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
         .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
-        .build();    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+        .build();
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // create cluster manager
     _manager = HelixManagerFactory

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
@@ -286,7 +286,8 @@ public class TestParticipantManager extends ZkTestBase {
     BestPossibleExternalViewVerifier verifier =
         new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
             .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
-            .build();    Assert.assertTrue(verifier.verifyByPolling());
+            .build();
+    Assert.assertTrue(verifier.verifyByPolling());
     String oldSessionId = participants[0].getSessionId();
 
     // expire zk-connection on localhost_12918

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalanceWithRackaware.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/DelayedAutoRebalancer/TestDelayedAutoRebalanceWithRackaware.java
@@ -63,7 +63,8 @@ public class TestDelayedAutoRebalanceWithRackaware extends TestDelayedAutoRebala
     _clusterVerifier =
         new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
             .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
-            .build();  }
+            .build();
+  }
 
   @Override
   protected IdealState createResourceWithDelayedRebalance(String clusterName, String db,

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedNodeSwap.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedNodeSwap.java
@@ -184,7 +184,6 @@ public class TestWagedNodeSwap extends ZkTestBase {
     _gSetupTool.getClusterManagementTool()
         .manuallyEnableMaintenanceMode(CLUSTER_NAME, false, "NodeSwapDone", Collections.emptyMap());
 
-    Thread.sleep(2000);
     Assert.assertTrue(_clusterVerifier.verify(5000));
 
     // Since only one node temporary down, the same partitions will be moved to the newly added node.
@@ -270,7 +269,6 @@ public class TestWagedNodeSwap extends ZkTestBase {
     _gSetupTool.getClusterManagementTool()
         .manuallyEnableMaintenanceMode(CLUSTER_NAME, false, "NodeSwapDone", Collections.emptyMap());
 
-    Thread.sleep(2000);
     Assert.assertTrue(_clusterVerifier.verify(5000));
 
     for (String db : _allDBs) {

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalance.java
@@ -143,7 +143,6 @@ public class TestWagedRebalance extends ZkTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(300);
 
     validate(_replica);
 
@@ -156,8 +155,6 @@ public class TestWagedRebalance extends ZkTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, moreDB, _replica);
       _allDBs.add(moreDB);
 
-      Thread.sleep(300);
-
       validate(_replica);
     }
 
@@ -166,8 +163,6 @@ public class TestWagedRebalance extends ZkTestBase {
       String moreDB = "More-Test-DB-" + j++;
       _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, moreDB);
       _allDBs.remove(moreDB);
-
-      Thread.sleep(300);
 
       validate(_replica);
     }
@@ -188,7 +183,6 @@ public class TestWagedRebalance extends ZkTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(300);
 
     validate(_replica);
 
@@ -290,7 +284,6 @@ public class TestWagedRebalance extends ZkTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(300);
     validate(_replica);
   }
 
@@ -301,7 +294,6 @@ public class TestWagedRebalance extends ZkTestBase {
         BuiltInStateModelDefinitions.MasterSlave.name(), PARTITIONS, _replica, _replica);
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, dbName, _replica);
     _allDBs.add(dbName);
-    Thread.sleep(300);
 
     validate(_replica);
 
@@ -311,7 +303,6 @@ public class TestWagedRebalance extends ZkTestBase {
     int newReplicaFactor = _replica - 1;
     is.setReplicas("" + newReplicaFactor);
     _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, dbName, is);
-    Thread.sleep(300);
 
     validate(newReplicaFactor);
 
@@ -320,7 +311,6 @@ public class TestWagedRebalance extends ZkTestBase {
     is.setNumPartitions(PARTITIONS + 1);
     _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, dbName, is);
     _gSetupTool.getClusterManagementTool().rebalance(CLUSTER_NAME, dbName, newReplicaFactor);
-    Thread.sleep(300);
 
     validate(newReplicaFactor);
     ExternalView ev =
@@ -333,7 +323,6 @@ public class TestWagedRebalance extends ZkTestBase {
     is = _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, dbName);
     is.setPreferenceList(dbName + "_customizedPartition", Collections.EMPTY_LIST);
     _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, dbName, is);
-    Thread.sleep(300);
 
     validate(newReplicaFactor);
     ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, dbName);
@@ -347,7 +336,6 @@ public class TestWagedRebalance extends ZkTestBase {
         BuiltInStateModelDefinitions.MasterSlave.name(), PARTITIONS, _replica, _replica);
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, dbName, _replica);
     _allDBs.add(dbName);
-    Thread.sleep(300);
 
     validate(_replica);
 
@@ -364,7 +352,6 @@ public class TestWagedRebalance extends ZkTestBase {
         _gSetupTool.getClusterManagementTool()
             .setInstanceConfig(CLUSTER_NAME, p.getInstanceName(), config);
       }
-      Thread.sleep(300);
 
       validate(_replica);
 
@@ -405,7 +392,6 @@ public class TestWagedRebalance extends ZkTestBase {
       _allDBs.add(db);
     }
 
-    Thread.sleep(300);
     // Verify if the partitions get assigned
     validate(2);
 
@@ -418,7 +404,6 @@ public class TestWagedRebalance extends ZkTestBase {
       newNode.syncStart();
     }
 
-    Thread.sleep(300);
     // Verify if the partitions get assigned
     validate(_replica);
   }
@@ -443,7 +428,6 @@ public class TestWagedRebalance extends ZkTestBase {
       _allDBs.add(db);
     }
 
-    Thread.sleep(300);
     // Verify if the partitions get assigned
     validate(2);
 
@@ -458,7 +442,6 @@ public class TestWagedRebalance extends ZkTestBase {
       newNode.syncStart();
     }
 
-    Thread.sleep(300);
     // Verify if the partitions get assigned
     validate(_replica);
   }
@@ -481,8 +464,6 @@ public class TestWagedRebalance extends ZkTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(300);
-
     validate(_replica);
   }
 
@@ -571,7 +552,6 @@ public class TestWagedRebalance extends ZkTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    Thread.sleep(300);
     validate(_replica);
 
     String newNodeName = "newNode-" + TestHelper.getTestMethodName() + "_" + START_PORT;
@@ -581,7 +561,6 @@ public class TestWagedRebalance extends ZkTestBase {
       _gSetupTool.addInstanceToCluster(CLUSTER_NAME, newNodeName);
       participant.syncStart();
 
-      Thread.sleep(300);
       validate(_replica);
 
       Assert.assertFalse(_allDBs.stream().anyMatch(db -> {
@@ -597,7 +576,6 @@ public class TestWagedRebalance extends ZkTestBase {
 
       clusterConfig.setGlobalRebalancePreference(ClusterConfig.DEFAULT_GLOBAL_REBALANCE_PREFERENCE);
       configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
-      Thread.sleep(300);
       validate(_replica);
 
       Assert.assertTrue(_allDBs.stream().anyMatch(db -> {
@@ -641,8 +619,6 @@ public class TestWagedRebalance extends ZkTestBase {
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
       _allDBs.add(db);
     }
-    // TODO remove this sleep after fix https://github.com/apache/helix/issues/526
-    Thread.sleep(300);
     validate(_replica);
 
     // Adding one more resource. Since it is added after the other resources, the assignment is
@@ -652,8 +628,6 @@ public class TestWagedRebalance extends ZkTestBase {
         BuiltInStateModelDefinitions.MasterSlave.name(), PARTITIONS, _replica, _replica);
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, moreDB, _replica);
     _allDBs.add(moreDB);
-    // TODO remove this sleep after fix https://github.com/apache/helix/issues/526
-    Thread.sleep(300);
     validate(_replica);
     ExternalView oldEV =
         _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, moreDB);
@@ -664,8 +638,6 @@ public class TestWagedRebalance extends ZkTestBase {
 
     // After reset done, the rebalancer will try to rebalance all the partitions since it has
     // forgotten the previous state.
-    // TODO remove this sleep after fix https://github.com/apache/helix/issues/526
-    Thread.sleep(300);
     validate(_replica);
     ExternalView newEV =
         _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, moreDB);
@@ -682,7 +654,6 @@ public class TestWagedRebalance extends ZkTestBase {
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, dbName, _replica);
     _allDBs.add(dbName);
     // waiting for the DBs being dropped.
-    Thread.sleep(300);
     validate(_replica);
 
     // Record the current Ideal State and Resource Config for recreating.
@@ -693,14 +664,12 @@ public class TestWagedRebalance extends ZkTestBase {
     _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, dbName);
     _allDBs.remove(dbName);
     // waiting for the DBs being dropped.
-    Thread.sleep(100);
     validate(_replica);
 
     // Recreate the DB.
     _gSetupTool.getClusterManagementTool().addResource(CLUSTER_NAME, dbName, is);
     _allDBs.add(dbName);
     // waiting for the DBs to be recreated.
-    Thread.sleep(100);
     validate(_replica);
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableSnapshot.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableSnapshot.java
@@ -105,7 +105,6 @@ public class TestRoutingTableSnapshot extends ZkTestBase {
           IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
       _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db1, NUM_REPLICAS);
 
-      Thread.sleep(200);
       ZkHelixClusterVerifier clusterVerifier =
           new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
               .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureHighThreshold.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureHighThreshold.java
@@ -22,6 +22,7 @@ package org.apache.helix.integration.task;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import org.apache.helix.HelixException;
+import org.apache.helix.TestHelper;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.model.MasterSlaveSMD;
@@ -59,7 +60,9 @@ public class TestJobFailureHighThreshold extends TaskSynchronizedTestBase {
     _controller.syncStart();
 
     _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(_clusterVerifier.verifyByPolling(10000, 100));
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureTaskNotStarted.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobFailureTaskNotStarted.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixException;
+import org.apache.helix.TestHelper;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
@@ -83,7 +84,10 @@ public class TestJobFailureTaskNotStarted extends TaskSynchronizedTestBase {
     _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
 
     _clusterVerifier =
-        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR).build();
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
+            .setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
   }
 
   protected void startParticipantsWithStuckTaskStateModelFactory() {

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestJobTimeout.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestJobTimeout.java
@@ -143,7 +143,8 @@ public final class TestJobTimeout extends TaskSynchronizedTestBase {
     // Check that there are no SLAVE replicas
     BestPossibleExternalViewVerifier verifier =
         new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
-            .setZkAddr(ZK_ADDR).build();
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(verifier.verifyByPolling());
     ExternalView view =
         _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, DB_NAME);

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestRebalanceRunningTask.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestRebalanceRunningTask.java
@@ -261,7 +261,9 @@ public final class TestRebalanceRunningTask extends TaskSynchronizedTestBase {
     startParticipant(_initialNumNodes);
     ZkHelixClusterVerifier clusterVerifier =
         new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
-            .setResources(Sets.newHashSet(DATABASE)).build();
+            .setResources(Sets.newHashSet(DATABASE))
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
     Assert.assertTrue(clusterVerifier.verify(10 * 1000));
 
     // Wait until master is switched to new instance and two masters exist on two different instances


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolve #1448 3rd part.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Stabilizing several tests by giving a starting up waiting periods up-on
constructing BestPossibleExternalViewVerifier.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

pending github run
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
