### PR TITLE
Fix TaskStateModelFactory no msds endpoint multizk situation

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManager.java
@@ -364,13 +364,6 @@ public interface HelixManager {
   String getMetadataStoreConnectionString();
 
   /**
-   * @return the RealmAwareZkConnectionConfig usd to create a realm aware zkClient
-   */
-  default RealmAwareZkClient.RealmAwareZkConnectionConfig getRealmAwareZkConnectionConfig() {
-    return null;
-  }
-
-  /**
    * Returns the instanceName used to connect to the cluster
    * @return the associated instance name
    */

--- a/helix-core/src/main/java/org/apache/helix/HelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManager.java
@@ -50,7 +50,6 @@ import org.apache.helix.participant.HelixStateMachineEngine;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.spectator.RoutingTableProvider;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
 

--- a/helix-core/src/main/java/org/apache/helix/HelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManager.java
@@ -50,6 +50,7 @@ import org.apache.helix.participant.HelixStateMachineEngine;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.spectator.RoutingTableProvider;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
 
@@ -361,6 +362,13 @@ public interface HelixManager {
    * @return a string used to connect to metadata store
    */
   String getMetadataStoreConnectionString();
+
+  /**
+   * @return the RealmAwareZkConnectionConfig usd to create a realm aware zkClient
+   */
+  default RealmAwareZkClient.RealmAwareZkConnectionConfig getRealmAwareZkConnectionConfig() {
+    return null;
+  }
 
   /**
    * Returns the instanceName used to connect to the cluster

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -692,6 +692,9 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     return _zkAddress;
   }
 
+  /**
+   * @return the RealmAwareZkConnectionConfig usd to create a realm aware zkClient
+   */
   public RealmAwareZkClient.RealmAwareZkConnectionConfig getRealmAwareZkConnectionConfig() {
     return _realmAwareZkConnectionConfig;
   }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -692,6 +692,10 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     return _zkAddress;
   }
 
+  public RealmAwareZkClient.RealmAwareZkConnectionConfig getRealmAwareZkConnectionConfig() {
+    return _realmAwareZkConnectionConfig;
+  }
+
   @Override
   public String getInstanceName() {
     return _instanceName;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -693,7 +693,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
   }
 
   /**
-   * @return the RealmAwareZkConnectionConfig usd to create a realm aware zkClient
+   * @return the RealmAwareZkConnectionConfig used to create a realm aware ZkClient
    */
   public RealmAwareZkClient.RealmAwareZkConnectionConfig getRealmAwareZkConnectionConfig() {
     return _realmAwareZkConnectionConfig;

--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
@@ -147,10 +147,16 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
     if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddress == null) {
       String clusterName = manager.getClusterName();
       String shardingKey = HelixUtil.clusterNameToShardingKey(clusterName);
+      RealmAwareZkClient.RealmAwareZkConnectionConfig zkConnectionConfig =
+          manager.getRealmAwareZkConnectionConfig();
       RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =
           new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder()
               .setRealmMode(RealmAwareZkClient.RealmMode.SINGLE_REALM)
-              .setZkRealmShardingKey(shardingKey).build();
+              .setZkRealmShardingKey(shardingKey).setRoutingDataSourceEndpoint(
+              (zkConnectionConfig != null) ? zkConnectionConfig.getRoutingDataSourceEndpoint()
+                  : null).setRoutingDataSourceType(
+              (zkConnectionConfig != null) ? zkConnectionConfig.getRoutingDataSourceType() : null)
+              .build();
       try {
         return new FederatedZkClient(connectionConfig, clientConfig);
       } catch (InvalidRoutingDataException | IllegalArgumentException e) {

--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
@@ -140,8 +140,10 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
     // can use manager's connection). We need to think about the right order and determine if we
     // want to enforce it, which may cause backward incompatibility.
     if (!(manager instanceof ZKHelixManager)) {
-      throw new IllegalArgumentException(
-          "Provided manager must be a ZKHelixManager for configurable thread pool.");
+      // TODO: None-ZKHelixManager cannot initialize this class. After interface rework of
+      // HelixManager, the initialization should be allowed.
+      throw new UnsupportedOperationException(
+          "Only ZKHelixManager is supported for configurable thread pool.");
     }
     RealmAwareZkClient.RealmAwareZkClientConfig clientConfig =
         new RealmAwareZkClient.RealmAwareZkClientConfig().setZkSerializer(new ZNRecordSerializer());

--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
@@ -153,6 +153,11 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
     if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddress == null) {
       RealmAwareZkClient.RealmAwareZkConnectionConfig zkConnectionConfig =
           ((ZKHelixManager) manager).getRealmAwareZkConnectionConfig();
+      // TODO: a fallback logic is created because it's possible for the ZKHelixManager to not
+      // have a connection config, since a connection config may be created during
+      // ZKHelixManager.connect(). This is the same problem as described earlier because connect()
+      // may happen before or after TaskStateModelFactory initialization. Clean this up after that
+      // problem is fixed.
       if (zkConnectionConfig == null) {
         String clusterName = manager.getClusterName();
         String shardingKey = HelixUtil.clusterNameToShardingKey(clusterName);

--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
@@ -145,20 +145,8 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
     String zkAddress = manager.getMetadataStoreConnectionString();
 
     if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddress == null) {
-      String clusterName = manager.getClusterName();
-      String shardingKey = HelixUtil.clusterNameToShardingKey(clusterName);
-      RealmAwareZkClient.RealmAwareZkConnectionConfig zkConnectionConfig =
-          manager.getRealmAwareZkConnectionConfig();
-      RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =
-          new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder()
-              .setRealmMode(RealmAwareZkClient.RealmMode.SINGLE_REALM)
-              .setZkRealmShardingKey(shardingKey).setRoutingDataSourceEndpoint(
-              (zkConnectionConfig != null) ? zkConnectionConfig.getRoutingDataSourceEndpoint()
-                  : null).setRoutingDataSourceType(
-              (zkConnectionConfig != null) ? zkConnectionConfig.getRoutingDataSourceType() : null)
-              .build();
       try {
-        return new FederatedZkClient(connectionConfig, clientConfig);
+        return new FederatedZkClient(manager.getRealmAwareZkConnectionConfig(), clientConfig);
       } catch (InvalidRoutingDataException | IllegalArgumentException e) {
         throw new HelixException("Failed to create FederatedZkClient!", e);
       }

--- a/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
@@ -157,7 +157,7 @@ public class TestTaskStateModelFactory extends TaskTestBase {
   }
 
   @Test(dependsOnMethods = "testZkClientCreationSingleZk",
-      expectedExceptions = IllegalArgumentException.class)
+      expectedExceptions = UnsupportedOperationException.class)
   public void testZkClientCreationNonZKManager() {
     TaskStateModelFactory.createZkClient(new MockManager());
   }

--- a/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
@@ -106,6 +106,14 @@ public class TestTaskStateModelFactory extends TaskTestBase {
             anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
     Assert.assertTrue(zkClient instanceof FederatedZkClient);
 
+    // Test no connection config case
+    when(participantManager.getRealmAwareZkConnectionConfig()).thenReturn(null);
+    zkClient = TaskStateModelFactory.createZkClient(participantManager);
+    Assert.assertEquals(TaskUtil
+        .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
+            anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
+    Assert.assertTrue(zkClient instanceof FederatedZkClient);
+
     // Remove server endpoint key and use connection config to specify endpoint
     System.clearProperty(SystemPropertyKeys.MSDS_SERVER_ENDPOINT_KEY);
     RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1643 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When not specifying a zkaddress or enabling multizk, it's possible for customers to not specify an msds endpoint in the system properties. When that's the case, the federated zkclient created in TaskStateModelFactory will fail. The msds endpoint contained in the manager's connection config should be respected.

When https://github.com/apache/helix/pull/1178 was introduced and the possibility of not including msds endpoint in system property was added, this section of code was in a feature branch, and was therefore not covered. This section of code was under old assumptions that became outdated during its development. 

### Tests

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
