### PR TITLE
Remove a potential deadlock when shutting down a RoutingTableProvider.

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/TestZkCallbackHandlerLeak.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestZkCallbackHandlerLeak.java
@@ -305,7 +305,7 @@ public class TestZkCallbackHandlerLeak extends ZkUnitTestBase {
   }
 
   @Test
-  public void testDanglingCallbackHanlderFix() throws Exception {
+  public void testDanglingCallbackHandler() throws Exception {
     String className = TestHelper.getTestClassName();
     String methodName = TestHelper.getTestMethodName();
     String clusterName = className + "_" + methodName;
@@ -379,6 +379,10 @@ public class TestZkCallbackHandlerLeak extends ZkUnitTestBase {
     // clean up
     controller.syncStop();
     rp.shutdown();
+
+    Assert.assertTrue(rpManager.getHandlers().isEmpty(),
+        "HelixManager should not have any callback handlers after shutting down RoutingTableProvider");
+
     rpManager.syncStop();
     for (int i = 0; i < n; i++) {
       participants[i].syncStop();
@@ -474,6 +478,10 @@ public class TestZkCallbackHandlerLeak extends ZkUnitTestBase {
       participants[i].syncStop();
     }
     rp.shutdown();
+
+    Assert.assertTrue(rpManager.getHandlers().isEmpty(),
+        "HelixManager should not have any callback handlers after shutting down RoutingTableProvider");
+
     rpManager.syncStop();
     TestHelper.dropCluster(clusterName, _gZkClient);
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1748 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR aims to avoid a potential deadlock that happens in a race condition when shutting down RoutingTableProvider.

The race condition happens when the RoutingTableProvider is shut down and the corresponding HelixManager is processing an onLiveInstanceChange event. Both threads require 2 locks, HelixManager lock, and RoutingTableProvider._lastSeenSessions, in different orders.
To resolve this problem, this PR changes 2 logic.
1. Remove the _lastSeenSessions lock usage. So no more deadlock. The logic correctness is now ensured by the AtomicReference.getAndSet method.
2. Remove LiveInstanceChangeListener in the shutdown call before processing the other logic. This is a missing logic and should be done regardless of the deadlock problem. Moreover, this change also avoids a more complicated race condition introduced by the previous change that may lead to CurrentStates callback handler leakage.

Test cases in TestZkCallbackHandlerLeak have been updated to validate the logic changes.

### Tests

- [X] The following tests are written for this issue:

TestZkCallbackHandlerLeak

I run the test over the weekend, passed continuously 3533 times already.

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
