### PR TITLE
Applying per replica logic for entire stage

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/common/PartitionStateMap.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/common/PartitionStateMap.java
@@ -39,10 +39,18 @@ public class PartitionStateMap {
     _stateMap = new HashMap<>();
   }
 
+  // Deep copy of the partitionStateMap is a safer way.
   public PartitionStateMap(String resourceName,
       Map<Partition, Map<String, String>> partitionStateMap) {
     _resourceName = resourceName;
-    _stateMap = partitionStateMap;
+    _stateMap = new HashMap<>();
+    for (Partition partition : partitionStateMap.keySet()) {
+      Map<String, String> map = new HashMap<>();
+      for (Map.Entry<String, String> entry : partitionStateMap.get(partition).entrySet()) {
+        map.put(entry.getKey(), entry.getValue());
+      }
+      _stateMap.put(partition, map);
+    }
   }
 
   public Set<Partition> partitionSet() {

--- a/helix-core/src/main/java/org/apache/helix/controller/common/PartitionStateMap.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/common/PartitionStateMap.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import java.util.stream.Collectors;
 import org.apache.helix.model.Partition;
 
 /**
@@ -40,17 +41,11 @@ public class PartitionStateMap {
   }
 
   // Deep copy of the partitionStateMap is a safer way.
-  public PartitionStateMap(String resourceName,
-      Map<Partition, Map<String, String>> partitionStateMap) {
+  public PartitionStateMap(String resourceName, Map<Partition, Map<String, String>> partitionStateMap) {
     _resourceName = resourceName;
-    _stateMap = new HashMap<>();
-    for (Partition partition : partitionStateMap.keySet()) {
-      Map<String, String> map = new HashMap<>();
-      for (Map.Entry<String, String> entry : partitionStateMap.get(partition).entrySet()) {
-        map.put(entry.getKey(), entry.getValue());
-      }
-      _stateMap.put(partition, map);
-    }
+    _stateMap = partitionStateMap.entrySet()
+        .stream()
+        .collect(Collectors.toMap(e -> e.getKey(), e -> new HashMap<>(e.getValue())));
   }
 
   public Set<Partition> partitionSet() {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -323,7 +323,7 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
     // for the new one. This is for backward-compatibility
     int threshold = 1; // Default threshold for ErrorOrRecoveryPartitionThresholdForLoadBalance
     // Keep the error count as partition level. This logic only applies to downward state transition determination
-    int partitionCount = (int) currentStateOutput.getCurrentStateMap(resourceName)
+    int numPartitionsWithErrorReplica = (int) currentStateOutput.getCurrentStateMap(resourceName)
         .values()
         .stream()
         .filter(i -> i.values().contains(HelixDefinedState.ERROR.name()))
@@ -340,9 +340,10 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
 
     // Perform regular load balance only if the number of partitions in recovery and in error is
     // less than the threshold. Otherwise, only allow downward-transition load balance
-    boolean onlyDownwardLoadBalance = partitionCount > threshold;
+    boolean onlyDownwardLoadBalance = numPartitionsWithErrorReplica > threshold;
 
-    chargePendingTransition(resource, currentStateOutput, throttleController, cache, preferenceLists, stateModelDef, intermediatePartitionStateMap);
+    chargePendingTransition(resource, currentStateOutput, throttleController, cache, preferenceLists, stateModelDef,
+        intermediatePartitionStateMap);
 
     // Sort partitions in case of urgent partition need to take the quota first.
     List<Partition> partitions = new ArrayList<>(resource.getPartitions());

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageOutput.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageOutput.java
@@ -64,6 +64,10 @@ public class MessageOutput {
     return Collections.emptyList();
   }
 
+  public Map<Partition, List<Message>> getResourceMessageMap(String resourceName) {
+    return _messagesMap.getOrDefault(resourceName, Collections.emptyMap());
+  }
+
   @Override
   public String toString() {
     return _messagesMap.toString();


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

resolves #343 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This commit contains:
1. Per resource looping with dynamic rebalance type computation and partition level ordering.
2. Let entire stage works against per replica throttling logic.

For global change contexts please refer: #1713 



### Tests

Split PRs. The branch will not able to compile or test until finishes code change.
Will have tests files and testing result in last several PRs.


- [ ] The following tests are written for this issue:


- The following is the result of the "mvn test" command on the appropriate module:


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
