### PR TITLE
Add PR Template Section for Backward Compatibility Breaking Changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,12 @@ Any of the following keywords can be used: close, closes, closed, fix, fixes, fi
 
 (If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)
 
+### Changes that Break Backward Compatibility (Optional)
+
+- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
+
+(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)
+
 ### Documentation (Optional)
 
 - In case of new functionality, my PR adds documentation in the following wiki page:


### PR DESCRIPTION
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Updates the PR template to include a section where developers can include changes that break backward compatibility. They are encouraged to include these changes in the commit description so that other developers can be easily aware of them. 

This is motivated by the fact that feature branches may not be updated by non-backward-compatible changes applied to the master branch. That could cause incorrect or incomplete logic in the feature branch that becomes erroneous after merging. 