### PR TITLE
Change participant message monitor to use dynamic metric

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ParticipantMessageMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ParticipantMessageMonitor.java
@@ -46,7 +46,9 @@ public class ParticipantMessageMonitor extends DynamicMBeanProvider {
    * The current processed state of the message
    */
   public enum ProcessedMessageState {
-    DISCARDED, FAILED, COMPLETED
+    DISCARDED,
+    FAILED,
+    COMPLETED
   }
 
   public ParticipantMessageMonitor(String participantName, ObjectName objectName) {
@@ -84,7 +86,7 @@ public class ParticipantMessageMonitor extends DynamicMBeanProvider {
   }
 
   public void decrementPendingMessages(int count) {
-    decrementSimpleDynamicMetric(_pendingMessages, count);
+    incrementSimpleDynamicMetric(_pendingMessages, -1 * count);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ParticipantMessageMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ParticipantMessageMonitor.java
@@ -19,81 +19,72 @@ package org.apache.helix.monitoring.mbeans;
  * under the License.
  */
 
-public class ParticipantMessageMonitor implements ParticipantMessageMonitorMBean {
+import java.util.ArrayList;
+import java.util.List;
+import javax.management.JMException;
+import javax.management.ObjectName;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
+
+
+public class ParticipantMessageMonitor extends DynamicMBeanProvider {
   public static final String PARTICIPANT_KEY = "ParticipantName";
   public static final String PARTICIPANT_STATUS_KEY = "ParticipantMessageStatus";
+
+  // For registering dynamic metrics
+  private final ObjectName _initObjectName;
+  private final String _participantName;
+
+  private SimpleDynamicMetric<Long> _receivedMessages;
+  private SimpleDynamicMetric<Long> _discardedMessages;
+  private SimpleDynamicMetric<Long> _completedMessages;
+  private SimpleDynamicMetric<Long> _failedMessages;
+  private SimpleDynamicMetric<Long> _pendingMessages;
 
   /**
    * The current processed state of the message
    */
   public enum ProcessedMessageState {
-    DISCARDED,
-    FAILED,
-    COMPLETED
+    DISCARDED, FAILED, COMPLETED
   }
 
-  private final String _participantName;
-  private long _receivedMessages = 0;
-  private long _discardedMessages = 0;
-  private long _completedMessages = 0;
-  private long _failedMessages = 0;
-  private long _pendingMessages = 0;
-
-  public ParticipantMessageMonitor(String participantName) {
+  public ParticipantMessageMonitor(String participantName, ObjectName objectName) {
     _participantName = participantName;
+    _initObjectName = objectName;
+    _receivedMessages = new SimpleDynamicMetric("ReceivedMessages", 0L);
+    _discardedMessages = new SimpleDynamicMetric("DiscardedMessages", 0L);
+    _completedMessages = new SimpleDynamicMetric("CompletedMessages", 0L);
+    _failedMessages = new SimpleDynamicMetric("FailedMessages", 0L);
+    _pendingMessages = new SimpleDynamicMetric("PendingMessages", 0L);
   }
 
   public String getParticipantBeanName() {
     return String.format("%s=%s", PARTICIPANT_KEY, _participantName);
   }
 
-  public void incrementReceivedMessages(int count) {
-    _receivedMessages += count;
+  public void incrementReceivedMessages(long count) {
+    incrementSimpleDynamicMetric(_receivedMessages, count);
   }
 
   public void incrementDiscardedMessages(int count) {
-    _discardedMessages += count;
+    incrementSimpleDynamicMetric(_discardedMessages, count);
   }
 
   public void incrementCompletedMessages(int count) {
-    _completedMessages += count;
+    incrementSimpleDynamicMetric(_completedMessages, count);
   }
 
   public void incrementFailedMessages(int count) {
-    _failedMessages += count;
+    incrementSimpleDynamicMetric(_failedMessages, count);
   }
 
   public void incrementPendingMessages(int count) {
-    _pendingMessages += count;
+    incrementSimpleDynamicMetric(_pendingMessages, count);
   }
 
   public void decrementPendingMessages(int count) {
-    _pendingMessages -= count;
-  }
-
-  @Override
-  public long getReceivedMessages() {
-    return _receivedMessages;
-  }
-
-  @Override
-  public long getDiscardedMessages() {
-    return _discardedMessages;
-  }
-
-  @Override
-  public long getCompletedMessages() {
-    return _completedMessages;
-  }
-
-  @Override
-  public long getFailedMessages() {
-    return _failedMessages;
-  }
-
-  @Override
-  public long getPendingMessages() {
-    return _pendingMessages;
+    decrementSimpleDynamicMetric(_pendingMessages, count);
   }
 
   @Override
@@ -101,4 +92,20 @@ public class ParticipantMessageMonitor implements ParticipantMessageMonitorMBean
     return PARTICIPANT_STATUS_KEY;
   }
 
+  /**
+   * This method registers the dynamic metrics.
+   * @return
+   * @throws JMException
+   */
+  @Override
+  public DynamicMBeanProvider register() throws JMException {
+    List<DynamicMetric<?, ?>> attributeList = new ArrayList<>();
+    attributeList.add(_receivedMessages);
+    attributeList.add(_discardedMessages);
+    attributeList.add(_completedMessages);
+    attributeList.add(_failedMessages);
+    attributeList.add(_pendingMessages);
+    doRegister(attributeList, _initObjectName);
+    return this;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ParticipantMessageMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ParticipantMessageMonitorMBean.java
@@ -8,7 +8,6 @@ package org.apache.helix.monitoring.mbeans;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -21,7 +20,7 @@ package org.apache.helix.monitoring.mbeans;
 
 import org.apache.helix.monitoring.SensorNameProvider;
 
-
+@Deprecated
 public interface ParticipantMessageMonitorMBean extends SensorNameProvider {
   public long getReceivedMessages();
   public long getDiscardedMessages();

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ParticipantStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ParticipantStatusMonitor.java
@@ -49,7 +49,8 @@ public class ParticipantStatusMonitor {
     try {
       _beanServer = ManagementFactory.getPlatformMBeanServer();
       if (isParticipant) {
-        _messageMonitor = new ParticipantMessageMonitor(instanceName);
+        _messageMonitor =
+            new ParticipantMessageMonitor(instanceName, getObjectName(_messageMonitor.getParticipantBeanName()));
         _messageLatencyMonitor =
             new MessageLatencyMonitor(MonitorDomainNames.CLMParticipantReport.name(), instanceName);
         _messageLatencyMonitor.register();

--- a/metrics-common/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
+++ b/metrics-common/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
@@ -228,14 +228,6 @@ public abstract class DynamicMBeanProvider implements DynamicMBean, SensorNamePr
   }
 
   /**
-   * NOTE: This method is not thread-safe nor atomic.
-   * Decrement the value of a given SimpleDynamicMetric with input value.
-   */
-  protected void decrementSimpleDynamicMetric(SimpleDynamicMetric<Long> metric, long value) {
-    metric.updateValue(metric.getValue() - value);
-  }
-
-  /**
    * Return the interval length for the underlying reservoir used by the MBean metric configured
    * in the system env variables. If not found, use default value.
    */

--- a/metrics-common/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
+++ b/metrics-common/src/main/java/org/apache/helix/monitoring/mbeans/dynamicMBeans/DynamicMBeanProvider.java
@@ -228,6 +228,14 @@ public abstract class DynamicMBeanProvider implements DynamicMBean, SensorNamePr
   }
 
   /**
+   * NOTE: This method is not thread-safe nor atomic.
+   * Decrement the value of a given SimpleDynamicMetric with input value.
+   */
+  protected void decrementSimpleDynamicMetric(SimpleDynamicMetric<Long> metric, long value) {
+    metric.updateValue(metric.getValue() - value);
+  }
+
+  /**
    * Return the interval length for the underlying reservoir used by the MBean metric configured
    * in the system env variables. If not found, use default value.
    */


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixed #1683 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
ParticipantMessageMonitor used a static metric implementation. To uniform our metrics in Helix-core, we would like to convert all static metrics to dynamic metric framework. The PR serves as an example for this cleanup work. 

### Tests
helix-core
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestResourceChangeDetector.testResetSnapshots:453 expected:<0> but was:<1>
[ERROR]   TestPauseSignal.testPauseSignal:106 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1264, Failures: 2, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:35 h
[INFO] Finished at: 2021-03-24T13:38:47-07:00

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
