### PR TITLE
Increase largest possible rebalance preference ratio

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithmFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithmFactory.java
@@ -49,7 +49,7 @@ public class ConstraintBasedAlgorithmFactory {
   // The weight for BaselineInfluenceConstraint used when we are forcing a baseline converge. This
   // number, multiplied by the max score returned by BaselineInfluenceConstraint, must be greater
   // than the total maximum sum of all other constraints, in order to overpower other constraints.
-  private static final float FORCE_BASELINE_CONVERGE_WEIGHT = Integer.MAX_VALUE;
+  private static final float FORCE_BASELINE_CONVERGE_WEIGHT = 100000f;
 
   static {
     Properties properties =

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithmFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithmFactory.java
@@ -49,7 +49,7 @@ public class ConstraintBasedAlgorithmFactory {
   // The weight for BaselineInfluenceConstraint used when we are forcing a baseline converge. This
   // number, multiplied by the max score returned by BaselineInfluenceConstraint, must be greater
   // than the total maximum sum of all other constraints, in order to overpower other constraints.
-  private static final float FORCE_BASELINE_CONVERGE_WEIGHT = 10000f;
+  private static final float FORCE_BASELINE_CONVERGE_WEIGHT = Integer.MAX_VALUE;
 
   static {
     Properties properties =

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -164,7 +164,7 @@ public class ClusterConfig extends HelixProperty {
           .put(GlobalRebalancePreferenceKey.EVENNESS, 1)
           .put(GlobalRebalancePreferenceKey.LESS_MOVEMENT, 1)
           .put(GlobalRebalancePreferenceKey.FORCE_BASELINE_CONVERGE, 0).build();
-  private final static int MAX_REBALANCE_PREFERENCE = 10;
+  private final static int MAX_REBALANCE_PREFERENCE = 1000;
   private final static int MIN_REBALANCE_PREFERENCE = 0;
   public final static boolean DEFAULT_GLOBAL_REBALANCE_ASYNC_MODE_ENABLED = true;
   private static final int GLOBAL_TARGET_TASK_THREAD_POOL_SIZE_NOT_SET = -1;


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1667 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

For certain clusters, we need extreme evenness:movement ratio to obtain a good distribution. The current maximum ratio of 10:1 is not enough.

This PR increases the maximum weight to 1000 for these extreme cases. 

### Tests

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 1265, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,096.014 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1265, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:25 h
[INFO] Finished at: 2021-03-09T17:10:06-08:00
[INFO] ------------------------------------------------------------------------
```
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
