### PR TITLE
Improve the GenericHelixController global tracking record to support multiple controller objects for the same cluster in one JVM.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/util/RebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/RebalanceUtil.java
@@ -159,9 +159,10 @@ public class RebalanceUtil {
       LOG.error("Failed to issue a pipeline run. Delay is invalid.");
       return;
     }
-    GenericHelixController controller = GenericHelixController.getController(clusterName);
-    if (controller != null) {
-      controller.scheduleOnDemandRebalance(delay, shouldRefreshCache);
+    GenericHelixController leaderController =
+        GenericHelixController.getLeaderController(clusterName);
+    if (leaderController != null) {
+      leaderController.scheduleOnDemandRebalance(delay, shouldRefreshCache);
     } else {
       LOG.error("Failed to issue a pipeline. Controller for cluster {} does not exist.",
           clusterName);

--- a/helix-core/src/test/java/org/apache/helix/tools/TestHelixAdminCli.java
+++ b/helix-core/src/test/java/org/apache/helix/tools/TestHelixAdminCli.java
@@ -724,11 +724,6 @@ public class TestHelixAdminCli extends ZkTestBase {
     HelixAdmin admin = _gSetupTool.getClusterManagementTool();
     TestHelper.verify(() -> {
       if (admin.getResourceExternalView(grandClusterName, clusterName) == null) {
-        // TODO: Remove the following logic once https://github.com/apache/helix/issues/1617 is fixed.
-        // TODO: For now, we may need to touch the IdealState to trigger a new rebalance since the test
-        // TODO: is running multiple GenericHelixController instances in one JVM.
-        IdealState is = admin.getResourceIdealState(grandClusterName, clusterName);
-        admin.setResourceIdealState(grandClusterName, clusterName, is);
         return false;
       }
       return true;

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -671,13 +671,6 @@ public class TestClusterAccessor extends AbstractTestClass {
 
     boolean result = TestHelper.verify(() -> {
       LiveInstance leader = normalAccessor.getProperty(normKeyBuilder.controllerLeader());
-      if (leader == null) {
-        // TODO: Remove the following logic once https://github.com/apache/helix/issues/1617 is fixed.
-        // TODO: For now, we may need to touch the IdealState to trigger a new rebalance since the test
-        // TODO: is running multiple GenericHelixController instances in one JVM.
-        IdealState is = normalAccessor.getProperty(keyBuilder.idealStates(ACTIVATE_NORM_CLUSTER));
-        normalAccessor.setProperty(keyBuilder.idealStates(ACTIVATE_NORM_CLUSTER), is);
-      }
       return leader != null;
     }, 12000);
     Assert.assertTrue(result);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1617

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR refines the GenericHelixController global tracking record so it acts as expected even we have more than one instance in the JVM. This impacts test logic only in general.

### Tests

- [X] The following tests are written for this issue:

The previously added workaround code has been removed. So the new logic can be tested by the original code.

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
