### PR TITLE
Change partition status in Helix UI to be colorblind-friendly

### DIFF
--- a/helix-front/client/app/resource/partition-list/partition-list.component.html
+++ b/helix-front/client/app/resource/partition-list/partition-list.component.html
@@ -49,7 +49,8 @@
       [draggable]="false"
       [canAutoResize]="false">
       <ng-template let-value="value" ngx-datatable-cell-template>
-        <mat-icon [ngClass]="value ? 'status-ready' : 'status-not-ready'">lens</mat-icon>
+        <mat-icon *ngIf="value" [ngClass]="'status-ready'">check_circle</mat-icon>
+        <mat-icon *ngIf="!value" [ngClass]="'status-not-ready'">error</mat-icon>
       </ng-template>
     </ngx-datatable-column>
     <ngx-datatable-column name="Name"></ngx-datatable-column>

--- a/helix-front/client/app/resource/partition-list/partition-list.component.scss
+++ b/helix-front/client/app/resource/partition-list/partition-list.component.scss
@@ -5,11 +5,11 @@ div.message {
 }
 
 .status-ready {
-  color: mat-color(mat-palette($mat-green));
+  color: mat-color(mat-palette($mat-blue));
 }
 
 .status-not-ready {
-  color: mat-color(mat-palette($mat-orange), darker);
+  color: mat-color(mat-palette($mat-grey, 900, 900, 900), darker);
 }
 
 .footer {

--- a/helix-front/client/app/shared/state-label/state-label.component.scss
+++ b/helix-front/client/app/shared/state-label/state-label.component.scss
@@ -9,9 +9,9 @@
 }
 
 .state-label-ready {
-  border-color: mat-color(mat-palette($mat-green), darker);
+  border-color: mat-color(mat-palette($mat-blue), darker);
 }
 
 .state-label-not-ready {
-  border-color: mat-color(mat-palette($mat-orange), darker);
+  border-color: mat-color(mat-palette($mat-grey, 900, 900, 900), darker);
 }


### PR DESCRIPTION
This commit changes the partition status colors and adds some signs to the status icons in Helix UI to be more colorblind-friendly.

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1784 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR changes the partition status colors in Helix UI from green/orange to blue(#2196F3)/black(#212121) to be more colorblind- friendly. The colors are chosen such that they have a contrast ratio of at least 3:1 against each other and the background. Moreover, a checkmark is placed in the icon for ready status, and an exclamation point for the not-ready status. Screenshots of the changes are the following:

![Screen Shot 2021-06-07 at 10 26 35 AM](https://user-images.githubusercontent.com/67170754/121063197-da757380-c77a-11eb-9b5c-472caafd5317.png) ![Screen Shot 2021-06-07 at 10 28 21 AM](https://user-images.githubusercontent.com/67170754/121063394-17da0100-c77b-11eb-90b3-70de6e5ec9f1.png)




### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
