### PR TITLE
Upgrade maven plugins to improve build speed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -581,12 +581,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.3</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9</version>
+          <version>3.2.0</version>
           <configuration>
             <skip>true</skip>
           </configuration>
@@ -594,6 +594,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
+          <version>3.2.1</version>
           <executions>
             <execution>
               <id>attach-sources</id>
@@ -615,7 +616,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.2</version>
+          <version>3.2.0</version>
           <executions>
             <execution>
               <goals>
@@ -736,6 +737,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1669 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Maven package plugins in helix are way too old. We found that the build time on some linux machines are ~X5 longer: 0:50 min -> 4:40 min.

Troubleshooting tells maven jar plugins take a much longer time to package jars because of a large number of id group check by maven plugins. And upgrading the maven plugins completely solves the problem: 4:40 min -> 0:28 min.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

```
11:20:38,148 [INFO] ------------------------------------------------------------------------
11:20:38,148 [INFO] BUILD SUCCESS
11:20:38,148 [INFO] ------------------------------------------------------------------------
11:20:38,149 [INFO] Total time:  28.482 s
11:20:38,149 [INFO] Finished at: 2021-03-22T11:20:38-07:00
11:20:38,149 [INFO] ------------------------------------------------------------------------
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
