### PR TITLE
Add TF Available Threads Metrics

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/task/TaskSchedulingStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/task/TaskSchedulingStage.java
@@ -81,13 +81,16 @@ public class TaskSchedulingStage extends AbstractBaseStage {
     // Reset current INIT/RUNNING tasks on participants for throttling
     cache.resetActiveTaskCount(currentStateOutput);
 
+    ClusterStatusMonitor clusterStatusMonitor =
+        event.getAttribute(AttributeName.clusterStatusMonitor.name());
     buildQuotaBasedWorkflowPQsAndInitDispatchers(cache,
-        (HelixManager) event.getAttribute(AttributeName.helixmanager.name()),
-        (ClusterStatusMonitor) event.getAttribute(AttributeName.clusterStatusMonitor.name()));
+        (HelixManager) event.getAttribute(AttributeName.helixmanager.name()), clusterStatusMonitor);
 
     final BestPossibleStateOutput bestPossibleStateOutput =
         compute(event, resourceMap, currentStateOutput);
     event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
+
+    cache.getAssignableInstanceManager().recordAvailableThreadsPerType(clusterStatusMonitor);
   }
 
   private BestPossibleStateOutput compute(ClusterEvent event, Map<String, Resource> resourceMap,

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/task/TaskSchedulingStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/task/TaskSchedulingStage.java
@@ -90,7 +90,10 @@ public class TaskSchedulingStage extends AbstractBaseStage {
         compute(event, resourceMap, currentStateOutput);
     event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
 
-    cache.getAssignableInstanceManager().recordAvailableThreadsPerType(clusterStatusMonitor);
+    if (clusterStatusMonitor != null) {
+      clusterStatusMonitor.updateAvailableThreadsPerJob(cache.getAssignableInstanceManager()
+          .getGlobalCapacityMap());
+    }
   }
 
   private BestPossibleStateOutput compute(ClusterEvent event, Map<String, Resource> resourceMap,

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -757,6 +757,18 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   }
 
   /**
+   * For each JobType, report their total available threads across all instances to corresponding
+   * jobMonitors
+   * @param threadCapacityMap
+   */
+  public void updateAvailableThreadsPerJob(Map<String, Integer> threadCapacityMap) {
+    for (String jobType : threadCapacityMap.keySet()) {
+      JobMonitor jobMonitor = getJobMonitor(jobType);
+      jobMonitor.updateAvailableThreadGauge((long) threadCapacityMap.get(jobType));
+    }
+  }
+
+  /**
    * TODO: Separate Workflow/Job Monitors from ClusterStatusMonitor because ClusterStatusMonitor is
    * getting too big.
    * Returns the appropriate JobMonitor for the given type. If it does not exist, create one and

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/JobMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/JobMonitor.java
@@ -57,6 +57,7 @@ public class JobMonitor extends DynamicMBeanProvider {
   private SimpleDynamicMetric<Long> _existingJobGauge;
   private SimpleDynamicMetric<Long> _queuedJobGauge;
   private SimpleDynamicMetric<Long> _runningJobGauge;
+  private SimpleDynamicMetric<Long> _availableThreadGauge;
   @Deprecated // To be removed (replaced by jobLatencyGauge Histogram)
   private SimpleDynamicMetric<Long> _maximumJobLatencyGauge;
   @Deprecated // To be removed (replaced by jobLatencyGauge Histogram)
@@ -81,6 +82,7 @@ public class JobMonitor extends DynamicMBeanProvider {
     _existingJobGauge = new SimpleDynamicMetric("ExistingJobGauge", 0L);
     _queuedJobGauge = new SimpleDynamicMetric("QueuedJobGauge", 0L);
     _runningJobGauge = new SimpleDynamicMetric("RunningJobGauge", 0L);
+    _availableThreadGauge = new SimpleDynamicMetric("AvailableThreadGauge", 0L);
     _maximumJobLatencyGauge = new SimpleDynamicMetric("MaximumJobLatencyGauge", 0L);
     _jobLatencyCount = new SimpleDynamicMetric("JobLatencyCount", 0L);
 
@@ -159,6 +161,14 @@ public class JobMonitor extends DynamicMBeanProvider {
   }
 
   /**
+   * Update the available thread count to the AvailableThreadGauge
+   * @param availableThreads
+   */
+  public void updateAvailableThreadGauge(long availableThreads) {
+    _availableThreadGauge.updateValue(availableThreads);
+  }
+
+  /**
    * Update SubmissionToProcessDelay to its corresponding HistogramDynamicMetric.
    * @param delay
    */
@@ -196,6 +206,7 @@ public class JobMonitor extends DynamicMBeanProvider {
     attributeList.add(_existingJobGauge);
     attributeList.add(_queuedJobGauge);
     attributeList.add(_runningJobGauge);
+    attributeList.add(_availableThreadGauge);
     attributeList.add(_maximumJobLatencyGauge);
     attributeList.add(_jobLatencyCount);
     attributeList.add(_jobLatencyGauge);

--- a/helix-core/src/main/java/org/apache/helix/task/AssignableInstanceManager.java
+++ b/helix-core/src/main/java/org/apache/helix/task/AssignableInstanceManager.java
@@ -37,6 +37,8 @@ import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
+import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
+import org.apache.helix.monitoring.mbeans.JobMonitor;
 import org.apache.helix.task.assigner.AssignableInstance;
 import org.apache.helix.task.assigner.TaskAssignResult;
 import org.slf4j.Logger;
@@ -606,6 +608,17 @@ public class AssignableInstanceManager {
     }
     if (instanceNode.size() > 0) {
       LOG.info("Current quota capacity: {}", instanceNode.toString());
+    }
+  }
+
+  /**
+   * For each JobType, record their total available threads across all instances
+   * @param clusterStatusMonitor
+   */
+  public void recordAvailableThreadsPerType(ClusterStatusMonitor clusterStatusMonitor) {
+    for (String jobType : _globalThreadBasedQuotaMap.keySet()) {
+      JobMonitor jobMonitor = clusterStatusMonitor.getJobMonitor(jobType);
+      jobMonitor.updateAvailableThreadGauge((long) _globalThreadBasedQuotaMap.get(jobType));
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/task/AssignableInstanceManager.java
+++ b/helix-core/src/main/java/org/apache/helix/task/AssignableInstanceManager.java
@@ -37,8 +37,6 @@ import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
-import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
-import org.apache.helix.monitoring.mbeans.JobMonitor;
 import org.apache.helix.task.assigner.AssignableInstance;
 import org.apache.helix.task.assigner.TaskAssignResult;
 import org.slf4j.Logger;
@@ -463,6 +461,14 @@ public class AssignableInstanceManager {
   }
 
   /**
+   * Returns a mapping of: jobType -> available threads in all instances for this jobType
+   * @return globalThreadBasedQuotaMap
+   */
+  public Map<String, Integer> getGlobalCapacityMap() {
+    return Collections.unmodifiableMap(_globalThreadBasedQuotaMap);
+  }
+
+  /**
    * Check remained global quota of certain quota type for skipping redundant computation
    * @param quotaType
    * @return
@@ -608,19 +614,6 @@ public class AssignableInstanceManager {
     }
     if (instanceNode.size() > 0) {
       LOG.info("Current quota capacity: {}", instanceNode.toString());
-    }
-  }
-
-  /**
-   * For each JobType, record their total available threads across all instances
-   * @param clusterStatusMonitor
-   */
-  public void recordAvailableThreadsPerType(ClusterStatusMonitor clusterStatusMonitor) {
-    if (clusterStatusMonitor != null) {
-      for (String jobType : _globalThreadBasedQuotaMap.keySet()) {
-        JobMonitor jobMonitor = clusterStatusMonitor.getJobMonitor(jobType);
-        jobMonitor.updateAvailableThreadGauge((long) _globalThreadBasedQuotaMap.get(jobType));
-      }
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/task/AssignableInstanceManager.java
+++ b/helix-core/src/main/java/org/apache/helix/task/AssignableInstanceManager.java
@@ -616,9 +616,11 @@ public class AssignableInstanceManager {
    * @param clusterStatusMonitor
    */
   public void recordAvailableThreadsPerType(ClusterStatusMonitor clusterStatusMonitor) {
-    for (String jobType : _globalThreadBasedQuotaMap.keySet()) {
-      JobMonitor jobMonitor = clusterStatusMonitor.getJobMonitor(jobType);
-      jobMonitor.updateAvailableThreadGauge((long) _globalThreadBasedQuotaMap.get(jobType));
+    if (clusterStatusMonitor != null) {
+      for (String jobType : _globalThreadBasedQuotaMap.keySet()) {
+        JobMonitor jobMonitor = clusterStatusMonitor.getJobMonitor(jobType);
+        jobMonitor.updateAvailableThreadGauge((long) _globalThreadBasedQuotaMap.get(jobType));
+      }
     }
   }
 

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -535,7 +535,7 @@ public class TestClusterStatusMonitor {
     assignableInstanceManager.buildAssignableInstances(clusterConfig, taskDataCache,
         liveInstanceMap, instanceConfigMap);
 
-    assignableInstanceManager.recordAvailableThreadsPerType(monitor);
+    monitor.updateAvailableThreadsPerJob(assignableInstanceManager.getGlobalCapacityMap());
     ObjectName type1ObjectName = monitor.getObjectName(monitor.getJobBeanName("type1"));
     ObjectName type2ObjectName = monitor.getObjectName(monitor.getJobBeanName("type2"));
     Assert.assertTrue(_server.isRegistered(type1ObjectName));
@@ -552,7 +552,7 @@ public class TestClusterStatusMonitor {
     when(taskAssignResult.getQuotaType()).thenReturn("type2");
     assignableInstanceManager.assign("UnknownInstance", taskAssignResult);
 
-    assignableInstanceManager.recordAvailableThreadsPerType(monitor);
+    monitor.updateAvailableThreadsPerJob(assignableInstanceManager.getGlobalCapacityMap());
     Assert.assertEquals(_server.getAttribute(type1ObjectName, "AvailableThreadGauge"), 88L);
     Assert.assertEquals(_server.getAttribute(type2ObjectName, "AvailableThreadGauge"), 29L);
   }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -44,6 +44,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.apache.helix.TestHelper;
+import org.apache.helix.common.caches.TaskDataCache;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.task.AssignableInstanceManager;
+import org.apache.helix.task.assigner.TaskAssignResult;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.controller.stages.BestPossibleStateOutput;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
@@ -56,9 +61,12 @@ import org.apache.helix.model.Resource;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.tools.DefaultIdealStateCalculator;
 import org.apache.helix.tools.StateModelConfigGenerator;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.testng.collections.Sets;
+
+import static org.mockito.Mockito.when;
 
 
 public class TestClusterStatusMonitor {
@@ -492,6 +500,61 @@ public class TestClusterStatusMonitor {
       Assert.assertFalse(_server.isRegistered(instanceObjectName),
           "Failed to unregister instance monitor for instance: " + instance);
     }
+  }
+
+  @Test
+  public void testRecordAvailableThreadsPerType() throws Exception {
+    String className = TestHelper.getTestClassName();
+    String methodName = TestHelper.getTestMethodName();
+    String clusterName = className + "_" + methodName;
+
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor(clusterName);
+    monitor.active();
+    ObjectName clusterMonitorObjName = monitor.getObjectName(monitor.clusterBeanName());
+    Assert.assertTrue(_server.isRegistered(clusterMonitorObjName));
+
+    Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
+    Map<String, LiveInstance> liveInstanceMap = new HashMap<>();
+    for (int i = 0; i < 3; i++) {
+      String instanceName = "localhost_" + (12918 + i);
+      LiveInstance liveInstance = new LiveInstance(instanceName);
+      InstanceConfig instanceConfig = new InstanceConfig(instanceName);
+      liveInstanceMap.put(instanceName, liveInstance);
+      instanceConfigMap.put(instanceName, instanceConfig);
+    }
+
+    ClusterConfig clusterConfig = new ClusterConfig(clusterName);
+    clusterConfig.resetTaskQuotaRatioMap();
+    clusterConfig.setTaskQuotaRatio("type1", 30);
+    clusterConfig.setTaskQuotaRatio("type2", 10);
+
+    TaskDataCache taskDataCache = Mockito.mock(TaskDataCache.class);
+    when(taskDataCache.getJobConfigMap()).thenReturn(Collections.emptyMap());
+
+    AssignableInstanceManager assignableInstanceManager = new AssignableInstanceManager();
+    assignableInstanceManager.buildAssignableInstances(clusterConfig, taskDataCache,
+        liveInstanceMap, instanceConfigMap);
+
+    assignableInstanceManager.recordAvailableThreadsPerType(monitor);
+    ObjectName type1ObjectName = monitor.getObjectName(monitor.getJobBeanName("type1"));
+    ObjectName type2ObjectName = monitor.getObjectName(monitor.getJobBeanName("type2"));
+    Assert.assertTrue(_server.isRegistered(type1ObjectName));
+    Assert.assertEquals(_server.getAttribute(type1ObjectName, "AvailableThreadGauge"), 90L);
+    Assert.assertTrue(_server.isRegistered(type2ObjectName));
+    Assert.assertEquals(_server.getAttribute(type2ObjectName, "AvailableThreadGauge"), 30L);
+
+    TaskAssignResult taskAssignResult = Mockito.mock(TaskAssignResult.class);
+    when(taskAssignResult.getQuotaType()).thenReturn("type1");
+    // Use non-existing instance to bypass the actual assignment, but still decrease thread counts
+    assignableInstanceManager.assign("UnknownInstance", taskAssignResult);
+    // Do it twice for type 1
+    assignableInstanceManager.assign("UnknownInstance", taskAssignResult);
+    when(taskAssignResult.getQuotaType()).thenReturn("type2");
+    assignableInstanceManager.assign("UnknownInstance", taskAssignResult);
+
+    assignableInstanceManager.recordAvailableThreadsPerType(monitor);
+    Assert.assertEquals(_server.getAttribute(type1ObjectName, "AvailableThreadGauge"), 88L);
+    Assert.assertEquals(_server.getAttribute(type2ObjectName, "AvailableThreadGauge"), 29L);
   }
 
   private void verifyCapacityMetrics(ClusterStatusMonitor monitor, Map<String, Double> maxUsageMap,


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1833

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

There is no existing metrics about Task Framework available threads. Certain production issues are caused by simple reasons such as out of threads, and in order to spot those reasons, developers have to spend time reading through logs. 

With metrics for available threads, grouped by job types and aggregated on the cluster level, it's now easy for developers to find the thread availability of any cluster. 

### Tests

- [x] The following tests are written for this issue:

TestClusterStatusMonitor.testRecordAvailableThreadsPerType

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
