### PR TITLE
Compatible support for ZNRecord to work with Jackson 1 mapper

### DIFF
--- a/helix-common/src/main/java/org/apache/helix/ZNRecord.java
+++ b/helix-common/src/main/java/org/apache/helix/ZNRecord.java
@@ -19,20 +19,20 @@ package org.apache.helix;
  * under the License.
  */
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
-
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 /**
- * Deprecated; please use ZNRecord in zookeeper-api instead.
- *
+ * @deprecated
+ * Please use {@link org.apache.helix.zookeeper.datamodel.ZNRecord}
+ * in zookeeper-api instead.
+ * <p>
  * Generic Record Format to store data at a Node This can be used to store
  * simpleFields mapFields listFields
  */
 @Deprecated
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonSerialize(include = Inclusion.NON_NULL)
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 public class ZNRecord extends org.apache.helix.zookeeper.datamodel.ZNRecord {
   public ZNRecord(String id) {
     super(id);

--- a/helix-core/src/main/java/org/apache/helix/store/PropertyJsonSerializer.java
+++ b/helix-core/src/main/java/org/apache/helix/store/PropertyJsonSerializer.java
@@ -22,12 +22,11 @@ package org.apache.helix.store;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
 
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.apache.helix.HelixException;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.codehaus.jackson.map.DeserializationConfig;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,10 +41,10 @@ public class PropertyJsonSerializer<T> implements PropertySerializer<T> {
 
   @Override
   public byte[] serialize(T data) throws PropertyStoreException {
-
-    mapper.enable(SerializationFeature.INDENT_OUTPUT);
-    mapper.enable(MapperFeature.AUTO_DETECT_FIELDS);
-    mapper.enable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS);
+    SerializationConfig serializationConfig = mapper.getSerializationConfig();
+    serializationConfig.set(SerializationConfig.Feature.INDENT_OUTPUT, true);
+    serializationConfig.set(SerializationConfig.Feature.AUTO_DETECT_FIELDS, true);
+    serializationConfig.set(SerializationConfig.Feature.CAN_OVERRIDE_ACCESS_MODIFIERS, true);
     StringWriter sw = new StringWriter();
 
     try {
@@ -68,9 +67,10 @@ public class PropertyJsonSerializer<T> implements PropertySerializer<T> {
   public T deserialize(byte[] bytes) throws PropertyStoreException {
     ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
 
-    mapper.enable(MapperFeature.AUTO_DETECT_FIELDS);
-    mapper.enable(MapperFeature.AUTO_DETECT_SETTERS);
-    mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    DeserializationConfig deserializationConfig = mapper.getDeserializationConfig();
+    deserializationConfig.set(DeserializationConfig.Feature.AUTO_DETECT_FIELDS, true);
+    deserializationConfig.set(DeserializationConfig.Feature.AUTO_DETECT_SETTERS, true);
+    deserializationConfig.set(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, true);
     try {
       T value = mapper.readValue(bais, _clazz);
       return value;

--- a/helix-core/src/test/java/org/apache/helix/TestShuffledIdealState.java
+++ b/helix-core/src/test/java/org/apache/helix/TestShuffledIdealState.java
@@ -31,10 +31,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.helix.tools.IdealCalculatorByConsistentHashing;
 import org.apache.helix.tools.IdealStateCalculatorByRush;
 import org.apache.helix.tools.IdealStateCalculatorByShuffling;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.introspect.CodehausJacksonIntrospector;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
 
 public class TestShuffledIdealState {
@@ -65,7 +66,8 @@ public class TestShuffledIdealState {
     IdealCalculatorByConsistentHashing.printNodeOfflineOverhead(result3);
 
     // System.out.println(result);
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper =
+        new ObjectMapper().setAnnotationIntrospector(new CodehausJacksonIntrospector());
 
     // ByteArrayOutputStream baos = new ByteArrayOutputStream();
     StringWriter sw = new StringWriter();

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZNRecordSerializer.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZNRecordSerializer.java
@@ -326,7 +326,6 @@ public class TestZNRecordSerializer {
 
       try {
         mapper.writeValue(sw, data);
-
         return sw.toString().getBytes();
       } catch (Exception e) {
         LOG.error("Error during serialization of data", e);
@@ -348,8 +347,7 @@ public class TestZNRecordSerializer {
         deserializationConfig.set(DeserializationConfig.Feature.AUTO_DETECT_SETTERS, true);
         deserializationConfig.set(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
-        T value = mapper.readValue(bais, _clazz);
-        return value;
+        return mapper.readValue(bais, _clazz);
       } catch (Exception e) {
         LOG.error("Error during deserialization of bytes: " + new String(bytes), e);
       }

--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -124,11 +124,6 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>2.11.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <version>2.11.0</version>
     </dependency>

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -32,11 +32,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.helix.HelixException;
 import org.apache.helix.rest.common.ContextPropertyKeys;
 import org.apache.helix.rest.common.HelixRestNamespace;
 import org.apache.helix.rest.server.auditlog.AuditLog;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.introspect.CodehausJacksonIntrospector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,6 +161,12 @@ public class AbstractResource {
   }
 
   protected static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  // Needs a separate object reader for ZNRecord annotated with Jackson 1
+  // TODO: remove AnnotationIntrospector config once ZNRecord upgrades Jackson
+  protected static ObjectReader ZNRECORD_READER = new ObjectMapper()
+      .setAnnotationIntrospector(new CodehausJacksonIntrospector())
+      .readerFor(ZNRecord.class);
 
   protected static String toJson(Object object)
       throws IOException {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/AbstractHelixResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/AbstractHelixResource.java
@@ -83,7 +83,7 @@ public class AbstractHelixResource extends AbstractResource {
 
   protected static ZNRecord toZNRecord(String data)
       throws IOException {
-    return OBJECT_MAPPER.reader(ZNRecord.class).readValue(data);
+    return ZNRECORD_READER.readValue(data);
   }
 
   private ServerContext getServerContext() {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAccessor.java
@@ -279,7 +279,7 @@ public class ResourceAccessor extends AbstractHelixResource {
           TypeReference<Map<String, ZNRecord>> typeRef =
               new TypeReference<Map<String, ZNRecord>>() {
               };
-          input = OBJECT_MAPPER.readValue(content, typeRef);
+          input = ZNRECORD_READER.forType(typeRef).readValue(content);
         } catch (IOException e) {
           _logger.error("Failed to deserialize user's input {}, Exception: {}", content, e);
           return badRequest("Input is not a valid map of String-ZNRecord pairs!");

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.base.Joiner;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
@@ -78,6 +79,7 @@ import org.apache.helix.util.ZKClientPool;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
+import org.apache.helix.zookeeper.introspect.CodehausJacksonIntrospector;
 import org.apache.helix.zookeeper.zkclient.ZkServer;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -115,6 +117,9 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
   protected static ConfigAccessor _configAccessor;
   protected static BaseDataAccessor<ZNRecord> _baseAccessor;
   protected static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  protected static ObjectReader ZNRECORD_READER = new ObjectMapper()
+      .setAnnotationIntrospector(new CodehausJacksonIntrospector())
+      .readerFor(ZNRecord.class);
   protected static boolean _init = false;
 
   // For testing namespaced access
@@ -475,7 +480,7 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
 
   protected static ZNRecord toZNRecord(String data)
       throws IOException {
-    return OBJECT_MAPPER.reader(ZNRecord.class).readValue(data);
+    return ZNRECORD_READER.readValue(data);
   }
 
   protected String get(String uri, Map<String, String> queryParams, int expectedReturnStatus,

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -584,11 +584,11 @@ public class TestClusterAccessor extends AbstractTestClass {
 
     String oneModelUri = urlBase + oneModel;
     String oneResult = get(oneModelUri, null, Response.Status.OK.getStatusCode(), true);
-    ZNRecord oneRecord = OBJECT_MAPPER.readValue(oneResult, ZNRecord.class);
+    ZNRecord oneRecord = toZNRecord(oneResult);
 
     String twoResult =
         get("clusters/" + cluster + "/statemodeldefs/" + twoModel, null, Response.Status.OK.getStatusCode(), true);
-    ZNRecord twoRecord = OBJECT_MAPPER.readValue(twoResult, ZNRecord.class);
+    ZNRecord twoRecord = toZNRecord(twoResult);
 
     // delete one, expect success
     String deleteOneUri = urlBase + oneRecord.getId();
@@ -619,7 +619,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     Assert.assertTrue(setOneRsp.getStatus() == Response.Status.OK.getStatusCode());
 
     String oneResult2 = get(oneModelUri, null, Response.Status.OK.getStatusCode(), true);
-    ZNRecord oneRecord2 = OBJECT_MAPPER.readValue(oneResult2, ZNRecord.class);
+    ZNRecord oneRecord2 = toZNRecord(oneResult2);
     Assert.assertEquals(oneRecord2, newRecord);
 
     // set the delete one with original; namely restore the original condition
@@ -628,7 +628,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     Assert.assertTrue(setOneRsp2.getStatus() == Response.Status.OK.getStatusCode());
 
     String oneResult3 = get(oneModelUri, null, Response.Status.OK.getStatusCode(), true);
-    ZNRecord oneRecord3 = OBJECT_MAPPER.readValue(oneResult3, ZNRecord.class);
+    ZNRecord oneRecord3 = toZNRecord(oneResult3);
     Assert.assertEquals(oneRecord3, oneRecord);
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
@@ -994,7 +994,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     // Now test the getCloudConfig method.
     String body = get(urlBase, null, Response.Status.OK.getStatusCode(), true);
 
-    ZNRecord recordFromRest = new ObjectMapper().reader(ZNRecord.class).readValue(body);
+    ZNRecord recordFromRest = toZNRecord(body);
     CloudConfig cloudConfigRest = new CloudConfig.Builder(recordFromRest).build();
     CloudConfig cloudConfigZk = _configAccessor.getCloudConfig("TestCloud");
 
@@ -1112,7 +1112,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     // Now get the Cloud Config and make sure the information is correct
     String body = get(urlBase, null, Response.Status.OK.getStatusCode(), true);
 
-    ZNRecord recordFromRest = new ObjectMapper().reader(ZNRecord.class).readValue(body);
+    ZNRecord recordFromRest = toZNRecord(body);
     CloudConfig cloudConfigRest = new CloudConfig.Builder(recordFromRest).build();
     Assert.assertTrue(cloudConfigRest.isCloudEnabled());
     Assert.assertEquals(cloudConfigRest.getCloudID(), "TestCloudID");
@@ -1139,7 +1139,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     // Now get the Cloud Config and make sure the information has been updated
     body = get(urlBase, null, Response.Status.OK.getStatusCode(), true);
 
-    recordFromRest = new ObjectMapper().reader(ZNRecord.class).readValue(body);
+    recordFromRest = toZNRecord(body);
     cloudConfigRest = new CloudConfig.Builder(recordFromRest).build();
     Assert.assertTrue(cloudConfigRest.isCloudEnabled());
     Assert.assertEquals(cloudConfigRest.getCloudID(), "TestCloudIdNew");
@@ -1198,7 +1198,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     // Now test the getCustomizedStateConfig method.
     String body = get(urlBase, null, Response.Status.OK.getStatusCode(), true);
 
-    ZNRecord recordFromRest = new ObjectMapper().reader(ZNRecord.class).readValue(body);
+    ZNRecord recordFromRest = toZNRecord(body);
     CustomizedStateConfig customizedConfigRest = new CustomizedStateConfig.Builder(recordFromRest).build();
     CustomizedStateConfig customizedConfigZk = _configAccessor.getCustomizedStateConfig("TestClusterCustomized");
 
@@ -1298,7 +1298,7 @@ public class TestClusterAccessor extends AbstractTestClass {
   private ClusterConfig getClusterConfigFromRest(String cluster) throws IOException {
     String body = get("clusters/" + cluster + "/configs", null, Response.Status.OK.getStatusCode(), true);
 
-    ZNRecord record = new ObjectMapper().reader(ZNRecord.class).readValue(body);
+    ZNRecord record = toZNRecord(body);
     ClusterConfig clusterConfigRest = new ClusterConfig(record);
     ClusterConfig clusterConfigZk = _configAccessor.getClusterConfig(cluster);
     Assert.assertEquals(clusterConfigZk, clusterConfigRest, "cluster config from response: "

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPropertyStoreAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPropertyStoreAccessor.java
@@ -85,7 +85,7 @@ public class TestPropertyStoreAccessor extends AbstractTestClass {
     String data =
         new JerseyUriRequestBuilder("clusters/{}/propertyStore/ZnRecord").format(TEST_CLUSTER)
             .isBodyReturnExpected(true).get(this);
-    ZNRecord record = OBJECT_MAPPER.reader(ZNRecord.class).readValue(data);
+    ZNRecord record = toZNRecord(data);
     Assert.assertEquals(record.getId(), TEST_ZNRECORD.getId());
   }
 

--- a/metadata-store-directory-common/metadata-store-directory-common-1.0.2-SNAPSHOT.ivy
+++ b/metadata-store-directory-common/metadata-store-directory-common-1.0.2-SNAPSHOT.ivy
@@ -47,7 +47,7 @@ under the License.
         <artifact name="snakeyaml" m:classifier="sources" ext="jar"/>
     </dependency>
 		<dependency org="org.apache.helix" name="helix-core" rev="1.0.2-SNAPSHOT" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
-		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.10.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.11.0" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="commons-io" name="commons-io" rev="1.4" conf="compile->compile(default);runtime->runtime(default);default->default"/>
 	</dependencies>

--- a/metadata-store-directory-common/pom.xml
+++ b/metadata-store-directory-common/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.10.2</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -74,11 +74,6 @@
       <version>2.11.0</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>2.11.0</version>
-    </dependency>
-    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.14</version>
@@ -113,6 +108,11 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>1.9.13</version>
     </dependency>
   </dependencies>
   <build>

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/SessionAwareZNRecord.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/SessionAwareZNRecord.java
@@ -19,7 +19,7 @@ package org.apache.helix.zookeeper.datamodel;
  * under the License.
  */
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonIgnore;
 
 /**
  * A class represents a session aware ZNRecord: the ZNRecord should be written to zk by

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/ZNRecord.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/ZNRecord.java
@@ -24,25 +24,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
 import org.apache.helix.zookeeper.constant.ZkSystemPropertyKeys;
 import org.apache.helix.zookeeper.datamodel.serializer.JacksonPayloadSerializer;
 import org.apache.helix.zookeeper.datamodel.serializer.PayloadSerializer;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * Generic Record Format to store data at a Node This can be used to store
  * simpleFields mapFields listFields
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonSerialize(include = Inclusion.NON_NULL)
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 public class ZNRecord {
   static Logger _logger = LoggerFactory.getLogger(ZNRecord.class);
   private final String id;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/serializer/ZNRecordJacksonSerializer.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/serializer/ZNRecordJacksonSerializer.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.introspect.CodehausJacksonIntrospector;
 import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 
@@ -32,7 +33,9 @@ import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
  * this serializer doesn't check for the size of the resulting binary.
  */
 public class ZNRecordJacksonSerializer implements ZkSerializer {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+      // TODO: remove it after upgrading ZNRecord's annotations to Jackson 2
+      .setAnnotationIntrospector(new CodehausJacksonIntrospector());
 
   @Override
   public byte[] serialize(Object record) throws ZkMarshallingError {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/serializer/ZNRecordSerializer.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/serializer/ZNRecordSerializer.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.introspect.CodehausJacksonIntrospector;
 import org.apache.helix.zookeeper.util.GZipCompressionUtil;
 import org.apache.helix.zookeeper.util.ZNRecordUtil;
 import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
@@ -36,10 +37,12 @@ import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class ZNRecordSerializer implements ZkSerializer {
-  private static Logger LOG = LoggerFactory.getLogger(ZNRecordSerializer.class);
-  private static ObjectMapper mapper = new ObjectMapper();
+  private static final Logger LOG = LoggerFactory.getLogger(ZNRecordSerializer.class);
+
+  private static ObjectMapper mapper = new ObjectMapper()
+      // TODO: remove it after upgrading ZNRecord's annotations to Jackson 2
+      .setAnnotationIntrospector(new CodehausJacksonIntrospector());
 
   private static int getListFieldBound(ZNRecord record) {
     int max = Integer.MAX_VALUE;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/serializer/ZNRecordStreamingSerializer.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/datamodel/serializer/ZNRecordStreamingSerializer.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 
 
 public class ZNRecordStreamingSerializer implements ZkSerializer {
-  private static Logger LOG = LoggerFactory.getLogger(ZNRecordStreamingSerializer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ZNRecordStreamingSerializer.class);
 
   private static int getListFieldBound(ZNRecord record) {
     int max = Integer.MAX_VALUE;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/introspect/CodehausJacksonIntrospector.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/introspect/CodehausJacksonIntrospector.java
@@ -19,13 +19,13 @@ package org.apache.helix.zookeeper.introspect;
  * under the License.
  */
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties.Value;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize.Typing;
 import com.fasterxml.jackson.databind.introspect.Annotated;
-import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
@@ -48,34 +48,22 @@ import org.codehaus.jackson.map.annotate.NoClass;
 public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
   private static final long serialVersionUID = 1L;
 
-  @SuppressWarnings("deprecation")
-  @Override
-  public String findEnumValue(Enum<?> value) {
-    return value.name();
+  public Value findPropertyIgnorals(Annotated a) {
+    JsonIgnoreProperties ignoreAnnotation = a.getAnnotation(JsonIgnoreProperties.class);
+    if (ignoreAnnotation != null) {
+      return Value.forIgnoreUnknown(ignoreAnnotation.ignoreUnknown());
+    }
+    return super.findPropertyIgnorals(a);
   }
 
   @SuppressWarnings("deprecation")
   @Override
-  public Boolean findIgnoreUnknownProperties(AnnotatedClass ac) {
-    JsonIgnoreProperties ignore = ac.getAnnotation(JsonIgnoreProperties.class);
-    return (ignore == null) ? null : ignore.ignoreUnknown();
-  }
-
-  @SuppressWarnings("deprecation")
-  @Override
-  public String[] findPropertiesToIgnore(Annotated ac) {
-    JsonIgnoreProperties ignore = ac.getAnnotation(JsonIgnoreProperties.class);
-    return (ignore == null) ? null : ignore.value();
-  }
-
-  @SuppressWarnings("deprecation")
-  @Override
-  public Class<?> findDeserializationContentType(Annotated am, JavaType baseContentType) {
-    JsonSerialize ann = am.getAnnotation(JsonSerialize.class);
-    if (ann != null) {
-      Class<?> cls = ann.contentAs();
-      if (cls != NoClass.class) {
-        return cls;
+  public Class<?> findDeserializationContentType(Annotated a, JavaType baseContentType) {
+    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
+    if (serializeAnnotation != null) {
+      Class<?> serClass = serializeAnnotation.contentAs();
+      if (serClass != NoClass.class) {
+        return serClass;
       }
     }
     return null;
@@ -98,20 +86,20 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
   }
 
   public String findDeserializationName(AnnotatedField af) {
-    JsonProperty pann = af.getAnnotation(JsonProperty.class);
-    return pann == null ? null : pann.value();
+    JsonProperty propertyAnnotation = af.getAnnotation(JsonProperty.class);
+    return propertyAnnotation == null ? null : propertyAnnotation.value();
   }
 
   public String findDeserializationName(AnnotatedMethod am) {
-    JsonProperty pann = am.getAnnotation(JsonProperty.class);
-    return pann == null ? null : pann.value();
+    JsonProperty propertyAnnotation = am.getAnnotation(JsonProperty.class);
+    return propertyAnnotation == null ? null : propertyAnnotation.value();
   }
 
   public String findDeserializationName(AnnotatedParameter param) {
     if (param != null) {
-      JsonProperty pann = param.getAnnotation(JsonProperty.class);
-      if (pann != null) {
-        return pann.value();
+      JsonProperty propertyAnnotation = param.getAnnotation(JsonProperty.class);
+      if (propertyAnnotation != null) {
+        return propertyAnnotation.value();
       }
     }
     return null;
@@ -119,12 +107,12 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
 
   @SuppressWarnings("deprecation")
   @Override
-  public Class<?> findSerializationContentType(Annotated am, JavaType baseType) {
-    JsonSerialize ann = am.getAnnotation(JsonSerialize.class);
-    if (ann != null) {
-      Class<?> cls = ann.contentAs();
-      if (cls != NoClass.class) {
-        return cls;
+  public Class<?> findSerializationContentType(Annotated a, JavaType baseType) {
+    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
+    if (serializeAnnotation != null) {
+      Class<?> serClass = serializeAnnotation.contentAs();
+      if (serClass != NoClass.class) {
+        return serClass;
       }
     }
     return null;
@@ -135,10 +123,10 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
    */
   @Override
   public JsonInclude.Value findPropertyInclusion(Annotated a) {
-    JsonSerialize ann = a.getAnnotation(JsonSerialize.class);
-    if (ann != null) {
+    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
+    if (serializeAnnotation != null) {
       for (Include include : Include.values()) {
-        if (include.name().equals(ann.include().name())) {
+        if (include.name().equals(serializeAnnotation.include().name())) {
           return JsonInclude.Value.construct(include, include);
         }
       }
@@ -149,25 +137,27 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
   @SuppressWarnings("deprecation")
   @Override
   public Include findSerializationInclusion(Annotated a, Include defValue) {
-    JsonSerialize ann = a.getAnnotation(JsonSerialize.class);
-    return ann == null ? defValue : Include.valueOf(ann.include().name());
+    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
+    return serializeAnnotation == null ? defValue
+        : Include.valueOf(serializeAnnotation.include().name());
   }
 
   @SuppressWarnings("deprecation")
   @Override
   public Include findSerializationInclusionForContent(Annotated a, JsonInclude.Include defValue) {
-    JsonSerialize ann = a.getAnnotation(JsonSerialize.class);
-    return ann == null ? defValue : Include.valueOf(ann.include().name());
+    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
+    return serializeAnnotation == null ? defValue
+        : Include.valueOf(serializeAnnotation.include().name());
   }
 
   @SuppressWarnings("deprecation")
   @Override
-  public Class<?> findSerializationKeyType(Annotated am, JavaType baseType) {
-    JsonSerialize ann = am.getAnnotation(JsonSerialize.class);
-    if (ann != null) {
-      Class<?> cls = ann.keyAs();
-      if (cls != NoClass.class) {
-        return cls;
+  public Class<?> findSerializationKeyType(Annotated a, JavaType baseType) {
+    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
+    if (serializeAnnotation != null) {
+      Class<?> serClass = serializeAnnotation.keyAs();
+      if (serClass != NoClass.class) {
+        return serClass;
       }
     }
     return null;
@@ -176,11 +166,11 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
   @SuppressWarnings("deprecation")
   @Override
   public Class<?> findSerializationType(Annotated a) {
-    JsonSerialize ann = a.getAnnotation(JsonSerialize.class);
-    if (ann != null) {
-      Class<?> cls = ann.as();
-      if (cls != NoClass.class) {
-        return cls;
+    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
+    if (serializeAnnotation != null) {
+      Class<?> serClass = serializeAnnotation.as();
+      if (serClass != NoClass.class) {
+        return serClass;
       }
     }
     return null;
@@ -188,8 +178,8 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
 
   @Override
   public Typing findSerializationTyping(Annotated a) {
-    JsonSerialize ann = a.getAnnotation(JsonSerialize.class);
-    return ann == null ? null : Typing.valueOf(ann.typing().name());
+    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
+    return serializeAnnotation == null ? null : Typing.valueOf(serializeAnnotation.typing().name());
   }
 
   @Override
@@ -212,9 +202,9 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
   }
 
   public String findSerializationName(AnnotatedField af) {
-    JsonProperty pann = af.getAnnotation(JsonProperty.class);
-    if (pann != null) {
-      return pann.value();
+    JsonProperty propertyAnnotation = af.getAnnotation(JsonProperty.class);
+    if (propertyAnnotation != null) {
+      return propertyAnnotation.value();
     }
 
     if (af.hasAnnotation(JsonSerialize.class)) {
@@ -223,11 +213,10 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
     return null;
   }
 
-  @SuppressWarnings("deprecation")
   public String findSerializationName(AnnotatedMethod am) {
-    JsonProperty pann = am.getAnnotation(JsonProperty.class);
-    if (pann != null) {
-      return pann.value();
+    JsonProperty propertyAnnotation = am.getAnnotation(JsonProperty.class);
+    if (propertyAnnotation != null) {
+      return propertyAnnotation.value();
     }
 
     if (am.hasAnnotation(JsonSerialize.class)) {
@@ -243,19 +232,19 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
   }
 
   @Override
-  public boolean hasIgnoreMarker(AnnotatedMember m) {
-    JsonIgnore ann = m.getAnnotation(JsonIgnore.class);
-    return (ann != null && ann.value());
+  public boolean hasIgnoreMarker(AnnotatedMember am) {
+    JsonIgnore ignoreAnnotation = am.getAnnotation(JsonIgnore.class);
+    return (ignoreAnnotation != null && ignoreAnnotation.value());
   }
 
   /*
    * handling of serializers
    */
   @Override
-  public Object findSerializer(Annotated am) {
-    JsonSerialize ann = am.getAnnotation(JsonSerialize.class);
-    if (ann != null) {
-      Class<? extends JsonSerializer<?>> serClass = ann.using();
+  public Object findSerializer(Annotated a) {
+    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
+    if (serializeAnnotation != null) {
+      Class<? extends JsonSerializer<?>> serClass = serializeAnnotation.using();
       if (serClass != JsonSerializer.None.class) {
         return serClass;
       }
@@ -264,10 +253,10 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
   }
 
   @Override
-  public Object findKeySerializer(Annotated am) {
-    JsonSerialize ann = am.getAnnotation(JsonSerialize.class);
-    if (ann != null) {
-      Class<? extends JsonSerializer<?>> serClass = ann.keyUsing();
+  public Object findKeySerializer(Annotated a) {
+    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
+    if (serializeAnnotation != null) {
+      Class<? extends JsonSerializer<?>> serClass = serializeAnnotation.keyUsing();
       if (serClass != JsonSerializer.None.class) {
         return serClass;
       }
@@ -276,10 +265,10 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
   }
 
   @Override
-  public Object findContentSerializer(Annotated am) {
-    JsonSerialize ann = am.getAnnotation(JsonSerialize.class);
-    if (ann != null) {
-      Class<? extends JsonSerializer<?>> serClass = ann.contentUsing();
+  public Object findContentSerializer(Annotated a) {
+    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
+    if (serializeAnnotation != null) {
+      Class<? extends JsonSerializer<?>> serClass = serializeAnnotation.contentUsing();
       if (serClass != JsonSerializer.None.class) {
         return serClass;
       }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/introspect/CodehausJacksonIntrospector.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/introspect/CodehausJacksonIntrospector.java
@@ -1,0 +1,289 @@
+package org.apache.helix.zookeeper.introspect;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.PropertyName;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize.Typing;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
+import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
+import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.codehaus.jackson.map.annotate.NoClass;
+
+/**
+ * This introspector works with jackson 1 annotations used in
+ * {@link org.apache.helix.zookeeper.datamodel.ZNRecord}.
+ * This is supposed used ONLY in Helix as it could be deprecated in the next major release.
+ */
+// TODO: remove this class once upgrading to Jackson 2.x in ZNRecord
+public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
+  private static final long serialVersionUID = 1L;
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public String findEnumValue(Enum<?> value) {
+    return value.name();
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public Boolean findIgnoreUnknownProperties(AnnotatedClass ac) {
+    JsonIgnoreProperties ignore = ac.getAnnotation(JsonIgnoreProperties.class);
+    return (ignore == null) ? null : ignore.ignoreUnknown();
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public String[] findPropertiesToIgnore(Annotated ac) {
+    JsonIgnoreProperties ignore = ac.getAnnotation(JsonIgnoreProperties.class);
+    return (ignore == null) ? null : ignore.value();
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public Class<?> findDeserializationContentType(Annotated am, JavaType baseContentType) {
+    JsonSerialize ann = am.getAnnotation(JsonSerialize.class);
+    if (ann != null) {
+      Class<?> cls = ann.contentAs();
+      if (cls != NoClass.class) {
+        return cls;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public PropertyName findNameForDeserialization(Annotated a) {
+    String name = null;
+    if (a instanceof AnnotatedField) {
+      name = findDeserializationName((AnnotatedField) a);
+    } else if (a instanceof AnnotatedMethod) {
+      name = findDeserializationName((AnnotatedMethod) a);
+    } else if (a instanceof AnnotatedParameter) {
+      name = findDeserializationName((AnnotatedParameter) a);
+    }
+    if (name == null) {
+      return null;
+    }
+    return name.isEmpty() ? PropertyName.USE_DEFAULT : new PropertyName(name);
+  }
+
+  public String findDeserializationName(AnnotatedField af) {
+    JsonProperty pann = af.getAnnotation(JsonProperty.class);
+    return pann == null ? null : pann.value();
+  }
+
+  public String findDeserializationName(AnnotatedMethod am) {
+    JsonProperty pann = am.getAnnotation(JsonProperty.class);
+    return pann == null ? null : pann.value();
+  }
+
+  public String findDeserializationName(AnnotatedParameter param) {
+    if (param != null) {
+      JsonProperty pann = param.getAnnotation(JsonProperty.class);
+      if (pann != null) {
+        return pann.value();
+      }
+    }
+    return null;
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public Class<?> findSerializationContentType(Annotated am, JavaType baseType) {
+    JsonSerialize ann = am.getAnnotation(JsonSerialize.class);
+    if (ann != null) {
+      Class<?> cls = ann.contentAs();
+      if (cls != NoClass.class) {
+        return cls;
+      }
+    }
+    return null;
+  }
+
+  /*
+   * Handles JsonSerialize.Inclusion
+   */
+  @Override
+  public JsonInclude.Value findPropertyInclusion(Annotated a) {
+    JsonSerialize ann = a.getAnnotation(JsonSerialize.class);
+    if (ann != null) {
+      for (Include include : Include.values()) {
+        if (include.name().equals(ann.include().name())) {
+          return JsonInclude.Value.construct(include, include);
+        }
+      }
+    }
+    return JsonInclude.Value.empty();
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public Include findSerializationInclusion(Annotated a, Include defValue) {
+    JsonSerialize ann = a.getAnnotation(JsonSerialize.class);
+    return ann == null ? defValue : Include.valueOf(ann.include().name());
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public Include findSerializationInclusionForContent(Annotated a, JsonInclude.Include defValue) {
+    JsonSerialize ann = a.getAnnotation(JsonSerialize.class);
+    return ann == null ? defValue : Include.valueOf(ann.include().name());
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public Class<?> findSerializationKeyType(Annotated am, JavaType baseType) {
+    JsonSerialize ann = am.getAnnotation(JsonSerialize.class);
+    if (ann != null) {
+      Class<?> cls = ann.keyAs();
+      if (cls != NoClass.class) {
+        return cls;
+      }
+    }
+    return null;
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public Class<?> findSerializationType(Annotated a) {
+    JsonSerialize ann = a.getAnnotation(JsonSerialize.class);
+    if (ann != null) {
+      Class<?> cls = ann.as();
+      if (cls != NoClass.class) {
+        return cls;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Typing findSerializationTyping(Annotated a) {
+    JsonSerialize ann = a.getAnnotation(JsonSerialize.class);
+    return ann == null ? null : Typing.valueOf(ann.typing().name());
+  }
+
+  @Override
+  public PropertyName findNameForSerialization(Annotated a) {
+    String name;
+    if (a instanceof AnnotatedField) {
+      name = findSerializationName((AnnotatedField) a);
+    } else if (a instanceof AnnotatedMethod) {
+      name = findSerializationName((AnnotatedMethod) a);
+    } else {
+      name = null;
+    }
+    if (name != null) {
+      if (name.length() == 0) { // empty String means 'default'
+        return PropertyName.USE_DEFAULT;
+      }
+      return new PropertyName(name);
+    }
+    return null;
+  }
+
+  public String findSerializationName(AnnotatedField af) {
+    JsonProperty pann = af.getAnnotation(JsonProperty.class);
+    if (pann != null) {
+      return pann.value();
+    }
+
+    if (af.hasAnnotation(JsonSerialize.class)) {
+      return "";
+    }
+    return null;
+  }
+
+  @SuppressWarnings("deprecation")
+  public String findSerializationName(AnnotatedMethod am) {
+    JsonProperty pann = am.getAnnotation(JsonProperty.class);
+    if (pann != null) {
+      return pann.value();
+    }
+
+    if (am.hasAnnotation(JsonSerialize.class)) {
+      return "";
+    }
+    return null;
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public boolean hasCreatorAnnotation(Annotated a) {
+    return a.hasAnnotation(JsonCreator.class);
+  }
+
+  @Override
+  public boolean hasIgnoreMarker(AnnotatedMember m) {
+    JsonIgnore ann = m.getAnnotation(JsonIgnore.class);
+    return (ann != null && ann.value());
+  }
+
+  /*
+   * handling of serializers
+   */
+  @Override
+  public Object findSerializer(Annotated am) {
+    JsonSerialize ann = am.getAnnotation(JsonSerialize.class);
+    if (ann != null) {
+      Class<? extends JsonSerializer<?>> serClass = ann.using();
+      if (serClass != JsonSerializer.None.class) {
+        return serClass;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Object findKeySerializer(Annotated am) {
+    JsonSerialize ann = am.getAnnotation(JsonSerialize.class);
+    if (ann != null) {
+      Class<? extends JsonSerializer<?>> serClass = ann.keyUsing();
+      if (serClass != JsonSerializer.None.class) {
+        return serClass;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Object findContentSerializer(Annotated am) {
+    JsonSerialize ann = am.getAnnotation(JsonSerialize.class);
+    if (ann != null) {
+      Class<? extends JsonSerializer<?>> serClass = ann.contentUsing();
+      if (serClass != JsonSerializer.None.class) {
+        return serClass;
+      }
+    }
+    return null;
+  }
+}

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/datamodel/serializer/TestZNRecordSerializeWriteSizeLimit.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/datamodel/serializer/TestZNRecordSerializeWriteSizeLimit.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.helix.zookeeper.constant.ZkSystemPropertyKeys;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.introspect.CodehausJacksonIntrospector;
 import org.apache.helix.zookeeper.util.GZipCompressionUtil;
 import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
@@ -187,6 +188,7 @@ public class TestZNRecordSerializeWriteSizeLimit {
   // Returns raw serialized bytes before being compressed.
   private byte[] serialize(Object data) {
     ObjectMapper mapper = new ObjectMapper();
+    mapper.setAnnotationIntrospector(new CodehausJacksonIntrospector());
     mapper.enable(SerializationFeature.INDENT_OUTPUT);
     mapper.enable(MapperFeature.AUTO_DETECT_FIELDS);
     mapper.enable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS);

--- a/zookeeper-api/zookeeper-api-1.0.2-SNAPSHOT.ivy
+++ b/zookeeper-api/zookeeper-api-1.0.2-SNAPSHOT.ivy
@@ -45,6 +45,7 @@ under the License.
     </dependency>
 		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.11.0" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.11.0" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.13" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.8" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 	</dependencies>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1655 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Jackson was upgraded in helix from 1.x to 2.x (https://github.com/apache/helix/pull/1293). Jackson 1.x does not support Jackson 2.x annotations.

This PR rolls back Jackson 2 annotations to Jackson 1, and adds a custom `CodehausJacksonAnnotationIntrospector` to make Jackson 2 work with Jackson 1 annotations. The custom "CodehausJacksonAnnotationIntrospector" is based on Jackson's recommendation on GitHub doc: https://github.com/FasterXML/jackson-annotations,
Backwards compatibility: You can make Jackson 2 use Jackson 1 annotations with [jackson-legacy-introspector](https://github.com/Laures/jackson-legacy-introspector)

The introspector is simplified and customized to ONLY work with Jackson 1 annotations in helix. It is implemented for backward compatibility, and should be deprecated once all Jackson 1 annotations are upgrade/removed in Helix.

Classes that roll back to use Jackson 1 annotations:
- `ZNRecord`
- `SessionAwareZNRecord`

### Tests

- [x] The following tests are written for this issue:

 - `testCodehausJacksonSerializer`

- The following is the result of the "mvn test" command on the appropriate module:

zookeeper-api
```
[INFO] Tests run: 53, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 67.799 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 53, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:11 min
[INFO] Finished at: 2021-02-26T17:56:52-08:00
[INFO] ------------------------------------------------------------------------
```

helix-core
```
[INFO] Tests run: 1264, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4,989.124 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1264, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:23 h
[INFO] Finished at: 2021-02-28T14:25:40-08:00
[INFO] ------------------------------------------------------------------------
```

helix-rest
```
[INFO] Tests run: 171, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 93.342 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 171, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:38 min
[INFO] Finished at: 2021-02-27T21:08:48-08:00
[INFO] ------------------------------------------------------------------------
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
