### PR TITLE
Rename property CLUSTER_PAUSE to CLUSTER_FREEZE in PauseSignal

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/PauseSignal.java
+++ b/helix-core/src/main/java/org/apache/helix/model/PauseSignal.java
@@ -32,7 +32,7 @@ public class PauseSignal extends HelixProperty {
 
   public enum PauseSignalProperty {
     REASON,
-    CLUSTER_PAUSE,
+    CLUSTER_FREEZE,
     FROM_HOST,
     CANCEL_PENDING_ST,
     TRIGGER_TIME
@@ -76,11 +76,11 @@ public class PauseSignal extends HelixProperty {
   }
 
   public void setClusterPause(boolean pause) {
-    _record.setBooleanField(PauseSignalProperty.CLUSTER_PAUSE.name(), pause);
+    _record.setBooleanField(PauseSignalProperty.CLUSTER_FREEZE.name(), pause);
   }
 
   public boolean isClusterPause() {
-    return _record.getBooleanField(PauseSignalProperty.CLUSTER_PAUSE.name(), false);
+    return _record.getBooleanField(PauseSignalProperty.CLUSTER_FREEZE.name(), false);
   }
 
   public void setFromHost(String host) {

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterFreezeMode.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterFreezeMode.java
@@ -158,11 +158,15 @@ public class TestClusterFreezeMode extends ZkTestBase {
         .build();
     _gSetupTool.getClusterManagementTool().setClusterManagementMode(request);
 
+    // Wait for all live instances are marked as frozen
+    verifyLiveInstanceStatus(_participants, LiveInstance.LiveInstanceStatus.FROZEN);
+
     // Pending ST message exists
     Assert.assertTrue(
         _gZkClient.exists(keyBuilder.message(message.getTgtName(), message.getMsgId()).getPath()));
 
-    // Cluster is in progress to cluster pause because there is a pending state transition message
+    // Even live instance status is marked as frozen, Cluster is in progress to cluster freeze
+    // because there is a pending state transition message
     ClusterStatus expectedClusterStatus = new ClusterStatus();
     expectedClusterStatus.setManagementMode(ClusterManagementMode.Type.CLUSTER_FREEZE);
     expectedClusterStatus.setManagementModeStatus(ClusterManagementMode.Status.IN_PROGRESS);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1805

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Rename property CLUSTER_PAUSE to CLUSTER_FREEZE in PauseSignal.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

```
20:22:08,180 [INFO] Tests run: 1282, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4,975.911 s - in TestSuite
20:22:08,707 [INFO]
20:22:08,707 [INFO] Results:
20:22:08,707 [INFO]
20:22:08,707 [INFO] Tests run: 1282, Failures: 0, Errors: 0, Skipped: 0
20:22:08,707 [INFO]
20:22:08,711 [INFO]
20:22:08,711 [INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core ---
20:22:08,742 [INFO] Loading execution data file /home/hulu/Projects/helix/helix-core/target/jacoco.exec
20:22:09,215 [INFO] Analyzed bundle 'Apache Helix :: Core' with 911 classes
20:22:10,713 [INFO] ------------------------------------------------------------------------
20:22:10,714 [INFO] BUILD SUCCESS
20:22:10,714 [INFO] ------------------------------------------------------------------------
20:22:10,715 [INFO] Total time:  01:23 h
20:22:10,715 [INFO] Finished at: 2021-07-15T20:22:10-07:00
20:22:10,716 [INFO] ------------------------------------------------------------------------
```

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
