### PR TITLE
Enforce the jacoco-maven-plugin version to avoid warning message.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -781,6 +781,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.6</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

This is to avoid the build warning that the version of jacoco-maven-plugin is not setup.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Enforce the jacoco-maven-plugin version to avoid warning message.

### Tests

- [X] The following tests are written for this issue:

Tested by building the project.

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
