### PR TITLE
Enforce id field in Helix rest to update resource config

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -501,7 +501,7 @@ public class ClusterAccessor extends AbstractHelixResource {
       return badRequest("Input is not a valid ZNRecord!");
     }
 
-    if (!record.getId().equals(clusterId)) {
+    if (!clusterId.equals(record.getId())) {
       return badRequest("ID does not match the cluster name in input!");
     }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAccessor.java
@@ -422,6 +422,11 @@ public class ResourceAccessor extends AbstractHelixResource {
       _logger.error("Failed to deserialize user's input " + content + ", Exception: " + e);
       return badRequest("Input is not a valid ZNRecord!");
     }
+
+    if (!resourceName.equals(record.getId())) {
+      return badRequest("ID does not match the resourceName name in input!");
+    }
+
     ResourceConfig resourceConfig = new ResourceConfig(record);
     ConfigAccessor configAccessor = getConfigAccessor();
     try {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
@@ -380,6 +380,29 @@ public class TestResourceAccessor extends AbstractTestClass {
    * @throws Exception
    */
   @Test(dependsOnMethods = "updateResourceConfig")
+  public void updateResourceConfigIDMissing() throws Exception {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    // An invalid input which does not have any ID
+    String dummyInput = "{\"simpleFields\":{}}";
+
+    String dummyResourceName = "RESOURCE_TEST_DUMMY";
+    // Update the config with dummy input
+    Entity entity = Entity.entity(dummyInput, MediaType.APPLICATION_JSON_TYPE);
+    // As id field is missing, the response of the post request should be BAD_REQUEST
+    post("clusters/" + CLUSTER_NAME + "/resources/" + dummyResourceName + "/configs", null, entity,
+        Response.Status.BAD_REQUEST.getStatusCode());
+    ResourceConfig resourceConfig =
+        _configAccessor.getResourceConfig(CLUSTER_NAME, dummyResourceName);
+    // Since the id is missing in the input, the znode should not get created.
+    Assert.assertNull(resourceConfig);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  /**
+   * Test "delete" command of updateResourceConfig.
+   * @throws Exception
+   */
+  @Test(dependsOnMethods = "updateResourceConfigIDMissing")
   public void deleteFromResourceConfig() throws Exception {
     ZNRecord record = new ZNRecord(RESOURCE_NAME);
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixes #1671  

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
In this PR, in the update resource config REST call, the id field will be validated to avoid the creation of ZNodes that does not have any id.

### Tests

- [x] The following tests are written for this issue:
TestResourceAccessor.updateResourceConfigIDMissing

- [x] The following is the result of the "mvn test" command on the appropriate module:
Helix-core:
```
[INFO] Tests run: 1264, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4,984.101 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1264, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:23 h
[INFO] Finished at: 2021-03-16T12:40:03-07:00
[INFO] ------------------------------------------------------------------------
```
Helix-rest:
```
[INFO] Tests run: 172, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 93.331 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 172, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:40 min
[INFO] Finished at: 2021-03-18T10:11:01-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)


