### PR TITLE
Use WAGED rebalancer as the default rebalancer for the controller resources in the super cluster.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1266,11 +1266,10 @@ public class ZKHelixAdmin implements HelixAdmin {
     idealState.setNumPartitions(1);
     idealState.setStateModelDefRef("LeaderStandby");
     idealState.setRebalanceMode(RebalanceMode.FULL_AUTO);
-    idealState.setRebalancerClassName(DelayedAutoRebalancer.class.getName());
-    idealState.setRebalanceStrategy(CrushEdRebalanceStrategy.class.getName());
+    idealState.setRebalancerClassName(WagedRebalancer.class.getName());
     // TODO: Give user an option, say from RestAPI to config the number of replicas.
     idealState.setReplicas(Integer.toString(DEFAULT_SUPERCLUSTER_REPLICA));
-    idealState.getRecord().setListField(clusterName, new ArrayList<String>());
+    idealState.getRecord().setListField(clusterName, new ArrayList<>());
 
     List<String> controllers = getInstancesInCluster(grandCluster);
     if (controllers.size() == 0) {
@@ -1278,10 +1277,12 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     ZKHelixDataAccessor accessor =
-        new ZKHelixDataAccessor(grandCluster, new ZkBaseDataAccessor<ZNRecord>(_zkClient));
+        new ZKHelixDataAccessor(grandCluster, new ZkBaseDataAccessor<>(_zkClient));
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
 
     accessor.setProperty(keyBuilder.idealStates(idealState.getResourceName()), idealState);
+    LOG.info("Cluster {} has been added to grand cluster {} with rebalance configuration {}.",
+        clusterName, grandCluster, idealState.getRecord().getSimpleFields().toString());
   }
 
   @Override

--- a/helix-core/src/test/java/org/apache/helix/integration/TestAddClusterV2.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestAddClusterV2.java
@@ -21,10 +21,13 @@ package org.apache.helix.integration;
 
 import java.util.Date;
 
+import org.apache.helix.HelixAdmin;
 import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.integration.manager.ClusterDistributedController;
 import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.tools.ClusterSetup;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier;
@@ -90,7 +93,13 @@ public class TestAddClusterV2 extends ZkTestBase {
 
   @Test
   public void Test() {
-
+    // Verify the super cluster resources are all rebalanced by the WAGED rebalancer.
+    HelixAdmin admin = _gSetupTool.getClusterManagementTool();
+    for (String clusterName : admin.getResourcesInCluster(CONTROLLER_CLUSTER)) {
+      IdealState is = _gSetupTool.getClusterManagementTool()
+          .getResourceIdealState(CONTROLLER_CLUSTER, clusterName);
+      Assert.assertEquals(is.getRebalancerClassName(), WagedRebalancer.class.getName());
+    }
   }
 
   @AfterClass


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1618 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR changes the default rebalancer for the controller resources in the supercluster to be the WAGED rebalancer.

### Tests

- [X] The following tests are written for this issue:

TestAddClusterV2 has been modified accordingly.

- The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 1259, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,544.234 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1259, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
