### PR TITLE
Fix flaky TestAssignableInstanceManager

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/task/TestAssignableInstanceManager.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestAssignableInstanceManager.java
@@ -116,7 +116,7 @@ public class TestAssignableInstanceManager {
     }
   }
 
-  @Test
+  @Test(dependsOnMethods = "testGetAssignableInstanceMap")
   public void testGetTaskAssignResultMap() {
     Map<String, TaskAssignResult> taskAssignResultMap =
         _assignableInstanceManager.getTaskAssignResultMap();
@@ -125,7 +125,7 @@ public class TestAssignableInstanceManager {
     }
   }
 
-  @Test
+  @Test(dependsOnMethods = "testGetTaskAssignResultMap")
   public void testUpdateAssignableInstances() {
     Map<String, LiveInstance> newLiveInstances = new HashMap<>();
     Map<String, InstanceConfig> newInstanceConfigs = new HashMap<>();


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1707 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

If `testUpdateAssignableInstances` runs before `testGetAssignableInstanceMap`, `testGetAssignableInstanceMap` fails consistently because `testUpdateAssignableInstances` removed the old live instances that has already been populated. 

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

```
[ERROR] Tests run: 1265, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 5,081.347 s <<< FAILURE! - in TestSuite
[ERROR] testResetSnapshots(org.apache.helix.controller.changedetector.TestResourceChangeDetector)  Time elapsed: 0.081 s  <<< FAILURE!
java.lang.AssertionError: expected:<0> but was:<1>
        at org.apache.helix.controller.changedetector.TestResourceChangeDetector.testResetSnapshots(TestResourceChangeDetector.java:453)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestResourceChangeDetector.testResetSnapshots:453 expected:<0> but was:<1>
[INFO] 
[ERROR] Tests run: 1265, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:24 h
[INFO] Finished at: 2021-04-22T15:02:13-07:00
[INFO] ------------------------------------------------------------------------
```

```
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.331 s - in org.apache.helix.controller.changedetector.TestResourceChangeDetector
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /home/nesun/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 890 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  39.415 s
[INFO] Finished at: 2021-04-22T18:12:31-07:00
[INFO] ------------------------------------------------------------------------
```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
