### PR TITLE
Directly use Best Possible State to calculate DifferenceWithIdealStateGauge metrics instead of relying on the persisted IdealState.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -205,7 +205,9 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
     // As we are not listening on external view change, external view will be
     // refreshed once during the cache's first refresh() call, or when full refresh is required
     if (_propertyDataChangedMap.get(HelixConstants.ChangeType.EXTERNAL_VIEW).getAndSet(false)) {
-      _externalViewCache.refresh(accessor);
+      synchronized (_externalViewCache) {
+        _externalViewCache.refresh(accessor);
+      }
     }
   }
 
@@ -269,7 +271,9 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
    * @return
    */
   public Map<String, ExternalView> getExternalViews() {
-    return _externalViewCache.getPropertyMap();
+    synchronized (_externalViewCache) {
+      return _externalViewCache.getPropertyMap();
+    }
   }
 
   /**
@@ -277,8 +281,10 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
    * @param externalViews
    */
   public void updateExternalViews(List<ExternalView> externalViews) {
-    for (ExternalView ev : externalViews) {
-      _externalViewCache.setProperty(ev);
+    synchronized (_externalViewCache) {
+      for (ExternalView ev : externalViews) {
+        _externalViewCache.setProperty(ev);
+      }
     }
   }
 
@@ -312,8 +318,10 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
    */
 
   public void removeExternalViews(List<String> resourceNames) {
-    for (String resourceName : resourceNames) {
-      _externalViewCache.deletePropertyByName(resourceName);
+    synchronized (_externalViewCache) {
+      for (String resourceName : resourceNames) {
+        _externalViewCache.deletePropertyByName(resourceName);
+      }
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ExternalViewComputeStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ExternalViewComputeStage.java
@@ -182,11 +182,8 @@ public class ExternalViewComputeStage extends AbstractAsyncBaseStage {
           && (resourceConfig == null || !resourceConfig.isMonitoringDisabled()) // monitoring not disabled
           && !idealState.getStateModelDefRef() // and not a job resource
           .equalsIgnoreCase(DefaultSchedulerMessageHandlerFactory.SCHEDULER_TASK_QUEUE)) {
-        StateModelDefinition stateModelDef =
-            cache.getStateModelDef(idealState.getStateModelDefRef());
         clusterStatusMonitor
-            .setResourceStatus(view, cache.getIdealState(view.getResourceName()),
-                stateModelDef, totalPendingMessageCount);
+            .setResourcePendingMessages(resourceName ,totalPendingMessageCount);
         monitoringResources.add(resourceName);
       }
     }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -533,17 +533,28 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     }
   }
 
-  public void setResourceStatus(ExternalView externalView, IdealState idealState,
-      StateModelDefinition stateModelDef, int messageCount) {
+  public void setResourceState(String resourceName, ExternalView externalView,
+      IdealState idealState, StateModelDefinition stateModelDef) {
     try {
-      ResourceMonitor resourceMonitor = getOrCreateResourceMonitor(externalView.getId());
+      ResourceMonitor resourceMonitor = getOrCreateResourceMonitor(resourceName);
 
       if (resourceMonitor != null) {
         resourceMonitor.updateResourceState(externalView, idealState, stateModelDef);
-        resourceMonitor.updatePendingStateTransitionMessages(messageCount);
       }
     } catch (Exception e) {
       LOG.error("Fail to set resource status, resource: " + idealState.getResourceName(), e);
+    }
+  }
+
+  public void setResourcePendingMessages(String resourceName, int messageCount) {
+    try {
+      ResourceMonitor resourceMonitor = getOrCreateResourceMonitor(resourceName);
+
+      if (resourceMonitor != null) {
+        resourceMonitor.updatePendingStateTransitionMessages(messageCount);
+      }
+    } catch (Exception e) {
+      LOG.error("Fail to set pending resource messages, resource: " + resourceName, e);
     }
   }
 

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterAggregateMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterAggregateMetrics.java
@@ -181,7 +181,7 @@ public class TestClusterAggregateMetrics extends ZkTestBase {
     Assert.assertEquals(_beanValueMap.get(PARTITION_COUNT), 5L);
     Assert.assertEquals(_beanValueMap.get(ERROR_PARTITION_COUNT), 0L);
     Assert.assertEquals(_beanValueMap.get(WITHOUT_TOPSTATE_COUNT), 5L);
-    Assert.assertEquals(_beanValueMap.get(IS_EV_MISMATCH_COUNT), 5L);
+    Assert.assertEquals(_beanValueMap.get(IS_EV_MISMATCH_COUNT), 0L);
 
     // Re-enable all Participants (instances)
     for (int i = 0; i < NUM_PARTICIPANTS; i++) {

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -278,7 +278,7 @@ public class TestClusterStatusMonitor {
     StateModelDefinition stateModelDef =
         BuiltInStateModelDefinitions.MasterSlave.getStateModelDefinition();
 
-    monitor.setResourceStatus(externalView, idealState, stateModelDef, 0);
+    monitor.setResourceState(testDB, externalView, idealState, stateModelDef);
 
     Assert.assertEquals(monitor.getTotalPartitionGauge(), numPartition);
     Assert.assertEquals(monitor.getTotalResourceGauge(), 1);
@@ -287,7 +287,7 @@ public class TestClusterStatusMonitor {
     Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), 0);
     Assert.assertEquals(monitor.getStateTransitionCounter(), 0);
     Assert.assertEquals(monitor.getPendingStateTransitionGuage(), 0);
-
+    Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), 0);
 
     int lessMinActiveReplica = 6;
     Random r = new Random();
@@ -311,13 +311,14 @@ public class TestClusterStatusMonitor {
       externalView.setStateMap(partition, map);
     }
 
-    monitor.setResourceStatus(externalView, idealState, stateModelDef, 0);
+    monitor.setResourceState(testDB, externalView, idealState, stateModelDef);
     Assert.assertEquals(monitor.getTotalPartitionGauge(), numPartition);
     Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), lessMinActiveReplica);
     Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0);
     Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), lessMinActiveReplica);
     Assert.assertEquals(monitor.getStateTransitionCounter(), 0);
     Assert.assertEquals(monitor.getPendingStateTransitionGuage(), 0);
