### PR TITLE
Properly clean up TaskCurrentState sessions

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/PropertyKey.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyKey.java
@@ -487,6 +487,16 @@ public class PropertyKey {
     }
 
     /**
+     * Get a property key associated with {@link CurrentState} of an instance. This key is for
+     * TaskCurrentState specifically.
+     * @param instanceName
+     * @return {@link PropertyKey}
+     */
+    public PropertyKey taskCurrentStateSessions(String instanceName) {
+      return new PropertyKey(TASKCURRENTSTATES, CurrentState.class, _clusterName, instanceName);
+    }
+
+    /**
      * Get a property key associated with {@link CurrentState} of an instance and session. This key
      * is for TaskCurrentState specifically.
      * @param instanceName

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -418,7 +418,16 @@ public class ParticipantManager {
       String path = _keyBuilder.currentStates(_instanceName, session).getPath();
       LOG.info("Removing current states from previous sessions. path: " + path);
       _zkclient.deleteRecursively(path);
-      path = _keyBuilder.taskCurrentStates(_instanceName, session).getPath();
+    }
+
+    // Remove all previous task current state sessions
+    for (String session : _dataAccessor
+        .getChildNames(_keyBuilder.taskCurrentStateSessions(_instanceName))) {
+      if (session.equals(_sessionId)) {
+        continue;
+      }
+
+      String path = _keyBuilder.taskCurrentStates(_instanceName, session).getPath();
       LOG.info("Removing task current states from previous sessions. path: " + path);
       _zkclient.deleteRecursively(path);
     }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -154,6 +154,7 @@ public class ParticipantManager {
     // should not be created by an expired zk session.
     createLiveInstance();
     carryOverPreviousCurrentState();
+    removePreviousTaskCurrentStates();
 
     /**
      * setup message listener
@@ -362,6 +363,7 @@ public class ParticipantManager {
         }
 
         // If the the current state is related to tasks, there is no need to carry it over to new session.
+        // Note: this check is not necessary due to TaskCurrentStates, but keep it for backwards compatibility
         if (stateModelDefRef.equals(TaskConstants.STATE_MODEL_NAME)) {
           continue;
         }
@@ -419,8 +421,12 @@ public class ParticipantManager {
       LOG.info("Removing current states from previous sessions. path: " + path);
       _zkclient.deleteRecursively(path);
     }
+  }
 
-    // Remove all previous task current state sessions
+  /**
+   * Remove all previous task current state sessions
+   */
+  private void removePreviousTaskCurrentStates() {
     for (String session : _dataAccessor
         .getChildNames(_keyBuilder.taskCurrentStateSessions(_instanceName))) {
       if (session.equals(_sessionId)) {

--- a/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
@@ -929,8 +929,13 @@ public class ZkTestBase {
             LOG.error("Current state not empty for " + participant);
             return false;
           }
-          CurrentState taskCurrentState =
-              accessor.getProperty(keyBuilder.taskCurrentState(participant, sessionId, _resourceName));
+        }
+
+        List<String> taskSessionIds =
+            accessor.getChildNames(keyBuilder.taskCurrentStateSessions(participant));
+        for (String sessionId : taskSessionIds) {
+          CurrentState taskCurrentState = accessor
+              .getProperty(keyBuilder.taskCurrentState(participant, sessionId, _resourceName));
           Map<String, String> taskPartitionStateMap = taskCurrentState.getPartitionStateMap();
           if (taskPartitionStateMap != null && !taskPartitionStateMap.isEmpty()) {
             LOG.error("Task current state not empty for " + participant);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1735 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently, old TaskCurrentState session cleanup is dependent on regular CurrentState sessions: for each session in the CurrentState path, the same session will be removed in the TaskCurrentState path. 

This is normally acceptable because both CurrentStates are created by the same session, however, under certain unusual circumstances, this may not behave correctly. For example, after creating a TaskCurrentState, if a user changes Helix versions to a version before TaskCurrentState is introduced, then the clean up logic will only clean up regular CurrentState and leave the TaskCurrentState - this leaves a TaskCurrentState session that doesn't exist on CurrentState side, which will never be cleaned up using the current logic. 

### Tests

- [x] The following tests are written for this issue:

TestHandleSession.testRemoveOldSession

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
