### PR TITLE
Add response metadata to response header for partitionAssignment

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -131,10 +131,11 @@ public class AbstractResource {
   }
 
   protected Response OKWithHeader(Object entity, String headerName, Object headerValue) {
-    if (headerName == null || headerName.length()==0)
+    if (headerName == null || headerName.length() == 0) {
       return OK(entity);
-    else
+    } else {
       return Response.ok(entity).header(headerName, headerValue).build();
+    }
   }
 
   protected Response created() {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -130,6 +130,11 @@ public class AbstractResource {
     return Response.ok().build();
   }
 
+  protected Response OKWithHeader(Object entity, String headerName, Object headerValue) {
+
+    return Response.ok(entity).header(headerName, headerValue).build();
+  }
+
   protected Response created() {
     return Response.status(Response.Status.CREATED).build();
   }
@@ -154,6 +159,16 @@ public class AbstractResource {
     try {
       String jsonStr = toJson(entity);
       return OK(jsonStr);
+    } catch (IOException e) {
+      _logger.error("Failed to convert " + entity + " to JSON response", e);
+      return serverError();
+    }
+  }
+
+  protected Response JSONRepresentation(Object entity, String headerName, Object headerValue) {
+    try {
+      String jsonStr = toJson(entity);
+      return OKWithHeader(jsonStr, headerName, headerValue);
     } catch (IOException e) {
       _logger.error("Failed to convert " + entity + " to JSON response", e);
       return serverError();

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -131,7 +131,10 @@ public class AbstractResource {
   }
 
   protected Response OKWithHeader(Object entity, String headerName, Object headerValue) {
-    return Response.ok(entity).header(headerName, headerValue).build();
+    if (headerName == null || headerName.length()==0)
+      return OK(entity);
+    else
+      return Response.ok(entity).header(headerName, headerValue).build();
   }
 
   protected Response created() {
@@ -155,15 +158,13 @@ public class AbstractResource {
   }
 
   protected Response JSONRepresentation(Object entity) {
-    try {
-      String jsonStr = toJson(entity);
-      return OK(jsonStr);
-    } catch (IOException e) {
-      _logger.error("Failed to convert " + entity + " to JSON response", e);
-      return serverError();
-    }
+    return JSONRepresentation(entity, null, null);
   }
 
+  /**
+   * Any metadata about the response could be conveyed through the entity headers.
+   * More details can be found at 'REST-API-Design-Rulebook' -- Ch4 Metadata Design
+   */
   protected Response JSONRepresentation(Object entity, String headerName, Object headerValue) {
     try {
       String jsonStr = toJson(entity);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -131,7 +131,6 @@ public class AbstractResource {
   }
 
   protected Response OKWithHeader(Object entity, String headerName, Object headerValue) {
-
     return Response.ok(entity).header(headerName, headerValue).build();
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
@@ -65,6 +65,8 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
       org.apache.helix.rest.server.resources.helix.ResourceAssignmentOptimizerAccessor.class
           .getName());
 
+  private static String RESPONSE_HEADER_KEY = "Setting";
+
   private static class InputFields {
     List<String> newInstances = new ArrayList<>();
     List<String> instancesToRemove = new ArrayList<>();
@@ -140,7 +142,7 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
       result = computeOptimalAssignmentForResources(inputFields, clusterState, clusterId);
       // 4. Serialize result to JSON and return.
       // TODO: We will need to include user input to response header since user may do async call.
-      return JSONRepresentation(result);
+      return JSONRepresentation(result, RESPONSE_HEADER_KEY, buildResponseHeaders(inputFields));
     } catch (InvalidParameterException ex) {
       return badRequest(ex.getMessage());
     } catch (JsonProcessingException e) {
@@ -369,5 +371,14 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
       }
     }
     result.put(resource, partitionAssignments);
+  }
+
+  private Map<String,Object> buildResponseHeaders(InputFields inputFields) {
+    Map<String,Object> headers= new HashMap<>();
+    headers.put("Format", inputFields.returnFormat.name());
+    headers.put("Resource-Filter", inputFields.resourceFilter);
+    headers.put("Instance-Filter", inputFields.instanceFilter);
+
+    return headers;
   }
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
@@ -65,8 +65,8 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
       org.apache.helix.rest.server.resources.helix.ResourceAssignmentOptimizerAccessor.class
           .getName());
 
-  private static String RESPONSE_HEADER_KEY = "Setting";
-  private static String[] RESPONSE_HEADER_FIELDS =
+  public static String RESPONSE_HEADER_KEY = "Setting";
+  public static String[] RESPONSE_HEADER_FIELDS =
       new String[]{"instanceFilter", "resourceFilter", "returnFormat"};
 
   private static class InputFields {
@@ -376,7 +376,7 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
   }
 
   private Map<String,Object> buildResponseHeaders(InputFields inputFields) {
-    Map<String,Object> headers= new HashMap<>();
+    Map<String, Object> headers= new HashMap<>();
     headers.put(RESPONSE_HEADER_FIELDS[0], inputFields.instanceFilter);
     headers.put(RESPONSE_HEADER_FIELDS[1], inputFields.resourceFilter);
     headers.put(RESPONSE_HEADER_FIELDS[2], inputFields.returnFormat.name());

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
@@ -66,6 +66,8 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
           .getName());
 
   private static String RESPONSE_HEADER_KEY = "Setting";
+  private static String[] RESPONSE_HEADER_FIELDS =
+      new String[]{"instanceFilter", "resourceFilter", "returnFormat"};
 
   private static class InputFields {
     List<String> newInstances = new ArrayList<>();
@@ -375,10 +377,9 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
 
   private Map<String,Object> buildResponseHeaders(InputFields inputFields) {
     Map<String,Object> headers= new HashMap<>();
-    headers.put("Format", inputFields.returnFormat.name());
-    headers.put("Resource-Filter", inputFields.resourceFilter);
-    headers.put("Instance-Filter", inputFields.instanceFilter);
-
+    headers.put(RESPONSE_HEADER_FIELDS[0], inputFields.instanceFilter);
+    headers.put(RESPONSE_HEADER_FIELDS[1], inputFields.resourceFilter);
+    headers.put(RESPONSE_HEADER_FIELDS[2], inputFields.returnFormat.name());
     return headers;
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
@@ -527,7 +527,7 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
     post(uri, queryParams, entity,expectedReturnStatus, false);
   }
 
-  protected String post(String uri, Map<String, String> queryParams, Entity entity,
+  protected Response post(String uri, Map<String, String> queryParams, Entity entity,
       int expectedReturnStatus, boolean  expectBodyReturned) {
     WebTarget webTarget = target(uri);
     if (queryParams != null) {
@@ -536,9 +536,8 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
       }
     }
     Response response = webTarget.request().post(entity);
-    String result = response.readEntity(String.class);
     Assert.assertEquals(response.getStatus(), expectedReturnStatus);
-    return result;
+    return response;
   }
 
   protected void delete(String uri, int expectedReturnStatus) {


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1746

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

User may call this API asynchronously. We should return some metadata of the response to user as well.  

### Tests

- [X] The following tests are written for this issue:

testComputePartitionAssignment

- The following is the result of the "mvn test" command on the appropriate module:
```
[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 325.848 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /Users/xialu/Documents/WorkSpace/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 79 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  05:34 min
[INFO] Finished at: 2021-07-21T14:51:27-07:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