+    Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), lessMinActiveReplica);
 
     int missTopState = 7;
     externalView = new ExternalView(TestResourceMonitor.deepCopyZNRecord(idealStateRecord));
@@ -339,13 +340,14 @@ public class TestClusterStatusMonitor {
       externalView.setStateMap(partition, map);
     }
 
-    monitor.setResourceStatus(externalView, idealState, stateModelDef, 0);
+    monitor.setResourceState(testDB, externalView, idealState, stateModelDef);
     Assert.assertEquals(monitor.getTotalPartitionGauge(), numPartition);
     Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), 0);
     Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), missTopState);
     Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), missTopState);
     Assert.assertEquals(monitor.getStateTransitionCounter(), 0);
     Assert.assertEquals(monitor.getPendingStateTransitionGuage(), 0);
+    Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), missTopState);
 
     int missReplica = 5;
     externalView = new ExternalView(TestResourceMonitor.deepCopyZNRecord(idealStateRecord));
@@ -364,13 +366,14 @@ public class TestClusterStatusMonitor {
       externalView.setStateMap(partition, map);
     }
 
-    monitor.setResourceStatus(externalView, idealState, stateModelDef, 0);
+    monitor.setResourceState(testDB, externalView, idealState, stateModelDef);
     Assert.assertEquals(monitor.getTotalPartitionGauge(), numPartition);
     Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), 0);
     Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0);
     Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), missReplica);
     Assert.assertEquals(monitor.getStateTransitionCounter(), 0);
     Assert.assertEquals(monitor.getPendingStateTransitionGuage(), 0);
+    Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), missReplica);
 
     int messageCount = 4;
     List<Message> messages = new ArrayList<>();
@@ -386,7 +389,7 @@ public class TestClusterStatusMonitor {
 
     // test pending state transition message report and read
     messageCount = new Random().nextInt(numPartition) + 1;
-    monitor.setResourceStatus(externalView, idealState, stateModelDef, messageCount);
+    monitor.setResourcePendingMessages(testDB, messageCount);
     Assert.assertEquals(monitor.getPendingStateTransitionGuage(), messageCount);
 
     // Reset monitor.


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolve #1670 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR aims to resolve the undesired dependencies between DifferenceWithIdealStateGauge metric and the PERSIST_XXXXXX_ASSIGNMENT configuration. Before the change, if the assignment is not persisted, then the metric will report incorrect data.
To fix the issue, the calculation must be moved from the ExternalViewComputeStage to the BestPossibleStateCalcStage. Because the Best Possible State is only available in the BestPossibleStateCalcStage assuming the PERSIST_XXXXXX_ASSIGNMENT option is not turned on. In addition to the main logic migration, other changes listed following are required to ensure multi-thread safety.
1. Concurrent control of the EV cache since it will now be read in the BestPossibleStateCalcStage in addition to the ExternalViewComputeStage.
2. Minor changes in the diff computing logic for the corner cases since the Best Possible State state mapping is not exactly the same as IdealState persist assignment.
3. Cleanup PersistAssignmentStage logic so it won't modify the IdealState cache anymore. It is supposed to be read-only.
4. Test cases are modified to cover the changes. Also, the metric is now reporting correct results in some corner cases such as all the nodes are disabled. The test cases which are testing based on the wrong behavior have been fixed.

### Tests

- [X] The following tests are written for this issue:

Modify TestClusterAggregateMetrics.java according to the new behavior.
Adding new checks in TestClusterStatusMonitor.java to validate the DifferenceWithIdealStateGauge result.

- The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 1264, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,080.412 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1264, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:24 h
[INFO] Finished at: 2021-04-13T20:15:05-07:00
[INFO] ------------------------------------------------------------------------

Note that TestCleanupExternalView is not stable currently. It frequently fails in the master branch too. We will take care of that separately.

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
