### PR TITLE
Close zkClients created by TaskStateModelFactory

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
@@ -52,6 +52,9 @@ import org.slf4j.LoggerFactory;
 public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
   private static Logger LOG = LoggerFactory.getLogger(TaskStateModelFactory.class);
 
+  // Unit in minutes. Need a retry timeout to prevent zkClient from hanging infinitely.
+  private static int ZKCLIENT_OPERATION_RETRY_TIMEOUT = 5;
+
   private final HelixManager _manager;
   private final Map<String, TaskFactory> _taskFactoryRegistry;
   private final ScheduledExecutorService _taskExecutor;
@@ -135,7 +138,8 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
     RealmAwareZkClient.RealmAwareZkClientConfig clientConfig =
         new RealmAwareZkClient.RealmAwareZkClientConfig().setZkSerializer(new ZNRecordSerializer());
     // Set operation retry timeout to prevent hanging infinitely
-    clientConfig.setOperationRetryTimeout(Duration.ofMinutes(5).toMillis());
+    clientConfig
+        .setOperationRetryTimeout(Duration.ofMinutes(ZKCLIENT_OPERATION_RETRY_TIMEOUT).toMillis());
     String zkAddress = manager.getMetadataStoreConnectionString();
 
     if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddress == null) {

--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
@@ -19,6 +19,7 @@ package org.apache.helix.task;
  * under the License.
  */
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -134,7 +135,7 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
     RealmAwareZkClient.RealmAwareZkClientConfig clientConfig =
         new RealmAwareZkClient.RealmAwareZkClientConfig().setZkSerializer(new ZNRecordSerializer());
     // Set operation retry timeout to prevent hanging infinitely
-    clientConfig.setOperationRetryTimeout((long) 60000);
+    clientConfig.setOperationRetryTimeout(Duration.ofMinutes(5).toMillis());
     String zkAddress = manager.getMetadataStoreConnectionString();
 
     if (Boolean.getBoolean(SystemPropertyKeys.MULTI_ZK_ENABLED) || zkAddress == null) {

--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
@@ -53,7 +53,7 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
   private static Logger LOG = LoggerFactory.getLogger(TaskStateModelFactory.class);
 
   // Unit in minutes. Need a retry timeout to prevent zkClient from hanging infinitely.
-  private static int ZKCLIENT_OPERATION_RETRY_TIMEOUT = 5;
+  private static final int ZKCLIENT_OPERATION_RETRY_TIMEOUT = 5;
 
   private final HelixManager _manager;
   private final Map<String, TaskFactory> _taskFactoryRegistry;

--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
@@ -157,12 +157,9 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
       }
     }
 
-    // Fail early instead of retrying and blocking TaskStateModelFactory creation
-    HelixZkClient.ZkClientConfig zkClientConfig =
-        clientConfig.createHelixZkClientConfig().setZkSerializer(new ZNRecordSerializer());
-    zkClientConfig.setOperationRetryTimeout((long) 60000);
     return SharedZkClientFactory.getInstance()
-        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress), zkClientConfig);
+        .buildZkClient(new HelixZkClient.ZkConnectionConfig(zkAddress),
+            clientConfig.createHelixZkClientConfig().setZkSerializer(new ZNRecordSerializer()));
   }
 
   private static ScheduledExecutorService createThreadPoolExecutor(HelixManager manager) {
@@ -183,6 +180,8 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
       zkClient.close();
     }
 
