### PR TITLE
Add stop server wait time to be 10 seconds in MockMetadataStoreDirectoryServer to avoid test failure.

### DIFF
--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/mock/MockMetadataStoreDirectoryServer.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/mock/MockMetadataStoreDirectoryServer.java
@@ -50,6 +50,7 @@ public class MockMetadataStoreDirectoryServer {
       MetadataStoreRoutingConstants.MSDS_GET_ALL_REALMS_ENDPOINT;
   protected static final int NOT_IMPLEMENTED = 501;
   protected static final int OK = 200;
+  protected static final int STOP_WAIT_SEC = 10;
   protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   protected final String _hostname;
@@ -104,7 +105,7 @@ public class MockMetadataStoreDirectoryServer {
 
   public void stopServer() {
     if (_server != null) {
-      _server.stop(0);
+      _server.stop(STOP_WAIT_SEC);
     }
     _executor.shutdown();
     LOG.info(


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1839 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change aims to reduce the unexpected test failure due to http endpoint in use. The additional timeout shall help the test terminate server instances gracefully.

### Tests

- [X] The following tests are written for this issue:

This PR fixes test.

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
