### PR TITLE
Add a Waged rebalancer util api that do not need raw zk address.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
@@ -23,16 +23,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.waged.constraints.ConstraintBasedAlgorithmFactory;
-import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.manager.zk.ZkBucketDataAccessor;
 import org.apache.helix.model.ClusterConfig;
-import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceAssignment;
 
 
@@ -45,9 +41,9 @@ import org.apache.helix.model.ResourceAssignment;
  * This class is to be used in the cluster verifiers, tests, or util methods.
  */
 public class ReadOnlyWagedRebalancer extends WagedRebalancer {
-  public ReadOnlyWagedRebalancer(String metadataStoreAddress, String clusterName,
+  public ReadOnlyWagedRebalancer(ZkBucketDataAccessor zkBucketDataAccessor, String clusterName,
       Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> preferences) {
-    super(new ReadOnlyAssignmentMetadataStore(metadataStoreAddress, clusterName),
+    super(new ReadOnlyAssignmentMetadataStore(zkBucketDataAccessor, clusterName),
         ConstraintBasedAlgorithmFactory.getInstance(preferences), Optional.empty());
   }
 
@@ -65,8 +61,9 @@ public class ReadOnlyWagedRebalancer extends WagedRebalancer {
   }
 
   private static class ReadOnlyAssignmentMetadataStore extends AssignmentMetadataStore {
-    ReadOnlyAssignmentMetadataStore(String metadataStoreAddress, String clusterName) {
-      super(new ZkBucketDataAccessor(metadataStoreAddress), clusterName);
+
+    ReadOnlyAssignmentMetadataStore(ZkBucketDataAccessor zkBucketDataAccessor, String clusterName) {
+      super(zkBucketDataAccessor, clusterName);
     }
 
     @Override

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -43,6 +43,7 @@ import org.apache.helix.controller.stages.ClusterEventType;
 import org.apache.helix.controller.stages.CurrentStateComputationStage;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.controller.stages.ResourceComputationStage;
+import org.apache.helix.manager.zk.ZkBucketDataAccessor;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -463,7 +464,7 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
   private class DryrunWagedRebalancer extends org.apache.helix.controller.rebalancer.waged.ReadOnlyWagedRebalancer {
     public DryrunWagedRebalancer(String metadataStoreAddress, String clusterName,
         Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> preferences) {
-      super(metadataStoreAddress, clusterName, preferences);
+      super(new ZkBucketDataAccessor(metadataStoreAddress), clusterName, preferences);
     }
 
     @Override


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1755 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

ReadOnlyWagedRebalancer should not require a was Zk address in constructor.
In a multi ZK scenario, the address might be a mock address or a fake one. Passing a raw ZK address does not make sense.

### Tests

- [X] The following tests are written for this issue:
This API will be called by a REST API added in PR #1747. Unit test added in that PR will cover this change. 


- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
