### PR TITLE
Get rid of non-official ZK error code to avoid NPEs.

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1276,7 +1276,7 @@ public class ZkClient implements Watcher {
           });
     } catch (RuntimeException e) {
       // Process callback to release caller from waiting
-      cb.processResult(ZkAsyncCallbacks.UNKNOWN_RET_CODE, path,
+      cb.processResult(KeeperException.Code.APIERROR.intValue(), path,
           new ZkAsyncCallMonitorContext(_monitor, startT, 0, true));
       throw e;
     }
@@ -1960,14 +1960,9 @@ public class ZkClient implements Watcher {
                 });
         return null;
       });
-    } catch (ZkSessionMismatchedException e) {
-      // Process callback to release caller from waiting
-      cb.processResult(ZkAsyncCallbacks.ZK_SESSION_MISMATCHED_CODE, path,
-          new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
-      throw e;
     } catch (RuntimeException e) {
       // Process callback to release caller from waiting
-      cb.processResult(ZkAsyncCallbacks.UNKNOWN_RET_CODE, path,
+      cb.processResult(KeeperException.Code.APIERROR.intValue(), path,
           new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
       throw e;
     }
@@ -2003,14 +1998,9 @@ public class ZkClient implements Watcher {
             });
         return null;
       });
-    } catch (ZkSessionMismatchedException e) {
-      // Process callback to release caller from waiting
-      cb.processResult(ZkAsyncCallbacks.ZK_SESSION_MISMATCHED_CODE, path,
-          new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
-      throw e;
     } catch (RuntimeException e) {
       // Process callback to release caller from waiting
-      cb.processResult(ZkAsyncCallbacks.UNKNOWN_RET_CODE, path,
+      cb.processResult(KeeperException.Code.APIERROR.intValue(), path,
           new ZkAsyncCallMonitorContext(_monitor, startT, 0, false), null);
       throw e;
     }
@@ -2031,7 +2021,7 @@ public class ZkClient implements Watcher {
       });
     } catch (RuntimeException e) {
       // Process callback to release caller from waiting
-      cb.processResult(ZkAsyncCallbacks.UNKNOWN_RET_CODE, path,
+      cb.processResult(KeeperException.Code.APIERROR.intValue(), path,
           new ZkAsyncCallMonitorContext(_monitor, startT, 0, true), null, null);
       throw e;
     }
@@ -2052,7 +2042,7 @@ public class ZkClient implements Watcher {
       });
     } catch (RuntimeException e) {
       // Process callback to release caller from waiting
-      cb.processResult(ZkAsyncCallbacks.UNKNOWN_RET_CODE, path,
+      cb.processResult(KeeperException.Code.APIERROR.intValue(), path,
           new ZkAsyncCallMonitorContext(_monitor, startT, 0, true), null);
       throw e;
     }
@@ -2073,7 +2063,7 @@ public class ZkClient implements Watcher {
       });
     } catch (RuntimeException e) {
       // Process callback to release caller from waiting
-      cb.processResult(ZkAsyncCallbacks.UNKNOWN_RET_CODE, path,
+      cb.processResult(KeeperException.Code.APIERROR.intValue(), path,
           new ZkAsyncCallMonitorContext(_monitor, startT, 0, false));
       throw e;
     }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
@@ -35,13 +35,6 @@ import org.slf4j.LoggerFactory;
 
 public class ZkAsyncCallbacks {
   private static Logger LOG = LoggerFactory.getLogger(ZkAsyncCallbacks.class);
-  public static final int UNKNOWN_RET_CODE = 255;
-
-  // Whenever there's a mismatch between the expected Zookeeper session ID and the actual
-  // Zookeeper session ID for the async operation, the ZkClient which performs the async
-  // operation passes this return code to the async callback indicate that it has caught
-  // a ZkSessionMismatchedException.
-  public static final int ZK_SESSION_MISMATCHED_CODE = 127;
 
   public static class GetDataCallbackHandler extends DefaultCallback implements DataCallback {
     public byte[] _data;
@@ -182,7 +175,7 @@ public class ZkAsyncCallbacks {
    */
   public static abstract class DefaultCallback implements CancellableZkAsyncCallback {
     AtomicBoolean _isOperationDone = new AtomicBoolean(false);
-    int _rc = UNKNOWN_RET_CODE;
+    int _rc = KeeperException.Code.APIERROR.intValue();
 
     public void callback(int rc, String path, Object ctx) {
       if (rc != 0 && LOG.isDebugEnabled()) {
@@ -282,10 +275,6 @@ public class ZkAsyncCallbacks {
      * @return true if the error is transient and the operation may succeed when being retried.
      */
     protected boolean needRetry(int rc) {
-      if (rc == ZK_SESSION_MISMATCHED_CODE) {
-        LOG.error("Actual session ID doesn't match with expected session ID. Skip retrying.");
-        return false;
-      }
       try {
         switch (Code.get(rc)) {
         /** Connection to the server has been lost */

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -887,7 +887,7 @@ public class TestRawZkClient extends ZkTestBase {
 
       // Ensure the async callback is cancelled because of the exception
       Assert.assertTrue(createCallback.waitForSuccess(), "Callback operation should be done");
-      Assert.assertEquals(createCallback.getRc(), ZkAsyncCallbacks.ZK_SESSION_MISMATCHED_CODE);
+      Assert.assertEquals(createCallback.getRc(), KeeperException.Code.APIERROR.intValue());
     }
 
     Assert.assertFalse(zkClient.exists(path));
@@ -915,7 +915,7 @@ public class TestRawZkClient extends ZkTestBase {
 
       // Ensure the async callback is cancelled because of the exception
       Assert.assertTrue(setDataCallback.waitForSuccess(), "Callback operation should be done");
-      Assert.assertEquals(setDataCallback.getRc(), ZkAsyncCallbacks.ZK_SESSION_MISMATCHED_CODE);
+      Assert.assertEquals(setDataCallback.getRc(), KeeperException.Code.APIERROR.intValue());
     }
 
     TestHelper.verify(() -> zkClient.delete(path), TestHelper.WAIT_DURATION);

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestZkClientAsyncRetry.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestZkClientAsyncRetry.java
@@ -42,7 +42,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks.UNKNOWN_RET_CODE;
 import static org.apache.zookeeper.KeeperException.Code.CONNECTIONLOSS;
 
 /**
@@ -143,7 +142,7 @@ public class TestZkClientAsyncRetry extends ZkTestBase {
         }
         ZkAsyncCallbacks.CreateCallbackHandler createCallback =
             new ZkAsyncCallbacks.CreateCallbackHandler();
-        Assert.assertEquals(createCallback.getRc(), UNKNOWN_RET_CODE);
+        Assert.assertEquals(createCallback.getRc(), KeeperException.Code.APIERROR.intValue());
         testZkClient.setAsyncCallRC(code.intValue());
         if (code == CONNECTIONLOSS || code == KeeperException.Code.SESSIONEXPIRED
             || code == KeeperException.Code.SESSIONMOVED) {
@@ -190,7 +189,7 @@ public class TestZkClientAsyncRetry extends ZkTestBase {
       // 1. Test async set retry
       ZkAsyncCallbacks.SetDataCallbackHandler setCallback =
           new ZkAsyncCallbacks.SetDataCallbackHandler();
-      Assert.assertEquals(setCallback.getRc(), UNKNOWN_RET_CODE);
+      Assert.assertEquals(setCallback.getRc(), KeeperException.Code.APIERROR.intValue());
 
       tmpRecord.setSimpleField("test", "data");
       testZkClient.setAsyncCallRC(CONNECTIONLOSS.intValue());
@@ -214,7 +213,7 @@ public class TestZkClientAsyncRetry extends ZkTestBase {
       // 2. Test async delete
       ZkAsyncCallbacks.DeleteCallbackHandler deleteCallback =
           new ZkAsyncCallbacks.DeleteCallbackHandler();
-      Assert.assertEquals(deleteCallback.getRc(), UNKNOWN_RET_CODE);
+      Assert.assertEquals(deleteCallback.getRc(), KeeperException.Code.APIERROR.intValue());
 
       testZkClient.setAsyncCallRC(CONNECTIONLOSS.intValue());
       // Async delete will be pending due to the mock error rc is retryable.
@@ -254,7 +253,7 @@ public class TestZkClientAsyncRetry extends ZkTestBase {
       // 1. Test async create retry
       ZkAsyncCallbacks.CreateCallbackHandler createCallback =
           new ZkAsyncCallbacks.CreateCallbackHandler();
-      Assert.assertEquals(createCallback.getRc(), UNKNOWN_RET_CODE);
+      Assert.assertEquals(createCallback.getRc(), KeeperException.Code.APIERROR.intValue());
 
       tmpRecord.setSimpleField("test", "data");
       testZkClient.setAsyncCallRC(CONNECTIONLOSS.intValue());
@@ -280,7 +279,7 @@ public class TestZkClientAsyncRetry extends ZkTestBase {
       // 1. Test async set retry
       ZkAsyncCallbacks.SetDataCallbackHandler setCallback =
           new ZkAsyncCallbacks.SetDataCallbackHandler();
-      Assert.assertEquals(setCallback.getRc(), UNKNOWN_RET_CODE);
+      Assert.assertEquals(setCallback.getRc(), KeeperException.Code.APIERROR.intValue());
 
       tmpRecord.setSimpleField("test", "data");
       testZkClient.setAsyncCallRC(CONNECTIONLOSS.intValue());
@@ -317,7 +316,7 @@ public class TestZkClientAsyncRetry extends ZkTestBase {
       // 1. Test async exist check
       ZkAsyncCallbacks.ExistsCallbackHandler existsCallback =
           new ZkAsyncCallbacks.ExistsCallbackHandler();
-      Assert.assertEquals(existsCallback.getRc(), UNKNOWN_RET_CODE);
+      Assert.assertEquals(existsCallback.getRc(), KeeperException.Code.APIERROR.intValue());
 
       testZkClient.setAsyncCallRC(CONNECTIONLOSS.intValue());
       // Async exist check will be pending due to the mock error rc is retryable.
@@ -339,7 +338,7 @@ public class TestZkClientAsyncRetry extends ZkTestBase {
       // 2. Test async get
       ZkAsyncCallbacks.GetDataCallbackHandler getCallback =
           new ZkAsyncCallbacks.GetDataCallbackHandler();
-      Assert.assertEquals(getCallback.getRc(), UNKNOWN_RET_CODE);
+      Assert.assertEquals(getCallback.getRc(), KeeperException.Code.APIERROR.intValue());
 
       testZkClient.setAsyncCallRC(CONNECTIONLOSS.intValue());
       // Async get will be pending due to the mock error rc is retryable.
@@ -423,7 +422,7 @@ public class TestZkClientAsyncRetry extends ZkTestBase {
       // Test asyncGet failure
       ZkAsyncCallbacks.GetDataCallbackHandler getCallback =
           new ZkAsyncCallbacks.GetDataCallbackHandler();
-      Assert.assertEquals(getCallback.getRc(), UNKNOWN_RET_CODE);
+      Assert.assertEquals(getCallback.getRc(), KeeperException.Code.APIERROR.intValue());
       // asyncGet should fail because the return code is APIERROR
       testZkClient.setAsyncCallRC(KeeperException.Code.APIERROR.intValue());
       testZkClient.asyncGetData(NODE_PATH, getCallback);
@@ -445,7 +444,7 @@ public class TestZkClientAsyncRetry extends ZkTestBase {
       // Test asyncExists failure
       ZkAsyncCallbacks.ExistsCallbackHandler existsCallback =
           new ZkAsyncCallbacks.ExistsCallbackHandler();
-      Assert.assertEquals(existsCallback.getRc(), UNKNOWN_RET_CODE);
+      Assert.assertEquals(existsCallback.getRc(), KeeperException.Code.APIERROR.intValue());
       // asyncExists should fail because the return code is APIERROR
       testZkClient.setAsyncCallRC(KeeperException.Code.APIERROR.intValue());
       testZkClient.asyncExists(NODE_PATH, existsCallback);
@@ -467,7 +466,7 @@ public class TestZkClientAsyncRetry extends ZkTestBase {
       // Test asyncSet failure
       ZkAsyncCallbacks.SetDataCallbackHandler setCallback =
           new ZkAsyncCallbacks.SetDataCallbackHandler();
-      Assert.assertEquals(setCallback.getRc(), UNKNOWN_RET_CODE);
+      Assert.assertEquals(setCallback.getRc(), KeeperException.Code.APIERROR.intValue());
       // asyncSet should fail because the return code is APIERROR
       testZkClient.setAsyncCallRC(KeeperException.Code.APIERROR.intValue());
       testZkClient.asyncSetData(NODE_PATH, tmpRecord, -1, setCallback);
@@ -481,7 +480,7 @@ public class TestZkClientAsyncRetry extends ZkTestBase {
       // Test asyncDelete failure
       ZkAsyncCallbacks.DeleteCallbackHandler deleteCallback =
           new ZkAsyncCallbacks.DeleteCallbackHandler();
-      Assert.assertEquals(deleteCallback.getRc(), UNKNOWN_RET_CODE);
+      Assert.assertEquals(deleteCallback.getRc(), KeeperException.Code.APIERROR.intValue());
       // asyncDelete should fail because the return code is APIERROR
       testZkClient.setAsyncCallRC(KeeperException.Code.APIERROR.intValue());
       testZkClient.asyncDelete(NODE_PATH, deleteCallback);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

This PR will partially fix unstable tests like #1763 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR removes the non-official ZK error codes that are returned in Helix ZkClient. The original design was made for differentiating the failure cases. However, that design causes unexpected NPE since most of Helix's logic relies on the Zookeeper KeeperException class to identify the error types.

FYI,
```
2021-05-27T13:44:01.7121680Z 1810401 [ExternalViewComputeWorker-TestClusterStatusMonitorLifecycle0_2] ERROR org.apache.helix.controller.pipeline.AbstractAsyncBaseStage  - Failed to process DEFAULT::ExternalViewComputeStage asynchronously
2021-05-27T13:44:01.7127825Z java.lang.NullPointerException
2021-05-27T13:44:01.7130637Z 	at org.apache.helix.manager.zk.ZkBaseDataAccessor.set(ZkBaseDataAccessor.java:912)
2021-05-27T13:44:01.7135009Z 	at org.apache.helix.manager.zk.ZkBaseDataAccessor.setChildren(ZkBaseDataAccessor.java:856)
2021-05-27T13:44:01.7140459Z 	at org.apache.helix.manager.zk.ZKHelixDataAccessor.setChildren(ZKHelixDataAccessor.java:578)
2021-05-27T13:44:01.7146249Z 	at org.apache.helix.controller.stages.ExternalViewComputeStage.execute(ExternalViewComputeStage.java:134)
2021-05-27T13:44:01.7149517Z 	at org.apache.helix.controller.pipeline.AbstractAsyncBaseStage$1.run(AbstractAsyncBaseStage.java:47)
2021-05-27T13:44:01.7152294Z 	at org.apache.helix.controller.GenericHelixController$3.handleEvent(GenericHelixController.java:701)
2021-05-27T13:44:01.7154919Z 	at org.apache.helix.controller.GenericHelixController$3.handleEvent(GenericHelixController.java:697)
2021-05-27T13:44:01.7157110Z 	at org.apache.helix.common.DedupEventProcessor.run(DedupEventProcessor.java:61)
```

One option is to change all the logic that reads KeeperException. It would cause a huge change and potentially diverge Helix from the official Zookeeper release. So it would eventually make the whole ZK error processing logics harder to maintain.

Here, I proposed to convert back to the official ZK error code. Given the current processing logic does not need a different customized code to branch, I don't see any necessity of having these additional error codes.

### Tests

- [X] The following tests are written for this issue:

Related tests have been modified.

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
