### PR TITLE
Correct getAssignmentForWagedFullAutoImpl snapshot behavior 

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
@@ -60,6 +60,10 @@ public class ReadOnlyWagedRebalancer extends WagedRebalancer {
     return failureTypes;
   }
 
+  public void updateChangeDetectorSnapshots(ResourceControllerDataProvider dataProvider) {
+    getChangeDetector().updateSnapshots(dataProvider);
+  }
+
   private static class ReadOnlyAssignmentMetadataStore extends AssignmentMetadataStore {
     ReadOnlyAssignmentMetadataStore(String metadataStoreAddress, String clusterName) {
       super(new ZkBucketDataAccessor(metadataStoreAddress), clusterName);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -786,6 +786,10 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     return _metricCollector;
   }
 
+  protected ResourceChangeDetector getChangeDetector() {
+    return _changeDetector;
+  }
+
   @Override
   protected void finalize()
       throws Throwable {

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -250,6 +250,10 @@ public final class HelixUtil {
           new ResourceControllerDataProvider(globalSyncClusterConfig.getClusterName());
       dataProvider.requireFullRefresh();
       dataProvider.refresh(helixDataAccessor);
+      // first prepare waged rebalancer with a snapshot, so that it can react on the difference
+      // between the current status and the overwritten status
+      readOnlyWagedRebalancer.updateChangeDetectorSnapshots(dataProvider);
+
       dataProvider.setClusterConfig(globalSyncClusterConfig);
       dataProvider.setInstanceConfigMap(instanceConfigs.stream()
           .collect(Collectors.toMap(InstanceConfig::getInstanceName, Function.identity())));

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -245,14 +245,14 @@ public final class HelixUtil {
         new ClusterEvent(globalSyncClusterConfig.getClusterName(), ClusterEventType.Unknown);
 
     try {
-      // Obtain a refreshed dataProvider (cache) and overwrite cluster parameters with the given parameters
+      // First, prepare waged rebalancer with a snapshot, so that it can react on the difference
+      // between the current snapshot and the provided parameters which act as the new snapshot
       ResourceControllerDataProvider dataProvider =
           new ResourceControllerDataProvider(globalSyncClusterConfig.getClusterName());
       dataProvider.requireFullRefresh();
       dataProvider.refresh(helixDataAccessor);
-      // first prepare waged rebalancer with a snapshot, so that it can react on the difference
-      // between the current status and the overwritten status
       readOnlyWagedRebalancer.updateChangeDetectorSnapshots(dataProvider);
+      // Refresh dataProvider completely to populate _refreshedChangeTypes
       dataProvider.requireFullRefresh();
       dataProvider.refresh(helixDataAccessor);
 

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -253,6 +253,8 @@ public final class HelixUtil {
       // first prepare waged rebalancer with a snapshot, so that it can react on the difference
       // between the current status and the overwritten status
       readOnlyWagedRebalancer.updateChangeDetectorSnapshots(dataProvider);
+      dataProvider.requireFullRefresh();
+      dataProvider.refresh(helixDataAccessor);
 
       dataProvider.setClusterConfig(globalSyncClusterConfig);
       dataProvider.setInstanceConfigMap(instanceConfigs.stream()


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1729 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

`getAssignmentForWagedFullAutoImpl` doesn't correctly assign a snapshot to the read-only rebalancer before applying the parameters as a new snapshot. That means when the Waged rebalancer compares snapshots, it always treats every bit of metadata from the parameters as new metadata since the old snapshot is missing, therefore it always triggers a complete global rebalance as if the cluster is newly created. 

This isn't the intended behavior. The intended behavior is that `getAssignmentForWagedFullAutoImpl` acts as a simulation -  the parameters are as if applied without actually applying them, and the Waged rebalancer reaction can be observed. To correctly simulate, the read-only rebalancer must have an old snapshot that aligns with the current metadata of the cluster, so it can react to metadata changes properly - for example, if the difference between current metadata and the parameters only contains 1 ResourceConfig change, the global rebalance should only affect that resource. 

### Tests

- The following is the result of the "mvn test" command on the appropriate module:

```
[ERROR] Tests run: 1265, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 5,250.877 s <<< FAILURE! - in TestSuite
[ERROR] testLostZkConnection(org.apache.helix.integration.TestZkConnectionLost)  Time elapsed: 127.742 s  <<< FAILURE!
org.apache.helix.HelixException: Workflow testLostZkConnection_20210508T023618 context is empty or not in states: [COMPLETED], current state: IN_PROGRESS.
        at org.apache.helix.integration.TestZkConnectionLost.testLostZkConnection(TestZkConnectionLost.java:174)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestZkConnectionLost.testLostZkConnection:174 » Helix Workflow testLostZkConne...
[INFO] 
[ERROR] Tests run: 1265, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:27 h
[INFO] Finished at: 2021-05-07T20:00:29-07:00
[INFO] ------------------------------------------------------------------------
```

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 79.922 s - in org.apache.helix.integration.TestZkConnectionLost
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /home/nesun/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 890 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:30 min
[INFO] Finished at: 2021-05-10T11:11:38-07:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
