### PR TITLE
Fix management mode history duplicate recording

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ManagementModeStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ManagementModeStage.java
@@ -135,31 +135,18 @@ public class ManagementModeStage extends AbstractBaseStage {
 
   private void recordClusterStatus(ClusterManagementMode mode, PauseSignal pauseSignal,
       String controllerName, HelixDataAccessor accessor) {
-    // update cluster status
+    // Read cluster status from metadata store
     PropertyKey statusPropertyKey = accessor.keyBuilder().clusterStatus();
     ClusterStatus clusterStatus = accessor.getProperty(statusPropertyKey);
     if (clusterStatus == null) {
       clusterStatus = new ClusterStatus();
     }
 
-    ClusterManagementMode.Type recordedType = clusterStatus.getManagementMode();
-    ClusterManagementMode.Status recordedStatus = clusterStatus.getManagementModeStatus();
-
-    if (mode.getMode().equals(recordedType) && mode.getStatus().equals(recordedStatus)) {
+    if (mode.getMode().equals(clusterStatus.getManagementMode())
+        && mode.getStatus().equals(clusterStatus.getManagementModeStatus())) {
       // No need to update status and avoid duplicates when it's the same as metadata store
       LOG.debug("Skip recording duplicate status mode={}, status={}", mode.getMode(),
           mode.getStatus());
-      return;
-    }
-
-    // If there is any pending message sent by users, status could be computed as in progress.
-    // Skip recording status change to avoid confusion after cluster is already fully frozen.
-    if (ClusterManagementMode.Type.CLUSTER_FREEZE.equals(recordedType)
-        && ClusterManagementMode.Status.COMPLETED.equals(recordedStatus)
-        && ClusterManagementMode.Type.CLUSTER_FREEZE.equals(mode.getMode())
-        && ClusterManagementMode.Status.IN_PROGRESS.equals(mode.getStatus())) {
-      LOG.info("Skip recording status mode={}, status={}, because cluster is fully frozen",
-          mode.getMode(), mode.getStatus());
       return;
     }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestManagementModeStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestManagementModeStage.java
@@ -35,6 +35,7 @@ import org.apache.helix.controller.pipeline.Pipeline;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.ClusterStatus;
+import org.apache.helix.model.ControllerHistory;
 import org.apache.helix.model.LiveInstance;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -93,15 +94,40 @@ public class TestManagementModeStage extends ZkTestBase {
     ClusterStatus clusterStatus = _accessor.getProperty(_accessor.keyBuilder().clusterStatus());
     Assert.assertEquals(clusterStatus.getManagementMode(), ClusterManagementMode.Type.CLUSTER_FREEZE);
 
+    ControllerHistory history =
+        _accessor.getProperty(_accessor.keyBuilder().controllerLeaderHistory());
+    Assert.assertNull(history);
 
-    // Mark a live instance to be pause state
-    LiveInstance liveInstance = liveInstances.get(0);
-    liveInstance.setStatus(LiveInstance.LiveInstanceStatus.FROZEN);
-    PropertyKey liveInstanceKey =
-        _accessor.keyBuilder().liveInstance(liveInstance.getInstanceName());
-    _accessor.updateProperty(liveInstanceKey, liveInstance);
+    // Mark both live instances to be frozen, then entering freeze mode is complete
+    for (int i = 0; i < 2; i++) {
+      LiveInstance liveInstance = liveInstances.get(i);
+      liveInstance.setStatus(LiveInstance.LiveInstanceStatus.FROZEN);
+      PropertyKey liveInstanceKey =
+          _accessor.keyBuilder().liveInstance(liveInstance.getInstanceName());
+      _accessor.updateProperty(liveInstanceKey, liveInstance);
+    }
     // Require cache refresh
     cache.notifyDataChange(HelixConstants.ChangeType.LIVE_INSTANCE);
+    runPipeline(event, dataRefresh, false);
+    managementModeStage.process(event);
+
+    // Freeze mode is complete
+    clusterStatus = _accessor.getProperty(_accessor.keyBuilder().clusterStatus());
+    Assert.assertEquals(clusterStatus.getManagementMode(), ClusterManagementMode.Type.CLUSTER_FREEZE);
+    Assert.assertEquals(clusterStatus.getManagementModeStatus(),
+        ClusterManagementMode.Status.COMPLETED);
+
+    // Management history is recorded
+    history = _accessor.getProperty(_accessor.keyBuilder().controllerLeaderHistory());
+    Assert.assertEquals(history.getManagementModeHistory().size(), 1);
+    String lastHistory = history.getManagementModeHistory().get(0);
+    Assert.assertTrue(lastHistory.contains("MODE=" + ClusterManagementMode.Type.CLUSTER_FREEZE));
+    Assert.assertTrue(lastHistory.contains("STATUS=" + ClusterManagementMode.Status.COMPLETED));
+
+    // No duplicate management mode history entries
+    managementModeStage.process(event);
+    history = _accessor.getProperty(_accessor.keyBuilder().controllerLeaderHistory());
+    Assert.assertEquals(history.getManagementModeHistory().size(), 1);
 
     // Unfreeze cluster
     request = ClusterManagementModeRequest.newBuilder()
@@ -119,11 +145,15 @@ public class TestManagementModeStage extends ZkTestBase {
     Assert.assertEquals(clusterStatus.getManagementModeStatus(),
         ClusterManagementMode.Status.IN_PROGRESS);
 
-    // remove froze status to mark the live instance to be normal status
-    liveInstance = _accessor.getProperty(liveInstanceKey);
-    liveInstance.getRecord().getSimpleFields()
-        .remove(LiveInstance.LiveInstanceProperty.STATUS.name());
-    _accessor.setProperty(liveInstanceKey, liveInstance);
+    // remove froze status to mark the live instances to be normal status
+    for (int i = 0; i < 2; i++) {
+      LiveInstance liveInstance = liveInstances.get(i);
+      PropertyKey liveInstanceKey =
+          _accessor.keyBuilder().liveInstance(liveInstance.getInstanceName());
+      liveInstance.getRecord().getSimpleFields()
+          .remove(LiveInstance.LiveInstanceProperty.STATUS.name());
+      _accessor.setProperty(liveInstanceKey, liveInstance);
+    }
     // Require cache refresh
     cache.notifyDataChange(HelixConstants.ChangeType.LIVE_INSTANCE);
     runPipeline(event, dataRefresh, false);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixed #1845

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The management mode history has duplicate entries. It does not impact the normal function, but it's good to get it fixed to avoid confusion.

Enable cluster freeze mode in a staging cluster. Because of multiple events(live instance change events), the management mode pipeline could be run multiple times. Then the same mode history is recorded multiple times.

```
 "MANAGEMENT_MODE_HISTORY": [
      "{STATUS=COMPLETED, CONTROLLER=host1, MODE=CLUSTER_FREEZE, FROM_HOST=host2, TIME=2021-08-18T20:58:51.659Z}",
      "{STATUS=COMPLETED, CONTROLLER=host1, MODE=CLUSTER_FREEZE, FROM_HOST=host2, TIME=2021-08-18T21:02:08.893Z}",
      "{STATUS=COMPLETED, CONTROLLER=host1, MODE=CLUSTER_FREEZE, FROM_HOST=host2, TIME=2021-08-18T21:09:03.659Z}",
      "{STATUS=COMPLETED, CONTROLLER=host1, MODE=CLUSTER_FREEZE, FROM_HOST=host2 TIME=2021-08-18T21:13:03.660Z}
```

### Tests

- [x] The following tests are written for this issue:

TestManagementModeStage
TestClusterFreezeMode

- The following is the result of the "mvn test" command on the appropriate module:

```
12:45:13,985 [INFO] Results:
12:45:13,985 [INFO]
12:45:13,985 [ERROR] Failures:
12:45:13,985 [ERROR]   TestZeroReplicaAvoidance.testWagedRebalancer:182 expected:<true> but was:<false>
12:45:13,985 [INFO]
12:45:13,985 [ERROR] Tests run: 1282, Failures: 1, Errors: 0, Skipped: 0
12:45:13,986 [INFO]
12:45:13,991 [INFO] ------------------------------------------------------------------------
12:45:13,992 [INFO] BUILD FAILURE
12:45:13,992 [INFO] ------------------------------------------------------------------------
12:45:13,993 [INFO] Total time:  01:21 h
12:45:13,993 [INFO] Finished at: 2021-08-23T12:45:13-07:00
12:45:13,993 [INFO] ------------------------------------------------------------------------


13:50:28,577 [INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.701 s - in TestSuite
13:50:28,962 [INFO]
13:50:28,962 [INFO] Results:
13:50:28,963 [INFO]
13:50:28,963 [INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
13:50:28,963 [INFO]
13:50:28,967 [INFO]
13:50:28,968 [INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core ---
13:50:29,003 [INFO] Loading execution data file /home/hulu/Projects/helix/helix-core/target/jacoco.exec
13:50:29,473 [INFO] Analyzed bundle 'Apache Helix :: Core' with 909 classes
13:50:30,936 [INFO] ------------------------------------------------------------------------
13:50:30,936 [INFO] BUILD SUCCESS
13:50:30,937 [INFO] ------------------------------------------------------------------------
13:50:30,938 [INFO] Total time:  37.736 s
13:50:30,938 [INFO] Finished at: 2021-08-23T13:50:30-07:00
13:50:30,939 [INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
