### PR TITLE
Stabilize TestInstancesAccessor

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -46,7 +46,7 @@ public class TestInstancesAccessor extends AbstractTestClass {
   private final static String CLUSTER_NAME = "TestCluster_0";
 
   @Test
-  public void testInstancesStoppable_zoneBased() throws Exception {
+  public void testInstancesStoppable_zoneBased() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     // Select instances with zone based
     String content =

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -48,32 +48,6 @@ public class TestInstancesAccessor extends AbstractTestClass {
   @Test
   public void testInstancesStoppable_zoneBased() throws Exception {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
-    // Make sure that cluster config exists
-    boolean isClusterConfigExist = TestHelper.verify(() -> {
-      ClusterConfig clusterConfig;
-      try {
-        clusterConfig = _configAccessor.getClusterConfig(STOPPABLE_CLUSTER);
-      } catch (Exception e) {
-        return false;
-      }
-      return (clusterConfig != null);
-    }, TestHelper.WAIT_DURATION);
-    Assert.assertTrue(isClusterConfigExist);
-    // Make sure that instance config exists for the instance0 to instance5
-    List<String> existingInstances = new ArrayList<>(Arrays.asList("instance0", "instance1",
-        "instance2", "instance3", "instance4", "instance5"));
-    for (String instance: existingInstances) {
-      boolean isinstanceConfigExist = TestHelper.verify(() -> {
-        InstanceConfig instanceConfig;
-        try {
-          instanceConfig = _configAccessor.getInstanceConfig(STOPPABLE_CLUSTER, instance);
-        } catch (Exception e) {
-          return false;
-        }
-        return (instanceConfig != null);
-      }, TestHelper.WAIT_DURATION);
-      Assert.assertTrue(isinstanceConfigExist);
-    }
     // Select instances with zone based
     String content =
         String.format("{\"%s\":\"%s\",\"%s\":[\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\", \"%s\"]}",

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -46,8 +46,34 @@ public class TestInstancesAccessor extends AbstractTestClass {
   private final static String CLUSTER_NAME = "TestCluster_0";
 
   @Test
-  public void testInstancesStoppable_zoneBased() throws IOException {
+  public void testInstancesStoppable_zoneBased() throws Exception {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
+    // Make sure that cluster config exists
+    boolean isClusterConfigExist = TestHelper.verify(() -> {
+      ClusterConfig clusterConfig;
+      try {
+        clusterConfig = _configAccessor.getClusterConfig(STOPPABLE_CLUSTER);
+      } catch (Exception e) {
+        return false;
+      }
+      return (clusterConfig != null);
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(isClusterConfigExist);
+    // Make sure that instance config exists for the instance0 to instance5
+    List<String> existingInstances = new ArrayList<>(Arrays.asList("instance0", "instance1",
+        "instance2", "instance3", "instance4", "instance5"));
+    for (String instance: existingInstances) {
+      boolean isinstanceConfigExist = TestHelper.verify(() -> {
+        InstanceConfig instanceConfig;
+        try {
+          instanceConfig = _configAccessor.getInstanceConfig(STOPPABLE_CLUSTER, instance);
+        } catch (Exception e) {
+          return false;
+        }
+        return (instanceConfig != null);
+      }, TestHelper.WAIT_DURATION);
+      Assert.assertTrue(isinstanceConfigExist);
+    }
     // Select instances with zone based
     String content =
         String.format("{\"%s\":\"%s\",\"%s\":[\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\", \"%s\"]}",


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixes #1821  

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
TestInstancesAccessor is unstable because the cluster might not be stable while the test runs the stoppable check and cluster config and instance config can be missing. In this commit, the test waits until the cluster config and instance config get created and then proceeds for the stoppable checks.

### Tests

- [x] The following is the result of the "mvn test" command on the appropriate module:
Helix-rest:
```[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 127.842 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /home/anajari/my_repos/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 79 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:16 min
[INFO] Finished at: 2021-07-21T19:46:04-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)


