### PR TITLE
Improve auto enter maintenance mode

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -947,6 +947,10 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     return _isMaintenanceModeEnabled;
   }
 
+  public void enableMaintenanceMode() {
+    _isMaintenanceModeEnabled = true;
+  }
+
   public boolean hasMaintenanceSignalChanged() {
     return _hasMaintenanceSignalChanged;
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -947,6 +947,11 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     return _isMaintenanceModeEnabled;
   }
 
+  /**
+   * Mark the pipeline to enable maintenance mode. It is not supposed to use anywhere
+   * except in the auto enter maintenance mode logic when offline instances exceeded.
+   */
+  // TODO: refactor it to writable cache once read-only/writable caches are separated.
   public void enableMaintenanceMode() {
     _isMaintenanceModeEnabled = true;
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -116,8 +116,8 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
         event.getAttribute(AttributeName.clusterStatusMonitor.name());
     WagedRebalancer wagedRebalancer = event.getAttribute(AttributeName.STATEFUL_REBALANCER.name());
 
-    // Check whether the offline/disabled instance count in the cluster reaches the set limit,
-    // if yes, pause the rebalancer.
+    // Check whether the offline/disabled instance count in the cluster exceeds the set limit,
+    // if yes, put the cluster into maintenance mode.
     boolean isValid =
         validateOfflineInstancesLimit(cache, event.getAttribute(AttributeName.helixmanager.name()));
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -200,9 +200,6 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     if (maxOfflineInstancesAllowed >= 0) {
       int offlineCount = cache.getAllInstances().size() - cache.getEnabledLiveInstances().size();
       if (offlineCount > maxOfflineInstancesAllowed) {
-        // Enable maintenance mode in cache so the maintenance rebalancer is used for this pipeline
-        cache.enableMaintenanceMode();
-
         String errMsg = String.format(
             "Offline Instances count %d greater than allowed count %d. Put cluster %s into "
                 + "maintenance mode.",
@@ -219,6 +216,10 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
           LogUtil.logError(logger, _eventId, "Failed to put cluster " + cache.getClusterName()
               + " into maintenance mode, HelixManager is not set!");
         }
+
+        // Enable maintenance mode in cache so the maintenance rebalancer is used for this pipeline
+        cache.enableMaintenanceMode();
+
         return false;
       }
     }

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
@@ -80,7 +80,7 @@ public class TestBestPossibleStateCalcStage extends BaseStageTest {
    * the maintenance rebalancer is used immediately. No bootstraps in the best possible output.
    */
   @Test
-  public void testAutoEnterMaintenanceMode() {
+  public void testAutoEnterMaintenanceWhenExceedingOfflineNodes() {
     String[] resources = new String[]{"testResourceName"};
     int numInstances = 3;
     int numPartitions = 3;
@@ -91,6 +91,7 @@ public class TestBestPossibleStateCalcStage extends BaseStageTest {
     List<String> liveInstances = setupLiveInstances(numInstances);
     setupStateModel();
 
+    // Set offline instances threshold
     ClusterConfig clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
     clusterConfig.setMaxOfflineInstancesAllowed(1);
     setClusterConfig(clusterConfig);

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
@@ -20,14 +20,16 @@ package org.apache.helix.controller.stages;
  */
 
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.IdealState.RebalanceMode;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
-import org.testng.AssertJUnit;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class TestBestPossibleStateCalcStage extends BaseStageTest {
@@ -66,10 +68,78 @@ public class TestBestPossibleStateCalcStage extends BaseStageTest {
         event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.name());
     for (int p = 0; p < 5; p++) {
       Partition resource = new Partition("testResourceName_" + p);
-      AssertJUnit.assertEquals("MASTER", output.getInstanceStateMap("testResourceName", resource)
+      Assert.assertEquals("MASTER", output.getInstanceStateMap("testResourceName", resource)
           .get("localhost_" + (p + 1) % 5));
     }
     System.out.println("END TestBestPossibleStateCalcStage at "
         + new Date(System.currentTimeMillis()));
+  }
+
+  /*
+   * Tests the pipeline detects offline instances exceed the threshold and auto enters maintenance,
+   * the maintenance rebalancer is used immediately. No bootstraps in the best possible output.
+   */
+  @Test
+  public void testAutoEnterMaintenanceMode() {
+    String[] resources = new String[]{"testResourceName"};
+    int numInstances = 3;
+    int numPartitions = 3;
+
+    setupIdealState(numInstances, resources, numPartitions, 1, RebalanceMode.FULL_AUTO,
+        BuiltInStateModelDefinitions.MasterSlave.name());
+    setupInstances(numInstances);
+    List<String> liveInstances = setupLiveInstances(numInstances);
+    setupStateModel();
+
+    ClusterConfig clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+    clusterConfig.setMaxOfflineInstancesAllowed(1);
+    setClusterConfig(clusterConfig);
+
+    Map<String, Resource> resourceMap =
+        getResourceMap(resources, numPartitions, BuiltInStateModelDefinitions.MasterSlave.name());
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+
+    for (int p = 0; p < numPartitions; p++) {
+      Partition partition = new Partition("testResourceName_" + p);
+      currentStateOutput
+          .setCurrentState("testResourceName", partition, "localhost_" + (p + 1) % numInstances,
+              "MASTER");
+    }
+
+    // Disable 2 instances so the pipeline should enter maintenance
+    for (int i = 0; i < 2; i++) {
+      admin.enableInstance(_clusterName, liveInstances.get(i), false);
+    }
+
+    event.addAttribute(AttributeName.helixmanager.name(), manager);
+    event.addAttribute(AttributeName.RESOURCES.name(), resourceMap);
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), resourceMap);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new BestPossibleStateCalcStage());
+
+    BestPossibleStateOutput output = event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.name());
+
+    // State on the disabled instances should be OFFLINE instead of DROPPED
+    // because of maintenance rebalancer.
+    Assert.assertEquals(
+        output.getInstanceStateMap("testResourceName", new Partition("testResourceName_2"))
+            .get("localhost_0"),
+        "OFFLINE",
+        "Actual state should not be DROPPED");
+
+    Assert.assertEquals(
+        output.getInstanceStateMap("testResourceName", new Partition("testResourceName_0"))
+            .get("localhost_1"),
+        "OFFLINE",
+        "Actual state should not be DROPPED");
+
+    // No state change for localhost_2 because the replica is already MASTER
+    Assert.assertNull(
+        output.getInstanceStateMap("testResourceName", new Partition("testResourceName_1"))
+            .get("localhost_2"));
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/mock/MockManager.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockManager.java
@@ -259,8 +259,7 @@ public class MockManager implements HelixManager {
 
   @Override
   public HelixAdmin getClusterManagmentTool() {
-    // TODO Auto-generated method stub
-    return null;
+    return new MockHelixAdmin(this);
   }
 
   @Override


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1648 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Assume enter M mode threshold is 5. Now 20 nodes are down at the same time, the running pipeline creates the maintenance znode. Instead of using the maintenance rebalancer immediately, this running pipeline still continues with the normal rebalancer, which bootstraps new partitions on the online instances. The following pipelines after this running pipeline will use the maintenance rebalancer.

This PR improves auto enter maintenance mode logic by enabling maintenance mode in the data cache, so the best possible mapping can be computed by the maintenance rebalancer immediately for the first pipeline.

### Tests

- [x] The following tests are written for this issue:

  `testAutoEnterMaintenanceWhenExceedingOfflineNodes`

- The following is the result of the "mvn test" command on the appropriate module:

```
2021-02-17T10:22:16.4954654Z [ERROR] Tests run: 1263, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 5,150.633 s <<< FAILURE! - in TestSuite
2021-02-17T10:22:16.4957382Z [ERROR] testMultipleJobAssignment(org.apache.helix.integration.task.TestTaskAssignmentCalculator)  Time elapsed: 0.645 s  <<< FAILURE!
2021-02-17T10:22:16.4959646Z java.lang.AssertionError: expected:<5> but was:<4>
2021-02-17T10:22:16.4969348Z 	at org.apache.helix.integration.task.TestTaskAssignmentCalculator.testMultipleJobAssignment(TestTaskAssignmentCalculator.java:127)
2021-02-17T10:22:16.4972230Z 
2021-02-17T10:22:16.8778474Z [ERROR] Failures: 
2021-02-17T10:22:16.8786962Z [ERROR]   TestTaskAssignmentCalculator.testMultipleJobAssignment:127 expected:<5> but was:<4>
2021-02-17T10:22:16.8791240Z [ERROR] Tests run: 1263, Failures: 1, Errors: 0, Skipped: 0


[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.61 s - in org.apache.helix.integration.task.TestTaskAssignmentCalculator
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18.801 s
[INFO] Finished at: 2021-02-17T22:45:49-08:00
[INFO] ------------------------------------------------------------------------
```


### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
