### PR TITLE
Fix the CI script definition so the file list is passed to the steps that execute unit test.

### DIFF
--- a/.github/workflows/Helix-PR-CI.yml
+++ b/.github/workflows/Helix-PR-CI.yml
@@ -11,34 +11,36 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: Get Changed Files
-      run: git fetch origin master > /dev/null 2>&1; git diff --name-only origin/master HEAD
-      id: find-diff
-    - name: Build with Maven
-      run: mvn clean install -Dmaven.test.skip.exec=true
-    - name: Test metrics-common
-      run: cd metrics-common; mvn -q test
-      if: ${{ contains(steps.find-diff.outputs, 'metrics-common') && (success() || failure()) }}
-    - name: Test metadata-store-directory-common
-      run: cd metadata-store-directory-common; mvn -q test
-      if: ${{ contains(steps.find-diff.outputs, 'metadata-store-directory-common') && (success() || failure()) }}
-    - name: Test zookeeper-api
-      run: cd zookeeper-api; mvn -q test
-      if: ${{ contains(steps.find-diff.outputs, 'zookeeper-api') && (success() || failure()) }}
-    - name: Test helix-common
-      run: cd helix-common; mvn -q test
-      if: ${{ contains(steps.find-diff.outputs, 'helix-common') && (success() || failure()) }}
-    - name: Test helix-lock
-      run: cd helix-lock; mvn -q test
-      if: ${{ contains(steps.find-diff.outputs, 'helix-lock') && (success() || failure()) }}
-    - name: Test helix-rest
-      run: cd helix-rest; mvn -q test
-      if: ${{ contains(steps.find-diff.outputs, 'helix-rest') && (success() || failure()) }}
-    - name: Test helix-core
-      run: cd helix-core; mvn -q test
-      if: ${{ contains(steps.find-diff.outputs, 'helix-core') && (success() || failure()) }}
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Get Changed Files
+        run: |
+          git fetch origin master
+          echo "::set-output name=files::$(git diff --name-only origin/master HEAD)"
+        id: find-diff
+      - name: Build with Maven
+        run: mvn clean install -Dmaven.test.skip.exec=true
+      - name: Test metrics-common
+        run: cd metrics-common; mvn -q test
+        if: ${{ contains(steps.find-diff.outputs.files, 'metrics-common') && (success() || failure()) }}
+      - name: Test metadata-store-directory-common
+        run: cd metadata-store-directory-common; mvn -q test
+        if: ${{ contains(steps.find-diff.outputs.files, 'metadata-store-directory-common') && (success() || failure()) }}
+      - name: Test zookeeper-api
+        run: cd zookeeper-api; mvn -q test
+        if: ${{ contains(steps.find-diff.outputs.files, 'zookeeper-api') && (success() || failure()) }}
+      - name: Test helix-common
+        run: cd helix-common; mvn -q test
+        if: ${{ contains(steps.find-diff.outputs.files, 'helix-common') && (success() || failure()) }}
+      - name: Test helix-lock
+        run: cd helix-lock; mvn -q test
+        if: ${{ contains(steps.find-diff.outputs.files, 'helix-lock') && (success() || failure()) }}
+      - name: Test helix-rest
+        run: cd helix-rest; mvn -q test
+        if: ${{ contains(steps.find-diff.outputs.files, 'helix-rest') && (success() || failure()) }}
+      - name: Test helix-core
+        run: cd helix-core; mvn -q test
+        if: ${{ contains(steps.find-diff.outputs.files, 'helix-core') && (success() || failure()) }}


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

CI test does not run correctly.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

The previous CI script fix does not trigger the expected unit test since the diff file list is not passed to the later steps.
This PR will help to fix this issue.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- [ ] The following is the result of the "mvn test" command on the appropriate module:

(Before CI test pass, please copy & paste the result of "mvn test")

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
