### PR TITLE
Stabilize TestTaskCurrentStatePathDisabled

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskCurrentStatePathDisabled.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskCurrentStatePathDisabled.java
@@ -72,8 +72,9 @@ public class TestTaskCurrentStatePathDisabled extends TaskTestBase {
     ZkClient clientP0 = (ZkClient) _participants[0].getZkClient();
     String sessionIdP0 = ZkTestHelper.getSessionId(clientP0);
     PropertyKey.Builder keyBuilder = _manager.getHelixDataAccessor().keyBuilder();
-    Assert.assertNotNull(_manager.getHelixDataAccessor()
-        .getProperty(keyBuilder.taskCurrentState(instanceP0, sessionIdP0, namespacedJobName0)));
+    Assert.assertTrue(TestHelper.verify(() -> _manager.getHelixDataAccessor()
+        .getProperty(keyBuilder.taskCurrentState(instanceP0, sessionIdP0, namespacedJobName0))
+        != null, TestHelper.WAIT_DURATION));
     Assert.assertNull(_manager.getHelixDataAccessor()
         .getProperty(keyBuilder.currentState(instanceP0, sessionIdP0, namespacedJobName0)));
 
@@ -91,10 +92,11 @@ public class TestTaskCurrentStatePathDisabled extends TaskTestBase {
     _driver.start(jobQueue1.build());
     String namespacedJobName1 = TaskUtil.getNamespacedJobName(jobQueueName1, "JOB1");
     _driver.pollForJobState(jobQueueName1, namespacedJobName1, TaskState.IN_PROGRESS);
+    Assert.assertTrue(TestHelper.verify(() -> _manager.getHelixDataAccessor()
+        .getProperty(keyBuilder.currentState(instanceP0, sessionIdP0, namespacedJobName1))
+        != null, TestHelper.WAIT_DURATION));
     Assert.assertNull(_manager.getHelixDataAccessor()
         .getProperty(keyBuilder.taskCurrentState(instanceP0, sessionIdP0, namespacedJobName1)));
-    Assert.assertNotNull(_manager.getHelixDataAccessor()
-        .getProperty(keyBuilder.currentState(instanceP0, sessionIdP0, namespacedJobName1)));
     System.setProperty(SystemPropertyKeys.TASK_CURRENT_STATE_PATH_DISABLED, "false");
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskCurrentStatePathDisabled.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestTaskCurrentStatePathDisabled.java
@@ -33,6 +33,7 @@ import org.apache.helix.task.TaskState;
 import org.apache.helix.task.TaskUtil;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -50,6 +51,12 @@ public class TestTaskCurrentStatePathDisabled extends TaskTestBase {
     _numPartitions = 1;
     _numNodes = 1;
     super.beforeClass();
+  }
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    super.afterClass();
+    System.setProperty(SystemPropertyKeys.TASK_CURRENT_STATE_PATH_DISABLED, "false");
   }
 
   @Test
@@ -97,6 +104,5 @@ public class TestTaskCurrentStatePathDisabled extends TaskTestBase {
         != null, TestHelper.WAIT_DURATION));
     Assert.assertNull(_manager.getHelixDataAccessor()
         .getProperty(keyBuilder.taskCurrentState(instanceP0, sessionIdP0, namespacedJobName1)));
-    System.setProperty(SystemPropertyKeys.TASK_CURRENT_STATE_PATH_DISABLED, "false");
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1596 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Since current states are created on the participant side, assertions performed on them are advised to be implemented with `verify` instead of a plain assertion. TestTaskCurrentStatePathDisabled could be unstable due to the `assertNotNull` it performs on current states. It's possible that at the time of checking, current states are not created yet, causing the test to fail. 

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 1255, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,272.263 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1255, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:27 h
[INFO] Finished at: 2021-01-05T17:00:27-08:00
[INFO] ------------------------------------------------------------------------
```
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
