### PR TITLE
Add cluster pause change listener for controller to resume cluster

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixConstants.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixConstants.java
@@ -44,7 +44,8 @@ public interface HelixConstants {
     TARGET_EXTERNAL_VIEW (PropertyType.TARGETEXTERNALVIEW),
     CONTROLLER (PropertyType.CONTROLLER),
     MESSAGES_CONTROLLER (PropertyType.MESSAGES_CONTROLLER),
-    HEALTH (PropertyType.HEALTHREPORT);
+    HEALTH (PropertyType.HEALTHREPORT),
+    CLUSTER_PAUSE (PropertyType.PAUSE);
     // @formatter:on
 
     private final PropertyType _propertyType;

--- a/helix-core/src/main/java/org/apache/helix/HelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManager.java
@@ -23,7 +23,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.helix.api.listeners.ClusterConfigChangeListener;
+import org.apache.helix.api.listeners.ClusterPauseChangeListener;
 import org.apache.helix.api.listeners.ConfigChangeListener;
 import org.apache.helix.api.listeners.ControllerChangeListener;
 import org.apache.helix.api.listeners.CurrentStateChangeListener;
@@ -241,8 +243,7 @@ public interface HelixManager {
   }
 
   /**
-
-   * @see CustomizedStateRootChangeListener#onCustomizedStateRootChange(String, NotificationContext)
+   * @see CustomizedStateRootChangeListener#onCustomizedStateRootChange(String, List, NotificationContext)
    * @param listener
    * @param instanceName
    */
@@ -306,6 +307,15 @@ public interface HelixManager {
    * @param listener
    */
   void addControllerMessageListener(MessageListener listener);
+
+  /**
+   * Adds cluster pause change listener
+   *
+   * @param listener {@link ClusterPauseChangeListener}
+   */
+  default void addClusterPauseChangeListener(ClusterPauseChangeListener listener) {
+    throw new NotImplementedException("Not implemented!");
+  }
 
   /**
    * Add message listener for controller

--- a/helix-core/src/main/java/org/apache/helix/api/listeners/ClusterPauseChangeListener.java
+++ b/helix-core/src/main/java/org/apache/helix/api/listeners/ClusterPauseChangeListener.java
@@ -1,4 +1,4 @@
-package org.apache.helix.controller.stages;
+package org.apache.helix.api.listeners;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,26 +19,18 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
-public enum ClusterEventType {
-  IdealStateChange,
-  CurrentStateChange,
-  TaskCurrentStateChange,
-  CustomizedStateChange,
-  ConfigChange,
-  ClusterConfigChange,
-  ResourceConfigChange,
-  InstanceConfigChange,
-  CustomizeStateConfigChange,
-  LiveInstanceChange,
-  MessageChange,
-  ExternalViewChange,
-  CustomizedViewChange,
-  TargetExternalViewChange,
-  ClusterPause,
-  Resume,
-  PeriodicalRebalance,
-  OnDemandRebalance,
-  RetryRebalance,
-  StateVerifier,
-  Unknown
+import org.apache.helix.NotificationContext;
+import org.apache.helix.model.PauseSignal;
+
+/**
+ * Interface to implement to listen for changes to cluster pause signal.
+ */
+public interface ClusterPauseChangeListener {
+  /**
+   * Invoked when cluster pause changes
+   *
+   * @param pauseSignal
+   * @param context
+   */
+  void onClusterPauseChange(PauseSignal pauseSignal, NotificationContext context);
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -19,7 +19,6 @@ package org.apache.helix.controller;
  * under the License.
  */
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,6 +48,7 @@ import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyKey.Builder;
 import org.apache.helix.api.exceptions.HelixMetaDataAccessException;
 import org.apache.helix.api.listeners.ClusterConfigChangeListener;
+import org.apache.helix.api.listeners.ClusterPauseChangeListener;
 import org.apache.helix.api.listeners.ControllerChangeListener;
 import org.apache.helix.api.listeners.CurrentStateChangeListener;
 import org.apache.helix.api.listeners.CustomizedStateChangeListener;
@@ -129,13 +129,19 @@ import static org.apache.helix.HelixConstants.ChangeType;
  * 4. select the messages that can be sent, needs messages and state model constraints <br>
  * 5. send messages
  */
-public class GenericHelixController implements IdealStateChangeListener, LiveInstanceChangeListener,
-                                               MessageListener, CurrentStateChangeListener,
+public class GenericHelixController implements IdealStateChangeListener,
+                                               LiveInstanceChangeListener,
+                                               MessageListener,
+                                               CurrentStateChangeListener,
                                                TaskCurrentStateChangeListener,
                                                CustomizedStateRootChangeListener,
                                                CustomizedStateChangeListener,
-    CustomizedStateConfigChangeListener, ControllerChangeListener,
-    InstanceConfigChangeListener, ResourceConfigChangeListener, ClusterConfigChangeListener {
+                                               CustomizedStateConfigChangeListener,
+                                               ControllerChangeListener,
+                                               InstanceConfigChangeListener,
+                                               ResourceConfigChangeListener,
+                                               ClusterConfigChangeListener,
+                                               ClusterPauseChangeListener {
   private static final Logger logger =
       LoggerFactory.getLogger(GenericHelixController.class.getName());
 
@@ -1183,6 +1189,17 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
         Collections.<String, Object>emptyMap());
     logger
         .info("END: GenericClusterController.onClusterConfigChange() for cluster " + _clusterName);
+  }
+
+  @Override
+  @PreFetch(enabled = false)
+  public void onClusterPauseChange(PauseSignal pauseSignal, NotificationContext context) {
+    logger.info("START: GenericClusterController.onClusterPauseChange() for cluster {}",
+        _clusterName);
+    notifyCaches(context, ChangeType.CLUSTER_PAUSE);
+    pushToEventQueues(ClusterEventType.ClusterPause, context, Collections.emptyMap());
+    logger.info("END: GenericClusterController.onClusterPauseChange() for cluster {}",
+        _clusterName);
   }
 
   private void notifyCaches(NotificationContext context, ChangeType changeType) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -55,6 +55,7 @@ import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.PropertyType;
 import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.api.listeners.ClusterConfigChangeListener;
+import org.apache.helix.api.listeners.ClusterPauseChangeListener;
 import org.apache.helix.api.listeners.ConfigChangeListener;
 import org.apache.helix.api.listeners.ControllerChangeListener;
 import org.apache.helix.api.listeners.CurrentStateChangeListener;
@@ -564,6 +565,12 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
   public void addControllerMessageListener(MessageListener listener) {
     addListener(listener, new Builder(_clusterName).controllerMessages(),
         ChangeType.MESSAGES_CONTROLLER, new EventType[] { EventType.NodeChildrenChanged });
+  }
+
+  @Override
+  public void addClusterPauseChangeListener(ClusterPauseChangeListener listener) {
+    addListener(listener, new Builder(_clusterName).pause(), ChangeType.CLUSTER_PAUSE,
+        new EventType[]{EventType.NodeDataChanged});
   }
 
   @Deprecated

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestControllerDataProviderSelectiveUpdate.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestControllerDataProviderSelectiveUpdate.java
@@ -150,4 +150,31 @@ public class TestControllerDataProviderSelectiveUpdate extends ZkStandAloneCMTes
     // 2 Resource Config Changes
     Assert.assertEquals(accessor.getReadCount(PropertyType.CONFIGS), 2);
   }
+
+  @Test
+  public void testClusterPauseSignalUpdate() {
+    MockZkHelixDataAccessor accessor =
+        new MockZkHelixDataAccessor(CLUSTER_NAME, new ZkBaseDataAccessor<>(_gZkClient));
+
+    ResourceControllerDataProvider cache =
+        new ResourceControllerDataProvider("CLUSTER_" + TestHelper.getTestClassName());
+    accessor.clearReadCounters();
+    _gSetupTool.getClusterManagementTool().enableCluster(CLUSTER_NAME, false);
+    cache.refresh(accessor);
+    Assert.assertEquals(accessor.getReadCount(PropertyType.PAUSE), 1);
+
+    accessor.clearReadCounters();
+    cache.refresh(accessor);
+    Assert.assertEquals(accessor.getReadCount(PropertyType.PAUSE), 0);
+
+    cache.notifyDataChange(HelixConstants.ChangeType.CLUSTER_PAUSE);
+    cache.refresh(accessor);
+    Assert.assertEquals(accessor.getReadCount(PropertyType.PAUSE), 1);
+
+    accessor.clearReadCounters();
+    _gSetupTool.getClusterManagementTool().enableCluster(CLUSTER_NAME, true);
+    cache.notifyDataChange(HelixConstants.ChangeType.CLUSTER_PAUSE);
+    cache.refresh(accessor);
+    Assert.assertEquals(accessor.getReadCount(PropertyType.PAUSE), 1);
+  }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1743 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

For cluster pause mode feature: controller needs to listen to the pause signal change and resume the cluster from pause mode upon pause signal change.

This PR does implements following:
- Add ClusterPauseChangeListener in HelixManager, watching pause data change for exiting cluster pause
- Implements pause signal data change callback to notify controller
- Selectively update cache for pause signal

### Tests

- [x] The following tests are written for this issue:

 - `testClusterPauseSignalUpdate`
 - add logic to check pause change notification in `testPauseSignal`

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
