### PR TITLE
Remove lock in HelixStateTransitionHandler

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -369,9 +369,7 @@ public class HelixStateTransitionHandler extends MessageHandler {
     taskResult.setCompleteTime(System.currentTimeMillis());
     // add task result to context for postHandling
     context.add(MapKey.HELIX_TASK_RESULT.toString(), taskResult);
-    synchronized (_stateModel) {
-      postHandleMessage();
-    }
+    postHandleMessage();
 
     return taskResult;
   }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -318,60 +318,62 @@ public class HelixStateTransitionHandler extends MessageHandler {
     NotificationContext context = _notificationContext;
     Message message = _message;
 
-    synchronized (_stateModel) {
-      HelixTaskResult taskResult = new HelixTaskResult();
-      HelixManager manager = context.getManager();
+    HelixTaskResult taskResult = new HelixTaskResult();
+    HelixManager manager = context.getManager();
 
-      _statusUpdateUtil.logInfo(message, HelixStateTransitionHandler.class,
-          "Message handling task begin execute", manager);
-      message.setExecuteStartTimeStamp(System.currentTimeMillis());
+    _statusUpdateUtil
+        .logInfo(message, HelixStateTransitionHandler.class, "Message handling task begin execute",
+            manager);
+    message.setExecuteStartTimeStamp(System.currentTimeMillis());
 
-      try {
-        preHandleMessage();
-        invoke(manager, context, taskResult, message);
-      } catch (HelixDuplicatedStateTransitionException e) {
-        // Duplicated state transition problem is fine
-        taskResult.setSuccess(true);
-        taskResult.setMessage(e.toString());
-        taskResult.setInfo(e.getMessage());
-      } catch (HelixStateMismatchException e) {
-        // Simply log error and return from here if State mismatch.
-        // The current state of the state model is intact.
+    try {
+      preHandleMessage();
+      invoke(manager, context, taskResult, message);
+    } catch (HelixDuplicatedStateTransitionException e) {
+      // Duplicated state transition problem is fine
+      taskResult.setSuccess(true);
+      taskResult.setMessage(e.toString());
+      taskResult.setInfo(e.getMessage());
+    } catch (HelixStateMismatchException e) {
+      // Simply log error and return from here if State mismatch.
+      // The current state of the state model is intact.
+      taskResult.setSuccess(false);
+      taskResult.setMessage(e.toString());
+      taskResult.setException(e);
+    } catch (Exception e) {
+      String errorMessage =
+          "Exception while executing a state transition task " + message.getPartitionName();
+      logger.error(errorMessage, e);
+      if (e.getCause() != null && e.getCause() instanceof InterruptedException) {
+        e = (InterruptedException) e.getCause();
+      }
+
+      if (e instanceof HelixRollbackException || (e.getCause() != null && e
+          .getCause() instanceof HelixRollbackException)) {
+        // TODO : Support cancel to any state
+        logger.info(
+            "Rollback happened of state transition on resource \"" + _message.getResourceName()
+                + "\" partition \"" + _message.getPartitionName() + "\" from \"" + _message
+                .getFromState() + "\" to \"" + _message.getToState() + "\"");
+        taskResult.setCancelled(true);
+      } else {
+        _statusUpdateUtil
+            .logError(message, HelixStateTransitionHandler.class, e, errorMessage, manager);
         taskResult.setSuccess(false);
         taskResult.setMessage(e.toString());
         taskResult.setException(e);
-      } catch (Exception e) {
-        String errorMessage =
-            "Exception while executing a state transition task " + message.getPartitionName();
-        logger.error(errorMessage, e);
-        if (e.getCause() != null && e.getCause() instanceof InterruptedException) {
-          e = (InterruptedException) e.getCause();
-        }
-
-        if (e instanceof HelixRollbackException
-            || (e.getCause() != null && e.getCause() instanceof HelixRollbackException)) {
-          // TODO : Support cancel to any state
-          logger.info("Rollback happened of state transition on resource \""
-              + _message.getResourceName() + "\" partition \"" + _message.getPartitionName()
-              + "\" from \"" + _message.getFromState() + "\" to \"" + _message.getToState() + "\"");
-          taskResult.setCancelled(true);
-        } else {
-          _statusUpdateUtil.logError(message, HelixStateTransitionHandler.class, e, errorMessage,
-              manager);
-          taskResult.setSuccess(false);
-          taskResult.setMessage(e.toString());
-          taskResult.setException(e);
-          taskResult.setInterrupted(e instanceof InterruptedException);
-        }
+        taskResult.setInterrupted(e instanceof InterruptedException);
       }
-
-      taskResult.setCompleteTime(System.currentTimeMillis());
-      // add task result to context for postHandling
-      context.add(MapKey.HELIX_TASK_RESULT.toString(), taskResult);
-      postHandleMessage();
-
-      return taskResult;
     }
+
+    taskResult.setCompleteTime(System.currentTimeMillis());
+    // add task result to context for postHandling
+    context.add(MapKey.HELIX_TASK_RESULT.toString(), taskResult);
+    synchronized (_stateModel) {
+      postHandleMessage();
+    }
+
+    return taskResult;
   }
 
   private void invoke(HelixManager manager, NotificationContext context, HelixTaskResult taskResult,


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1675 Remove requested state update in task framwork.
This is the first PR of the issue. 
This PR is for lock scope deduction only, because lock scope change expects more review and has independent logic itself.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

*High level design of the lock scope: 

We can prevent over write by checking the in memory state _stateModel and update ZK conditionally in message handling. Also the in memory state _stateModel update (in both task Runner thread and state transition handling thread), comparing and ZK update need to be protected by a lock.

*Is it safe to do so? 
In current message handling design, `HelixTaskExecutor` (a message lister that creates and schedules all message handler) guarantees that only one on going state transition per each partition/task at a time, removing this synchronization shouldn't cause any problem. 
When `onMessage` receives a STATE_TRANSITION_CANCELLATION messages and a ST message for the same entity, a `HelixStateTransitionCancellationHanlder` is created can call cancel(). Changing the lock scope does not have any influence on `HelixStateTransitionCancellationHanlder`.


*Why need to Remove lock in HelixStateTransitionHandle
In the design to remove requested state, task runner thread update CurrentState when task finishes or ends with error state. 
However, it is possible that the state transition handler is also trying to update CurrentState. It could be an INIT→ RUNNING, RUNNING→CANCEL, or any other state transition message message. We will run into the write conflict.
This PR removes this redundant synchronization. Will add a smaller scoped lock in the PR that removes requested state.


### Tests

- [X] The following tests are written for this issue:
Our current Task framework tests covers all state transition types, should be able to cover this change. 

- The following is the result of the "mvn test" command on the appropriate module:
```
[ERROR] Failures:                                                                                                                                                                      
[ERROR] org.apache.helix.integration.rebalancer.DelayedAutoRebalancer.TestDelayedAutoRebalanceWithDisabledInstance.beforeTest(org.apache.helix.integration.rebalancer.DelayedAutoRebalan
cer.TestDelayedAutoRebalanceWithDisabledInstance)                                                                                                                                      
[ERROR]   Run 1: TestDelayedAutoRebalanceWithDisabledInstance.beforeTest:304->enableInstance:315 expected:<true> but was:<false>                                                       
[INFO]   Run 2: PASS                                                                                                                                                                   
[INFO]                                                                                                                                                                                 
[INFO]                                                                        
[ERROR] Tests run: 9, Failures: 1, Errors: 0, Skipped: 6                       
[INFO]                                                        
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE                                                                                                                                                                   
[INFO] ------------------------------------------------------------------------                                          
[INFO] Total time:  40.449 s                                                                                                                                                           
[INFO] Finished at: 2021-04-19T16:45:27-07:00  
[INFO] ------------------------------------------------------------------------
rerun:
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 78.981 s - in org.apache.helix.integration.rebalancer.DelayedAutoRebalancer.TestDelayedAutoRebalanceWithDisabledI
nstance                                                            
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
