### PR TITLE
Add failure message for TestClusterAccessor 

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
@@ -161,7 +161,6 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
     }
   }
 
-
   @Override
   protected Application configure() {
     // Configure server context

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
@@ -161,6 +161,7 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
     }
   }
 
+
   @Override
   protected Application configure() {
     // Configure server context

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -92,7 +92,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     Assert.assertEquals(clusters, _clusters,
         "clusters from response: " + clusters + " vs clusters actually: " + _clusters);
 
-    Assert.assertEquals(_auditLogger.getAuditLogs().size(), 1);
+    validateAuditLogSize(1);
     AuditLog auditLog = _auditLogger.getAuditLogs().get(0);
     validateAuditLog(auditLog, HTTPMethods.GET.name(), "clusters",
         Response.Status.OK.getStatusCode(), body);
@@ -345,7 +345,7 @@ public class TestClusterAccessor extends AbstractTestClass {
 
     // verify the cluster has been deleted.
     Assert.assertFalse(_baseAccessor.exists("/" + cluster, 0));
-    Assert.assertEquals(_auditLogger.getAuditLogs().size(), 3);
+    validateAuditLogSize(3);
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
@@ -370,7 +370,7 @@ public class TestClusterAccessor extends AbstractTestClass {
 
     // verify the cluster is paused.
     Assert.assertFalse(_baseAccessor.exists(keyBuilder.pause().getPath(), 0));
-    Assert.assertEquals(_auditLogger.getAuditLogs().size(), 2);
+    validateAuditLogSize(2);
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
@@ -1305,10 +1305,16 @@ public class TestClusterAccessor extends AbstractTestClass {
     post("clusters/" + cluster + "/configs", ImmutableMap.of("command", command.name()), entity,
         Response.Status.OK.getStatusCode());
 
-    Assert.assertEquals(_auditLogger.getAuditLogs().size(), 1);
+    validateAuditLogSize(1);
     AuditLog auditLog = _auditLogger.getAuditLogs().get(0);
     validateAuditLog(auditLog, HTTPMethods.POST.name(), "clusters/" + cluster + "/configs",
         Response.Status.OK.getStatusCode(), null);
+  }
+
+  private void validateAuditLogSize(int expected) {
+    Assert.assertEquals(_auditLogger.getAuditLogs().size(), expected,
+        "AuditLog:" + _auditLogger.getAuditLogs().toString());
+
   }
 
   private ClusterConfig createClusterConfig(String cluster) {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -34,7 +34,6 @@ import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.sun.research.ws.wadl.HTTPMethods;
 import org.apache.helix.ConfigAccessor;
@@ -43,8 +42,6 @@ import org.apache.helix.PropertyKey;
 import org.apache.helix.TestHelper;
 import org.apache.helix.cloud.azure.AzureConstants;
 import org.apache.helix.cloud.constants.CloudProvider;
-import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
-import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.integration.manager.ClusterDistributedController;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
@@ -721,7 +718,7 @@ public class TestClusterAccessor extends AbstractTestClass {
     }
   }
 
-  @Test
+  @Test(dependsOnMethods = "testEnableWagedRebalanceForAllResources")
   public void testCreateRESTConfig() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String cluster = _clusters.iterator().next();

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -1314,7 +1314,6 @@ public class TestClusterAccessor extends AbstractTestClass {
   private void validateAuditLogSize(int expected) {
     Assert.assertEquals(_auditLogger.getAuditLogs().size(), expected,
         "AuditLog:" + _auditLogger.getAuditLogs().toString());
-
   }
 
   private ClusterConfig createClusterConfig(String cluster) {


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1761

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

We notice one CI failure with in TestClusterAccessor. It failed because there are more than one expected audit logs in `_auditLogger`. It is hard to debug witch rest integration test interference TestClusterAccessor with current info.
This change adds a failure message when `_auditLogger` size check fails for better debugging experience. 

### Tests

- [X] The following tests are written for this issue:

N/A

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
