### PR TITLE
Skip cancellation for partition reset pending message

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -211,8 +211,8 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
         }
 
         if (desiredState.equals(NO_DESIRED_STATE) || desiredState.equalsIgnoreCase(currentState)) {
-          if (desiredState.equals(NO_DESIRED_STATE) || pendingMessage != null && !currentState
-              .equalsIgnoreCase(pendingMessage.getToState())) {
+          if (shouldCreateSTCancellation(pendingMessage, currentState, desiredState,
+              stateModelDef.getInitialState())) {
             message = createStateTransitionCancellationMessage(manager, resource,
                 partition.getPartitionName(), instanceName, sessionIdMap.get(instanceName),
                 stateModelDef.getId(), pendingMessage.getFromState(), pendingMessage.getToState(),
@@ -269,6 +269,23 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
         }
       }
     } // end of for-each-partition
+  }
+
+  private boolean shouldCreateSTCancellation(Message pendingMessage, String currentState,
+      String desiredState, String initialState) {
+    if (pendingMessage == null) {
+      return false;
+    }
+    if (NO_DESIRED_STATE.equals(desiredState)) {
+      return true;
+    }
+
+    // Don't cancel the ST for below scenarios:
+    // 1. current state has arrived at pending message's to state
+    // 2. pending message is an ERROR reset: ERROR -> initState (eg. OFFLINE)
+    return !currentState.equalsIgnoreCase(pendingMessage.getToState())
+        && !HelixDefinedState.ERROR.name().equals(pendingMessage.getFromState())
+        && !initialState.equals(pendingMessage.getToState());
   }
 
   private void logAndAddToCleanUp(Map<String, Map<String, Message>> messagesToCleanUp,
@@ -437,10 +454,10 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
       boolean isCancellationEnabled, String currentState) {
 
     if (isCancellationEnabled && cancellationMessage == null) {
-      LogUtil.logInfo(logger, _eventId,
-          "Send cancellation message of the state transition for " + resource.getResourceName()
-              + "." + partitionName + " on " + instanceName + ", currentState: " + currentState
-              + ", nextState: " + (nextState == null ? "N/A" : nextState));
+      logger.info("Event {} : Send cancellation message of the state transition for {}.{} on {}, "
+              + "currentState: {}, nextState: {},  toState: {}",
+          _eventId, resource.getResourceName(), partitionName, instanceName,
+          currentState, nextState == null ? "N/A" : nextState, toState);
 
       String uuid = UUID.randomUUID().toString();
       String managerSessionId = manager.getSessionId();

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -211,7 +211,7 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
         }
 
         if (desiredState.equals(NO_DESIRED_STATE) || desiredState.equalsIgnoreCase(currentState)) {
-          if (shouldCreateSTCancellation(pendingMessage, currentState, desiredState,
+          if (shouldCreateSTCancellation(pendingMessage, desiredState,
               stateModelDef.getInitialState())) {
             message = createStateTransitionCancellationMessage(manager, resource,
                 partition.getPartitionName(), instanceName, sessionIdMap.get(instanceName),
@@ -271,8 +271,8 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
     } // end of for-each-partition
   }
 
-  private boolean shouldCreateSTCancellation(Message pendingMessage, String currentState,
-      String desiredState, String initialState) {
+  private boolean shouldCreateSTCancellation(Message pendingMessage, String desiredState,
+      String initialState) {
     if (pendingMessage == null) {
       return false;
     }
@@ -280,12 +280,12 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
       return true;
     }
 
-    // Don't cancel the ST for below scenarios:
-    // 1. current state has arrived at pending message's to state
+    // Cancel the ST except below scenarios:
+    // 1. pending message toState is desired state
     // 2. pending message is an ERROR reset: ERROR -> initState (eg. OFFLINE)
-    return !currentState.equalsIgnoreCase(pendingMessage.getToState())
-        && !HelixDefinedState.ERROR.name().equals(pendingMessage.getFromState())
-        && !initialState.equals(pendingMessage.getToState());
+    return !desiredState.equalsIgnoreCase(pendingMessage.getToState())
+        && !(HelixDefinedState.ERROR.name().equals(pendingMessage.getFromState())
+        && initialState.equals(pendingMessage.getToState()));
   }
 
   private void logAndAddToCleanUp(Map<String, Map<String, Message>> messagesToCleanUp,

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestCancellationMessageGeneration.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestCancellationMessageGeneration.java
@@ -19,8 +19,8 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,16 +44,15 @@ import org.testng.annotations.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-
-/**
- * This test checks the cancellation message generation when currentState=null and desiredState=DROPPED
- */
 public class TestCancellationMessageGeneration extends MessageGenerationPhase {
   private static final String TEST_CLUSTER = "testCluster";
   private static final String TEST_RESOURCE = "resource0";
   private static final String TEST_INSTANCE = "instance0";
   private static final String TEST_PARTITION = "partition0";
 
+  /*
+   * This test checks the cancellation message generation when currentState=null and desiredState=DROPPED
+   */
   @Test
   public void TestOFFLINEToDROPPED() throws Exception {
 
@@ -112,5 +111,80 @@ public class TestCancellationMessageGeneration extends MessageGenerationPhase {
     processEvent(event, resourcesStateMap);
     MessageOutput output = event.getAttribute(AttributeName.MESSAGES_ALL.name());
     Assert.assertEquals(output.getMessages(TEST_RESOURCE, partition).size(), 1);
+  }
+
+  /*
+   * Tests that no cancellation message is created for
+   * pending ST message of error partition reset.
+   */
+  @Test
+  public void testNoCancellationForErrorReset() throws Exception {
+    ClusterEvent event = new ClusterEvent(TEST_CLUSTER, ClusterEventType.Unknown);
+
+    // Set current state to event
+    CurrentStateOutput currentStateOutput = mock(CurrentStateOutput.class);
+    Partition partition = mock(Partition.class);
+    when(partition.getPartitionName()).thenReturn(TEST_PARTITION);
+    when(currentStateOutput.getCurrentState(TEST_RESOURCE, partition, TEST_INSTANCE))
+        .thenReturn("ERROR");
+
+    // Pending message for error partition reset
+    Message pendingMessage = mock(Message.class);
+    when(pendingMessage.getFromState()).thenReturn("ERROR");
+    when(pendingMessage.getToState()).thenReturn("OFFLINE");
+    when(currentStateOutput.getPendingMessage(TEST_RESOURCE, partition, TEST_INSTANCE))
+        .thenReturn(pendingMessage);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+
+    // Set helix manager to event
+    event.addAttribute(AttributeName.helixmanager.name(), mock(HelixManager.class));
+
+    StateModelDefinition stateModelDefinition =
+        new StateModelDefinition.Builder("TestStateModel").addState("ONLINE", 1).addState("OFFLINE")
+            .addState("DROPPED").addState("ERROR").initialState("OFFLINE")
+            .addTransition("ERROR", "OFFLINE", 1).addTransition("ONLINE", "OFFLINE", 2)
+            .addTransition("OFFLINE", "DROPPED", 3).addTransition("OFFLINE", "ONLINE", 4)
+            .build();
+
+    // Set controller data provider to event
+    BaseControllerDataProvider cache = mock(BaseControllerDataProvider.class);
+    when(cache.getStateModelDef(TaskConstants.STATE_MODEL_NAME)).thenReturn(stateModelDefinition);
+    Map<String, LiveInstance> liveInstances= mock(Map.class);
+    LiveInstance mockLiveInstance = mock(LiveInstance.class);
+    when(mockLiveInstance.getInstanceName()).thenReturn(TEST_INSTANCE);
+    when(mockLiveInstance.getEphemeralOwner()).thenReturn("TEST");
+    when(liveInstances.values()).thenReturn(Collections.singletonList(mockLiveInstance));
+    when(cache.getLiveInstances()).thenReturn(liveInstances);
+    ClusterConfig clusterConfig = mock(ClusterConfig.class);
+    when(cache.getClusterConfig()).thenReturn(clusterConfig);
+    when(clusterConfig.isStateTransitionCancelEnabled()).thenReturn(true);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(), cache);
+
+    // Set event attribute: resources to rebalance
+    Map<String, Resource> resourceMap = new HashMap<>();
+    Resource resource = mock(Resource.class);
+    when(resource.getResourceName()).thenReturn(TEST_RESOURCE);
+    List<Partition> partitions = Collections.singletonList(partition);
+    when(resource.getPartitions()).thenReturn(partitions);
+    when(resource.getStateModelDefRef()).thenReturn(TaskConstants.STATE_MODEL_NAME);
+    resourceMap.put(TEST_RESOURCE, resource);
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), resourceMap);
+
+    // set up resource state map
+    ResourcesStateMap resourcesStateMap = new ResourcesStateMap();
+    PartitionStateMap partitionStateMap = new PartitionStateMap(TEST_RESOURCE);
+    Map<Partition, Map<String, String>> stateMap = partitionStateMap.getStateMap();
+    Map<String, String> instanceStateMap = new HashMap<>();
+    instanceStateMap.put(TEST_INSTANCE, HelixDefinedState.ERROR.name());
+    stateMap.put(partition, instanceStateMap);
+    resourcesStateMap.setState(TEST_RESOURCE, partition, instanceStateMap);
+
+    // Process the event
+    processEvent(event, resourcesStateMap);
+    MessageOutput output = event.getAttribute(AttributeName.MESSAGES_ALL.name());
+
+    // No cancellation message is created
+    Assert.assertTrue(output.getMessages(TEST_RESOURCE, partition).isEmpty(),
+        "Should not create cancellation message");
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1636 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Helix ST cancellation is a feature that helix can cancel pending or ongoing partition assignment state transitions(ST) that are unnecessary due to some reasons, eg. pending state does not match the target state. The feature expects ST messages are only sent by helix controller so controller knows what kind of ST can be cancelled.

Root cause: When SN resets partition with ERROR -> OFFLINE ST, helix controller determines it is an unnecessary ST so it sends out cancellation, which is expected for helix ST cancellation feature.

This PR improves it by skipping cancelling the reset ST sent by Admin or participant.

This PR adds a logic: Helix controller should not cancel the pending ST if the pending ST is ERROR -> initialState

### Tests

- [x] The following tests are written for this issue:

 - `testNoCancellationForErrorReset`
 - `testCancelOnlineToOffline`

- [x] The following is the result of the "mvn test" command on the appropriate module:

Tests in helix-core
```
[INFO] Tests run: 1260, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,600.299 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1260, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:33 h
[INFO] Finished at: 2021-02-04T20:21:07-08:00
[INFO] ------------------------------------------------------------------------
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
