### PR TITLE
fix test Helix-rest testAddConfigFields

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -224,7 +224,7 @@ public class TestClusterAccessor extends AbstractTestClass {
   @Test(dependsOnMethods = "testGetClusterTopologyAndFaultZoneMap")
   public void testAddConfigFields() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
-    String cluster = _clusters.iterator().next();
+    String cluster = "TestCluster_1";
     ClusterConfig oldConfig = getClusterConfigFromRest(cluster);
 
     ClusterConfig configDelta = new ClusterConfig(cluster);
@@ -249,7 +249,7 @@ public class TestClusterAccessor extends AbstractTestClass {
   @Test(dependsOnMethods = "testAddConfigFields")
   public void testUpdateConfigFields() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
-    String cluster = _clusters.iterator().next();
+    String cluster = "TestCluster_1";
     ClusterConfig config = getClusterConfigFromRest(cluster);
 
     ZNRecord record = config.getRecord();

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -224,6 +224,7 @@ public class TestClusterAccessor extends AbstractTestClass {
   @Test(dependsOnMethods = "testGetClusterTopologyAndFaultZoneMap")
   public void testAddConfigFields() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
+    //Need to use TestCluster_1 here since other test may add unwanted key to listField. issue-1336
     String cluster = "TestCluster_1";
     ClusterConfig oldConfig = getClusterConfigFromRest(cluster);
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1336  

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

The test is constantly failing on master now. The direct reason is the same, there is an empty INSTANCE_CAPACITY_KEYS=[], list so we get a IndexOutOfBoundsException error.

My theory is that, this empty list could be added by TestInstancesAccessor.testValidateWeightForAllInstances() or TestPerInstanceAccessor.testValidateWeightForInstance() since these two tests and TestClusterAccessor.testUpdateConfigFields() uses the same cluster "TestCluster_0".

In the test log where testUpdateConfigFields is failing, the two tests that added this empty list always happens before this testUpdateConfigFields.

My solution is simply changing the cluster for testUpdateConfigFields to another test cluster and use "TestCluster_0" only for WAGED related tests.


### Tests

- [X] The following tests are written for this issue:

NA

- [X] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 171, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 246.815 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 171, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:10 min
[INFO] Finished at: 2020-11-25T11:20:46-08:00
[INFO] ------------------------------------------------------------------------
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
