### PR TITLE
Fix the ConcurrentModificationException in ClusterEvent.java

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEvent.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEvent.java
@@ -19,10 +19,10 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
-import java.util.HashMap;
 import java.util.Map;
-
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +37,7 @@ public class ClusterEvent {
   @Deprecated
   public ClusterEvent(ClusterEventType eventType) {
     _eventType = eventType;
-    _eventAttributeMap = new HashMap<>();
+    _eventAttributeMap = new ConcurrentHashMap<>();
     _creationTime = System.currentTimeMillis();
     _eventId = UUID.randomUUID().toString();
   }
@@ -50,7 +50,7 @@ public class ClusterEvent {
     _clusterName = clusterName;
     _eventType = eventType;
 
-    _eventAttributeMap = new HashMap<>();
+    _eventAttributeMap = new ConcurrentHashMap<>();
     _creationTime = System.currentTimeMillis();
     _eventId = eventId;
   }

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestClusterEvent.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestClusterEvent.java
@@ -19,16 +19,56 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
+import java.util.ConcurrentModificationException;
+import java.util.concurrent.CountDownLatch;
+
+import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
-@Test
+
 public class TestClusterEvent {
+
   @Test
-  public void testSimplePutandGet() {
+  public void testSimplePutAndGet() {
     ClusterEvent event = new ClusterEvent(ClusterEventType.Unknown);
     AssertJUnit.assertEquals(event.getEventType(), ClusterEventType.Unknown);
     event.addAttribute("attr1", "value");
     AssertJUnit.assertEquals(event.getAttribute("attr1"), "value");
+  }
+
+  @Test
+  public void testThreadSafeClone() throws InterruptedException {
+    String clusterName = "TestCluster";
+    ClusterEvent event = new ClusterEvent(clusterName, ClusterEventType.Unknown, "testId");
+    for (int i = 0; i < 100; i++) {
+      event.addAttribute(String.valueOf(i), i);
+    }
+    final CountDownLatch wait = new CountDownLatch(1);
+    Thread thread = new Thread(() -> {
+      String threadName = Thread.currentThread().getName();
+      try {
+        wait.await();
+      } catch (InterruptedException e) {
+        //ignore the exception
+      }
+      // update the original event's attribute map
+      for (int i = 0; i < 100; i++) {
+        event.addAttribute(threadName + i, threadName);
+      }
+    });
+
+    thread.start();
+
+    try {
+      wait.countDown();
+      ClusterEvent clonedEvent = event.clone("cloneId");
+      Assert.assertEquals(clonedEvent.getClusterName(), clusterName);
+      Assert.assertEquals(clonedEvent.getEventId(), "cloneId");
+    } catch (ConcurrentModificationException e) {
+      Assert.fail("Didn't expect any ConcurrentModificationException to occur", e);
+    } finally {
+      thread.join();
+    }
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Backport PR#785 to fix #784 to next 0.9.x release. 

### Description

Fixes possible `ConcurrentModificationException` and `NullPointerException` when accessing `_eventAttributeMap ` in `ClusterEvent`. The `NullPointerException` can happen if one thread triggers resizing of the `_eventAttributeMap ` and while the resizing is in progress, another thread tries to access value which is not yet added to the resized map.

This is basically just cherry-picking commit for #785 to helix-0.9.x branch.

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
