### PR TITLE
Remove unused field in ZKHelixDataAccessor - code clean with no logic change

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixDataAccessor.java
@@ -58,8 +58,7 @@ public class ZKHelixDataAccessor implements HelixDataAccessor {
   private final Builder _propertyKeyBuilder;
   private final GroupCommit _groupCommit = new GroupCommit();
 
-  public ZKHelixDataAccessor(String clusterName,
-      BaseDataAccessor<ZNRecord> baseDataAccessor) {
+  public ZKHelixDataAccessor(String clusterName, BaseDataAccessor<ZNRecord> baseDataAccessor) {
     _clusterName = clusterName;
     _baseDataAccessor = baseDataAccessor;
     _propertyKeyBuilder = new PropertyKey.Builder(_clusterName);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixDataAccessor.java
@@ -30,6 +30,7 @@ import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.GroupCommit;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixProperty;
+import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyKey.Builder;
 import org.apache.helix.PropertyPathBuilder;
@@ -62,6 +63,13 @@ public class ZKHelixDataAccessor implements HelixDataAccessor {
     _clusterName = clusterName;
     _baseDataAccessor = baseDataAccessor;
     _propertyKeyBuilder = new PropertyKey.Builder(_clusterName);
+  }
+
+  @Deprecated
+  public ZKHelixDataAccessor(String clusterName, InstanceType instanceType,
+      BaseDataAccessor<ZNRecord> baseDataAccessor) {
+    this(clusterName, baseDataAccessor);
+
   }
 
   /* Copy constructor */

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixDataAccessor.java
@@ -30,7 +30,6 @@ import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.GroupCommit;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixProperty;
-import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyKey.Builder;
 import org.apache.helix.PropertyPathBuilder;
@@ -55,19 +54,13 @@ import org.slf4j.LoggerFactory;
 public class ZKHelixDataAccessor implements HelixDataAccessor {
   private static Logger LOG = LoggerFactory.getLogger(ZKHelixDataAccessor.class);
   private final BaseDataAccessor<ZNRecord> _baseDataAccessor;
-  final InstanceType _instanceType;
   private final String _clusterName;
   private final Builder _propertyKeyBuilder;
   private final GroupCommit _groupCommit = new GroupCommit();
 
-  public ZKHelixDataAccessor(String clusterName, BaseDataAccessor<ZNRecord> baseDataAccessor) {
-    this(clusterName, null, baseDataAccessor);
-  }
-
-  public ZKHelixDataAccessor(String clusterName, InstanceType instanceType,
+  public ZKHelixDataAccessor(String clusterName,
       BaseDataAccessor<ZNRecord> baseDataAccessor) {
     _clusterName = clusterName;
-    _instanceType = instanceType;
     _baseDataAccessor = baseDataAccessor;
     _propertyKeyBuilder = new PropertyKey.Builder(_clusterName);
   }
@@ -75,7 +68,6 @@ public class ZKHelixDataAccessor implements HelixDataAccessor {
   /* Copy constructor */
   public ZKHelixDataAccessor(ZKHelixDataAccessor dataAccessor) {
     _clusterName = dataAccessor._clusterName;
-    _instanceType = dataAccessor._instanceType;
     _baseDataAccessor = dataAccessor._baseDataAccessor;
     _propertyKeyBuilder = new PropertyKey.Builder(_clusterName);
   }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -743,7 +743,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
 
       _baseDataAccessor = createBaseDataAccessor();
 
-      _dataAccessor = new ZKHelixDataAccessor(_clusterName, _instanceType, _baseDataAccessor);
+      _dataAccessor = new ZKHelixDataAccessor(_clusterName, _baseDataAccessor);
       _configAccessor = new ConfigAccessor(_zkclient);
 
       if (_instanceType == InstanceType.CONTROLLER

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -58,7 +58,6 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Partition;
-import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/CrushRebalancers/TestCrushAutoRebalanceNonRack.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/CrushRebalancers/TestCrushAutoRebalanceNonRack.java
@@ -29,7 +29,6 @@ import java.util.Set;
 
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
-import org.apache.helix.InstanceType;
 import org.apache.helix.TestHelper;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.strategy.CrushRebalanceStrategy;
@@ -272,7 +271,7 @@ public class TestCrushAutoRebalanceNonRack extends ZkStandAloneCMTestBase {
 
     // shutdown participants, keep only two left
     HelixDataAccessor helixDataAccessor =
-        new ZKHelixDataAccessor(CLUSTER_NAME, InstanceType.PARTICIPANT, _baseAccessor);
+        new ZKHelixDataAccessor(CLUSTER_NAME, _baseAccessor);
     for (int i = 2; i < _participants.size(); i++) {
       MockParticipantManager p = _participants.get(i);
       p.syncStop();

--- a/helix-core/src/test/java/org/apache/helix/mock/MockZkHelixDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockZkHelixDataAccessor.java
@@ -34,7 +34,7 @@ public class MockZkHelixDataAccessor extends ZKHelixDataAccessor {
   Map<PropertyType, Integer> _readPathCounters = new HashMap<>();
 
   public MockZkHelixDataAccessor(String clusterName, BaseDataAccessor<ZNRecord> baseDataAccessor) {
-    super(clusterName, null, baseDataAccessor);
+    super(clusterName, baseDataAccessor);
   }
 
   @Deprecated

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
@@ -29,7 +29,6 @@ import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
-import org.apache.helix.InstanceType;
 import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
@@ -255,7 +254,7 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
           ZkBaseDataAccessor<ZNRecord> baseDataAccessor =
               new ZkBaseDataAccessor<>(getRealmAwareZkClient());
           _helixDataAccessorPool.put(clusterName,
-              new ZKHelixDataAccessor(clusterName, InstanceType.ADMINISTRATOR, baseDataAccessor));
+              new ZKHelixDataAccessor(clusterName, baseDataAccessor));
         }
         dataAccessor = _helixDataAccessorPool.get(clusterName);
       }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestInstanceService.java
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
-import org.apache.helix.InstanceType;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.ExternalView;
@@ -171,7 +170,7 @@ public class TestInstanceService {
         "}";
     BaseDataAccessor<ZNRecord> mockAccessor = mock(ZkBaseDataAccessor.class);
     ZKHelixDataAccessor zkHelixDataAccessor =
-        new ZKHelixDataAccessor(TEST_CLUSTER, InstanceType.ADMINISTRATOR, mockAccessor);
+        new ZKHelixDataAccessor(TEST_CLUSTER, mockAccessor);
     ZNRecord successPartitionReport = new ZNRecord(HelixDataAccessorWrapper.PARTITION_HEALTH_KEY);
 
     // Instance level check passed
@@ -234,7 +233,7 @@ public class TestInstanceService {
     String siblingInstance = "instance0.linkedin.com_1236";
     BaseDataAccessor<ZNRecord> mockAccessor = mock(ZkBaseDataAccessor.class);
     ZKHelixDataAccessor zkHelixDataAccessor =
-        new ZKHelixDataAccessor(TEST_CLUSTER, InstanceType.ADMINISTRATOR, mockAccessor);
+        new ZKHelixDataAccessor(TEST_CLUSTER, mockAccessor);
 
     when(mockAccessor.getChildNames(zkHelixDataAccessor.keyBuilder().liveInstances().getPath(), 2))
         .thenReturn(Arrays.asList(TEST_INSTANCE, siblingInstance));


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1755

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

` _instanceType` is never used in ZKHelixDataAccessor. 


### Tests

- [X] The following tests are written for this issue:

NA

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
