### PR TITLE
fix TestHelixAdminCli testDeactivateCluster flakiness

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/tools/TestHelixAdminCli.java
+++ b/helix-core/src/test/java/org/apache/helix/tools/TestHelixAdminCli.java
@@ -614,7 +614,7 @@ public class TestHelixAdminCli extends ZkTestBase {
     boolean leaderNotExists = TestHelper.verify(() -> {
       boolean isLeaderExists = _gZkClient.exists(path);
       return isLeaderExists == false;
-    }, 10000L);
+    }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(leaderNotExists, " mysterious leader out!");
 
     for (ClusterDistributedController controller : controllers) {


### PR DESCRIPTION


### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

fix #1300 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
fix TestHelixAdminCli testDeactivateCluster flakiness. As this
test does not wait till the cluster converge before tearing it
down. The tearing down process can have exceptions depending on
timing.

(Write a concise description including what, why, how)

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Before CI test pass, please copy & paste the result of "mvn test")

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
