### PR TITLE
Move subscribeForChange out of critical section

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -346,7 +346,6 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
     }
 
     synchronized (this) {
-
       if (!_expectTypes.contains(type)) {
         logger.warn("Callback handler {} received event in wrong order. Listener: {}, path: {}, "
             + "expected types: {}, but was {}", _uid, _listener, _path, _expectTypes, type);
@@ -359,9 +358,10 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
       }
     }
 
-    // This allows the listener to work with one change at a time
+    // This allows the Helix Manager to work with one change at a time
+    // TODO: Maybe we don't need to sync on _manager for all types of listener. PCould be a
+    // potential improvement candidate.
     synchronized (_manager) {
-
       if (_changeType == IDEAL_STATE) {
         IdealStateChangeListener idealStateChangeListener = (IdealStateChangeListener) _listener;
         List<IdealState> idealStates = preFetch(_propertyKey);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/CallbackHandler.java
@@ -340,26 +340,28 @@ public class CallbackHandler implements IZkChildListener, IZkDataListener {
   public void invoke(NotificationContext changeContext) throws Exception {
     Type type = changeContext.getType();
     long start = System.currentTimeMillis();
+    if (logger.isInfoEnabled()) {
+      logger.info("{} START: CallbackHandler {}, INVOKE {} listener: {} type: {}",
+          Thread.currentThread().getId(), _uid, _path, _listener, type);
+    }
 
-    // This allows the listener to work with one change at a time
-    synchronized (_manager) {
-      if (logger.isInfoEnabled()) {
-        logger
-            .info("{} START: CallbackHandler {}, INVOKE {} listener: {} type: {}", Thread.currentThread().getId(),
-                _uid, _path, _listener, type);
-      }
+    synchronized (this) {
 
       if (!_expectTypes.contains(type)) {
         logger.warn("Callback handler {} received event in wrong order. Listener: {}, path: {}, "
             + "expected types: {}, but was {}", _uid, _listener, _path, _expectTypes, type);
         return;
-
       }
       _expectTypes = nextNotificationType.get(type);
 
       if (type == Type.INIT || type == Type.FINALIZE || changeContext.getIsChildChange()) {
         subscribeForChanges(changeContext.getType(), _path, _watchChild);
       }
+    }
+
+    // This allows the listener to work with one change at a time
+    synchronized (_manager) {
+
       if (_changeType == IDEAL_STATE) {
         IdealStateChangeListener idealStateChangeListener = (IdealStateChangeListener) _listener;
         List<IdealState> idealStates = preFetch(_propertyKey);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1539

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

We found TaskScheduling stage is slow for task intensive workloads. From profiling result, we found the problem is:
TaskSchedulingStage.scheduleWorkflows -> getHelixPropertyStore() and CallBackHandler.invoke() all synchronized on zkHelixManager object, witch makes TaskSchedulingStage extremely slow.

This PR moves CallBackHandler.subscribeForChange(), witch takes majority of the time in invoke() out of the critical section.

### Tests

- [X] The following tests are written for this issue:

NA

- [X] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Results:
[INFO]
[ERROR] Failures: 
[ERROR]   TestBatchMessage.testParticipantIncompatibleWithBatchMsg:355 expected:<true> but was:<false>                                                                            
[INFO]
[ERROR] Tests run: 1250, Failures: 1, Errors: 0, Skipped: 0
rerun:
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 13.508 s - in org.apache.helix.integration.messaging.TestBatchMessage
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
