### PR TITLE
Fix ZkClient leakage by correctly setting usesExternalZkClient flag

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -134,14 +134,13 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
    */
   @Deprecated
   public ZkBaseDataAccessor(RealmAwareZkClient zkClient) {
-    if (zkClient == null) {
-      throw new NullPointerException("zkclient is null");
-    }
-    _zkClient = zkClient;
-    _usesExternalZkClient = true;
+    this(zkClient, true);
   }
 
   private ZkBaseDataAccessor(RealmAwareZkClient zkClient, boolean usesExternalZkClient) {
+    if (zkClient == null) {
+      throw new NullPointerException("zkclient is null");
+    }
     _zkClient = zkClient;
     _usesExternalZkClient = usesExternalZkClient;
   }
@@ -1317,9 +1316,11 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
      */
     public ZkBaseDataAccessor<T> build() {
       validate();
+      // Initialize ZkBaseDataAccessor with usesExternalZkClient = false so that
+      // ZkBaseDataAccessor::close() would close ZkClient as well to prevent thread leakage
       return new ZkBaseDataAccessor<>(
           createZkClient(_realmMode, _realmAwareZkConnectionConfig, _realmAwareZkClientConfig,
-              _zkAddress));
+              _zkAddress), false);
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -139,7 +139,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
 
   private ZkBaseDataAccessor(RealmAwareZkClient zkClient, boolean usesExternalZkClient) {
     if (zkClient == null) {
-      throw new NullPointerException("zkclient is null");
+      throw new IllegalArgumentException("zkclient is null");
     }
     _zkClient = zkClient;
     _usesExternalZkClient = usesExternalZkClient;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -138,7 +138,11 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
   private ZkCacheBaseDataAccessor(RealmAwareZkClient zkClient, String chrootPath,
       List<String> wtCachePaths, List<String> zkCachePaths) {
     _zkClient = zkClient;
-    _baseAccessor = new ZkBaseDataAccessor<>(_zkClient);
+    // Initialize ZkBaseDataAccessor with usesExternalZkClient = false so that
+    // ZkBaseDataAccessor::close() would close ZkClient as well to prevent thread leakage
+    // This is done for completeness; ZKCacheBaseDataAccessor closes zkClient anyways in stop(),
+    // so this is not necessary, strictly speaking.
+    _baseAccessor = new ZkBaseDataAccessor<>(_zkClient, false);
 
     _chrootPath = chrootPath;
     _wtCachePaths = wtCachePaths;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -138,11 +138,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
   private ZkCacheBaseDataAccessor(RealmAwareZkClient zkClient, String chrootPath,
       List<String> wtCachePaths, List<String> zkCachePaths) {
     _zkClient = zkClient;
-    // Initialize ZkBaseDataAccessor with usesExternalZkClient = false so that
-    // ZkBaseDataAccessor::close() would close ZkClient as well to prevent thread leakage
-    // This is done for completeness; ZKCacheBaseDataAccessor closes zkClient anyways in stop(),
-    // so this is not necessary, strictly speaking.
-    _baseAccessor = new ZkBaseDataAccessor<>(_zkClient, false);
+    _baseAccessor = new ZkBaseDataAccessor<>(_zkClient);
 
     _chrootPath = chrootPath;
     _wtCachePaths = wtCachePaths;

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -111,6 +111,8 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
   public BestPossibleExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Set<String> resources, Map<String, Map<String, String>> errStates,
       Set<String> expectLiveInstances, int waitTillVerify) {
+    // usesExternalZkClient = true because ZkClient is given by the caller
+    // at close(), we will not close this ZkClient because it might be being used elsewhere
     super(zkClient, clusterName, true, waitTillVerify);
     _errStates = errStates;
     _resources = resources;

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -111,7 +111,7 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
   public BestPossibleExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Set<String> resources, Map<String, Map<String, String>> errStates,
       Set<String> expectLiveInstances, int waitTillVerify) {
-    super(zkClient, clusterName, waitTillVerify);
+    super(zkClient, clusterName, true, waitTillVerify);
     _errStates = errStates;
     _resources = resources;
     _expectLiveInstances = expectLiveInstances;
@@ -121,7 +121,9 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
   private BestPossibleExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Map<String, Map<String, String>> errStates, Set<String> resources,
       Set<String> expectLiveInstances, int waitPeriodTillVerify) {
-    super(zkClient, clusterName, waitPeriodTillVerify);
+    // Initialize BestPossibleExternalViewVerifier with usesExternalZkClient = false so that
+    // BestPossibleExternalViewVerifier::close() would close ZkClient to prevent thread leakage
+    super(zkClient, clusterName, false, waitPeriodTillVerify);
     // Deep copy data from Builder
     _errStates = new HashMap<>();
     if (errStates != null) {

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -122,10 +122,10 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
 
   private BestPossibleExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Map<String, Map<String, String>> errStates, Set<String> resources,
-      Set<String> expectLiveInstances, int waitPeriodTillVerify) {
+      Set<String> expectLiveInstances, int waitPeriodTillVerify, boolean usesExternalZkClient) {
     // Initialize BestPossibleExternalViewVerifier with usesExternalZkClient = false so that
     // BestPossibleExternalViewVerifier::close() would close ZkClient to prevent thread leakage
-    super(zkClient, clusterName, false, waitPeriodTillVerify);
+    super(zkClient, clusterName, usesExternalZkClient, waitPeriodTillVerify);
     // Deep copy data from Builder
     _errStates = new HashMap<>();
     if (errStates != null) {
@@ -143,6 +143,7 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
     private Set<String> _resources;
     private Set<String> _expectLiveInstances;
     private RealmAwareZkClient _zkClient;
+    private boolean _usesExternalZkClient = false; // false by default
 
     public Builder(String clusterName) {
       _clusterName = clusterName;
@@ -168,7 +169,7 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
       return new BestPossibleExternalViewVerifier(
           createZkClient(RealmAwareZkClient.RealmMode.SINGLE_REALM, _realmAwareZkConnectionConfig,
               _realmAwareZkClientConfig, _zkAddress), _clusterName, _errStates, _resources,
-          _expectLiveInstances, _waitPeriodTillVerify);
+          _expectLiveInstances, _waitPeriodTillVerify, _usesExternalZkClient);
     }
 
     public String getClusterName() {
@@ -208,6 +209,7 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
 
     public Builder setZkClient(RealmAwareZkClient zkClient) {
       _zkClient = zkClient;
+      _usesExternalZkClient = true; // Set the flag since external ZkClient is used
       return this;
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ClusterLiveNodesVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ClusterLiveNodesVerifier.java
@@ -34,6 +34,8 @@ public class ClusterLiveNodesVerifier extends ZkHelixClusterVerifier {
   @Deprecated
   public ClusterLiveNodesVerifier(RealmAwareZkClient zkclient, String clusterName,
       List<String> expectLiveNodes) {
+    // usesExternalZkClient = true because ZkClient is given by the caller
+    // at close(), we will not close this ZkClient because it might be being used elsewhere
     super(zkclient, clusterName, true, 0);
     _expectLiveNodes = new HashSet<>(expectLiveNodes);
   }

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ClusterLiveNodesVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ClusterLiveNodesVerifier.java
@@ -34,13 +34,15 @@ public class ClusterLiveNodesVerifier extends ZkHelixClusterVerifier {
   @Deprecated
   public ClusterLiveNodesVerifier(RealmAwareZkClient zkclient, String clusterName,
       List<String> expectLiveNodes) {
-    super(zkclient, clusterName, 0);
+    super(zkclient, clusterName, true, 0);
     _expectLiveNodes = new HashSet<>(expectLiveNodes);
   }
 
   private ClusterLiveNodesVerifier(RealmAwareZkClient zkClient, String clusterName,
       Set<String> expectLiveNodes, int waitPeriodTillVerify) {
-    super(zkClient, clusterName, waitPeriodTillVerify);
+    // Initialize ClusterLiveNodesVerifier with usesExternalZkClient = false so that
+    // ClusterLiveNodesVerifier::close() would close ZkClient to prevent thread leakage
+    super(zkClient, clusterName, false, waitPeriodTillVerify);
     _expectLiveNodes = expectLiveNodes == null ? new HashSet<>() : new HashSet<>(expectLiveNodes);
   }
 

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
@@ -66,7 +66,11 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
   @Deprecated
   public StrictMatchExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Set<String> resources, Set<String> expectLiveInstances) {
-    this(zkClient, clusterName, resources, expectLiveInstances, false, 0);
+    super(zkClient, clusterName, true, 0);
+    _resources = resources == null ? new HashSet<>() : new HashSet<>(resources);
+    _expectLiveInstances =
+        expectLiveInstances == null ? new HashSet<>() : new HashSet<>(expectLiveInstances);
+    _isDeactivatedNodeAware = false;
   }
 
   @Deprecated
@@ -83,7 +87,7 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
       int waitPeriodTillVerify) {
     // Initialize StrictMatchExternalViewVerifier with usesExternalZkClient = false so that
     // StrictMatchExternalViewVerifier::close() would close ZkClient to prevent thread leakage
-    super(zkClient, clusterName, false, waitPeriodTillVerify);
+    super(zkClient, clusterName, false, 0);
     _resources = resources == null ? new HashSet<>() : new HashSet<>(resources);
     _expectLiveInstances =
         expectLiveInstances == null ? new HashSet<>() : new HashSet<>(expectLiveInstances);

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
@@ -86,10 +86,10 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
 
   private StrictMatchExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Set<String> resources, Set<String> expectLiveInstances, boolean isDeactivatedNodeAware,
-      int waitPeriodTillVerify) {
+      int waitPeriodTillVerify, boolean usesExternalZkClient) {
     // Initialize StrictMatchExternalViewVerifier with usesExternalZkClient = false so that
     // StrictMatchExternalViewVerifier::close() would close ZkClient to prevent thread leakage
-    super(zkClient, clusterName, false, 0);
+    super(zkClient, clusterName, usesExternalZkClient, 0);
     _resources = resources == null ? new HashSet<>() : new HashSet<>(resources);
     _expectLiveInstances =
         expectLiveInstances == null ? new HashSet<>() : new HashSet<>(expectLiveInstances);
@@ -103,6 +103,7 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
     private RealmAwareZkClient _zkClient;
     // For backward compatibility, set the default isDeactivatedNodeAware to be false.
     private boolean _isDeactivatedNodeAware = false;
+    private boolean _usesExternalZkClient = false; // false by default
 
     public StrictMatchExternalViewVerifier build() {
       if (_clusterName == null) {
@@ -111,7 +112,8 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
 
       if (_zkClient != null) {
         return new StrictMatchExternalViewVerifier(_zkClient, _clusterName, _resources,
-            _expectLiveInstances, _isDeactivatedNodeAware, _waitPeriodTillVerify);
+            _expectLiveInstances, _isDeactivatedNodeAware, _waitPeriodTillVerify,
+            _usesExternalZkClient);
       }
 
       if (_realmAwareZkConnectionConfig == null || _realmAwareZkClientConfig == null) {
@@ -124,7 +126,8 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
       return new StrictMatchExternalViewVerifier(
           createZkClient(RealmAwareZkClient.RealmMode.SINGLE_REALM, _realmAwareZkConnectionConfig,
               _realmAwareZkClientConfig, _zkAddress), _clusterName, _resources,
-          _expectLiveInstances, _isDeactivatedNodeAware, _waitPeriodTillVerify);
+          _expectLiveInstances, _isDeactivatedNodeAware, _waitPeriodTillVerify,
+          _usesExternalZkClient);
     }
 
     public Builder(String clusterName) {
@@ -160,6 +163,7 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
     @Deprecated
     public Builder setZkClient(RealmAwareZkClient zkClient) {
       _zkClient = zkClient;
+      _usesExternalZkClient = true; // Set the flag since external ZkClient is used
       return this;
     }
 

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
@@ -80,7 +80,7 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
 
   private StrictMatchExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Set<String> resources, Set<String> expectLiveInstances, boolean isDeactivatedNodeAware, int waitPeriodTillVerify) {
-    super(zkClient, clusterName, waitPeriodTillVerify);
+    super(zkClient, clusterName, false, waitPeriodTillVerify);
     _resources = resources == null ? new HashSet<>() : new HashSet<>(resources);
     _expectLiveInstances =
         expectLiveInstances == null ? new HashSet<>() : new HashSet<>(expectLiveInstances);

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
@@ -66,6 +66,8 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
   @Deprecated
   public StrictMatchExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Set<String> resources, Set<String> expectLiveInstances) {
+    // usesExternalZkClient = true because ZkClient is given by the caller
+    // at close(), we will not close this ZkClient because it might be being used elsewhere
     super(zkClient, clusterName, true, 0);
     _resources = resources == null ? new HashSet<>() : new HashSet<>(resources);
     _expectLiveInstances =

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
@@ -79,7 +79,10 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
   }
 
   private StrictMatchExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
-      Set<String> resources, Set<String> expectLiveInstances, boolean isDeactivatedNodeAware, int waitPeriodTillVerify) {
+      Set<String> resources, Set<String> expectLiveInstances, boolean isDeactivatedNodeAware,
+      int waitPeriodTillVerify) {
+    // Initialize StrictMatchExternalViewVerifier with usesExternalZkClient = false so that
+    // StrictMatchExternalViewVerifier::close() would close ZkClient to prevent thread leakage
     super(zkClient, clusterName, false, waitPeriodTillVerify);
     _resources = resources == null ? new HashSet<>() : new HashSet<>(resources);
     _expectLiveInstances =


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1561

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

ZkBaseDataAccessor and Helix API that uses it using its Builder were having zkClient thread leak issues because the usesExternalZkClient flag was not being set properly. Also, the family of Verifiers were having a similar issue. This change solves this by making sure the private/protected constructors used by the Builders of these classes set the flag correctly to false so that in their respective close() functions, the underlying zkClient (created by the Builder) would get closed.

### Tests

- [x] The following tests are written for this issue:

Manually monitored and tested

- [x] The following is the result of the "mvn test" command on the appropriate module:

> [INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1251, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:25 h

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
