### PR TITLE
Disable CORS by default in Helix REST

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
@@ -56,6 +56,7 @@ public class HelixRestServer {
   private static Logger LOG = LoggerFactory.getLogger(HelixRestServer.class);
 
   private static final String REST_DOMAIN = "org.apache.helix.rest";
+  private static final String CORS_ENABLED = "cors.enabled";
 
   // TODO: consider moving the following static context to ServerContext or any other place
   public static SSLContext REST_SERVER_SSL_CONTEXT;
@@ -164,7 +165,10 @@ public class HelixRestServer {
     }
     cfg.property(ContextPropertyKeys.METADATA.name(), namespace);
 
-    cfg.register(new CORSFilter());
+    if (Boolean.getBoolean(CORS_ENABLED)) {
+      // NOTE: CORS is disabled by default unless otherwise specified in System Properties.
+      cfg.register(new CORSFilter());
+    }
     cfg.register(new AuditLogFilter(_auditLoggers));
     return cfg;
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/filters/CORSFilter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/filters/CORSFilter.java
@@ -36,11 +36,15 @@ public class CORSFilter implements ContainerRequestFilter, ContainerResponseFilt
     if (request.getMethod().equalsIgnoreCase("OPTIONS")) {
       Response.ResponseBuilder builder = Response.ok();
 
+      // NOTE: Allow whichever HTTP Methods requested in the incoming request because the cluster
+      // administrator must be able to trigger such operations
+      // Helix REST uses GET, PUT, DELETE, POST
       String requestMethods = request.getHeaderString("Access-Control-Request-Method");
       if (requestMethods != null) {
         builder.header("Access-Control-Allow-Methods", requestMethods);
       }
 
+      // NOTE: All headers must be allowed for preflight
       String allowHeaders = request.getHeaderString("Access-Control-Request-Headers");
       if (allowHeaders != null) {
         builder.header("Access-Control-Allow-Headers", allowHeaders);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1704 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

CORS headers won't be included by default. If the REST admin wants to enable CORS, then they can do so by setting the boolean flag in System.Properties.

### Tests

- [ ] The following tests are written for this issue:

Will be tested manually.

- The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 173, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 244.489 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 173, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:14 min
[INFO] Finished at: 2021-04-21T14:02:23-07:00
[INFO] ------------------------------------------------------------------------

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
