### PR TITLE
Fix builds failing on some non-Oracle JDKs

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/assigner/ThreadCountBasedTaskAssigner.java
+++ b/helix-core/src/main/java/org/apache/helix/task/assigner/ThreadCountBasedTaskAssigner.java
@@ -32,7 +32,6 @@ import org.apache.helix.task.AssignableInstanceManager;
 import org.apache.helix.task.TaskConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class ThreadCountBasedTaskAssigner implements TaskAssigner {
   private static final Logger logger = LoggerFactory.getLogger(ThreadCountBasedTaskAssigner.class);
@@ -68,7 +67,7 @@ public class ThreadCountBasedTaskAssigner implements TaskAssigner {
   @Override
   public Map<String, TaskAssignResult> assignTasks(Iterable<AssignableInstance> assignableInstances,
       Iterable<TaskConfig> tasks, String quotaType) {
-    throw new NotImplementedException();
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -41,7 +41,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
@@ -263,7 +262,7 @@ public class InstancesAccessor extends AbstractHelixResource {
         break;
       case instance_based:
       default:
-        throw new NotImplementedException("instance_based selection is not supported yet!");
+        throw new UnsupportedOperationException("instance_based selection is not supported yet!");
       }
       return JSONRepresentation(result);
     } catch (HelixException e) {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1576 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The `ThreadCountBasedTaskAssigner` class accidentally included an exception from the `sun.reflect.generics.reflectiveObjects` package which is not available in some JDKs.  This PR replaces it with a standard unchecked exception `java.lang.UnsupportedOperationException`.

See https://www.oracle.com/java/technologies/faq-sun-packages.html

### Tests

- [x] The following tests are written for this issue:

n/a

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestCleanupExternalView.test:118 external-view for TestDB0 should be removed, but was: ZnRecord=TestDB0, {BUCKET_SIZE=0, IDEAL_STATE_MODE=AUTO, NUM_PARTITIONS=2, REBALANCE_MODE=SEMI_AUTO, REBALANCE_STRATEGY=DEFAULT, REPLICAS=2, STATE_MODEL_DEF_REF=MasterSlave, STATE_MODEL_FACTORY_NAME=DEFAULT}{TestDB0_0={localhost_12918=SLAVE, localhost_12919=MASTER}, TestDB0_1={localhost_12918=MASTER, localhost_12919=SLAVE}}{}, Stat=Stat {_version=4, _creationTime=1608081283398, _modifiedTime=1608081283962, _ephemeralOwner=0} expected:<true> but was:<false>
[ERROR]   TestEnableCompression.testEnableCompressionResource ? ThreadTimeout Method org...
[ERROR]   TestDelayedWagedRebalanceWithDisabledInstance.testPartitionMovementAfterDelayTime:87->TestDelayedAutoRebalanceWithDisabledInstance.testPartitionMovementAfterDelayTime:204->ZkTestBase.validateMinActiveAndTopStateReplica:535 Test-DB-createTestDBs0_0 has less active replica 2 then required 3 expected:<true> but was:<false>
[ERROR]   TestJobTimeoutTaskNotStarted.testTaskNotStarted:156 ? Helix Workflow timeoutWo...
[ERROR]   TestTaskNumAttempts.testTaskNumAttemptsWithDelay:76 expected:<3> but was:<2>
[ERROR]   TestWorkflowTermination.testWorkflowRunningTimeout:133->verifyWorkflowCleanup:268 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1253, Failures: 6, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:48 h
[INFO] Finished at: 2020-12-16T02:20:54Z
[INFO] ------------------------------------------------------------------------
```
I'm guessing these are some of the flaky tests alluded to on https://github.com/apache/helix/wiki/Pull-Request-Testing.  When run individually they seem ok:

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.86 s - in org.apache.helix.integration.TestCleanupExternalView
...
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 82.369 s - in org.apache.helix.integration.rebalancer.WagedRebalancer.TestDelayedWagedRebalanceWithDisabledInstance
...
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.091 s - in org.apache.helix.integration.task.TestJobTimeoutTaskNotStarted
...
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 28.194 s - in org.apache.helix.integration.task.TestTaskNumAttempts
...
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 39.655 s - in org.apache.helix.integration.task.TestWorkflowTermination
```

Except this one which I ran about 5 times, but never got to work (seems unrelated to my change though):
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 107.496 s <<< FAILURE! - in org.apache.helix.integration.TestEnableCompression
[ERROR] testEnableCompressionResource(org.apache.helix.integration.TestEnableCompression)  Time elapsed: 99.92 s  <<< FAILURE!
org.testng.internal.thread.ThreadTimeoutException: Method org.testng.internal.TestNGMethod.testEnableCompressionResource() didn't finish within the time-out 100000
	at org.apache.helix.integration.TestEnableCompression.testEnableCompressionResource(TestEnableCompression.java:122)
```

### Documentation (Optional)

- [x] In case of new functionality, my PR adds documentation in the following wiki page:

n/a

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
