### PR TITLE
Clarify error for ZkSessionMismatchedException in ZkAsyncCallbacks

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1962,8 +1962,10 @@ public class ZkClient implements Watcher {
       });
     } catch (RuntimeException e) {
       // Process callback to release caller from waiting
-      cb.processResult(ZkAsyncCallbacks.UNKNOWN_RET_CODE, path,
-          new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
+      int rc =
+          (e instanceof ZkSessionMismatchedException) ? ZkAsyncCallbacks.ZK_SESSION_MISMATCHED_CODE
+              : ZkAsyncCallbacks.UNKNOWN_RET_CODE;
+      cb.processResult(rc, path, new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
       throw e;
     }
   }
@@ -2000,8 +2002,10 @@ public class ZkClient implements Watcher {
       });
     } catch (RuntimeException e) {
       // Process callback to release caller from waiting
-      cb.processResult(ZkAsyncCallbacks.UNKNOWN_RET_CODE, path,
-          new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
+      int rc =
+          (e instanceof ZkSessionMismatchedException) ? ZkAsyncCallbacks.ZK_SESSION_MISMATCHED_CODE
+              : ZkAsyncCallbacks.UNKNOWN_RET_CODE;
+      cb.processResult(rc, path, new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
       throw e;
     }
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1960,12 +1960,15 @@ public class ZkClient implements Watcher {
                 });
         return null;
       });
+    } catch (ZkSessionMismatchedException e) {
+      // Process callback to release caller from waiting
+      cb.processResult(ZkAsyncCallbacks.ZK_SESSION_MISMATCHED_CODE, path,
+          new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
+      throw e;
     } catch (RuntimeException e) {
       // Process callback to release caller from waiting
-      int rc =
-          (e instanceof ZkSessionMismatchedException) ? ZkAsyncCallbacks.ZK_SESSION_MISMATCHED_CODE
-              : ZkAsyncCallbacks.UNKNOWN_RET_CODE;
-      cb.processResult(rc, path, new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
+      cb.processResult(ZkAsyncCallbacks.UNKNOWN_RET_CODE, path,
+          new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
       throw e;
     }
   }
@@ -2000,12 +2003,15 @@ public class ZkClient implements Watcher {
             });
         return null;
       });
+    } catch (ZkSessionMismatchedException e) {
+      // Process callback to release caller from waiting
+      cb.processResult(ZkAsyncCallbacks.ZK_SESSION_MISMATCHED_CODE, path,
+          new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
+      throw e;
     } catch (RuntimeException e) {
       // Process callback to release caller from waiting
-      int rc =
-          (e instanceof ZkSessionMismatchedException) ? ZkAsyncCallbacks.ZK_SESSION_MISMATCHED_CODE
-              : ZkAsyncCallbacks.UNKNOWN_RET_CODE;
-      cb.processResult(rc, path, new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
+      cb.processResult(ZkAsyncCallbacks.UNKNOWN_RET_CODE, path,
+          new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
       throw e;
     }
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
@@ -299,7 +299,7 @@ public class ZkAsyncCallbacks {
           return false;
         }
       } catch (ClassCastException | NullPointerException ex) {
-          LOG.error("Failed to handle unknown return code {}. Skip retrying.", rc, ex);
+        LOG.error("Failed to handle unknown return code {}. Skip retrying.", rc, ex);
         return false;
       }
     }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 public class ZkAsyncCallbacks {
   private static Logger LOG = LoggerFactory.getLogger(ZkAsyncCallbacks.class);
   public static final int UNKNOWN_RET_CODE = 255;
+  public static final int ZK_SESSION_MISMATCHED_CODE = 127;
 
   public static class GetDataCallbackHandler extends DefaultCallback implements DataCallback {
     public byte[] _data;
@@ -289,7 +290,11 @@ public class ZkAsyncCallbacks {
           return false;
         }
       } catch (ClassCastException | NullPointerException ex) {
-        LOG.error("Failed to handle unknown return code {}. Skip retrying.", rc, ex);
+        if(rc == ZK_SESSION_MISMATCHED_CODE) {
+          LOG.error("Actual session ID doesn't match with expected session ID. Skip retrying.");
+        } else {
+          LOG.error("Failed to handle unknown return code {}. Skip retrying.", rc, ex);
+        }
         return false;
       }
     }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -887,7 +887,7 @@ public class TestRawZkClient extends ZkTestBase {
 
       // Ensure the async callback is cancelled because of the exception
       Assert.assertTrue(createCallback.waitForSuccess(), "Callback operation should be done");
-      Assert.assertEquals(createCallback.getRc(), ZkAsyncCallbacks.UNKNOWN_RET_CODE);
+      Assert.assertEquals(createCallback.getRc(), ZkAsyncCallbacks.ZK_SESSION_MISMATCHED_CODE);
     }
 
     Assert.assertFalse(zkClient.exists(path));
@@ -915,7 +915,7 @@ public class TestRawZkClient extends ZkTestBase {
 
       // Ensure the async callback is cancelled because of the exception
       Assert.assertTrue(setDataCallback.waitForSuccess(), "Callback operation should be done");
-      Assert.assertEquals(setDataCallback.getRc(), ZkAsyncCallbacks.UNKNOWN_RET_CODE);
+      Assert.assertEquals(setDataCallback.getRc(), ZkAsyncCallbacks.ZK_SESSION_MISMATCHED_CODE);
     }
 
     TestHelper.verify(() -> zkClient.delete(path), TestHelper.WAIT_DURATION);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1717 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When there is a ZK session mismatch for async operations in ZkClient, passing UNKNOWN_RET_CODE to the appropriate ZkAsyncCallback and not checking for this condition in the needRetry() method in the ZkAsyncCallback results in throwing a NullPointerException which can be confusing. This PR defines an additional return code for the ZK session mismatch situation and by checking for this condition in the needRetry() method, provides a more meaningful message in the log.

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

helix-core:
```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestExpandCluster.testClusterExpansion:61 expected:<false> but was:<true>
[INFO] 
[ERROR] Tests run: 1265, Failures: 1, Errors: 0, Skipped: 2
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:56 h
[INFO] Finished at: 2021-04-28T09:57:01-07:00
[INFO] ------------------------------------------------------------------------
```

TestExpandCluster:
```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 94.638 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/rabashiz/IdeaProjects/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 890 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:41 min
[INFO] Finished at: 2021-04-28T10:01:06-07:00
[INFO] ------------------------------------------------------------------------
```

zookeeper-api:
```
[INFO] Results:
[INFO] 
[INFO] Tests run: 54, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ zookeeper-api ---
[INFO] Loading execution data file /Users/rabashiz/IdeaProjects/helix/zookeeper-api/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: ZooKeeper API' with 115 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  09:18 min
[INFO] Finished at: 2021-04-28T10:16:51-07:00
[INFO] ------------------------------------------------------------------------

```

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
