### PR TITLE
Fix ZkAddress null case for TaskStateModelFactory

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
@@ -142,8 +142,9 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
     // want to enforce it, which may cause backward incompatibility.
     RealmAwareZkClient.RealmAwareZkClientConfig clientConfig =
         new RealmAwareZkClient.RealmAwareZkClientConfig().setZkSerializer(new ZNRecordSerializer());
+    String zkAddress = manager.getMetadataStoreConnectionString();
 
-    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED)) {
+    if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddress == null) {
       String clusterName = manager.getClusterName();
       String shardingKey = HelixUtil.clusterNameToShardingKey(clusterName);
       RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =
@@ -158,7 +159,7 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
     }
 
     return SharedZkClientFactory.getInstance().buildZkClient(
-        new HelixZkClient.ZkConnectionConfig(manager.getMetadataStoreConnectionString()),
+        new HelixZkClient.ZkConnectionConfig(zkAddress),
         clientConfig.createHelixZkClientConfig().setZkSerializer(new ZNRecordSerializer()));
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.helix.HelixManager;
 import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.integration.task.TaskTestBase;
@@ -32,8 +33,11 @@ import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
 import org.apache.helix.msdcommon.mock.MockMetadataStoreDirectoryServer;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.routing.RoutingDataManager;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
 
 
 public class TestTaskStateModelFactory extends TaskTestBase {
@@ -82,6 +86,15 @@ public class TestTaskStateModelFactory extends TaskTestBase {
 
     RoutingDataManager.getInstance().reset();
     RealmAwareZkClient zkClient = TaskStateModelFactory.createZkClient(anyParticipantManager);
+    Assert.assertEquals(TaskUtil
+        .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
+            anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
+
+    // Turn off multiZk mode in System config, and remove zkAddress
+    System.setProperty(SystemPropertyKeys.MULTI_ZK_ENABLED, "false");
+    HelixManager participantManager = Mockito.spy(anyParticipantManager);
+    when(participantManager.getMetadataStoreConnectionString()).thenReturn(null);
+    zkClient = TaskStateModelFactory.createZkClient(participantManager);
     Assert.assertEquals(TaskUtil
         .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
             anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);

--- a/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
@@ -32,6 +32,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
 import org.apache.helix.msdcommon.mock.MockMetadataStoreDirectoryServer;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.apache.helix.zookeeper.impl.client.FederatedZkClient;
 import org.apache.helix.zookeeper.routing.RoutingDataManager;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -89,6 +90,7 @@ public class TestTaskStateModelFactory extends TaskTestBase {
     Assert.assertEquals(TaskUtil
         .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
             anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
+    Assert.assertTrue(zkClient instanceof FederatedZkClient);
 
     // Turn off multiZk mode in System config, and remove zkAddress
     System.setProperty(SystemPropertyKeys.MULTI_ZK_ENABLED, "false");
@@ -98,6 +100,7 @@ public class TestTaskStateModelFactory extends TaskTestBase {
     Assert.assertEquals(TaskUtil
         .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
             anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
+    Assert.assertTrue(zkClient instanceof FederatedZkClient);
 
     // Restore system properties
     if (prevMultiZkEnabled == null) {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fix #1626 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

If zkAddress is null for the HelixManager passed to TaskStateModelFactory and multizk is not enabled, a NullPointerException will be raised. This PR fixes that by adding a null check. 

When https://github.com/apache/helix/pull/1183 was introduced and null checks were added, this section of code was in a feature branch, and was therefore not covered by the PR 1183. 

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
