### PR TITLE
Cancel async callback when exception is thrown

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
@@ -194,7 +194,7 @@ public class ZkAsyncCallbacks {
         } else {
           LOG.warn(
               "The provided callback context {} is not ZkAsyncRetryCallContext. Skip retrying.",
-              ctx.getClass().getName());
+              ctx == null ? null : ctx.getClass().getName());
         }
       }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncRetryThread.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncRetryThread.java
@@ -49,7 +49,9 @@ public class ZkAsyncRetryThread extends Thread {
           context.cancel();
           interrupt();
         } catch (Throwable e) {
-          LOG.error("Error retrying callback " + context, e);
+          LOG.error("Error retrying callback {}, cancelling it", context, e);
+          // Cancel the context so the upstream caller can stop waiting
+          context.cancel();
         }
       }
     } catch (InterruptedException e) {

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -887,7 +887,7 @@ public class TestRawZkClient extends ZkTestBase {
 
       // Ensure the async callback is cancelled because of the exception
       Assert.assertTrue(createCallback.waitForSuccess(), "Callback operation should be done");
-      Assert.assertEquals(createCallback.getRc(), KeeperException.Code.BADARGUMENTS.intValue());
+      Assert.assertEquals(createCallback.getRc(), ZkAsyncCallbacks.UNKNOWN_RET_CODE);
     }
 
     Assert.assertFalse(zkClient.exists(path));
@@ -915,7 +915,7 @@ public class TestRawZkClient extends ZkTestBase {
 
       // Ensure the async callback is cancelled because of the exception
       Assert.assertTrue(setDataCallback.waitForSuccess(), "Callback operation should be done");
-      Assert.assertEquals(setDataCallback.getRc(), KeeperException.Code.BADARGUMENTS.intValue());
+      Assert.assertEquals(setDataCallback.getRc(), ZkAsyncCallbacks.UNKNOWN_RET_CODE);
     }
 
     TestHelper.verify(() -> zkClient.delete(path), TestHelper.WAIT_DURATION);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1591 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

ZkClient asyncCreate() has a mechanism to retry the operation if the KeeperException code is retryable. The method `doRetry()` will push next retry to the retry queue if the error code is retryable such as connection loss or session expired.

But in the retry run, if `ZkSessionMismatchedException` is thrown from `getExpectedZookeeper()`, the actual async callback is neither being retried nor cancelled - the retry request is neither pushed to the retry queue nor canceled, then there is no chance the operation is finished. It is like a lock, the lock is not released, then the caller calls `wait()` will keep waiting forever.

Impact:
This issue blocks following pipeline running.

Expected behavior:
Once an exception is thrown during the retry run, the callback context should be cancelled correctly.

### Tests

- [x] The following tests are written for this issue:

- testAsyncWriteRetryThrowException
- testAsyncWriteByExpectedSession

- [x] The following is the result of the "mvn test" command on the appropriate module:

In zookeeper-api

```
[INFO] Tests run: 51, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 64.415 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 51, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:08 min
[INFO] Finished at: 2020-12-10T15:34:19-08:00
[INFO] ------------------------------------------------------------------------
```

Helix-core
```
[INFO] Tests run: 1253, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,328.498 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1253, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:28 h
[INFO] Finished at: 2020-12-11T17:53:11-08:00
[INFO] ------------------------------------------------------------------------
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