+    LOG.info(
+        "Obtained target thread pool size: " + targetThreadPoolSize + ". Creating thread pool.");
     return Executors.newScheduledThreadPool(targetThreadPoolSize, new ThreadFactory() {
       private AtomicInteger threadId = new AtomicInteger(0);
 

--- a/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
@@ -92,23 +92,20 @@ public class TestTaskStateModelFactory extends TaskTestBase {
         testMSDSServerEndpointKey);
 
     RoutingDataManager.getInstance().reset();
-    RealmAwareZkClient zkClient = TaskStateModelFactory.createZkClient(anyParticipantManager);
-    verifyThreadPoolSizeAndZkClientClass(zkClient, anyParticipantManager,
-        TEST_TARGET_TASK_THREAD_POOL_SIZE, FederatedZkClient.class);
+    verifyThreadPoolSizeAndZkClientClass(anyParticipantManager, TEST_TARGET_TASK_THREAD_POOL_SIZE,
+        FederatedZkClient.class);
 
     // Turn off multiZk mode in System config, and remove zkAddress
     System.setProperty(SystemPropertyKeys.MULTI_ZK_ENABLED, "false");
     ZKHelixManager participantManager = Mockito.spy(anyParticipantManager);
     when(participantManager.getMetadataStoreConnectionString()).thenReturn(null);
-    zkClient = TaskStateModelFactory.createZkClient(participantManager);
-    verifyThreadPoolSizeAndZkClientClass(zkClient, anyParticipantManager,
-        TEST_TARGET_TASK_THREAD_POOL_SIZE, FederatedZkClient.class);
+    verifyThreadPoolSizeAndZkClientClass(participantManager, TEST_TARGET_TASK_THREAD_POOL_SIZE,
+        FederatedZkClient.class);
 
     // Test no connection config case
     when(participantManager.getRealmAwareZkConnectionConfig()).thenReturn(null);
-    zkClient = TaskStateModelFactory.createZkClient(participantManager);
-    verifyThreadPoolSizeAndZkClientClass(zkClient, anyParticipantManager,
-        TEST_TARGET_TASK_THREAD_POOL_SIZE, FederatedZkClient.class);
+    verifyThreadPoolSizeAndZkClientClass(participantManager, TEST_TARGET_TASK_THREAD_POOL_SIZE,
+        FederatedZkClient.class);
 
     // Remove server endpoint key and use connection config to specify endpoint
     System.clearProperty(SystemPropertyKeys.MSDS_SERVER_ENDPOINT_KEY);
@@ -118,9 +115,8 @@ public class TestTaskStateModelFactory extends TaskTestBase {
             .setRoutingDataSourceEndpoint(testMSDSServerEndpointKey)
             .setRoutingDataSourceType(RoutingDataReaderType.HTTP.name()).build();
     when(participantManager.getRealmAwareZkConnectionConfig()).thenReturn(connectionConfig);
-    zkClient = TaskStateModelFactory.createZkClient(participantManager);
-    verifyThreadPoolSizeAndZkClientClass(zkClient, anyParticipantManager,
-        TEST_TARGET_TASK_THREAD_POOL_SIZE, FederatedZkClient.class);
+    verifyThreadPoolSizeAndZkClientClass(participantManager, TEST_TARGET_TASK_THREAD_POOL_SIZE,
+        FederatedZkClient.class);
 
     // Restore system properties
     if (prevMultiZkEnabled == null) {
@@ -145,9 +141,8 @@ public class TestTaskStateModelFactory extends TaskTestBase {
     // Turn off multiZk mode in System config
     System.setProperty(SystemPropertyKeys.MULTI_ZK_ENABLED, "false");
 
-    RealmAwareZkClient zkClient = TaskStateModelFactory.createZkClient(anyParticipantManager);
-    verifyThreadPoolSizeAndZkClientClass(zkClient, anyParticipantManager,
-        TEST_TARGET_TASK_THREAD_POOL_SIZE, SharedZkClientFactory.InnerSharedZkClient.class);
+    verifyThreadPoolSizeAndZkClientClass(anyParticipantManager, TEST_TARGET_TASK_THREAD_POOL_SIZE,
+        SharedZkClientFactory.InnerSharedZkClient.class);
 
     // Restore system properties
     if (prevMultiZkEnabled == null) {
@@ -163,8 +158,9 @@ public class TestTaskStateModelFactory extends TaskTestBase {
     TaskStateModelFactory.createZkClient(new MockManager());
   }
 
-  private void verifyThreadPoolSizeAndZkClientClass(RealmAwareZkClient zkClient,
-      HelixManager helixManager, int threadPoolSize, Class<?> zkClientClass) {
+  private void verifyThreadPoolSizeAndZkClientClass(HelixManager helixManager, int threadPoolSize,
+      Class<?> zkClientClass) {
+    RealmAwareZkClient zkClient = TaskStateModelFactory.createZkClient(helixManager);
     try {
       Assert.assertEquals(TaskUtil.getTargetThreadPoolSize(zkClient, helixManager.getClusterName(),
           helixManager.getInstanceName()), threadPoolSize);

--- a/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
@@ -95,6 +95,7 @@ public class TestTaskStateModelFactory extends TaskTestBase {
         .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
             anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
     Assert.assertTrue(zkClient instanceof FederatedZkClient);
+    zkClient.close();
 
     // Turn off multiZk mode in System config, and remove zkAddress
     System.setProperty(SystemPropertyKeys.MULTI_ZK_ENABLED, "false");
@@ -105,6 +106,7 @@ public class TestTaskStateModelFactory extends TaskTestBase {
         .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
             anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
     Assert.assertTrue(zkClient instanceof FederatedZkClient);
+    zkClient.close();
 
     // Test no connection config case
     when(participantManager.getRealmAwareZkConnectionConfig()).thenReturn(null);
@@ -113,6 +115,7 @@ public class TestTaskStateModelFactory extends TaskTestBase {
         .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
             anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
     Assert.assertTrue(zkClient instanceof FederatedZkClient);
+    zkClient.close();
 
     // Remove server endpoint key and use connection config to specify endpoint
     System.clearProperty(SystemPropertyKeys.MSDS_SERVER_ENDPOINT_KEY);
@@ -127,6 +130,7 @@ public class TestTaskStateModelFactory extends TaskTestBase {
         .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
             anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
     Assert.assertTrue(zkClient instanceof FederatedZkClient);
+    zkClient.close();
 
     // Restore system properties
     if (prevMultiZkEnabled == null) {

--- a/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestTaskStateModelFactory.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.helix.HelixManager;
 import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.integration.task.TaskTestBase;
@@ -35,6 +36,7 @@ import org.apache.helix.msdcommon.mock.MockMetadataStoreDirectoryServer;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.constant.RoutingDataReaderType;
 import org.apache.helix.zookeeper.impl.client.FederatedZkClient;
+import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
 import org.apache.helix.zookeeper.routing.RoutingDataManager;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -91,31 +93,22 @@ public class TestTaskStateModelFactory extends TaskTestBase {
 
     RoutingDataManager.getInstance().reset();
     RealmAwareZkClient zkClient = TaskStateModelFactory.createZkClient(anyParticipantManager);
-    Assert.assertEquals(TaskUtil
-        .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
-            anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
-    Assert.assertTrue(zkClient instanceof FederatedZkClient);
-    zkClient.close();
+    verifyThreadPoolSizeAndZkClientClass(zkClient, anyParticipantManager,
+        TEST_TARGET_TASK_THREAD_POOL_SIZE, FederatedZkClient.class);
 
     // Turn off multiZk mode in System config, and remove zkAddress
     System.setProperty(SystemPropertyKeys.MULTI_ZK_ENABLED, "false");
     ZKHelixManager participantManager = Mockito.spy(anyParticipantManager);
     when(participantManager.getMetadataStoreConnectionString()).thenReturn(null);
     zkClient = TaskStateModelFactory.createZkClient(participantManager);
-    Assert.assertEquals(TaskUtil
-        .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
-            anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
-    Assert.assertTrue(zkClient instanceof FederatedZkClient);
-    zkClient.close();
+    verifyThreadPoolSizeAndZkClientClass(zkClient, anyParticipantManager,
+        TEST_TARGET_TASK_THREAD_POOL_SIZE, FederatedZkClient.class);
 
     // Test no connection config case
     when(participantManager.getRealmAwareZkConnectionConfig()).thenReturn(null);
     zkClient = TaskStateModelFactory.createZkClient(participantManager);
-    Assert.assertEquals(TaskUtil
-        .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
-            anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
-    Assert.assertTrue(zkClient instanceof FederatedZkClient);
-    zkClient.close();
+    verifyThreadPoolSizeAndZkClientClass(zkClient, anyParticipantManager,
+        TEST_TARGET_TASK_THREAD_POOL_SIZE, FederatedZkClient.class);
 
     // Remove server endpoint key and use connection config to specify endpoint
     System.clearProperty(SystemPropertyKeys.MSDS_SERVER_ENDPOINT_KEY);
@@ -126,11 +119,8 @@ public class TestTaskStateModelFactory extends TaskTestBase {
             .setRoutingDataSourceType(RoutingDataReaderType.HTTP.name()).build();
     when(participantManager.getRealmAwareZkConnectionConfig()).thenReturn(connectionConfig);
     zkClient = TaskStateModelFactory.createZkClient(participantManager);
-    Assert.assertEquals(TaskUtil
-        .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
-            anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
-    Assert.assertTrue(zkClient instanceof FederatedZkClient);
-    zkClient.close();
+    verifyThreadPoolSizeAndZkClientClass(zkClient, anyParticipantManager,
+        TEST_TARGET_TASK_THREAD_POOL_SIZE, FederatedZkClient.class);
 
     // Restore system properties
     if (prevMultiZkEnabled == null) {
@@ -156,9 +146,8 @@ public class TestTaskStateModelFactory extends TaskTestBase {
     System.setProperty(SystemPropertyKeys.MULTI_ZK_ENABLED, "false");
 
     RealmAwareZkClient zkClient = TaskStateModelFactory.createZkClient(anyParticipantManager);
-    Assert.assertEquals(TaskUtil
-        .getTargetThreadPoolSize(zkClient, anyParticipantManager.getClusterName(),
-            anyParticipantManager.getInstanceName()), TEST_TARGET_TASK_THREAD_POOL_SIZE);
+    verifyThreadPoolSizeAndZkClientClass(zkClient, anyParticipantManager,
+        TEST_TARGET_TASK_THREAD_POOL_SIZE, SharedZkClientFactory.InnerSharedZkClient.class);
 
     // Restore system properties
     if (prevMultiZkEnabled == null) {
@@ -172,5 +161,16 @@ public class TestTaskStateModelFactory extends TaskTestBase {
       expectedExceptions = UnsupportedOperationException.class)
   public void testZkClientCreationNonZKManager() {
     TaskStateModelFactory.createZkClient(new MockManager());
+  }
+
+  private void verifyThreadPoolSizeAndZkClientClass(RealmAwareZkClient zkClient,
+      HelixManager helixManager, int threadPoolSize, Class<?> zkClientClass) {
+    try {
+      Assert.assertEquals(TaskUtil.getTargetThreadPoolSize(zkClient, helixManager.getClusterName(),
+          helixManager.getInstanceName()), threadPoolSize);
+      Assert.assertEquals(zkClient.getClass(), zkClientClass);
+    } finally {
+      zkClient.close();
+    }
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1677 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

TaskStateModelFactory creates either a shared ZkClient or a FederatedZkClient to read the user-customized number for the configurable thread pool. Neither of the ZkClients are closed in the end, resulting in thread leakage. 

### Tests

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 1264, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,046.067 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1264, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:24 h
[INFO] Finished at: 2021-03-26T12:09:01-07:00
[INFO] ------------------------------------------------------------------------
```
### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
