### PR TITLE
Use 1 minute sliding window size for Helix rest metrics

### DIFF
--- a/helix-core/helix-core-1.0.2-SNAPSHOT.ivy
+++ b/helix-core/helix-core-1.0.2-SNAPSHOT.ivy
@@ -62,7 +62,7 @@ under the License.
     <dependency org="com.google.guava" name="guava" rev="15.0" conf="compile->compile(default);runtime->runtime(default);default->default"/>
     <dependency org="org.yaml" name="snakeyaml" rev="1.12" conf="compile->compile(default);runtime->runtime(default);default->default"/>
     <dependency org="commons-logging" name="commons-logging-api" rev="1.1" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
-    <dependency org="io.dropwizard.metrics" name="metrics-core" rev="4.1.12.1" conf="compile->compile(default);runtime->runtime(default);default->default"/>
+    <dependency org="io.dropwizard.metrics" name="metrics-core" rev="4.1.14" conf="compile->compile(default);runtime->runtime(default);default->default"/>
 	</dependencies>
 </ivy-module>
 

--- a/helix-rest/helix-rest-1.0.2-SNAPSHOT.ivy
+++ b/helix-rest/helix-rest-1.0.2-SNAPSHOT.ivy
@@ -50,7 +50,7 @@ under the License.
 		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.11.0" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.11.0" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
-		<dependency org="io.dropwizard.metrics" name="metrics-jersey2" rev="4.1.12.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
-		<dependency org="io.dropwizard.metrics" name="metrics-jmx" rev="4.1.12.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="io.dropwizard.metrics" name="metrics-jersey2" rev="4.1.14" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="io.dropwizard.metrics" name="metrics-jmx" rev="4.1.14" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 	</dependencies>
 </ivy-module>

--- a/pom.xml
+++ b/pom.xml
@@ -449,9 +449,9 @@
     <SKIP_INTEGRATION_TESTS>true</SKIP_INTEGRATION_TESTS>
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
 
-    <metrics-core.version>4.1.12.1</metrics-core.version>
-    <metrics-jersey2.version>4.1.12.1</metrics-jersey2.version>
-    <metrics-jmx.version>4.1.12.1</metrics-jmx.version>
+    <metrics-core.version>4.1.14</metrics-core.version>
+    <metrics-jersey2.version>4.1.14</metrics-jersey2.version>
+    <metrics-jmx.version>4.1.14</metrics-jmx.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fixed #1481 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR used the `SlidingTimeWindowReservoir` to replace the default `ExponentiallyDecayingReservoir` so that we can define the sliding window size for our metrics in Helix-rest. Currently the sliding window is set to 1 min.

### Tests

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)
[INFO] Tests run: 174, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 211.361 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 174, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /Users/mnzhang/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 74 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 03:36 min
[INFO] Finished at: 2021-05-20T16:06:45-07:00
[INFO] Final Memory: 34M/614M
[INFO] ------------------------------------------------------------------------

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
