### PR TITLE
Remove the logic that disables the partitions which fails to be state-transited from the ERROR state.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -263,11 +263,6 @@ public class HelixStateTransitionHandler extends MessageHandler {
         _stateModel.rollbackOnError(_message, _notificationContext, error);
         _currentStateDelta.setState(partitionKey, HelixDefinedState.ERROR.toString());
         _stateModel.updateState(HelixDefinedState.ERROR.toString());
-
-        // if we have errors transit from ERROR state, disable the partition
-        if (_message.getFromState().equalsIgnoreCase(HelixDefinedState.ERROR.toString())) {
-          disablePartition();
-        }
       }
     }
 
@@ -298,19 +293,6 @@ public class HelixStateTransitionHandler extends MessageHandler {
       _statusUpdateUtil.logError(_message, HelixStateTransitionHandler.class, e,
           "Error when update current-state ", _manager);
     }
-  }
-
-  void disablePartition() {
-    String instanceName = _manager.getInstanceName();
-    String resourceName = _message.getResourceName();
-    String partitionName = _message.getPartitionName();
-    String clusterName = _manager.getClusterName();
-    HelixAdmin admin = _manager.getClusterManagmentTool();
-    admin.enablePartition(false, clusterName, instanceName, resourceName,
-        Arrays.asList(partitionName));
-    logger.info("error in transit from ERROR to " + _message.getToState() + " for partition: "
-        + partitionName + ". disable it on " + instanceName);
-
   }
 
   @Override
@@ -443,11 +425,6 @@ public class HelixStateTransitionHandler extends MessageHandler {
         CurrentState currentStateDelta = new CurrentState(resourceName);
         currentStateDelta.setState(partition, HelixDefinedState.ERROR.toString());
         _stateModel.updateState(HelixDefinedState.ERROR.toString());
-
-        // if transit from ERROR state, disable the partition
-        if (_message.getFromState().equalsIgnoreCase(HelixDefinedState.ERROR.toString())) {
-          disablePartition();
-        }
 
         PropertyKey currentStateKey =
             _isTaskMessage && !_isTaskCurrentStatePathDisabled ? keyBuilder

--- a/helix-core/src/test/java/org/apache/helix/integration/TestDrop.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestDrop.java
@@ -273,11 +273,6 @@ public class TestDrop extends ZkTestBase {
     ZKHelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_gZkClient));
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
-    InstanceConfig config = accessor.getProperty(keyBuilder.instanceConfig("localhost_12918"));
-    List<String> disabledPartitions = config.getDisabledPartitions();
-    // System.out.println("disabledPartitions: " + disabledPartitions);
-    Assert.assertEquals(disabledPartitions.size(), 1, "TestDB0_4 should be disabled");
-    Assert.assertEquals(disabledPartitions.get(0), "TestDB0_4");
 
     // ExternalView should have TestDB0_4->localhost_12918_>ERROR
     Thread.sleep(250L);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

close #1720 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This logic is causing confusion when the partitions are disabled unexpected.
In reality, if the partition fails to finish a state-transition from the ERROR state, it will remain in the ERROR state. And disabling it, in addition, is not desired.

### Tests

- [x] The following tests are written for this issue:

There is no additional logic added. I also removed the test case which checks if the partition is disabled on such a failure.

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
