### PR TITLE
Send partitions list instead of string to custom client Rest API

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/client/CustomRestClientImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/client/CustomRestClientImpl.java
@@ -20,6 +20,7 @@ package org.apache.helix.rest.client;
  */
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +73,7 @@ class CustomRestClientImpl implements CustomRestClient {
       jsonNode.fields().forEachRemaining(kv -> result.put(kv.getKey(), kv.getValue().asBoolean()));
       return result;
     };
-    return handleResponse(post(url, customPayloads), jsonConverter);
+    return handleResponse(post(url, Collections.unmodifiableMap(customPayloads)), jsonConverter);
   }
 
   @Override
@@ -87,10 +88,10 @@ class CustomRestClientImpl implements CustomRestClient {
      */
     String url = baseUrl + PARTITION_HEALTH_STATUS;
     // To avoid ImmutableMap as parameter
-    Map<String, String> payLoads = new HashMap<>(customPayloads);
+    Map<String, Object> payLoads = new HashMap<>(customPayloads);
     // Add the entry: "partitions" : ["p1", "p3", "p9"]
     if (partitions != null) {
-      payLoads.put(PARTITIONS, partitions.toString());
+      payLoads.put(PARTITIONS, partitions);
     }
     JsonConverter jsonConverter = jsonNode -> {
       Map<String, Boolean> result = new HashMap<>();
@@ -124,7 +125,7 @@ class CustomRestClientImpl implements CustomRestClient {
   }
 
   @VisibleForTesting
-  protected HttpResponse post(String url, Map<String, String> payloads) throws IOException {
+  protected HttpResponse post(String url, Map<String, Object> payloads) throws IOException {
     HttpPost postRequest = new HttpPost(url);
     try {
       postRequest.setHeader("Accept", ACCEPT_CONTENT_TYPE);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1569 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

CustomRestClientImpl serializes the partitions list to a string before sending the payloads to the custom client health check Rest API. The custom client is expecting a list of partitions, but received a string. So the custom client returns an error 400. But actually the partitions are healthy. This is caused by the serialization/deserialization inconsistency between helix rest and custom client rest.

```
curl -X POST  http://localhost:11933/partitionHealthStatus -d '{"partitions":["p1"]}'
```
works but Helix will actually send below that doesn't work.
```
curl -X POST  http://localhost:11933/partitionHealthStatus -d '{"partitions":"[\"p1\"]"}'
```


### Tests

- [x] The following tests are written for this issue:

Manually tested by connecting to the SN. Payloads are printed out as expected: list of partitions, instead of a string. The response from SN is 200.

- [x] The following is the result of the "mvn test" command on the appropriate module:

helix rest tests:

```
[INFO] Tests run: 171, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 102.032 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 171, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:48 min
[INFO] Finished at: 2020-12-01T11:26:32-08:00
[INFO] ------------------------------------------------------------------------
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
