### PR TITLE
Fix controller pipeline invoking log info

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -729,7 +729,8 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
             "Controller pipeline is not invoked because event session doesn't match cluster " +
                 "manager session. Event type: {}, id: {}, session: {}, actual manager session: "
                 + "{}, instance: {}, cluster: {}", event.getEventType(), event.getEventId(),
-            eventSessionId.orElse("NOT_PRESENT"), managerSessionId, manager.getInstanceName(), manager.getClusterName());
+            eventSessionId.orElse("NOT_PRESENT"), managerSessionId, manager.getInstanceName(),
+            manager.getClusterName());
         return;
       }
     }
@@ -791,7 +792,7 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     event.addAttribute(AttributeName.ControllerDataProvider.name(), dataProvider);
 
     logger.info("START: Invoking {} controller pipeline for cluster: {}. Event type: {}, ID: {}. "
-            + "Event session ID: {}", manager.getClusterName(), dataProvider.getPipelineName(),
+            + "Event session ID: {}", dataProvider.getPipelineName(), manager.getClusterName(),
         event.getEventType(), event.getEventId(), eventSessionId.orElse("NOT_PRESENT"));
 
     long startTime = System.currentTimeMillis();


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1587 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The log in controller pipeline is incorrect: cluster name and pipeline name is mis-ordered

2020/12/09 00:00:00.003 INFO [GenericHelixController] [HelixController-pipeline-task-(3e8ae1f7)] [helix] [] START: Invoking cluster-name controller pipeline for cluster: TASK. Event type: OnDemandRebalance, ID: 3e8ae1f7. Event session ID: 60057fd565a1196

The cluster is should not be TASK but the real cluster name.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Before CI test pass, please copy & paste the result of "mvn test")

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
