### PR TITLE
Add option to continue checks on failures for stoppable api

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/json/instance/StoppableCheck.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/json/instance/StoppableCheck.java
@@ -78,4 +78,9 @@ public class StoppableCheck {
   public List<String> getFailedChecks() {
     return failedChecks;
   }
+
+  public void add(StoppableCheck other) {
+    failedChecks.addAll(other.getFailedChecks());
+    isStoppable = failedChecks.isEmpty();
+  }
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -151,7 +151,7 @@ public class InstancesAccessor extends AbstractHelixResource {
   public Response instancesOperations(
       @PathParam("clusterId") String clusterId,
       @QueryParam("command") String command,
-      @QueryParam("allChecks") boolean allChecks,
+      @QueryParam("continueOnFailures") boolean continueOnFailures,
       @QueryParam("skipZKRead") boolean skipZKRead,
       String content) {
     Command cmd;
@@ -181,7 +181,7 @@ public class InstancesAccessor extends AbstractHelixResource {
         admin.enableInstance(clusterId, enableInstances, false);
         break;
       case stoppable:
-        return batchGetStoppableInstances(clusterId, node, skipZKRead, allChecks);
+        return batchGetStoppableInstances(clusterId, node, skipZKRead, continueOnFailures);
       default:
         _logger.error("Unsupported command :" + command);
         return badRequest("Unsupported command :" + command);
@@ -198,7 +198,7 @@ public class InstancesAccessor extends AbstractHelixResource {
   }
 
   private Response batchGetStoppableInstances(String clusterId, JsonNode node, boolean skipZKRead,
-      boolean allChecks) throws IOException {
+      boolean continueOnFailures) throws IOException {
     try {
       // TODO: Process input data from the content
       InstancesAccessor.InstanceHealthSelectionBase selectionBase =
@@ -228,7 +228,7 @@ public class InstancesAccessor extends AbstractHelixResource {
           InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
       InstanceService instanceService =
           new InstanceServiceImpl((ZKHelixDataAccessor) getDataAccssor(clusterId),
-              getConfigAccessor(), skipZKRead, allChecks, getNamespace());
+              getConfigAccessor(), skipZKRead, continueOnFailures, getNamespace());
       ClusterService clusterService = new ClusterServiceImpl(getDataAccssor(clusterId), getConfigAccessor());
       ClusterTopology clusterTopology = clusterService.getClusterTopology(clusterId);
       switch (selectionBase) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -148,8 +148,12 @@ public class InstancesAccessor extends AbstractHelixResource {
   @ResponseMetered(name = HttpConstants.WRITE_REQUEST)
   @Timed(name = HttpConstants.WRITE_REQUEST)
   @POST
-  public Response instancesOperations(@PathParam("clusterId") String clusterId,
-      @QueryParam("skipZKRead") String skipZKRead, @QueryParam("command") String command, String content) {
+  public Response instancesOperations(
+      @PathParam("clusterId") String clusterId,
+      @QueryParam("command") String command,
+      @QueryParam("allChecks") boolean allChecks,
+      @QueryParam("skipZKRead") boolean skipZKRead,
+      String content) {
     Command cmd;
     try {
       cmd = Command.valueOf(command);
@@ -177,7 +181,7 @@ public class InstancesAccessor extends AbstractHelixResource {
         admin.enableInstance(clusterId, enableInstances, false);
         break;
       case stoppable:
-        return batchGetStoppableInstances(clusterId, node, Boolean.valueOf(skipZKRead));
+        return batchGetStoppableInstances(clusterId, node, skipZKRead, allChecks);
       default:
         _logger.error("Unsupported command :" + command);
         return badRequest("Unsupported command :" + command);
@@ -193,7 +197,8 @@ public class InstancesAccessor extends AbstractHelixResource {
     return OK();
   }
 
-  private Response batchGetStoppableInstances(String clusterId, JsonNode node, boolean skipZKRead) throws IOException {
+  private Response batchGetStoppableInstances(String clusterId, JsonNode node, boolean skipZKRead,
+      boolean allChecks) throws IOException {
     try {
       // TODO: Process input data from the content
       InstancesAccessor.InstanceHealthSelectionBase selectionBase =
@@ -223,7 +228,7 @@ public class InstancesAccessor extends AbstractHelixResource {
           InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
       InstanceService instanceService =
           new InstanceServiceImpl((ZKHelixDataAccessor) getDataAccssor(clusterId),
-              getConfigAccessor(), skipZKRead, getNamespace());
+              getConfigAccessor(), skipZKRead, allChecks, getNamespace());
       ClusterService clusterService = new ClusterServiceImpl(getDataAccssor(clusterId), getConfigAccessor());
       ClusterTopology clusterTopology = clusterService.getClusterTopology(clusterId);
       switch (selectionBase) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -138,9 +138,9 @@ public class PerInstanceAccessor extends AbstractHelixResource {
    * @param clusterId cluster id
    * @param instanceName Instance name to be checked
    * @param skipZKRead skip reading from zk server
-   * @param allChecks whether or not force to do all checks including helix own check,
+   * @param allChecks whether or not force to perform all checks including helix own check,
    *                  custom instance check and custom partition check. If false, when helix own
-   *                  check fails, the succeeding checks will not be performed.
+   *                  check fails, the subsequent custom checks will not be performed.
    * @return json response representing if queried instance is stoppable
    * @throws IOException if there is any IO/network error
    */
@@ -159,13 +159,13 @@ public class PerInstanceAccessor extends AbstractHelixResource {
     InstanceService instanceService =
         new InstanceServiceImpl((ZKHelixDataAccessor) dataAccessor, getConfigAccessor(), skipZKRead,
             allChecks, getNamespace());
-    StoppableCheck stoppableCheck = null;
+    StoppableCheck stoppableCheck;
     try {
       stoppableCheck =
           instanceService.getInstanceStoppableCheck(clusterId, instanceName, jsonContent);
     } catch (HelixException e) {
-      LOG.error(String.format("Current cluster %s has issue with health checks!", clusterId),
-          e);
+      LOG.error("Current cluster: {}, instance: {} has issue with health checks!", clusterId,
+          instanceName, e);
       return serverError(e);
     }
     return OK(OBJECT_MAPPER.writeValueAsString(stoppableCheck));

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -138,9 +138,9 @@ public class PerInstanceAccessor extends AbstractHelixResource {
    * @param clusterId cluster id
    * @param instanceName Instance name to be checked
    * @param skipZKRead skip reading from zk server
-   * @param allChecks whether or not force to perform all checks including helix own check,
-   *                  custom instance check and custom partition check. If false, when helix own
-   *                  check fails, the subsequent custom checks will not be performed.
+   * @param continueOnFailures whether or not continue to perform the subsequent checks if previous
+   *                           check fails. If false, when helix own check fails, the subsequent
+   *                           custom checks will not be performed.
    * @return json response representing if queried instance is stoppable
    * @throws IOException if there is any IO/network error
    */
@@ -154,11 +154,11 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       @PathParam("clusterId") String clusterId,
       @PathParam("instanceName") String instanceName,
       @QueryParam("skipZKRead") boolean skipZKRead,
-      @QueryParam("allChecks") boolean allChecks) throws IOException {
+      @QueryParam("continueOnFailures") boolean continueOnFailures) throws IOException {
     HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
     InstanceService instanceService =
         new InstanceServiceImpl((ZKHelixDataAccessor) dataAccessor, getConfigAccessor(), skipZKRead,
-            allChecks, getNamespace());
+            continueOnFailures, getNamespace());
     StoppableCheck stoppableCheck;
     try {
       stoppableCheck =

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
@@ -74,7 +74,7 @@ public class InstanceServiceImpl implements InstanceService {
   private final CustomRestClient _customRestClient;
   private final String _namespace;
   private final boolean _skipZKRead;
-  private final boolean _allChecks;
+  private final boolean _continueOnFailures;
 
   @Deprecated
   public InstanceServiceImpl(ZKHelixDataAccessor dataAccessor, ConfigAccessor configAccessor) {
@@ -87,7 +87,6 @@ public class InstanceServiceImpl implements InstanceService {
     this(dataAccessor, configAccessor, skipZKRead, HelixRestNamespace.DEFAULT_NAMESPACE_NAME);
   }
 
-  @Deprecated
   public InstanceServiceImpl(ZKHelixDataAccessor dataAccessor, ConfigAccessor configAccessor,
       boolean skipZKRead, String namespace) {
     this(dataAccessor, configAccessor, CustomRestClientFactory.get(), skipZKRead, false, namespace);
@@ -95,19 +94,20 @@ public class InstanceServiceImpl implements InstanceService {
 
   // TODO: too many params, convert to builder pattern
   public InstanceServiceImpl(ZKHelixDataAccessor dataAccessor, ConfigAccessor configAccessor,
-      boolean skipZKRead, boolean allChecks, String namespace) {
-    this(dataAccessor, configAccessor, CustomRestClientFactory.get(), skipZKRead, allChecks,
-        namespace);
+      boolean skipZKRead, boolean continueOnFailures, String namespace) {
+    this(dataAccessor, configAccessor, CustomRestClientFactory.get(), skipZKRead,
+        continueOnFailures, namespace);
   }
 
   @VisibleForTesting
   InstanceServiceImpl(ZKHelixDataAccessor dataAccessor, ConfigAccessor configAccessor,
-      CustomRestClient customRestClient, boolean skipZKRead, boolean allChecks, String namespace) {
+      CustomRestClient customRestClient, boolean skipZKRead, boolean continueOnFailures,
+      String namespace) {
     _dataAccessor = new HelixDataAccessorWrapper(dataAccessor, customRestClient, namespace);
     _configAccessor = configAccessor;
     _customRestClient = customRestClient;
     _skipZKRead = skipZKRead;
-    _allChecks = allChecks;
+    _continueOnFailures = continueOnFailures;
     _namespace = namespace;
   }
 
@@ -248,7 +248,7 @@ public class InstanceServiceImpl implements InstanceService {
           // put the check result of the failed-to-stop instances
           addStoppableCheck(finalStoppableCheckByInstance, instance, stoppableCheck);
         }
-        if (stoppableCheck.isStoppable() || _allChecks){
+        if (stoppableCheck.isStoppable() || _continueOnFailures){
           // instance passed this around of check or mandatory all checks
           // will be checked in the next round
           instancesForNextCheck.add(instance);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
@@ -231,9 +231,7 @@ public class InstanceServiceImpl implements InstanceService {
       stoppableChecks.put(instance, stoppableCheck);
     } else {
       // Merge two checks
-      StoppableCheck existedCheck = stoppableChecks.get(instance);
-      existedCheck.add(stoppableCheck);
-      stoppableChecks.put(instance, existedCheck);
+      stoppableChecks.get(instance).add(stoppableCheck);
     }
   }
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -31,7 +31,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.helix.TestHelper;
@@ -45,7 +44,6 @@ import org.testng.annotations.Test;
 
 public class TestInstancesAccessor extends AbstractTestClass {
   private final static String CLUSTER_NAME = "TestCluster_0";
-  private ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Test
   public void testInstancesStoppable_zoneBased() throws IOException {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -62,8 +62,13 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/stoppable")
         .format(STOPPABLE_CLUSTER, "instance1").post(this, entity);
     String stoppableCheckResult = response.readEntity(String.class);
-    Assert.assertEquals(stoppableCheckResult,
-        "{\"stoppable\":false,\"failedChecks\":[\"HELIX:EMPTY_RESOURCE_ASSIGNMENT\",\"HELIX:INSTANCE_NOT_ENABLED\",\"HELIX:INSTANCE_NOT_STABLE\"]}");
+
+    Map<String, Object> actualMap = OBJECT_MAPPER.readValue(stoppableCheckResult, Map.class);
+    List<String> failedChecks = Arrays.asList("HELIX:EMPTY_RESOURCE_ASSIGNMENT",
+        "HELIX:INSTANCE_NOT_ENABLED", "HELIX:INSTANCE_NOT_STABLE");
+    Map<String, Object> expectedMap =
+        ImmutableMap.of("stoppable", false, "failedChecks", failedChecks);
+    Assert.assertEquals(actualMap, expectedMap);
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
@@ -295,8 +295,8 @@ public class TestInstanceService {
 
   private static class MockInstanceServiceImpl extends InstanceServiceImpl {
     MockInstanceServiceImpl(ZKHelixDataAccessor dataAccessor, ConfigAccessor configAccessor,
-        CustomRestClient customRestClient, boolean skipZKRead, boolean allChecks) {
-      super(dataAccessor, configAccessor, customRestClient, skipZKRead, allChecks,
+        CustomRestClient customRestClient, boolean skipZKRead, boolean continueOnFailures) {
+      super(dataAccessor, configAccessor, customRestClient, skipZKRead, continueOnFailures,
           HelixRestNamespace.DEFAULT_NAMESPACE_NAME);
     }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1688 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Helix stoppable check currently does the check in 3 sequential stages: Helix standard checks, custom instance health check and custom partition health check. When one stage had any failure, the subsequent stages are not executed.

This poses an issue that if participant happens to ignore all the failed checks in stage 1 but stage 2/3 would have reported some other failures, then it would think it's safe to stop the instance when it's in fact not safe. For example, if an instance would fail INSTANCE_NOT_STABLE in stage 1 and custom partition health check in stage 3, Helix will only return INSTANCE_NOT_STABLE and if participant ignores this failure reason, it will consider the instance safe to stop when it's not.

Provide an option in Helix stoppable check API, such that when the option is used, Helix will always perform all checks and return all failed checks. Query param: **continueOnFailures**

### Tests

- [x] The following tests are written for this issue:

- testGetStoppableWithAllChecks

- The following is the result of the "mvn test" command on the appropriate module:

Helix rest
```
17:14:54,948 [INFO] Tests run: 172, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 92.112 s - in TestSuite
17:14:55,296 [INFO]
17:14:55,296 [INFO] Results:
17:14:55,296 [INFO]
17:14:55,296 [INFO] Tests run: 172, Failures: 0, Errors: 0, Skipped: 0
17:14:55,297 [INFO]
17:14:55,305 [INFO] ------------------------------------------------------------------------
17:14:55,305 [INFO] BUILD SUCCESS
17:14:55,306 [INFO] ------------------------------------------------------------------------
17:14:55,308 [INFO] Total time:  01:36 min
17:14:55,309 [INFO] Finished at: 2021-03-25T17:14:55-07:00
17:14:55,309 [INFO] ------------------------------------------------------------------------
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
