### PR TITLE
Use correct session ID in PerInstanceAccessor

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -534,10 +534,8 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     ArrayNode arrayOfResource =
         (ArrayNode) node.get(PerInstanceAccessor.PerInstanceProperties.resources.name());
     Assert.assertTrue(arrayOfResource.size() != 0);
-    System.out.println(arrayOfResource);
     String dbNameString= arrayOfResource.get(0).toString();
     String dbName = dbNameString.substring(1,dbNameString.length()-1);
-    System.out.println(dbName);
     // The below calls should successfully return
     body = new JerseyUriRequestBuilder("clusters/{}/instances/{}/resources/{}")
         .isBodyReturnExpected(true).format(CLUSTER_NAME, INSTANCE_NAME, dbName).get(this);

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -31,7 +31,9 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.HelixDataAccessor;
@@ -520,6 +522,25 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
         .expectedReturnStatusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
         .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
 
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testValidateDeltaInstanceConfigForUpdate")
+  public void testGetResourcesOnInstance() throws JsonProcessingException, InterruptedException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String body = new JerseyUriRequestBuilder("clusters/{}/instances/{}/resources")
+        .isBodyReturnExpected(true).format(CLUSTER_NAME, INSTANCE_NAME).get(this);
+    JsonNode node = OBJECT_MAPPER.readTree(body);
+    ArrayNode arrayOfResource =
+        (ArrayNode) node.get(PerInstanceAccessor.PerInstanceProperties.resources.name());
+    Assert.assertTrue(arrayOfResource.size() != 0);
+    System.out.println(arrayOfResource);
+    String dbNameString= arrayOfResource.get(0).toString();
+    String dbName = dbNameString.substring(1,dbNameString.length()-1);
+    System.out.println(dbName);
+    // The below calls should successfully return
+    body = new JerseyUriRequestBuilder("clusters/{}/instances/{}/resources/{}")
+        .isBodyReturnExpected(true).format(CLUSTER_NAME, INSTANCE_NAME, dbName).get(this);
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixes #1731   

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
In this PR, the correct session id has been used to read the current state information.

### Tests

- [x] The following tests are written for this issue:
TestPerInstanceAccessor.testGetResourcesOnInstance

- [x] The following is the result of the "mvn test" command on the appropriate module:
Helix-core:
```[INFO] Tests run: 1268, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4,975.196 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1268, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /home/anajari/my_repos/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 894 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:23 h
[INFO] Finished at: 2021-05-11T16:07:55-07:00
[INFO] ------------------------------------------------------------------------
```
Helix-rest:
```
[INFO] Tests run: 174, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 100.409 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 174, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /home/anajari/my_repos/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 74 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:46 min
[INFO] Finished at: 2021-05-11T16:14:54-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)


