### PR TITLE
Implement Helix lock priority and notification

### DIFF
--- a/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
@@ -19,6 +19,7 @@ package org.apache.helix.lock;
  * under the License.
  */
 
+import org.apache.helix.lock.helix.LockConstants;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
 
@@ -26,25 +27,14 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
  * Structure represents a lock node information, implemented using ZNRecord
  */
 public class LockInfo {
-
-  // Default values for each attribute if there are no current values set by user
-  public static final String DEFAULT_OWNER_TEXT = "";
-  public static final String DEFAULT_MESSAGE_TEXT = "";
-  public static final long DEFAULT_TIMEOUT_LONG = -1;
-  public static final int DEFAULT_PRIORITY_INT = -1;
-  public static final long DEFAULT_WAITING_TIMEOUT_LONG = -1;
-  public static final long DEFAULT_CLEANUP_TIMEOUT_LONG = -1;
-  public static final String DEFAULT_REQUESTOR_ID = "";
-  public static final int DEFAULT_REQUESTOR_PRIORITY_INT = -1;
-  public static final long DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG = -1;
-  public static final long DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG = -1;
-
   // default lock info represents the status of a unlocked lock
   public static final LockInfo defaultLockInfo =
-      new LockInfo(DEFAULT_OWNER_TEXT, DEFAULT_MESSAGE_TEXT, DEFAULT_TIMEOUT_LONG,
-          DEFAULT_PRIORITY_INT, DEFAULT_WAITING_TIMEOUT_LONG, DEFAULT_CLEANUP_TIMEOUT_LONG,
-          DEFAULT_REQUESTOR_ID, DEFAULT_REQUESTOR_PRIORITY_INT,
-          DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG, DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
+      new LockInfo(LockConstants.DEFAULT_OWNER_TEXT, LockConstants.DEFAULT_MESSAGE_TEXT,
+          LockConstants.DEFAULT_TIMEOUT_LONG, LockConstants.DEFAULT_PRIORITY_INT,
+          LockConstants.DEFAULT_WAITING_TIMEOUT_LONG, LockConstants.DEFAULT_CLEANUP_TIMEOUT_LONG,
+          LockConstants.DEFAULT_REQUESTOR_ID, LockConstants.DEFAULT_REQUESTOR_PRIORITY_INT,
+          LockConstants.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG,
+          LockConstants.DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
 
   public static final String ZNODE_ID = "LOCK";
   private ZNRecord _record;
@@ -70,10 +60,12 @@ public class LockInfo {
    */
   private LockInfo() {
     _record = new ZNRecord(ZNODE_ID);
-    setLockInfoFields(DEFAULT_OWNER_TEXT, DEFAULT_MESSAGE_TEXT, DEFAULT_TIMEOUT_LONG,
-        DEFAULT_PRIORITY_INT, DEFAULT_WAITING_TIMEOUT_LONG, DEFAULT_CLEANUP_TIMEOUT_LONG,
-        DEFAULT_REQUESTOR_ID, DEFAULT_REQUESTOR_PRIORITY_INT,
-        DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG, DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
+    setLockInfoFields(LockConstants.DEFAULT_OWNER_TEXT, LockConstants.DEFAULT_MESSAGE_TEXT,
+        LockConstants.DEFAULT_TIMEOUT_LONG, LockConstants.DEFAULT_PRIORITY_INT,
+        LockConstants.DEFAULT_WAITING_TIMEOUT_LONG, LockConstants.DEFAULT_CLEANUP_TIMEOUT_LONG,
+        LockConstants.DEFAULT_REQUESTOR_ID, LockConstants.DEFAULT_REQUESTOR_PRIORITY_INT,
+        LockConstants.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG,
+        LockConstants.DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
   }
 
   /**
@@ -85,21 +77,23 @@ public class LockInfo {
     if (znRecord != null) {
       String ownerId = znRecord.getSimpleField(LockInfoAttribute.OWNER.name());
       String message = znRecord.getSimpleField(LockInfoAttribute.MESSAGE.name());
-      long timeout = znRecord.getLongField(LockInfoAttribute.TIMEOUT.name(), DEFAULT_TIMEOUT_LONG);
-      int priority = znRecord.getIntField(LockInfoAttribute.PRIORITY.name(), DEFAULT_PRIORITY_INT);
-      long waitingTimeout = znRecord
-          .getLongField(LockInfoAttribute.WAITING_TIMEOUT.name(), DEFAULT_WAITING_TIMEOUT_LONG);
-      long cleanupTimeout = znRecord
-          .getLongField(LockInfoAttribute.CLEANUP_TIMEOUT.name(), DEFAULT_CLEANUP_TIMEOUT_LONG);
+      long timeout = znRecord
+          .getLongField(LockInfoAttribute.TIMEOUT.name(), LockConstants.DEFAULT_TIMEOUT_LONG);
+      int priority = znRecord
+          .getIntField(LockInfoAttribute.PRIORITY.name(), LockConstants.DEFAULT_PRIORITY_INT);
+      long waitingTimeout = znRecord.getLongField(LockInfoAttribute.WAITING_TIMEOUT.name(),
+          LockConstants.DEFAULT_WAITING_TIMEOUT_LONG);
+      long cleanupTimeout = znRecord.getLongField(LockInfoAttribute.CLEANUP_TIMEOUT.name(),
+          LockConstants.DEFAULT_CLEANUP_TIMEOUT_LONG);
       String requestorId = znRecord.getSimpleField(LockInfoAttribute.REQUESTOR_ID.name());
-      int requestorPriority = znRecord
-          .getIntField(LockInfoAttribute.REQUESTOR_PRIORITY.name(), DEFAULT_REQUESTOR_PRIORITY_INT);
+      int requestorPriority = znRecord.getIntField(LockInfoAttribute.REQUESTOR_PRIORITY.name(),
+          LockConstants.DEFAULT_REQUESTOR_PRIORITY_INT);
       long requestorWaitingTimeout = znRecord
           .getLongField(LockInfoAttribute.REQUESTOR_WAITING_TIMEOUT.name(),
-              DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
+              LockConstants.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
       long requestorRequestingTimestamp = znRecord
           .getLongField(LockInfoAttribute.REQUESTOR_REQUESTING_TIMESTAMP.name(),
-              DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
+              LockConstants.DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
       setLockInfoFields(ownerId, message, timeout, priority, waitingTimeout, cleanupTimeout,
           requestorId, requestorPriority, requestorWaitingTimeout, requestorRequestingTimestamp);
     }
@@ -134,9 +128,9 @@ public class LockInfo {
       long waitingTimeout, long cleanupTimeout, String requestorId, int requestorPriority,
       long requestorWaitingTimeout, long requestorRequestingTimestamp) {
     _record.setSimpleField(LockInfoAttribute.OWNER.name(),
-        ownerId == null ? DEFAULT_OWNER_TEXT : ownerId);
+        ownerId == null ? LockConstants.DEFAULT_OWNER_TEXT : ownerId);
     _record.setSimpleField(LockInfoAttribute.MESSAGE.name(),
-        message == null ? DEFAULT_MESSAGE_TEXT : message);
+        message == null ? LockConstants.DEFAULT_MESSAGE_TEXT : message);
     _record.setLongField(LockInfoAttribute.TIMEOUT.name(), timeout);
     _record.setIntField(LockInfoAttribute.PRIORITY.name(), priority);
     _record.setLongField(LockInfoAttribute.WAITING_TIMEOUT.name(), waitingTimeout);
@@ -155,7 +149,7 @@ public class LockInfo {
    */
   public String getOwner() {
     String owner = _record.getSimpleField(LockInfoAttribute.OWNER.name());
-    return owner == null ? DEFAULT_OWNER_TEXT : owner;
+    return owner == null ? LockConstants.DEFAULT_OWNER_TEXT : owner;
   }
 
   /**
@@ -164,7 +158,7 @@ public class LockInfo {
    */
   public String getMessage() {
     String message = _record.getSimpleField(LockInfoAttribute.MESSAGE.name());
-    return message == null ? DEFAULT_MESSAGE_TEXT : message;
+    return message == null ? LockConstants.DEFAULT_MESSAGE_TEXT : message;
   }
 
   /**
@@ -172,7 +166,8 @@ public class LockInfo {
    * @return the expiration timestamp of the lock, -1 if there is no timeout set
    */
   public Long getTimeout() {
-    return _record.getLongField(LockInfoAttribute.TIMEOUT.name(), DEFAULT_TIMEOUT_LONG);
+    return _record
+        .getLongField(LockInfoAttribute.TIMEOUT.name(), LockConstants.DEFAULT_TIMEOUT_LONG);
   }
 
   /**
@@ -180,7 +175,8 @@ public class LockInfo {
    * @return the priority of the lock, -1 if there is no priority set
    */
   public Integer getPriority() {
-    return _record.getIntField(LockInfoAttribute.PRIORITY.name(), DEFAULT_PRIORITY_INT);
+    return _record
+        .getIntField(LockInfoAttribute.PRIORITY.name(), LockConstants.DEFAULT_PRIORITY_INT);
   }
 
   /**
@@ -188,8 +184,8 @@ public class LockInfo {
    * @return the waiting timeout of the lock, -1 if there is no waiting timeout set
    */
   public Long getWaitingTimeout() {
-    return _record
-        .getLongField(LockInfoAttribute.WAITING_TIMEOUT.name(), DEFAULT_WAITING_TIMEOUT_LONG);
+    return _record.getLongField(LockInfoAttribute.WAITING_TIMEOUT.name(),
+        LockConstants.DEFAULT_WAITING_TIMEOUT_LONG);
   }
 
   /**
@@ -197,8 +193,8 @@ public class LockInfo {
    * @return the cleanup time of the lock, -1 if there is no cleanup timeout set
    */
   public Long getCleanupTimeout() {
-    return _record
-        .getLongField(LockInfoAttribute.CLEANUP_TIMEOUT.name(), DEFAULT_CLEANUP_TIMEOUT_LONG);
+    return _record.getLongField(LockInfoAttribute.CLEANUP_TIMEOUT.name(),
+        LockConstants.DEFAULT_CLEANUP_TIMEOUT_LONG);
   }
 
   /**
@@ -207,7 +203,7 @@ public class LockInfo {
    */
   public String getRequestorId() {
     String requestorId = _record.getSimpleField(LockInfoAttribute.REQUESTOR_ID.name());
-    return requestorId == null ? DEFAULT_REQUESTOR_ID : requestorId;
+    return requestorId == null ? LockConstants.DEFAULT_REQUESTOR_ID : requestorId;
   }
 
   /**
@@ -215,8 +211,8 @@ public class LockInfo {
    * @return the requestor priority of the lock, -1 if there is no requestor priority set
    */
   public int getRequestorPriority() {
-    return _record
-        .getIntField(LockInfoAttribute.REQUESTOR_PRIORITY.name(), DEFAULT_REQUESTOR_PRIORITY_INT);
+    return _record.getIntField(LockInfoAttribute.REQUESTOR_PRIORITY.name(),
+        LockConstants.DEFAULT_REQUESTOR_PRIORITY_INT);
   }
 
   /**
@@ -225,7 +221,7 @@ public class LockInfo {
    */
   public long getRequestorWaitingTimeout() {
     return _record.getLongField(LockInfoAttribute.REQUESTOR_WAITING_TIMEOUT.name(),
-        DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
+        LockConstants.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
   }
 
   /**
@@ -235,7 +231,7 @@ public class LockInfo {
    */
   public long getRequestorRequestingTimestamp() {
     return _record.getLongField(LockInfoAttribute.REQUESTOR_REQUESTING_TIMESTAMP.name(),
-        DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
+        LockConstants.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
   }
 
   /**

--- a/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
@@ -30,13 +30,23 @@ public class LockInfo {
   // Default values for each attribute if there are no current values set by user
   public static final String DEFAULT_OWNER_TEXT = "";
   public static final String DEFAULT_MESSAGE_TEXT = "";
-  public static final long DEFAULT_TIMEOUT_LONG = -1L;
+  public static final long DEFAULT_TIMEOUT_LONG = -1;
+  public static final int DEFAULT_PRIORITY_INT = -1;
+  public static final long DEFAULT_WAITING_TIMEOUT_LONG = -1;
+  public static final long DEFAULT_CLEANUP_TIMEOUT_LONG = -1;
+  public static final String DEFAULT_REQUESTOR_ID = "";
+  public static final int DEFAULT_REQUESTOR_PRIORITY_INT = -1;
+  public static final long DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG = -1;
+  public static final long DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG = -1;
 
   // default lock info represents the status of a unlocked lock
   public static final LockInfo defaultLockInfo =
-      new LockInfo(DEFAULT_OWNER_TEXT, DEFAULT_MESSAGE_TEXT, DEFAULT_TIMEOUT_LONG);
+      new LockInfo(DEFAULT_OWNER_TEXT, DEFAULT_MESSAGE_TEXT, DEFAULT_TIMEOUT_LONG,
+          DEFAULT_PRIORITY_INT, DEFAULT_WAITING_TIMEOUT_LONG, DEFAULT_CLEANUP_TIMEOUT_LONG,
+          DEFAULT_REQUESTOR_ID, DEFAULT_REQUESTOR_PRIORITY_INT,
+          DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG, DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
 
-  private static final String ZNODE_ID = "LOCK";
+  public static final String ZNODE_ID = "LOCK";
   private ZNRecord _record;
 
   /**
@@ -45,7 +55,14 @@ public class LockInfo {
   public enum LockInfoAttribute {
     OWNER,
     MESSAGE,
-    TIMEOUT
+    TIMEOUT,
+    PRIORITY,
+    WAITING_TIMEOUT,
+    CLEANUP_TIMEOUT,
+    REQUESTOR_ID,
+    REQUESTOR_PRIORITY,
+    REQUESTOR_WAITING_TIMEOUT,
+    REQUESTOR_REQUESTING_TIMESTAMP
   }
 
   /**
@@ -53,7 +70,10 @@ public class LockInfo {
    */
   private LockInfo() {
     _record = new ZNRecord(ZNODE_ID);
-    setLockInfoFields(DEFAULT_OWNER_TEXT, DEFAULT_MESSAGE_TEXT, DEFAULT_TIMEOUT_LONG);
+    setLockInfoFields(DEFAULT_OWNER_TEXT, DEFAULT_MESSAGE_TEXT, DEFAULT_TIMEOUT_LONG,
+        DEFAULT_PRIORITY_INT, DEFAULT_WAITING_TIMEOUT_LONG, DEFAULT_CLEANUP_TIMEOUT_LONG,
+        DEFAULT_REQUESTOR_ID, DEFAULT_REQUESTOR_PRIORITY_INT,
+        DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG, DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
   }
 
   /**
@@ -66,33 +86,67 @@ public class LockInfo {
       String ownerId = znRecord.getSimpleField(LockInfoAttribute.OWNER.name());
       String message = znRecord.getSimpleField(LockInfoAttribute.MESSAGE.name());
       long timeout = znRecord.getLongField(LockInfoAttribute.TIMEOUT.name(), DEFAULT_TIMEOUT_LONG);
-      setLockInfoFields(ownerId, message, timeout);
+      int priority = znRecord.getIntField(LockInfoAttribute.PRIORITY.name(), DEFAULT_PRIORITY_INT);
+      long waitingTimeout = znRecord
+          .getLongField(LockInfoAttribute.WAITING_TIMEOUT.name(), DEFAULT_WAITING_TIMEOUT_LONG);
+      long cleanupTimeout = znRecord
+          .getLongField(LockInfoAttribute.CLEANUP_TIMEOUT.name(), DEFAULT_CLEANUP_TIMEOUT_LONG);
+      String requestorId = znRecord.getSimpleField(LockInfoAttribute.REQUESTOR_ID.name());
+      int requestorPriority = znRecord
+          .getIntField(LockInfoAttribute.REQUESTOR_PRIORITY.name(), DEFAULT_REQUESTOR_PRIORITY_INT);
+      long requestorWaitingTimeout = znRecord
+          .getLongField(LockInfoAttribute.REQUESTOR_WAITING_TIMEOUT.name(),
+              DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
+      long requestorRequestingTimestamp = znRecord
+          .getLongField(LockInfoAttribute.REQUESTOR_REQUESTING_TIMESTAMP.name(),
+              DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
+      setLockInfoFields(ownerId, message, timeout, priority, waitingTimeout, cleanupTimeout,
+          requestorId, requestorPriority, requestorWaitingTimeout, requestorRequestingTimestamp);
     }
   }
 
   /**
-   * Initialize a LockInfo with data for each field, set all null info fields to default data
+   * Initialize a LockInfo with data for each field, set all null info fields to default data.
    * @param ownerId value of OWNER attribute
    * @param message value of MESSAGE attribute
    * @param timeout value of TIMEOUT attribute
+   * @param priority value of PRIORITY attribute
+   * @param waitingTimout value of WAITING_TIMEOUT attribute
+   * @param cleanupTimeout value of CLEANUP_TIMEOUT attribute
+   * @param requestorId value of REQUESTOR_ID attribute
+   * @param requestorPriority value of REQUESTOR_PRIORITY attribute
+   * @param requestorWaitingTimeout value of REQUESTOR_WAITING_TIMEOUT attribute
+   * @param requestorRequestingTimestamp value of REQUESTOR_REQUESTING_TIMESTAMP attribute
    */
-  public LockInfo(String ownerId, String message, long timeout) {
+  public LockInfo(String ownerId, String message, long timeout, int priority, long waitingTimout,
+      long cleanupTimeout, String requestorId, int requestorPriority, long requestorWaitingTimeout,
+      long requestorRequestingTimestamp) {
     this();
-    setLockInfoFields(ownerId, message, timeout);
+    setLockInfoFields(ownerId, message, timeout, priority, waitingTimout, cleanupTimeout,
+        requestorId, requestorPriority, requestorWaitingTimeout, requestorRequestingTimestamp);
   }
 
   /**
-   * Set each field of lock info to user provided values if the values are not null, null values are set to default values
-   * @param ownerId value of OWNER attribute
-   * @param message value of MESSAGE attribute
-   * @param timeout value of TIMEOUT attribute
+   * Set each field of lock info to user provided values if the values are not null. Null values
+   * are set to default values.
    */
-  private void setLockInfoFields(String ownerId, String message, long timeout) {
+  private void setLockInfoFields(String ownerId, String message, long timeout, int priority,
+      long waitingTimeout, long cleanupTimeout, String requestorId, int requestorPriority,
+      long requestorWaitingTimeout, long requestorRequestingTimestamp) {
     _record.setSimpleField(LockInfoAttribute.OWNER.name(),
         ownerId == null ? DEFAULT_OWNER_TEXT : ownerId);
     _record.setSimpleField(LockInfoAttribute.MESSAGE.name(),
         message == null ? DEFAULT_MESSAGE_TEXT : message);
     _record.setLongField(LockInfoAttribute.TIMEOUT.name(), timeout);
+    _record.setIntField(LockInfoAttribute.PRIORITY.name(), priority);
+    _record.setLongField(LockInfoAttribute.WAITING_TIMEOUT.name(), waitingTimeout);
+    _record.setLongField(LockInfoAttribute.CLEANUP_TIMEOUT.name(), cleanupTimeout);
+    _record.setSimpleField(LockInfoAttribute.REQUESTOR_ID.name(), requestorId);
+    _record.setIntField(LockInfoAttribute.REQUESTOR_PRIORITY.name(), requestorPriority);
+    _record
+        .setLongField(LockInfoAttribute.REQUESTOR_WAITING_TIMEOUT.name(), requestorWaitingTimeout);
+    _record.setLongField(LockInfoAttribute.REQUESTOR_REQUESTING_TIMESTAMP.name(),
+        requestorRequestingTimestamp);
   }
 
   /**
@@ -115,10 +169,73 @@ public class LockInfo {
 
   /**
    * Get the value for TIMEOUT attribute of the lock
-   * @return the expiring time of the lock, -1 if there is no timeout set
+   * @return the expiration timestamp of the lock, -1 if there is no timeout set
    */
   public Long getTimeout() {
     return _record.getLongField(LockInfoAttribute.TIMEOUT.name(), DEFAULT_TIMEOUT_LONG);
+  }
+
+  /**
+   * Get the value for PRIORITY attribute of the lock
+   * @return the priority of the lock, -1 if there is no priority set
+   */
+  public Integer getPriority() {
+    return _record.getIntField(LockInfoAttribute.PRIORITY.name(), DEFAULT_PRIORITY_INT);
+  }
+
+  /**
+   * Get the value for WAITING_TIMEOUT attribute of the lock
+   * @return the waiting timeout of the lock, -1 if there is no waiting timeout set
+   */
+  public Long getWaitingTimeout() {
+    return _record
+        .getLongField(LockInfoAttribute.WAITING_TIMEOUT.name(), DEFAULT_WAITING_TIMEOUT_LONG);
+  }
+
+  /**
+   * Get the value for CLEANUP_TIMEOUT attribute of the lock
+   * @return the cleanup time of the lock, -1 if there is no cleanup timeout set
+   */
+  public Long getCleanupTimeout() {
+    return _record
+        .getLongField(LockInfoAttribute.CLEANUP_TIMEOUT.name(), DEFAULT_CLEANUP_TIMEOUT_LONG);
+  }
+
+  /**
+   * Get the value for REQUESTOR_ID attribute of the lock
+   * @return the requestor id of the lock, -1 if there is no requestor id set
+   */
+  public String getRequestorId() {
+    String requestorId = _record.getSimpleField(LockInfoAttribute.REQUESTOR_ID.name());
+    return requestorId == null ? DEFAULT_REQUESTOR_ID : requestorId;
+  }
+
+  /**
+   * Get the value for REQUESTOR_PRIORITY attribute of the lock
+   * @return the requestor priority of the lock, -1 if there is no requestor priority set
+   */
+  public int getRequestorPriority() {
+    return _record
+        .getIntField(LockInfoAttribute.REQUESTOR_PRIORITY.name(), DEFAULT_REQUESTOR_PRIORITY_INT);
+  }
+
+  /**
+   * Get the value for REQUESTOR_WAITING_TIMEOUT attribute of the lock
+   * @return the requestor waiting timeout of the lock, -1 if there is no requestor timeout set
+   */
+  public long getRequestorWaitingTimeout() {
+    return _record.getLongField(LockInfoAttribute.REQUESTOR_WAITING_TIMEOUT.name(),
+        DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
+  }
+
+  /**
+   * Get the value for REQUESTOR_REQUESTING_TIMESTAMP attribute of the lock
+   * @return the requestor requesting timestamp of the lock, -1 if there is no requestor
+   * requestingi timestamp set
+   */
+  public long getRequestorRequestingTimestamp() {
+    return _record.getLongField(LockInfoAttribute.REQUESTOR_REQUESTING_TIMESTAMP.name(),
+        DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
   }
 
   /**

--- a/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
@@ -47,7 +47,7 @@ public class LockInfo {
     REQUESTOR_ID,
     REQUESTOR_PRIORITY,
     REQUESTOR_WAITING_TIMEOUT,
-    REQUESTOR_REQUESTING_TIMESTAMP
+    REQUESTING_TIMESTAMP
   }
 
   /**
@@ -55,12 +55,12 @@ public class LockInfo {
    */
   private LockInfo() {
     _record = new ZNRecord(ZNODE_ID);
-    setLockInfoFields(LockConstants.DEFAULT_OWNER_TEXT, LockConstants.DEFAULT_MESSAGE_TEXT,
+    setLockInfoFields(LockConstants.DEFAULT_USER_ID, LockConstants.DEFAULT_MESSAGE_TEXT,
         LockConstants.DEFAULT_TIMEOUT_LONG, LockConstants.DEFAULT_PRIORITY_INT,
         LockConstants.DEFAULT_WAITING_TIMEOUT_LONG, LockConstants.DEFAULT_CLEANUP_TIMEOUT_LONG,
-        LockConstants.DEFAULT_REQUESTOR_ID, LockConstants.DEFAULT_REQUESTOR_PRIORITY_INT,
-        LockConstants.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG,
-        LockConstants.DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
+        LockConstants.DEFAULT_USER_ID, LockConstants.DEFAULT_PRIORITY_INT,
+        LockConstants.DEFAULT_WAITING_TIMEOUT_LONG,
+        LockConstants.DEFAULT_REQUESTING_TIMESTAMP_LONG);
   }
 
   /**
@@ -72,7 +72,7 @@ public class LockInfo {
     if (znRecord != null) {
       _record = new ZNRecord(ZNODE_ID);
       String ownerId = znRecord.getSimpleField(LockInfoAttribute.OWNER.name()).isEmpty() ?
-          LockConstants.DEFAULT_OWNER_TEXT :
+          LockConstants.DEFAULT_USER_ID :
           znRecord.getSimpleField(LockInfoAttribute.OWNER.name());
       String message = znRecord.getSimpleField(LockInfoAttribute.MESSAGE.name());
       long timeout = znRecord
@@ -85,15 +85,15 @@ public class LockInfo {
           LockConstants.DEFAULT_CLEANUP_TIMEOUT_LONG);
       String requestorId = znRecord.getSimpleField(LockInfoAttribute.REQUESTOR_ID.name());
       int requestorPriority = znRecord.getIntField(LockInfoAttribute.REQUESTOR_PRIORITY.name(),
-          LockConstants.DEFAULT_REQUESTOR_PRIORITY_INT);
+          LockConstants.DEFAULT_PRIORITY_INT);
       long requestorWaitingTimeout = znRecord
           .getLongField(LockInfoAttribute.REQUESTOR_WAITING_TIMEOUT.name(),
-              LockConstants.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
-      long requestorRequestingTimestamp = znRecord
-          .getLongField(LockInfoAttribute.REQUESTOR_REQUESTING_TIMESTAMP.name(),
-              LockConstants.DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
+              LockConstants.DEFAULT_WAITING_TIMEOUT_LONG);
+      long requestingTimestamp = znRecord
+          .getLongField(LockInfoAttribute.REQUESTING_TIMESTAMP.name(),
+              LockConstants.DEFAULT_REQUESTING_TIMESTAMP_LONG);
       setLockInfoFields(ownerId, message, timeout, priority, waitingTimeout, cleanupTimeout,
-          requestorId, requestorPriority, requestorWaitingTimeout, requestorRequestingTimestamp);
+          requestorId, requestorPriority, requestorWaitingTimeout, requestingTimestamp);
     }
   }
 
@@ -108,14 +108,14 @@ public class LockInfo {
    * @param requestorId value of REQUESTOR_ID attribute
    * @param requestorPriority value of REQUESTOR_PRIORITY attribute
    * @param requestorWaitingTimeout value of REQUESTOR_WAITING_TIMEOUT attribute
-   * @param requestorRequestingTimestamp value of REQUESTOR_REQUESTING_TIMESTAMP attribute
+   * @param requestingTimestamp value of REQUESTING_TIMESTAMP attribute
    */
   public LockInfo(String ownerId, String message, long timeout, int priority, long waitingTimout,
       long cleanupTimeout, String requestorId, int requestorPriority, long requestorWaitingTimeout,
-      long requestorRequestingTimestamp) {
+      long requestingTimestamp) {
     _record = new ZNRecord(ZNODE_ID);
     setLockInfoFields(ownerId, message, timeout, priority, waitingTimout, cleanupTimeout,
-        requestorId, requestorPriority, requestorWaitingTimeout, requestorRequestingTimestamp);
+        requestorId, requestorPriority, requestorWaitingTimeout, requestingTimestamp);
   }
 
   /**
@@ -124,9 +124,9 @@ public class LockInfo {
    */
   private void setLockInfoFields(String ownerId, String message, long timeout, int priority,
       long waitingTimeout, long cleanupTimeout, String requestorId, int requestorPriority,
-      long requestorWaitingTimeout, long requestorRequestingTimestamp) {
+      long requestorWaitingTimeout, long requestingTimestamp) {
     _record.setSimpleField(LockInfoAttribute.OWNER.name(),
-        ownerId == null ? LockConstants.DEFAULT_OWNER_TEXT : ownerId);
+        ownerId == null ? LockConstants.DEFAULT_USER_ID : ownerId);
     _record.setSimpleField(LockInfoAttribute.MESSAGE.name(),
         message == null ? LockConstants.DEFAULT_MESSAGE_TEXT : message);
     _record.setLongField(LockInfoAttribute.TIMEOUT.name(), timeout);
@@ -137,8 +137,7 @@ public class LockInfo {
     _record.setIntField(LockInfoAttribute.REQUESTOR_PRIORITY.name(), requestorPriority);
     _record
         .setLongField(LockInfoAttribute.REQUESTOR_WAITING_TIMEOUT.name(), requestorWaitingTimeout);
-    _record.setLongField(LockInfoAttribute.REQUESTOR_REQUESTING_TIMESTAMP.name(),
-        requestorRequestingTimestamp);
+    _record.setLongField(LockInfoAttribute.REQUESTING_TIMESTAMP.name(), requestingTimestamp);
   }
 
   /**
@@ -147,7 +146,7 @@ public class LockInfo {
    */
   public String getOwner() {
     String owner = _record.getSimpleField(LockInfoAttribute.OWNER.name());
-    return owner == null ? LockConstants.DEFAULT_OWNER_TEXT : owner;
+    return owner == null ? LockConstants.DEFAULT_USER_ID : owner;
   }
 
   /**
@@ -201,7 +200,7 @@ public class LockInfo {
    */
   public String getRequestorId() {
     String requestorId = _record.getSimpleField(LockInfoAttribute.REQUESTOR_ID.name());
-    return requestorId == null ? LockConstants.DEFAULT_REQUESTOR_ID : requestorId;
+    return requestorId == null ? LockConstants.DEFAULT_USER_ID : requestorId;
   }
 
   /**
@@ -210,7 +209,7 @@ public class LockInfo {
    */
   public int getRequestorPriority() {
     return _record.getIntField(LockInfoAttribute.REQUESTOR_PRIORITY.name(),
-        LockConstants.DEFAULT_REQUESTOR_PRIORITY_INT);
+        LockConstants.DEFAULT_PRIORITY_INT);
   }
 
   /**
@@ -219,7 +218,7 @@ public class LockInfo {
    */
   public long getRequestorWaitingTimeout() {
     return _record.getLongField(LockInfoAttribute.REQUESTOR_WAITING_TIMEOUT.name(),
-        LockConstants.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
+        LockConstants.DEFAULT_WAITING_TIMEOUT_LONG);
   }
 
   /**
@@ -227,9 +226,9 @@ public class LockInfo {
    * @return the requestor requesting timestamp of the lock, -1 if there is no requestor
    * requestingi timestamp set
    */
-  public long getRequestorRequestingTimestamp() {
-    return _record.getLongField(LockInfoAttribute.REQUESTOR_REQUESTING_TIMESTAMP.name(),
-        LockConstants.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
+  public long getRequestingTimestamp() {
+    return _record.getLongField(LockInfoAttribute.REQUESTING_TIMESTAMP.name(),
+        LockConstants.DEFAULT_WAITING_TIMEOUT_LONG);
   }
 
   /**

--- a/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
@@ -54,7 +54,6 @@ public class LockInfo {
    * Initialize a default LockInfo instance
    */
   private LockInfo() {
-    _record = new ZNRecord(ZNODE_ID);
     setLockInfoFields(LockConstants.DEFAULT_USER_ID, LockConstants.DEFAULT_MESSAGE_TEXT,
         LockConstants.DEFAULT_TIMEOUT_LONG, LockConstants.DEFAULT_PRIORITY_INT,
         LockConstants.DEFAULT_WAITING_TIMEOUT_LONG, LockConstants.DEFAULT_CLEANUP_TIMEOUT_LONG,
@@ -68,7 +67,6 @@ public class LockInfo {
    * @param znRecord The ZNRecord contains lock node data that used to initialize the LockInfo
    */
   public LockInfo(ZNRecord znRecord) {
-    _record = new ZNRecord(ZNODE_ID);
     if (znRecord == null) {
       znRecord = new ZNRecord(ZNODE_ID);
     }
@@ -114,7 +112,6 @@ public class LockInfo {
   public LockInfo(String ownerId, String message, long timeout, int priority, long waitingTimout,
       long cleanupTimeout, String requestorId, int requestorPriority, long requestorWaitingTimeout,
       long requestingTimestamp) {
-    _record = new ZNRecord(ZNODE_ID);
     setLockInfoFields(ownerId, message, timeout, priority, waitingTimout, cleanupTimeout,
         requestorId, requestorPriority, requestorWaitingTimeout, requestingTimestamp);
   }
@@ -126,6 +123,7 @@ public class LockInfo {
   private void setLockInfoFields(String ownerId, String message, long timeout, int priority,
       long waitingTimeout, long cleanupTimeout, String requestorId, int requestorPriority,
       long requestorWaitingTimeout, long requestingTimestamp) {
+    _record = new ZNRecord(ZNODE_ID);
     _record.setSimpleField(LockInfoAttribute.OWNER.name(),
         ownerId == null ? LockConstants.DEFAULT_USER_ID : ownerId);
     _record.setSimpleField(LockInfoAttribute.MESSAGE.name(),

--- a/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
@@ -29,12 +29,7 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 public class LockInfo {
   // default lock info represents the status of a unlocked lock
   public static final LockInfo defaultLockInfo =
-      new LockInfo(LockConstants.DEFAULT_OWNER_TEXT, LockConstants.DEFAULT_MESSAGE_TEXT,
-          LockConstants.DEFAULT_TIMEOUT_LONG, LockConstants.DEFAULT_PRIORITY_INT,
-          LockConstants.DEFAULT_WAITING_TIMEOUT_LONG, LockConstants.DEFAULT_CLEANUP_TIMEOUT_LONG,
-          LockConstants.DEFAULT_REQUESTOR_ID, LockConstants.DEFAULT_REQUESTOR_PRIORITY_INT,
-          LockConstants.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG,
-          LockConstants.DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
+      new LockInfo();
 
   public static final String ZNODE_ID = "LOCK";
   private ZNRecord _record;
@@ -75,7 +70,10 @@ public class LockInfo {
   public LockInfo(ZNRecord znRecord) {
     this();
     if (znRecord != null) {
-      String ownerId = znRecord.getSimpleField(LockInfoAttribute.OWNER.name());
+      _record = new ZNRecord(ZNODE_ID);
+      String ownerId = znRecord.getSimpleField(LockInfoAttribute.OWNER.name()).isEmpty() ?
+          LockConstants.DEFAULT_OWNER_TEXT :
+          znRecord.getSimpleField(LockInfoAttribute.OWNER.name());
       String message = znRecord.getSimpleField(LockInfoAttribute.MESSAGE.name());
       long timeout = znRecord
           .getLongField(LockInfoAttribute.TIMEOUT.name(), LockConstants.DEFAULT_TIMEOUT_LONG);
@@ -115,7 +113,7 @@ public class LockInfo {
   public LockInfo(String ownerId, String message, long timeout, int priority, long waitingTimout,
       long cleanupTimeout, String requestorId, int requestorPriority, long requestorWaitingTimeout,
       long requestorRequestingTimestamp) {
-    this();
+    _record = new ZNRecord(ZNODE_ID);
     setLockInfoFields(ownerId, message, timeout, priority, waitingTimout, cleanupTimeout,
         requestorId, requestorPriority, requestorWaitingTimeout, requestorRequestingTimestamp);
   }

--- a/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
@@ -68,17 +68,19 @@ public class LockInfo {
    * @param znRecord The ZNRecord contains lock node data that used to initialize the LockInfo
    */
   public LockInfo(ZNRecord znRecord) {
-    this();
-    if (znRecord != null) {
-      _record = new ZNRecord(ZNODE_ID);
-      String ownerId = znRecord.getSimpleField(LockInfoAttribute.OWNER.name()).isEmpty() ?
-          LockConstants.DEFAULT_USER_ID :
-          znRecord.getSimpleField(LockInfoAttribute.OWNER.name());
-      String message = znRecord.getSimpleField(LockInfoAttribute.MESSAGE.name());
-      long timeout = znRecord
-          .getLongField(LockInfoAttribute.TIMEOUT.name(), LockConstants.DEFAULT_TIMEOUT_LONG);
-      int priority = znRecord
-          .getIntField(LockInfoAttribute.PRIORITY.name(), LockConstants.DEFAULT_PRIORITY_INT);
+    _record = new ZNRecord(ZNODE_ID);
+    if (znRecord == null) {
+      znRecord = new ZNRecord(ZNODE_ID);
+    }
+    String ownerId = znRecord.getSimpleField(LockInfoAttribute.OWNER.name()) == null
+        ? LockConstants.DEFAULT_USER_ID : znRecord.getSimpleField(LockInfoAttribute.OWNER.name());
+    String message = znRecord.getSimpleField(LockInfoAttribute.MESSAGE.name()) == null
+        ? LockConstants.DEFAULT_MESSAGE_TEXT
+        : znRecord.getSimpleField(LockInfoAttribute.MESSAGE.name());
+    long timeout =
+        znRecord.getLongField(LockInfoAttribute.TIMEOUT.name(), LockConstants.DEFAULT_TIMEOUT_LONG);
+    int priority =
+        znRecord.getIntField(LockInfoAttribute.PRIORITY.name(), LockConstants.DEFAULT_PRIORITY_INT);
       long waitingTimeout = znRecord.getLongField(LockInfoAttribute.WAITING_TIMEOUT.name(),
           LockConstants.DEFAULT_WAITING_TIMEOUT_LONG);
       long cleanupTimeout = znRecord.getLongField(LockInfoAttribute.CLEANUP_TIMEOUT.name(),
@@ -94,7 +96,6 @@ public class LockInfo {
               LockConstants.DEFAULT_REQUESTING_TIMESTAMP_LONG);
       setLockInfoFields(ownerId, message, timeout, priority, waitingTimeout, cleanupTimeout,
           requestorId, requestorPriority, requestorWaitingTimeout, requestingTimestamp);
-    }
   }
 
   /**

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/LockConstants.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/LockConstants.java
@@ -33,8 +33,12 @@ public class LockConstants {
   public static final long DEFAULT_REQUESTING_TIMESTAMP_LONG = -1;
 
   public enum LockStatus {
+    // The lock is already acquired and the requestor is the current lock owner
     LOCKED,
+    // The lock acquisition request is waiting on previous lock owner's cleanup work
     PENDING,
+    // The lock was in a PENDING status before, but it has been replaced by another higher
+    // priority lock and lose its waiting position.
     PREEMPTED,
   }
 }

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/LockConstants.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/LockConstants.java
@@ -24,14 +24,17 @@ package org.apache.helix.lock.helix;
  * Default values for each attribute if there are no current values set by user
  */
 public class LockConstants {
-  public static final String DEFAULT_OWNER_TEXT = "NONE";
+  public static final String DEFAULT_USER_ID = "NONE";
   public static final String DEFAULT_MESSAGE_TEXT = "NONE";
   public static final long DEFAULT_TIMEOUT_LONG = -1;
   public static final int DEFAULT_PRIORITY_INT = -1;
   public static final long DEFAULT_WAITING_TIMEOUT_LONG = -1;
   public static final long DEFAULT_CLEANUP_TIMEOUT_LONG = -1;
-  public static final String DEFAULT_REQUESTOR_ID = "NONE";
-  public static final int DEFAULT_REQUESTOR_PRIORITY_INT = -1;
-  public static final long DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG = -1;
-  public static final long DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG = -1;
+  public static final long DEFAULT_REQUESTING_TIMESTAMP_LONG = -1;
+
+  public enum LockStatus {
+    LOCKED,
+    PENDING,
+    PREEMPTED,
+  }
 }

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/LockConstants.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/LockConstants.java
@@ -1,0 +1,37 @@
+package org.apache.helix.lock.helix;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/*
+ * Default values for each attribute if there are no current values set by user
+ */
+public class LockConstants {
+  public static final String DEFAULT_OWNER_TEXT = "";
+  public static final String DEFAULT_MESSAGE_TEXT = "";
+  public static final long DEFAULT_TIMEOUT_LONG = -1;
+  public static final int DEFAULT_PRIORITY_INT = -1;
+  public static final long DEFAULT_WAITING_TIMEOUT_LONG = -1;
+  public static final long DEFAULT_CLEANUP_TIMEOUT_LONG = -1;
+  public static final String DEFAULT_REQUESTOR_ID = "";
+  public static final int DEFAULT_REQUESTOR_PRIORITY_INT = -1;
+  public static final long DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG = -1;
+  public static final long DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG = -1;
+}

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/LockConstants.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/LockConstants.java
@@ -24,13 +24,13 @@ package org.apache.helix.lock.helix;
  * Default values for each attribute if there are no current values set by user
  */
 public class LockConstants {
-  public static final String DEFAULT_OWNER_TEXT = "";
-  public static final String DEFAULT_MESSAGE_TEXT = "";
+  public static final String DEFAULT_OWNER_TEXT = "NONE";
+  public static final String DEFAULT_MESSAGE_TEXT = "NONE";
   public static final long DEFAULT_TIMEOUT_LONG = -1;
   public static final int DEFAULT_PRIORITY_INT = -1;
   public static final long DEFAULT_WAITING_TIMEOUT_LONG = -1;
   public static final long DEFAULT_CLEANUP_TIMEOUT_LONG = -1;
-  public static final String DEFAULT_REQUESTOR_ID = "";
+  public static final String DEFAULT_REQUESTOR_ID = "NONE";
   public static final int DEFAULT_REQUESTOR_PRIORITY_INT = -1;
   public static final long DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG = -1;
   public static final long DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG = -1;

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/LockListener.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/LockListener.java
@@ -1,0 +1,33 @@
+package org.apache.helix.lock.helix;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This interface has one method that lock users need to implement. The method is a callback
+ * method triggered when a lock is preempted by a higher priority lock request. This method is
+ * supposed to clean up the work done by the user and return the system to a stable state before
+ * releasing the lock.
+ */
+interface LockListener {
+  /**
+   * call back called when the lock is preempted
+   */
+  void onCleanupNotification();
+}

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
@@ -101,7 +101,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
    *                   lock encountered an exception during preempting lower priority lock
    * @param lockListener the listener associated to the lock
    */
-  public ZKDistributedNonblockingLock(LockScope scope, String zkAddress, Long leaseTimeout,
+  private ZKDistributedNonblockingLock(LockScope scope, String zkAddress, Long leaseTimeout,
       String lockMsg, String userId, int priority, long waitingTimeout, long cleanupTimeout,
       boolean isForceful, LockListener lockListener) {
     this(scope.getPath(), leaseTimeout, lockMsg, userId, priority, waitingTimeout, cleanupTimeout,

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
@@ -143,6 +143,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
     _cleanupTimeout = cleanupTimeout;
     _lockListener = lockListener;
     _isForceful = isForceful;
+    validateInput();
   }
 
   @Override
@@ -326,11 +327,8 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
           long remainingCleanupTime =
               curLockInfo.getCleanupTimeout() - (System.currentTimeMillis() - curLockInfo
                   .getRequestingTimestamp());
-          //_pendingTimeout = _waitingTimeout > remainingCleanupTime ? remainingCleanupTime :
-          // _waitingTimeout;
-          _pendingTimeout =
-              _waitingTimeout > curLockInfo.getCleanupTimeout() ? curLockInfo.getCleanupTimeout()
-                  : _waitingTimeout;
+          _pendingTimeout = _waitingTimeout > remainingCleanupTime ? remainingCleanupTime :
+           _waitingTimeout;
           return newRecord;
         }
       }
@@ -524,6 +522,21 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
       return new ZKDistributedNonblockingLock(_lockScope.getPath(), _timeout, _lockMsg, _userId,
           _priority, _waitingTimeout, _cleanupTimeout, _isForceful, _lockListener,
           baseDataAccessor);
+    }
+  }
+
+  private void validateInput() {
+    if (_lockPath == null) {
+      throw new IllegalArgumentException("Lock scope cannot be null");
+    }
+    if (_userId == null) {
+      throw new IllegalArgumentException("Owner Id cannot be null");
+    }
+    if (_leaseTimeout < 0 || _waitingTimeout < 0 || _cleanupTimeout < 0) {
+      throw new IllegalArgumentException("Timeout cannot be negative.");
+    }
+    if (_priority < 0) {
+      throw new IllegalArgumentException("Priority cannot be negative.");
     }
   }
 }

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
@@ -37,13 +37,6 @@ import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.helix.lock.LockInfo.DEFAULT_PRIORITY_INT;
-import static org.apache.helix.lock.LockInfo.DEFAULT_REQUESTOR_ID;
-import static org.apache.helix.lock.LockInfo.DEFAULT_REQUESTOR_PRIORITY_INT;
-import static org.apache.helix.lock.LockInfo.DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG;
-import static org.apache.helix.lock.LockInfo.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG;
-import static org.apache.helix.lock.LockInfo.DEFAULT_WAITING_TIMEOUT_LONG;
 import static org.apache.helix.lock.LockInfo.ZNODE_ID;
 
 
@@ -357,9 +350,10 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
             oldLockInfo.getPriority(), oldLockInfo.getWaitingTimeout(),
             oldLockInfo.getCleanupTimeout(),
             newLockZNRecord.getSimpleField(LockInfo.LockInfoAttribute.OWNER.name()), newLockZNRecord
-            .getIntField(LockInfo.LockInfoAttribute.PRIORITY.name(), DEFAULT_PRIORITY_INT),
-            newLockZNRecord.getLongField(LockInfo.LockInfoAttribute.WAITING_TIMEOUT.name(),
-                DEFAULT_WAITING_TIMEOUT_LONG), System.currentTimeMillis());
+            .getIntField(LockInfo.LockInfoAttribute.PRIORITY.name(),
+                LockConstants.DEFAULT_PRIORITY_INT), newLockZNRecord
+            .getLongField(LockInfo.LockInfoAttribute.WAITING_TIMEOUT.name(),
+                LockConstants.DEFAULT_WAITING_TIMEOUT_LONG), System.currentTimeMillis());
     return lockInfo.getRecord();
   }
 
@@ -372,13 +366,14 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
     znRecord.setIntField(LockInfo.LockInfoAttribute.PRIORITY.name(), _priority);
     znRecord.setLongField(LockInfo.LockInfoAttribute.WAITING_TIMEOUT.name(), _waitingTimeout);
     znRecord.setLongField(LockInfo.LockInfoAttribute.CLEANUP_TIMEOUT.name(), _cleanupTimeout);
-    znRecord.setSimpleField(LockInfo.LockInfoAttribute.REQUESTOR_ID.name(), DEFAULT_REQUESTOR_ID);
+    znRecord.setSimpleField(LockInfo.LockInfoAttribute.REQUESTOR_ID.name(),
+        LockConstants.DEFAULT_REQUESTOR_ID);
     znRecord.setIntField(LockInfo.LockInfoAttribute.REQUESTOR_PRIORITY.name(),
-        DEFAULT_REQUESTOR_PRIORITY_INT);
+        LockConstants.DEFAULT_REQUESTOR_PRIORITY_INT);
     znRecord.setLongField(LockInfo.LockInfoAttribute.REQUESTOR_WAITING_TIMEOUT.name(),
-        DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
+        LockConstants.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
     znRecord.setLongField(LockInfo.LockInfoAttribute.REQUESTOR_REQUESTING_TIMESTAMP.name(),
-        DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
+        LockConstants.DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
     return znRecord;
   }
 

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
@@ -31,8 +31,20 @@ import org.apache.helix.lock.LockScope;
 import org.apache.helix.manager.zk.GenericZkHelixApiBuilder;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.datamodel.ZNRecordUpdater;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
-import org.apache.log4j.Logger;
+import org.apache.helix.zookeeper.zkclient.IZkDataListener;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.helix.lock.LockInfo.DEFAULT_PRIORITY_INT;
+import static org.apache.helix.lock.LockInfo.DEFAULT_REQUESTOR_ID;
+import static org.apache.helix.lock.LockInfo.DEFAULT_REQUESTOR_PRIORITY_INT;
+import static org.apache.helix.lock.LockInfo.DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG;
+import static org.apache.helix.lock.LockInfo.DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG;
+import static org.apache.helix.lock.LockInfo.DEFAULT_WAITING_TIMEOUT_LONG;
+import static org.apache.helix.lock.LockInfo.ZNODE_ID;
 
 
 /**
@@ -40,60 +52,141 @@ import org.apache.log4j.Logger;
  * NOTE: do NOT use ephemeral nodes in this implementation because ephemeral mode is not supported
  * in ZooScalability mode.
  */
-public class ZKDistributedNonblockingLock implements DistributedLock {
-  private static final Logger LOG = Logger.getLogger(ZKDistributedNonblockingLock.class);
+public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataListener {
+  private static final Logger LOG = LoggerFactory.getLogger(ZKDistributedNonblockingLock.class);
 
   private final String _lockPath;
   private final String _userId;
-  private final long _timeout;
   private final String _lockMsg;
+  private final long _leaseTimeout;
+  private final long _waitingTimeout;
+  private final long _cleanupTimeout;
+  private final int _priority;
+  private final boolean _isForceful;
+  private final LockListener _lockListener;
   private final BaseDataAccessor<ZNRecord> _baseDataAccessor;
+  private boolean _isLocked;
+  private boolean _isPending;
+  private boolean _isPreempted;
+  private long _pendingTimeout;
 
   /**
    * Initialize the lock with user provided information, e.g.,cluster, scope, etc.
    * @param scope the scope to lock
    * @param zkAddress the zk address the cluster connects to
-   * @param timeout the timeout period of the lock
+   * @param leaseTimeout the leasing timeout period of the lock
    * @param lockMsg the reason for having this lock
    * @param userId a universal unique userId for lock owner identity
    */
-  public ZKDistributedNonblockingLock(LockScope scope, String zkAddress, Long timeout,
+  public ZKDistributedNonblockingLock(LockScope scope, String zkAddress, Long leaseTimeout,
       String lockMsg, String userId) {
-    this(scope.getPath(), timeout, lockMsg, userId, new ZkBaseDataAccessor<ZNRecord>(zkAddress));
+    this(scope.getPath(), leaseTimeout, lockMsg, userId, 0, Integer.MAX_VALUE, 0, false,
+        new LockListener() {
+          @Override
+          public void onCleanupNotification() {
+          }
+        }, new ZkBaseDataAccessor<ZNRecord>(zkAddress));
+  }
+
+  /**
+   * Initialize the lock with user provided information, e.g.,cluster, scope, etc.
+   * @param scope the scope to lock
+   * @param zkAddress the zk address the cluster connects to
+   * @param leaseTimeout the leasing timeout period of the lock
+   * @param lockMsg the reason for having this lock
+   * @param userId a universal unique userId for lock owner identity
+   * @param priority the priority of the lock
+   * @param waitingTimeout the waiting timeout period of the lock when the tryLock request is issued
+   * @param cleanupTimeout the time period needed to finish the cleanup work by the lock when it
+   *                      is preempted
+   * @param isForceful whether the lock is a forceful one. This determines the behavior when the
+   *                   lock encountered an exception during preempting lower priority lock
+   * @param lockListener the listener associated to the lock
+   */
+  public ZKDistributedNonblockingLock(LockScope scope, String zkAddress, Long leaseTimeout,
+      String lockMsg, String userId, int priority, long waitingTimeout, long cleanupTimeout,
+      boolean isForceful, LockListener lockListener) {
+    this(scope.getPath(), leaseTimeout, lockMsg, userId, priority, waitingTimeout, cleanupTimeout,
+        isForceful, lockListener, new ZkBaseDataAccessor<ZNRecord>(zkAddress));
   }
 
   /**
    * Initialize the lock with user provided information, e.g., lock path under zookeeper, etc.
    * @param lockPath the path of the lock under Zookeeper
-   * @param timeout the timeout period of the lock
+   * @param leaseTimeout the leasing timeout period of the lock
    * @param lockMsg the reason for having this lock
    * @param userId a universal unique userId for lock owner identity
+   * @param priority the priority of the lock
+   * @param waitingTimeout the waiting timeout period of the lock when the tryLock request is issued
+   * @param cleanupTimeout the time period needed to finish the cleanup work by the lock when it
+   *                      is preempted
+   * @param isForceful whether the lock is a forceful one. This determines the behavior when the
+   *                   lock encountered an exception during preempting lower priority lock
+   * @param lockListener the listener associated to the lock
    * @param baseDataAccessor baseDataAccessor instance to do I/O against ZK with
    */
-  private ZKDistributedNonblockingLock(String lockPath, Long timeout, String lockMsg, String userId,
-      BaseDataAccessor<ZNRecord> baseDataAccessor) {
+  private ZKDistributedNonblockingLock(String lockPath, Long leaseTimeout, String lockMsg,
+      String userId, int priority, long waitingTimeout, long cleanupTimeout, boolean isForceful,
+      LockListener lockListener, BaseDataAccessor<ZNRecord> baseDataAccessor) {
     _lockPath = lockPath;
-    if (timeout < 0) {
-      throw new IllegalArgumentException("The expiration time cannot be negative.");
+    if (leaseTimeout < 0 || waitingTimeout < 0 || cleanupTimeout < 0) {
+      throw new IllegalArgumentException("Timeout cannot be negative.");
     }
-    _timeout = timeout;
+    if (priority < 0) {
+      throw new IllegalArgumentException("Priority cannot be negative.");
+    }
+    _leaseTimeout = leaseTimeout;
     _lockMsg = lockMsg;
     _userId = userId;
     _baseDataAccessor = baseDataAccessor;
+    _priority = priority;
+    _waitingTimeout = waitingTimeout;
+    _cleanupTimeout = cleanupTimeout;
+    _lockListener = lockListener;
+    _isForceful = isForceful;
   }
 
   @Override
-  public boolean tryLock() {
+  public synchronized boolean tryLock() {
     // Set lock information fields
-    long deadline;
-    // Prevent value overflow
-    if (_timeout > Long.MAX_VALUE - System.currentTimeMillis()) {
-      deadline = Long.MAX_VALUE;
-    } else {
-      deadline = System.currentTimeMillis() + _timeout;
+    _baseDataAccessor.subscribeDataChanges(_lockPath, this);
+    LockUpdater updater = new LockUpdater(
+        new LockInfo(_userId, _lockMsg, getNonOverflowTimestamp(_leaseTimeout), _priority,
+            _waitingTimeout, _cleanupTimeout, null, 0, 0, 0));
+    boolean updateResult = _baseDataAccessor.update(_lockPath, updater, AccessOption.PERSISTENT);
+
+    // Check whether the lock request is still pending. If yes, we will wait for the period
+    // recorded in _pendingTimeout.
+    if (_isPending) {
+      try {
+        wait(_pendingTimeout);
+      } catch (InterruptedException e) {
+        throw new HelixException(
+            String.format("Interruption happened while %s is waiting for the " + "lock", _userId),
+            e);
+      }
+      // We have not acquired the lock yet.
+      if (!_isLocked) {
+        // If the reason for not being able to acquire the lock is due to high priority lock
+        // preemption, directly return false.
+        if (_isPreempted) {
+          return false;
+        } else {
+          // Forceful lock request will grab the lock even the current owner has not finished
+          // cleanup work, while non forceful lock request will get an exception.
+          if (_isForceful) {
+            ZNRecord znRecord = composeNewOwnerRecord();
+            LOG.info("Updating Zookeeper with new owner {} information", _userId);
+            _baseDataAccessor
+                .update(_lockPath, new ZNRecordUpdater(znRecord), AccessOption.PERSISTENT);
+            return true;
+          } else {
+            throw new HelixException("Cleanup has not been finished by lock owner");
+          }
+        }
+      }
     }
-    LockUpdater updater = new LockUpdater(new LockInfo(_userId, _lockMsg, deadline));
-    return _baseDataAccessor.update(_lockPath, updater, AccessOption.PERSISTENT);
+    return updateResult;
   }
 
   //TODO: update release lock logic so it would not leave empty znodes after the lock is released
@@ -125,6 +218,79 @@ public class ZKDistributedNonblockingLock implements DistributedLock {
     _baseDataAccessor.close();
   }
 
+  @Override
+  public void handleDataChange(String dataPath, Object data) throws Exception {
+    Stat stat = new Stat();
+    ZNRecord readData =
+        _baseDataAccessor.get(dataPath, stat, AccessOption.THROW_EXCEPTION_IFNOTEXIST);
+    LockInfo lockInfo = new LockInfo(readData);
+    // We are the current owner
+    if (lockInfo.getOwner().equals(_userId)) {
+      if (lockInfo.getRequestorId() == null || lockInfo.getPriority() > lockInfo
+          .getRequestorPriority()) {
+        LOG.info("We do not need to handle this data change");
+      } else {
+        _lockListener.onCleanupNotification();
+        // read the lock information again to avoid stale data
+        readData = _baseDataAccessor.get(dataPath, stat, AccessOption.THROW_EXCEPTION_IFNOTEXIST);
+        // If we are still the lock owner, clean the lock owner field.
+        if (lockInfo.getOwner().equals(_userId)) {
+          ZNRecord znRecord = new ZNRecord(readData);
+          znRecord.setSimpleField(LockInfo.LockInfoAttribute.OWNER.name(), "");
+          znRecord.setSimpleField(LockInfo.LockInfoAttribute.MESSAGE.name(), "");
+          znRecord.setLongField(LockInfo.LockInfoAttribute.TIMEOUT.name(), -1);
+          znRecord.setIntField(LockInfo.LockInfoAttribute.PRIORITY.name(), -1);
+          znRecord.setLongField(LockInfo.LockInfoAttribute.WAITING_TIMEOUT.name(), -1);
+          znRecord.setLongField(LockInfo.LockInfoAttribute.CLEANUP_TIMEOUT.name(), -1);
+          _baseDataAccessor
+              .update(_lockPath, new ZNRecordUpdater(znRecord), AccessOption.PERSISTENT);
+        } else {
+          LOG.info("We are not current lock owner");
+        }
+      }
+    } // We are the current requestor
+    else if (lockInfo.getRequestorId().equals(_userId)) {
+      // In case the owner field is empty, it means previous owner has finished cleanup work.
+      if (lockInfo.getOwner().isEmpty()) {
+        ZNRecord znRecord = composeNewOwnerRecord();
+        _baseDataAccessor.update(_lockPath, new ZNRecordUpdater(znRecord), AccessOption.PERSISTENT);
+        onAcquiredLockNotification();
+      } else {
+        LOG.info("We do not need to handle this data change");
+      }
+    } // If we are waiting for the lock, but find we are not the requestor any more, meaning we
+    // are preempted by an even higher priority request
+    else if (lockInfo.getRequestorId() != null && !lockInfo.getRequestorId().equals(_userId)
+        && _isPending) {
+      onDeniedPendingLockNotification();
+    }
+  }
+
+  /**
+   * call back called when the lock is acquired
+   */
+  public void onAcquiredLockNotification() {
+    synchronized (ZKDistributedNonblockingLock.this) {
+      _isLocked = true;
+      ZKDistributedNonblockingLock.this.notify();
+    }
+  }
+
+  /**
+   * call back called when the pending request is denied due to another higher priority request
+   */
+  public void onDeniedPendingLockNotification() {
+    synchronized (ZKDistributedNonblockingLock.this) {
+      _isLocked = false;
+      _isPreempted = true;
+      ZKDistributedNonblockingLock.this.notify();
+    }
+  }
+
+  @Override
+  public void handleDataDeleted(String dataPath) throws Exception {
+  }
+
   /**
    * Class that specifies how a lock node should be updated with another lock node
    */
@@ -144,16 +310,83 @@ public class ZKDistributedNonblockingLock implements DistributedLock {
       // If no one owns the lock, allow the update
       // If the user is the current lock owner, allow the update
       LockInfo curLockInfo = new LockInfo(current);
-      if (!(System.currentTimeMillis() < curLockInfo.getTimeout()) || isCurrentOwner()) {
+      if (System.currentTimeMillis() > curLockInfo.getTimeout() || isCurrentOwner()) {
         return _record;
       }
-      // For users who are not the lock owner and try to do an update on a lock that is held by
-      // someone else, exception thrown is to be caught by data accessor, and return false for
-      // the update
+
+      // higher priority lock request will preempt current lock owner that is with lower priority
+      if (!isCurrentOwner() && _priority > curLockInfo.getPriority() && curLockInfo.getRequestorId()
+          .isEmpty()) {
+        // update lock Znode with requestor information
+        ZNRecord newRecord = composeNewRequestorRecord(curLockInfo, _record);
+        _isPending = true;
+        _pendingTimeout =
+            _waitingTimeout > curLockInfo.getCleanupTimeout() ? curLockInfo.getCleanupTimeout()
+                : _waitingTimeout;
+        return newRecord;
+      }
+
+      // If the requestor field is not empty, and the coming lock request has a even higher
+      // priority. The new request will replace current requestor field of the lock
+      if (!isCurrentOwner() && _priority > curLockInfo.getPriority() && !curLockInfo
+          .getRequestorId().isEmpty() && _priority > curLockInfo.getRequestorPriority()) {
+        ZNRecord newRecord = composeNewRequestorRecord(curLockInfo, _record);
+        _isPending = true;
+        long remainingCleanupTime =
+            curLockInfo.getCleanupTimeout() - (System.currentTimeMillis() - curLockInfo
+                .getRequestorRequestingTimestamp());
+        _pendingTimeout =
+            _waitingTimeout > remainingCleanupTime ? remainingCleanupTime : _waitingTimeout;
+        return newRecord;
+      }
+
+      // For users who are not the lock owner and the priority is not higher than current lock
+      // owner, throw an exception. The exception will be caught by data accessor, and return
+      // false for the update
       LOG.error(
           "User " + _userId + " tried to update the lock at " + new Date(System.currentTimeMillis())
               + ". Lock path: " + _lockPath);
+
       throw new HelixException("User is not authorized to perform this operation.");
+    }
+  }
+
+  private ZNRecord composeNewRequestorRecord(LockInfo oldLockInfo, ZNRecord newLockZNRecord) {
+    LockInfo lockInfo =
+        new LockInfo(oldLockInfo.getOwner(), oldLockInfo.getMessage(), oldLockInfo.getTimeout(),
+            oldLockInfo.getPriority(), oldLockInfo.getWaitingTimeout(),
+            oldLockInfo.getCleanupTimeout(),
+            newLockZNRecord.getSimpleField(LockInfo.LockInfoAttribute.OWNER.name()), newLockZNRecord
+            .getIntField(LockInfo.LockInfoAttribute.PRIORITY.name(), DEFAULT_PRIORITY_INT),
+            newLockZNRecord.getLongField(LockInfo.LockInfoAttribute.WAITING_TIMEOUT.name(),
+                DEFAULT_WAITING_TIMEOUT_LONG), System.currentTimeMillis());
+    return lockInfo.getRecord();
+  }
+
+  private ZNRecord composeNewOwnerRecord() {
+    ZNRecord znRecord = new ZNRecord(ZNODE_ID);
+    znRecord.setSimpleField(LockInfo.LockInfoAttribute.OWNER.name(), _userId);
+    znRecord.setSimpleField(LockInfo.LockInfoAttribute.MESSAGE.name(), _lockMsg);
+    znRecord.setLongField(LockInfo.LockInfoAttribute.TIMEOUT.name(),
+        getNonOverflowTimestamp(_leaseTimeout));
+    znRecord.setIntField(LockInfo.LockInfoAttribute.PRIORITY.name(), _priority);
+    znRecord.setLongField(LockInfo.LockInfoAttribute.WAITING_TIMEOUT.name(), _waitingTimeout);
+    znRecord.setLongField(LockInfo.LockInfoAttribute.CLEANUP_TIMEOUT.name(), _cleanupTimeout);
+    znRecord.setSimpleField(LockInfo.LockInfoAttribute.REQUESTOR_ID.name(), DEFAULT_REQUESTOR_ID);
+    znRecord.setIntField(LockInfo.LockInfoAttribute.REQUESTOR_PRIORITY.name(),
+        DEFAULT_REQUESTOR_PRIORITY_INT);
+    znRecord.setLongField(LockInfo.LockInfoAttribute.REQUESTOR_WAITING_TIMEOUT.name(),
+        DEFAULT_REQUESTOR_WAITING_TIMEOUT_LONG);
+    znRecord.setLongField(LockInfo.LockInfoAttribute.REQUESTOR_REQUESTING_TIMESTAMP.name(),
+        DEFAULT_REQUESTOR_REQUESTING_TIMESTAMP_LONG);
+    return znRecord;
+  }
+
+  private long getNonOverflowTimestamp(Long timePeriod) {
+    if (timePeriod > Long.MAX_VALUE - System.currentTimeMillis()) {
+      return Long.MAX_VALUE;
+    } else {
+      return System.currentTimeMillis() + timePeriod;
     }
   }
 
@@ -165,6 +398,11 @@ public class ZKDistributedNonblockingLock implements DistributedLock {
     private String _userId;
     private long _timeout;
     private String _lockMsg;
+    private int _priority;
+    private long _waitingTimeout;
+    private long _cleanupTimeout;
+    private boolean _isForceful;
+    private LockListener _lockListener;
 
     public Builder() {
     }
@@ -189,6 +427,31 @@ public class ZKDistributedNonblockingLock implements DistributedLock {
       return this;
     }
 
+    public Builder setPriority(int priority) {
+      _priority = priority;
+      return this;
+    }
+
+    public Builder setWaitingTimeout(long waitingTimeout) {
+      _waitingTimeout = waitingTimeout;
+      return this;
+    }
+
+    public Builder setCleanupTimeout(long cleanupTimeout) {
+      _cleanupTimeout = cleanupTimeout;
+      return this;
+    }
+
+    public Builder setIsForceful(boolean isForceful) {
+      _isForceful = isForceful;
+      return this;
+    }
+
+    public Builder setLockListener(LockListener lockListener) {
+      _lockListener = lockListener;
+      return this;
+    }
+
     public ZKDistributedNonblockingLock build() {
       // Resolve which way we want to create BaseDataAccessor instance
       BaseDataAccessor<ZNRecord> baseDataAccessor;
@@ -205,6 +468,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock {
 
       // Return a ZKDistributedNonblockingLock instance
       return new ZKDistributedNonblockingLock(_lockScope.getPath(), _timeout, _lockMsg, _userId,
+          _priority, _waitingTimeout, _cleanupTimeout, _isForceful, _lockListener,
           baseDataAccessor);
     }
   }

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKLockConfig.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKLockConfig.java
@@ -1,0 +1,173 @@
+package org.apache.helix.lock.helix;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.lock.LockScope;
+import org.apache.helix.manager.zk.GenericZkHelixApiBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Hold configs used for a ZK distributed nonblocking lock.
+ */
+public class ZKLockConfig {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(org.apache.helix.lock.helix.ZKLockConfig.class.getName());
+  private LockScope _lockScope;
+  private String _zkAddress;
+  private Long _leaseTimeout;
+  private String _lockMsg;
+  private String _userId;
+  private int _priority;
+  private long _waitingTimeout;
+  private long _cleanupTimeout;
+  private boolean _isForceful;
+  private LockListener _lockListener;
+
+  private ZKLockConfig(LockScope lockScope, String zkAddress, Long leaseTimeout, String lockMsg,
+      String userId, int priority, long waitingTimeout, long cleanupTimeout, boolean isForceful,
+      LockListener lockListener) {
+    _lockScope = lockScope;
+    _zkAddress = zkAddress;
+    _leaseTimeout = leaseTimeout;
+    _lockMsg = lockMsg;
+    _userId = userId;
+    _priority = priority;
+    _waitingTimeout = waitingTimeout;
+    _cleanupTimeout = cleanupTimeout;
+    _lockListener = lockListener;
+    _isForceful = isForceful;
+  }
+
+  public LockScope getLockScope() {
+    return _lockScope;
+  }
+
+  public String getZkAddress() {
+    return _zkAddress;
+  }
+
+  public Long getLeaseTimeout() {
+    return _leaseTimeout;
+  }
+
+  public String getLockMsg() {
+    return _lockMsg;
+  }
+
+  public String getUserId() {
+    return _userId;
+  }
+
+  public int getPriority() {
+    return _priority;
+  }
+
+  public long getWaitingTimeout() {
+    return _waitingTimeout;
+  }
+
+  public long getCleanupTimeout() {
+    return _cleanupTimeout;
+  }
+
+  public boolean getIsForceful() {
+    return _isForceful;
+  }
+
+  public LockListener getLockListener() {
+    return _lockListener;
+  }
+
+  /**
+   * Builder class to use with ZKLockConfig.
+   */
+  public static class Builder extends GenericZkHelixApiBuilder<ZKLockConfig.Builder> {
+    private LockScope _lockScope;
+    private String _zkAddress;
+    private long _leaseTimeout;
+    private String _lockMsg;
+    private String _userId;
+    private int _priority;
+    private long _waitingTimeout;
+    private long _cleanupTimeout;
+    private boolean _isForceful;
+    private LockListener _lockListener;
+
+    public Builder() {
+    }
+
+    public ZKLockConfig build() {
+      return new ZKLockConfig(_lockScope, _zkAddress, _leaseTimeout, _lockMsg, _userId, _priority,
+          _waitingTimeout, _cleanupTimeout, _isForceful, _lockListener);
+    }
+
+    public ZKLockConfig.Builder setLockScope(LockScope lockScope) {
+      _lockScope = lockScope;
+      return this;
+    }
+
+    public ZKLockConfig.Builder setZkAdress(String zkAddress) {
+      _zkAddress = zkAddress;
+      return this;
+    }
+
+    public ZKLockConfig.Builder setUserId(String userId) {
+      _userId = userId;
+      return this;
+    }
+
+    public ZKLockConfig.Builder setLeaseTimeout(long leaseTimeout) {
+      _leaseTimeout = leaseTimeout;
+      return this;
+    }
+
+    public ZKLockConfig.Builder setLockMsg(String lockMsg) {
+      _lockMsg = lockMsg;
+      return this;
+    }
+
+    public ZKLockConfig.Builder setPriority(int priority) {
+      _priority = priority;
+      return this;
+    }
+
+    public ZKLockConfig.Builder setWaitingTimeout(long waitingTimeout) {
+      _waitingTimeout = waitingTimeout;
+      return this;
+    }
+
+    public ZKLockConfig.Builder setCleanupTimeout(long cleanupTimeout) {
+      _cleanupTimeout = cleanupTimeout;
+      return this;
+    }
+
+    public ZKLockConfig.Builder setIsForceful(boolean isForceful) {
+      _isForceful = isForceful;
+      return this;
+    }
+
+    public ZKLockConfig.Builder setLockListener(LockListener lockListener) {
+      _lockListener = lockListener;
+      return this;
+    }
+  }
+}

--- a/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLock.java
+++ b/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLock.java
@@ -107,6 +107,7 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
     fakeRecord.setSimpleField(LockInfo.LockInfoAttribute.OWNER.name(), fakeUserID);
     fakeRecord
         .setSimpleField(LockInfo.LockInfoAttribute.TIMEOUT.name(), String.valueOf(Long.MAX_VALUE));
+    fakeRecord.setIntField(LockInfo.LockInfoAttribute.PRIORITY.name(), 0);
     _gZkClient.create(_lockPath, fakeRecord, CreateMode.PERSISTENT);
 
     // Check if the user is lock owner
@@ -128,6 +129,7 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
     fakeRecord.setSimpleField(LockInfo.LockInfoAttribute.OWNER.name(), fakeUserID);
     fakeRecord.setSimpleField(LockInfo.LockInfoAttribute.TIMEOUT.name(),
         String.valueOf(System.currentTimeMillis()));
+    fakeRecord.setIntField(LockInfo.LockInfoAttribute.PRIORITY.name(), 0);
     _gZkClient.create(_lockPath, fakeRecord, CreateMode.PERSISTENT);
 
     // Acquire lock

--- a/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLockWithPriority.java
+++ b/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLockWithPriority.java
@@ -283,11 +283,11 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
     LockHelper lockHelper = new LockHelper(higherLock);
     Thread t_higher = new Thread(lockHelper);
     t_higher.start();
-    Thread.sleep(1000);
-    boolean higherResult = lockHelper.getResult();
-
-    Assert.assertFalse(higherLock.isCurrentOwner());
+    boolean higherResult = TestHelper.verify(() -> {
+      return lockHelper.getResult();
+    }, 1000);
     Assert.assertFalse(higherResult);
+    Assert.assertFalse(higherLock.isCurrentOwner());
 
     t_highest.start();
     t_highest.join();

--- a/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLockWithPriority.java
+++ b/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLockWithPriority.java
@@ -84,9 +84,11 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
   @Test
   public void testLowerPriorityRequestRejected() throws Exception {
     ZKDistributedNonblockingLock lock = createLockWithConfig();
-    ZKDistributedNonblockingLock lowerLock = new ZKDistributedNonblockingLock(_participantScope,
-        ZK_ADDR, 3600000L,
-        "lower priority lock", "low_lock", 0, 1000, 2000, false, createLockListener());
+    ZKDistributedNonblockingLock.Builder lockBuilder = new ZKDistributedNonblockingLock.Builder();
+    lockBuilder.setLockScope(_participantScope).setZkAddress(ZK_ADDR).setTimeout(3600000L)
+        .setLockMsg("lower priority lock").setUserId("low_lock").setPriority(0).setWaitingTimeout(1000)
+        .setCleanupTimeout(2000).setIsForceful(false).setLockListener(createLockListener());
+    ZKDistributedNonblockingLock lowerLock = lockBuilder.build();
 
     Thread t = new Thread() {
       @Override
@@ -117,9 +119,13 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
   public void testHigherPriorityRequestAcquired() throws Exception {
     ZKDistributedNonblockingLock lock = createLockWithConfig();
     // The waitingTimeout of higher priority request is larger than cleanup time of current owner
-    ZKDistributedNonblockingLock higherLock = new ZKDistributedNonblockingLock(_participantScope,
-        ZK_ADDR, 3600000L,
-        "higher priority lock", "high_lock", 2, 30000, 10000, false, createLockListener());
+
+    ZKDistributedNonblockingLock.Builder lockBuilder = new ZKDistributedNonblockingLock.Builder();
+    lockBuilder.setLockScope(_participantScope).setZkAddress(ZK_ADDR).setTimeout(3600000L)
+        .setLockMsg("higher priority lock").setUserId("high_lock").setPriority(2)
+        .setWaitingTimeout(30000).setCleanupTimeout(10000).setIsForceful(false)
+        .setLockListener(createLockListener());
+    ZKDistributedNonblockingLock higherLock = lockBuilder.build();
 
     Thread t = new Thread() {
       @Override
@@ -152,9 +158,12 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
     ZKDistributedNonblockingLock lock = createLockWithConfig();
     // The waitingTimeout of higher priority request is shorter than cleanup time of current
     // owner, and the higher priority request is not forceful.
-    ZKDistributedNonblockingLock higherLock_short =
-        new ZKDistributedNonblockingLock(_participantScope, ZK_ADDR, 3600000L,
-            "higher priority lock short", "high_lock_short", 2, 2000, 10000, false, createLockListener());
+    ZKDistributedNonblockingLock.Builder lockBuilder = new ZKDistributedNonblockingLock.Builder();
+    lockBuilder.setLockScope(_participantScope).setZkAddress(ZK_ADDR).setTimeout(3600000L)
+        .setLockMsg("higher priority lock short").setUserId("high_lock_short").setPriority(2)
+        .setWaitingTimeout(2000).setCleanupTimeout(10000).setIsForceful(false)
+        .setLockListener(createLockListener());
+    ZKDistributedNonblockingLock higherLock_short = lockBuilder.build();
 
     Thread t = new Thread() {
       @Override
@@ -196,14 +205,12 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
     ZKDistributedNonblockingLock lock = createLockWithConfig();
     // The waitingTimeout of higher priority request is shorter than cleanup time of current
     // owner, but the higher priority request is forceful.
-    ZKDistributedNonblockingLock higherLock_force =
-        new ZKDistributedNonblockingLock(_participantScope, ZK_ADDR, 3600000L,
-            "higher priority lock force", "high_lock_force", 2, 2000, 10000, true,
-            new LockListener() {
-              @Override
-              public void onCleanupNotification() {
-              }
-            });
+    ZKDistributedNonblockingLock.Builder lockBuilder = new ZKDistributedNonblockingLock.Builder();
+    lockBuilder.setLockScope(_participantScope).setZkAddress(ZK_ADDR).setTimeout(3600000L)
+        .setLockMsg("higher priority lock force").setUserId("high_lock_force").setPriority(2)
+        .setWaitingTimeout(2000).setCleanupTimeout(10000).setIsForceful(true)
+        .setLockListener(createLockListener());
+    ZKDistributedNonblockingLock higherLock_force = lockBuilder.build();
 
     Thread t = new Thread() {
       @Override
@@ -239,13 +246,21 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
   @Test
   public void testHigherPriorityRequestPreemptedByAnother() throws Exception {
     ZKDistributedNonblockingLock lock = createLockWithConfig();
-    ZKDistributedNonblockingLock higherLock = new ZKDistributedNonblockingLock(_participantScope,
-        ZK_ADDR, 3600000L,
-        "higher priority lock", "high_lock", 2, 30000, 10000, false, createLockListener());
 
-    ZKDistributedNonblockingLock highestLock = new ZKDistributedNonblockingLock(_participantScope
-        , ZK_ADDR, 3600000L,
-        "highest priority lock", "highest_lock", 3, 30000, 20000, false, createLockListener());
+    ZKDistributedNonblockingLock.Builder lockBuilder = new ZKDistributedNonblockingLock.Builder();
+    lockBuilder.setLockScope(_participantScope).setZkAddress(ZK_ADDR).setTimeout(3600000L)
+        .setLockMsg("higher priority lock").setUserId("high_lock").setPriority(2)
+        .setWaitingTimeout(30000).setCleanupTimeout(10000).setIsForceful(false)
+        .setLockListener(createLockListener());
+    ZKDistributedNonblockingLock higherLock = lockBuilder.build();
+
+    ZKDistributedNonblockingLock.Builder highestLockBuilder =
+        new ZKDistributedNonblockingLock.Builder();
+    highestLockBuilder.setLockScope(_participantScope).setZkAddress(ZK_ADDR).setTimeout(3600000L)
+        .setLockMsg("highest priority lock").setUserId("highest_lock").setPriority(3)
+        .setWaitingTimeout(30000).setCleanupTimeout(10000).setIsForceful(false)
+        .setLockListener(createLockListener());
+    ZKDistributedNonblockingLock highestLock = highestLockBuilder.build();
 
     Thread t = new Thread() {
       @Override

--- a/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLockWithPriority.java
+++ b/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLockWithPriority.java
@@ -83,10 +83,7 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
 
   @Test
   public void testLowerPriorityRequestRejected() throws Exception {
-    ZKDistributedNonblockingLock lock =
-        new ZKDistributedNonblockingLock(_participantScope, ZK_ADDR, 3600000L, "original "
-            + "lock", "original_lock", 1, 1000, 25000, false, _lockListener);
-
+    ZKDistributedNonblockingLock lock = createLockWithConfig();
     ZKDistributedNonblockingLock lowerLock = new ZKDistributedNonblockingLock(_participantScope,
         ZK_ADDR, 3600000L,
         "lower priority lock", "low_lock", 0, 1000, 2000, false, createLockListener());
@@ -118,10 +115,7 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
 
   @Test
   public void testHigherPriorityRequestAcquired() throws Exception {
-    ZKDistributedNonblockingLock lock =
-        new ZKDistributedNonblockingLock(_participantScope, ZK_ADDR, 3600000L, "original "
-            + "lock", "original_lock", 1, 1000, 25000, false, _lockListener);
-
+    ZKDistributedNonblockingLock lock = createLockWithConfig();
     // The waitingTimeout of higher priority request is larger than cleanup time of current owner
     ZKDistributedNonblockingLock higherLock = new ZKDistributedNonblockingLock(_participantScope,
         ZK_ADDR, 3600000L,
@@ -155,10 +149,7 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
 
   @Test
   public void testHigherPriorityRequestFailedAsCleanupHasNotDone() throws Exception {
-    ZKDistributedNonblockingLock lock =
-        new ZKDistributedNonblockingLock(_participantScope, ZK_ADDR, 3600000L, "original "
-            + "lock", "original_lock", 1, 1000, 25000, false, _lockListener);
-
+    ZKDistributedNonblockingLock lock = createLockWithConfig();
     // The waitingTimeout of higher priority request is shorter than cleanup time of current
     // owner, and the higher priority request is not forceful.
     ZKDistributedNonblockingLock higherLock_short =
@@ -202,10 +193,7 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
 
   @Test
   public void testHigherPriorityRequestForcefulAcquired() throws Exception {
-    ZKDistributedNonblockingLock lock =
-        new ZKDistributedNonblockingLock(_participantScope, ZK_ADDR, 3600000L, "original "
-            + "lock", "original_lock", 1, 1000, 25000, false, _lockListener);
-
+    ZKDistributedNonblockingLock lock = createLockWithConfig();
     // The waitingTimeout of higher priority request is shorter than cleanup time of current
     // owner, but the higher priority request is forceful.
     ZKDistributedNonblockingLock higherLock_force =
@@ -250,10 +238,7 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
 
   @Test
   public void testHigherPriorityRequestPreemptedByAnother() throws Exception {
-    ZKDistributedNonblockingLock lock =
-        new ZKDistributedNonblockingLock(_participantScope, ZK_ADDR, 3600000L, "original "
-            + "lock", "original_lock", 1, 1000, 25000, false, _lockListener);
-
+    ZKDistributedNonblockingLock lock = createLockWithConfig();
     ZKDistributedNonblockingLock higherLock = new ZKDistributedNonblockingLock(_participantScope,
         ZK_ADDR, 3600000L,
         "higher priority lock", "high_lock", 2, 30000, 10000, false, createLockListener());
@@ -328,6 +313,16 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
       public void onCleanupNotification() {
       }
     };
+  }
+
+  ZKDistributedNonblockingLock createLockWithConfig() {
+    ZKLockConfig.Builder builder = new ZKLockConfig.Builder();
+    builder.setLockScope(_participantScope).setZkAdress(ZK_ADDR).setLeaseTimeout(3600000L)
+        .setLockMsg("original lock").setUserId("original_lock").setPriority(1)
+        .setWaitingTimeout(1000).setCleanupTimeout(25000).setIsForceful(false)
+        .setLockListener(_lockListener);
+    ZKLockConfig zkLockConfig = builder.build();
+    return new ZKDistributedNonblockingLock(zkLockConfig);
   }
 }
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fixed #1563 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Current version of Helix lock does not support priority or preemption, meaning that if a client acquires a lock, no other client can grab it until it's timed out or released. This restricts the usage of Helix lock. In many occasions, priority and preemption is needed for lock, and preferably, when the lower priority client is preempted, it could be notified and given some time to bring the system back to stable state, e.g. do some rollback, etc. 
In this PR, we define a few concepts of the lock, like priority, different timeout, and whether the lock is forceful. These parameters of a lock will determine how Helix would handle the acquire request.
We also leverage Zookeeper to perform the notification and client would need to implement the cleanup callback if it is preempted.

### Tests

- [X] The following tests are written for this issue:
TestZKHelixNonblockingLockWithPriority

- [X] The following is the result of the "mvn test" command on the appropriate module:
helix-core:
[INFO] Tests run: 1253, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,070.423 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1253, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:24 h
[INFO] Finished at: 2020-12-14T13:37:09-08:00
[INFO] ------------------------------------------------------------------------
                                                                                    
                                                                                   

helix-rest:
[INFO] Tests run: 171, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 239.077 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 171, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:03 min
[INFO] Finished at: 2020-12-14T12:19:14-08:00
[INFO] -------------------------------------------


- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
