### PR TITLE
Add message util to create messages

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 
@@ -45,8 +44,6 @@ import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
-import org.apache.helix.model.Message.MessageState;
-import org.apache.helix.model.Message.MessageType;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceConfig;
@@ -212,10 +209,12 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
         if (desiredState.equals(NO_DESIRED_STATE) || desiredState.equalsIgnoreCase(currentState)) {
           if (shouldCreateSTCancellation(pendingMessage, desiredState,
               stateModelDef.getInitialState())) {
-            message = MessageUtil.createStateTransitionCancellationMessage(manager, resource,
-                partition.getPartitionName(), instanceName, sessionIdMap.get(instanceName),
-                stateModelDef.getId(), pendingMessage.getFromState(), pendingMessage.getToState(),
-                null, cancellationMessage, isCancellationEnabled, currentState);
+            message = MessageUtil
+                .createStateTransitionCancellationMessage(manager.getInstanceName(),
+                    manager.getSessionId(), resource, partition.getPartitionName(), instanceName,
+                    sessionIdMap.get(instanceName), stateModelDef.getId(),
+                    pendingMessage.getFromState(), pendingMessage.getToState(), null,
+                    cancellationMessage, isCancellationEnabled, currentState);
           }
         } else {
           if (nextState == null) {
@@ -234,9 +233,9 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
           } else {
             // Create new state transition message
             message = MessageUtil
-                .createStateTransitionMessage(manager, resource, partition.getPartitionName(),
-                    instanceName, currentState, nextState, sessionIdMap.get(instanceName),
-                    stateModelDef.getId());
+                .createStateTransitionMessage(manager.getInstanceName(), manager.getSessionId(),
+                    resource, partition.getPartitionName(), instanceName, currentState, nextState,
+                    sessionIdMap.get(instanceName), stateModelDef.getId());
 
             if (logger.isDebugEnabled()) {
               LogUtil.logDebug(logger, _eventId, String.format(
@@ -329,10 +328,10 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
                 + instanceName + ", pendingState: " + pendingState + ", currentState: "
                 + currentState + ", nextState: " + nextState + ", isRelay: " + pendingMessage.isRelayMessage());
 
-        message = MessageUtil.createStateTransitionCancellationMessage(manager, resource,
-            partition.getPartitionName(), instanceName, sessionIdMap.get(instanceName),
-            stateModelDef.getId(), pendingMessage.getFromState(), pendingState, nextState,
-            cancellationMessage, isCancellationEnabled, currentState);
+        message = MessageUtil.createStateTransitionCancellationMessage(manager.getInstanceName(),
+            manager.getSessionId(), resource, partition.getPartitionName(), instanceName,
+            sessionIdMap.get(instanceName), stateModelDef.getId(), pendingMessage.getFromState(),
+            pendingState, nextState, cancellationMessage, isCancellationEnabled, currentState);
       }
     }
     return message;

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -52,6 +52,7 @@ import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.util.HelixUtil;
+import org.apache.helix.util.MessageUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,8 +71,6 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
       .getSystemPropertyAsLong(SystemPropertyKeys.CONTROLLER_MESSAGE_PURGE_DELAY, 60 * 1000);
   private final static String PENDING_MESSAGE = "pending message";
   private final static String STALE_MESSAGE = "stale message";
-  // TODO: Make the message retry count configurable through the Cluster Config or IdealStates.
-  public final static int DEFAULT_STATE_TRANSITION_MESSAGE_RETRY_COUNT = 3;
 
   private static Logger logger = LoggerFactory.getLogger(MessageGenerationPhase.class);
 
@@ -213,7 +212,7 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
         if (desiredState.equals(NO_DESIRED_STATE) || desiredState.equalsIgnoreCase(currentState)) {
           if (shouldCreateSTCancellation(pendingMessage, desiredState,
               stateModelDef.getInitialState())) {
-            message = createStateTransitionCancellationMessage(manager, resource,
+            message = MessageUtil.createStateTransitionCancellationMessage(manager, resource,
                 partition.getPartitionName(), instanceName, sessionIdMap.get(instanceName),
                 stateModelDef.getId(), pendingMessage.getFromState(), pendingMessage.getToState(),
                 null, cancellationMessage, isCancellationEnabled, currentState);
@@ -234,9 +233,10 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
                     cancellationMessage, isCancellationEnabled);
           } else {
             // Create new state transition message
-            message = createStateTransitionMessage(manager, resource, partition.getPartitionName(),
-                instanceName, currentState, nextState, sessionIdMap.get(instanceName),
-                stateModelDef.getId());
+            message = MessageUtil
+                .createStateTransitionMessage(manager, resource, partition.getPartitionName(),
+                    instanceName, currentState, nextState, sessionIdMap.get(instanceName),
+                    stateModelDef.getId());
 
             if (logger.isDebugEnabled()) {
               LogUtil.logDebug(logger, _eventId, String.format(
@@ -329,7 +329,7 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
                 + instanceName + ", pendingState: " + pendingState + ", currentState: "
                 + currentState + ", nextState: " + nextState + ", isRelay: " + pendingMessage.isRelayMessage());
 
-        message = createStateTransitionCancellationMessage(manager, resource,
+        message = MessageUtil.createStateTransitionCancellationMessage(manager, resource,
             partition.getPartitionName(), instanceName, sessionIdMap.get(instanceName),
             stateModelDef.getId(), pendingMessage.getFromState(), pendingState, nextState,
             cancellationMessage, isCancellationEnabled, currentState);
@@ -413,72 +413,6 @@ public abstract class MessageGenerationPhase extends AbstractBaseStage {
       // the message is invalid and can be safely deleted immediately.
       return !currentState.equalsIgnoreCase(pendingMsg.getFromState());
     }
-  }
-
-  private Message createStateTransitionMessage(HelixManager manager, Resource resource,
-      String partitionName, String instanceName, String currentState, String nextState,
-      String sessionId, String stateModelDefName) {
-    String uuid = UUID.randomUUID().toString();
-    String managerSessionId = manager.getSessionId();
-    Message message = new Message(MessageType.STATE_TRANSITION, uuid);
-    message.setSrcName(manager.getInstanceName());
-    message.setTgtName(instanceName);
-    message.setMsgState(MessageState.NEW);
-    message.setPartitionName(partitionName);
-    message.setResourceName(resource.getResourceName());
-    message.setFromState(currentState);
-    message.setToState(nextState);
-    message.setTgtSessionId(sessionId);
-    message.setSrcSessionId(managerSessionId);
-    message.setExpectedSessionId(managerSessionId);
-    message.setStateModelDef(stateModelDefName);
-    message.setStateModelFactoryName(resource.getStateModelFactoryname());
-    message.setBucketSize(resource.getBucketSize());
-    // Set the retry count for state transition messages.
-    // TODO: make the retry count configurable in ClusterConfig or IdealState
-    message.setRetryCount(DEFAULT_STATE_TRANSITION_MESSAGE_RETRY_COUNT);
-
-    if (resource.getResourceGroupName() != null) {
-      message.setResourceGroupName(resource.getResourceGroupName());
-    }
-    if (resource.getResourceTag() != null) {
-      message.setResourceTag(resource.getResourceTag());
-    }
-
-    return message;
-  }
-
-  private Message createStateTransitionCancellationMessage(HelixManager manager, Resource resource,
-      String partitionName, String instanceName, String sessionId, String stateModelDefName,
-      String fromState, String toState, String nextState, Message cancellationMessage,
-      boolean isCancellationEnabled, String currentState) {
-
-    if (isCancellationEnabled && cancellationMessage == null) {
-      logger.info("Event {} : Send cancellation message of the state transition for {}.{} on {}, "
-              + "currentState: {}, nextState: {},  toState: {}",
-          _eventId, resource.getResourceName(), partitionName, instanceName,
-          currentState, nextState == null ? "N/A" : nextState, toState);
-
-      String uuid = UUID.randomUUID().toString();
-      String managerSessionId = manager.getSessionId();
-      Message message = new Message(MessageType.STATE_TRANSITION_CANCELLATION, uuid);
-      message.setSrcName(manager.getInstanceName());
-      message.setTgtName(instanceName);
-      message.setMsgState(MessageState.NEW);
-      message.setPartitionName(partitionName);
-      message.setResourceName(resource.getResourceName());
-      message.setFromState(fromState);
-      message.setToState(toState);
-      message.setTgtSessionId(sessionId);
-      message.setSrcSessionId(managerSessionId);
-      message.setExpectedSessionId(managerSessionId);
-      message.setStateModelDef(stateModelDefName);
-      message.setStateModelFactoryName(resource.getStateModelFactoryname());
-      message.setBucketSize(resource.getBucketSize());
-      return message;
-    }
-
-    return null;
   }
 
   private int getTimeOut(ClusterConfig clusterConfig, ResourceConfig resourceConfig,

--- a/helix-core/src/main/java/org/apache/helix/model/Message.java
+++ b/helix-core/src/main/java/org/apache/helix/model/Message.java
@@ -82,6 +82,7 @@ public class Message extends HelixProperty {
     RESOURCE_TAG,
     FROM_STATE,
     TO_STATE,
+    TO_STATUS,
     STATE_MODEL_DEF,
     CREATE_TIMESTAMP,
     COMPLETION_DUE_TIMESTAMP,
@@ -414,6 +415,10 @@ public class Message extends HelixProperty {
    */
   public String getToState() {
     return _record.getSimpleField(Attributes.TO_STATE.toString());
+  }
+
+  public void setToStatus(LiveInstance.LiveInstanceStatus status) {
+    _record.setEnumField(Attributes.TO_STATUS.name(), status);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/Message.java
+++ b/helix-core/src/main/java/org/apache/helix/model/Message.java
@@ -82,7 +82,6 @@ public class Message extends HelixProperty {
     RESOURCE_TAG,
     FROM_STATE,
     TO_STATE,
-    TO_STATUS,
     STATE_MODEL_DEF,
     CREATE_TIMESTAMP,
     COMPLETION_DUE_TIMESTAMP,
@@ -415,10 +414,6 @@ public class Message extends HelixProperty {
    */
   public String getToState() {
     return _record.getSimpleField(Attributes.TO_STATE.toString());
-  }
-
-  public void setToStatus(LiveInstance.LiveInstanceStatus status) {
-    _record.setEnumField(Attributes.TO_STATUS.name(), status);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/util/MessageUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/MessageUtil.java
@@ -1,0 +1,120 @@
+package org.apache.helix.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.UUID;
+
+import org.apache.helix.HelixManager;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.Message;
+import org.apache.helix.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message utils to operate on message such creating messages.
+ */
+public class MessageUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(MessageUtil.class);
+
+  // TODO: Make the message retry count configurable through the Cluster Config or IdealStates.
+  public final static int DEFAULT_STATE_TRANSITION_MESSAGE_RETRY_COUNT = 3;
+
+  public static Message createStateTransitionCancellationMessage(HelixManager manager,
+      Resource resource, String partitionName, String instanceName, String sessionId,
+      String stateModelDefName, String fromState, String toState, String nextState,
+      Message cancellationMessage, boolean isCancellationEnabled, String currentState) {
+    if (isCancellationEnabled && cancellationMessage == null) {
+      LOG.info("Create cancellation message of the state transition for {}.{} on {}, "
+              + "currentState: {}, nextState: {},  toState: {}", resource.getResourceName(),
+          partitionName, instanceName, currentState, nextState == null ? "N/A" : nextState,
+          toState);
+
+      Message message =
+          createMessage(Message.MessageType.STATE_TRANSITION_CANCELLATION, manager, resource,
+              partitionName, instanceName, currentState, nextState, sessionId, stateModelDefName);
+
+      message.setFromState(fromState);
+      message.setToState(toState);
+      return message;
+    }
+
+    return null;
+  }
+
+  public static Message createStateTransitionMessage(HelixManager manager, Resource resource,
+      String partitionName, String instanceName, String currentState, String nextState,
+      String sessionId, String stateModelDefName) {
+    Message message =
+        createMessage(Message.MessageType.STATE_TRANSITION, manager, resource, partitionName,
+            instanceName, currentState, nextState, sessionId, stateModelDefName);
+
+    // Set the retry count for state transition messages.
+    // TODO: make the retry count configurable in ClusterConfig or IdealState
+    message.setRetryCount(DEFAULT_STATE_TRANSITION_MESSAGE_RETRY_COUNT);
+
+    if (resource.getResourceGroupName() != null) {
+      message.setResourceGroupName(resource.getResourceGroupName());
+    }
+    if (resource.getResourceTag() != null) {
+      message.setResourceTag(resource.getResourceTag());
+    }
+
+    return message;
+  }
+
+  public static Message createStatusChangeMessage(LiveInstance.LiveInstanceStatus toStatus,
+      HelixManager manager, String instanceName, String sessionId) {
+    String managerSessionId = manager.getSessionId();
+    Message message =
+        new Message(Message.MessageType.PARTICIPANT_STATUS_CHANGE, UUID.randomUUID().toString());
+    message.setSrcName(manager.getInstanceName());
+    message.setSrcSessionId(managerSessionId);
+    message.setExpectedSessionId(managerSessionId);
+    message.setTgtName(instanceName);
+    message.setTgtSessionId(sessionId);
+    message.setToStatus(toStatus);
+    return message;
+  }
+
+  private static Message createMessage(Message.MessageType messageType, HelixManager manager,
+      Resource resource, String partitionName, String instanceName, String currentState,
+      String nextState, String sessionId, String stateModelDefName) {
+    String uuid = UUID.randomUUID().toString();
+    String managerSessionId = manager.getSessionId();
+
+    Message message = new Message(messageType, uuid);
+    message.setSrcName(manager.getInstanceName());
+    message.setTgtName(instanceName);
+    message.setMsgState(Message.MessageState.NEW);
+    message.setPartitionName(partitionName);
+    message.setFromState(currentState);
+    message.setToState(nextState);
+    message.setTgtSessionId(sessionId);
+    message.setSrcSessionId(managerSessionId);
+    message.setExpectedSessionId(managerSessionId);
+    message.setStateModelDef(stateModelDefName);
+    message.setResourceName(resource.getResourceName());
+    message.setStateModelFactoryName(resource.getStateModelFactoryname());
+    message.setBucketSize(resource.getBucketSize());
+
+    return message;
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestStateTransitionAppFailureHandling.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestStateTransitionAppFailureHandling.java
@@ -37,6 +37,7 @@ import org.apache.helix.mock.participant.MockTransition;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.Message;
 import org.apache.helix.participant.statemachine.StateModelFactory;
+import org.apache.helix.util.MessageUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -122,7 +123,7 @@ public class TestStateTransitionAppFailureHandling extends ZkStandAloneCMTestBas
       // Check if the factory has tried enough times before fail the message.
       Assert.assertEquals(retryCountUntilSucceed - retryFactoryMap.get(instanceName)
           .getRemainingRetryCountUntilSucceed(), instanceMessages.size()
-          * MessageGenerationPhase.DEFAULT_STATE_TRANSITION_MESSAGE_RETRY_COUNT);
+          * MessageUtil.DEFAULT_STATE_TRANSITION_MESSAGE_RETRY_COUNT);
     }
 
     // Verify that the partition is not initialized.
@@ -146,7 +147,7 @@ public class TestStateTransitionAppFailureHandling extends ZkStandAloneCMTestBas
     // Make the mock StateModelFactory return handler before last retry. So it will successfully
     // finish handler initialization.
     int retryCountUntilSucceed =
-        MessageGenerationPhase.DEFAULT_STATE_TRANSITION_MESSAGE_RETRY_COUNT - 1;
+        MessageUtil.DEFAULT_STATE_TRANSITION_MESSAGE_RETRY_COUNT - 1;
     Map<String, RetryStateModelFactory> retryFactoryMap = resetParticipants(retryCountUntilSucceed);
 
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, TEST_DB, _PARTITIONS, STATE_MODEL);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1795 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Message creation methods are private in message generation phase. Management mode stage will also need message generation methods to create ST cancellation and participant status change messages.
Message util will help with the purposes.

This PR moves the common message creation logic to a message util so multiple stages can reuse the code.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

```
02:40:56,670 [INFO] Tests run: 1271, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4,927.77 s - in TestSuite
02:40:57,126 [INFO]
02:40:57,126 [INFO] Results:
02:40:57,126 [INFO]
02:40:57,126 [INFO] Tests run: 1271, Failures: 0, Errors: 0, Skipped: 0
02:40:57,127 [INFO]
02:40:57,131 [INFO]
02:40:57,131 [INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core ---
02:40:57,635 [INFO] Analyzed bundle 'Apache Helix :: Core' with 907 classes
02:40:59,150 [INFO] ------------------------------------------------------------------------
02:40:59,151 [INFO] BUILD SUCCESS
02:40:59,151 [INFO] ------------------------------------------------------------------------
02:40:59,152 [INFO] Total time:  01:22 h
02:40:59,152 [INFO] Finished at: 2021-06-14T02:40:59-07:00
02:40:59,152 [INFO] ------------------------------------------------------------------------


18:14:59,168 [INFO] Tests run: 1271, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4,962.022 s - in TestSuite
18:14:59,644 [INFO]
18:14:59,645 [INFO] Results:
18:14:59,645 [INFO]
18:14:59,645 [INFO] Tests run: 1271, Failures: 0, Errors: 0, Skipped: 0
18:14:59,645 [INFO]
18:14:59,649 [INFO]
18:14:59,649 [INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core ---
18:15:00,145 [INFO] Analyzed bundle 'Apache Helix :: Core' with 907 classes
18:15:01,664 [INFO] ------------------------------------------------------------------------
18:15:01,664 [INFO] BUILD SUCCESS
18:15:01,665 [INFO] ------------------------------------------------------------------------
18:15:01,666 [INFO] Total time:  01:22 h
18:15:01,666 [INFO] Finished at: 2021-06-14T18:15:01-07:00
18:15:01,666 [INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
