### PR TITLE
Use activate/DeactivateInstances as keyword in PartitionAssignment API

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -198,9 +197,7 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
     // Add existing live instances and new instances from user input to instances list.
     Set<String> liveInstancesSet =
         new HashSet<>(dataAccessor.getChildNames(dataAccessor.keyBuilder().liveInstances()));
-    liveInstancesSet.addAll(
-        inputFields.activatedInstances.stream().filter(s -> !liveInstancesSet.contains(s))
-            .collect(Collectors.toList()));
+    liveInstancesSet.addAll(inputFields.activatedInstances);
     liveInstancesSet.removeAll(inputFields.deactivatedInstances);
 
     Map<String, InstanceConfig> instanceConfigMap =
@@ -296,7 +293,7 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
   }
 
   /*
-  * Return if there are instance exists in more than one lists in InstanceChangeMap
+  * Return if there are instance exists in more than one lists in InstanceChangeMap.
   */
   private void validateNoIntxnInstanceChange(InputFields inputFields) {
     Set<String> tempSet = new HashSet<>();

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
@@ -47,9 +47,8 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
 
   String cluster = "TestCluster_3";
   String instance1 = cluster + "dummyInstance_localhost_12930";
-  String swapNewInstance = "swapNewInstance";
   String urlBase = "clusters/TestCluster_3/partitionAssignment/";
-  String swapOldInstance, toRemoveInstance, disabledInstance;
+  String toDeactivatedInstance, toEnabledInstance;
   HelixDataAccessor helixDataAccessor;
   List<String> resources;
   List<String> liveInstances;
@@ -62,14 +61,13 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
     liveInstances =  helixDataAccessor.getChildNames(helixDataAccessor.keyBuilder().liveInstances());
     Assert.assertFalse(resources.isEmpty() || liveInstances.isEmpty());
 
-    toRemoveInstance = liveInstances.get(0);
-    swapOldInstance = liveInstances.get(1);
-    disabledInstance = liveInstances.get(2);
+    toDeactivatedInstance = liveInstances.get(0);
+    toEnabledInstance = liveInstances.get(2);
     InstanceConfig config = _gSetupTool.getClusterManagementTool()
-        .getInstanceConfig(cluster, disabledInstance);
+        .getInstanceConfig(cluster, toEnabledInstance);
     config.setInstanceEnabled(false);
     _gSetupTool.getClusterManagementTool()
-        .setInstanceConfig(cluster, disabledInstance, config);
+        .setInstanceConfig(cluster, toEnabledInstance, config);
 
   }
 
@@ -82,11 +80,10 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
       _gSetupTool.getClusterManagementTool().setResourceIdealState(cluster, resource, idealState);
     }
     InstanceConfig config = _gSetupTool.getClusterManagementTool()
-        .getInstanceConfig(cluster, disabledInstance);
+        .getInstanceConfig(cluster, toEnabledInstance);
     config.setInstanceEnabled(true);
     _gSetupTool.getClusterManagementTool()
-        .setInstanceConfig(cluster, disabledInstance, config);
-    System.out.println("dd");
+        .setInstanceConfig(cluster, toEnabledInstance, config);
 
   }
 
@@ -104,10 +101,8 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
     }
 
     // Test AddInstances, RemoveInstances and SwapInstances
-    String payload = "{\"InstanceChange\" : { \"OnlineInstances\" : [\"" + instance1
-        + "\"], \"ActivateInstances\" : [\"" + disabledInstance + "\"],"
-        + "\"DeactivateInstances\" : [ \"" + toRemoveInstance + "\"], \"SwapInstances\" : {\""
-        + swapOldInstance + "\" : \"" + swapNewInstance + "\"} }}  ";
+    String payload = "{\"InstanceChange\" : {  \"ActivateInstances\" : [\"" + toEnabledInstance + "\"],"
+        + "\"DeactivateInstances\" : [ \"" + toDeactivatedInstance + "\"] }}  ";
     Response response = post(urlBase, null, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE),
         Response.Status.OK.getStatusCode(), true);
     Map<String, Map<String, Map<String, String>>> resourceAssignments = OBJECT_MAPPER
@@ -116,11 +111,8 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
             });
     Set<String> hostSet = new HashSet<>();
     resourceAssignments.forEach((k, v) -> v.forEach((kk, vv) -> hostSet.addAll(vv.keySet())));
-    Assert.assertTrue(hostSet.contains(instance1));
-    Assert.assertTrue(hostSet.contains(disabledInstance));
-    Assert.assertTrue(hostSet.contains(swapNewInstance));
-    Assert.assertFalse(hostSet.contains(liveInstances.get(0)));
-    Assert.assertFalse(hostSet.contains(liveInstances.get(1)));
+    Assert.assertTrue(hostSet.contains(toEnabledInstance));
+    Assert.assertFalse(hostSet.contains(toDeactivatedInstance));
     // Validate header
     MultivaluedMap<String, Object> headers = response.getHeaders();
     Assert.assertTrue(headers.containsKey(ResourceAssignmentOptimizerAccessor.RESPONSE_HEADER_KEY));
@@ -192,11 +184,9 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
         partitionAssignmentMetadata3.get(0).toString());
 
     // Test Option CurrentState format with AddInstances, RemoveInstances and SwapInstances
-    String payload4 = "{\"InstanceChange\" : { \"OnlineInstances\" : [\"" + instance1
-        + "\"], \"ActivateInstances\" : [\"" + disabledInstance
-        + "\"], \"DeactivateInstances\" : [ \"" + toRemoveInstance + "\"], \"SwapInstances\" : {\""
-        + swapOldInstance + "\" : \"" + swapNewInstance
-        + "\"} }, \"Options\" : { \"ReturnFormat\" : \"CurrentStateFormat\" , \"ResourceFilter\" : [\""
+    String payload4 = "{\"InstanceChange\" : { \"ActivateInstances\" : [\"" + toEnabledInstance
+        + "\"], \"DeactivateInstances\" : [ \"" + toDeactivatedInstance + "\"] "
+        + "}, \"Options\" : { \"ReturnFormat\" : \"CurrentStateFormat\" , \"ResourceFilter\" : [\""
         + resources.get(0) + "\" , \"" + resources.get(1) + "\"]} } ";
     Response response4 =
         post(urlBase, null, Entity.entity(payload4, MediaType.APPLICATION_JSON_TYPE),
@@ -205,17 +195,11 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
     Map<String, Map<String, Map<String, String>>> resourceAssignments4 = OBJECT_MAPPER
         .readValue(body4, new TypeReference<HashMap<String, Map<String, Map<String, String>>>>() {
         });
-    // Validate outer map key is instance
+    // Validate target resources exist
     Set<String> resource4 = new HashSet<>();
     resourceAssignments4.forEach((k, v) -> v.forEach((kk, vv) -> resource4.add(kk)));
     Assert.assertTrue(resource4.contains(resources.get(0)));
     Assert.assertTrue(resource4.contains(resources.get(1)));
-    // First inner map key is resource
-    Assert.assertTrue(resourceAssignments4.containsKey(instance1));
-    Assert.assertTrue(hostSet.contains(disabledInstance));
-    Assert.assertTrue(resourceAssignments4.containsKey(swapNewInstance));
-    Assert.assertFalse(resourceAssignments4.containsKey(liveInstances.get(0)));
-    Assert.assertFalse(resourceAssignments4.containsKey(liveInstances.get(1)));
     // Validate header
     MultivaluedMap<String, Object> headers4 = response4.getHeaders();
     Assert
@@ -250,10 +234,8 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
     }
 
     // Test AddInstances, RemoveInstances and SwapInstances
-    String payload = "{\"InstanceChange\" : { \"OnlineInstances\" : [\"" + instance1
-        + "\"], \"ActivateInstances\" : [\"" + disabledInstance
-        + "\"], \"DeactivateInstances\" : [ \"" + toRemoveInstance + "\"], \"SwapInstances\" : {\""
-        + swapOldInstance + "\" : \"" + swapNewInstance + "\"} }}  ";
+    String payload = "{\"InstanceChange\" : {  \"ActivateInstances\" : [\"" + toEnabledInstance
+        + "\"], \"DeactivateInstances\" : [ \"" + toDeactivatedInstance + "\"] }}  ";
     String body = post(urlBase, null, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE),
         Response.Status.OK.getStatusCode(), true).readEntity(String.class);
     Map<String, Map<String, Map<String, String>>> resourceAssignments = OBJECT_MAPPER
@@ -261,11 +243,8 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
         });
     Set<String> hostSet = new HashSet<>();
     resourceAssignments.forEach((k, v) -> v.forEach((kk, vv) -> hostSet.addAll(vv.keySet())));
-    Assert.assertTrue(hostSet.contains(instance1));
-    Assert.assertTrue(hostSet.contains(disabledInstance));
-    Assert.assertTrue(hostSet.contains(swapNewInstance));
-    Assert.assertFalse(hostSet.contains(liveInstances.get(0)));
-    Assert.assertFalse(hostSet.contains(liveInstances.get(1)));
+    Assert.assertTrue(hostSet.contains(toEnabledInstance));
+    Assert.assertFalse(hostSet.contains(toDeactivatedInstance));
 
     // Test partitionAssignment host filter
     String payload2 = "{\"Options\" : { \"InstanceFilter\" : [\"" + liveInstances.get(0) + "\" , \""
@@ -300,20 +279,14 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
 
     // Test negative input
-    String payload4 = "{\"InstanceChange\" : { \"OnlineInstances\" : [\" nonExistInstanceName \"] }} ";
+    String payload4 = "{\"InstanceChange\" : { \"ActivateInstances\" : [\" nonExistInstanceName \"] }} ";
     post(urlBase, null, Entity.entity(payload4, MediaType.APPLICATION_JSON_TYPE),
         Response.Status.BAD_REQUEST.getStatusCode(), true);
 
     String payload5 =
-        "{\"InstanceChange\" : {  { \"OnlineInstances\" : [\"" + disabledInstance
-            + "\"], \"DeactivateInstances\" : [\"" +  disabledInstance + "\"] }} ";
+        "{\"InstanceChange\" : {  { \"ActivateInstances\" : [\"" + toDeactivatedInstance
+            + "\"], \"DeactivateInstances\" : [\"" +  toDeactivatedInstance + "\"] }} ";
     post(urlBase, null, Entity.entity(payload5, MediaType.APPLICATION_JSON_TYPE),
-        Response.Status.BAD_REQUEST.getStatusCode(), true);
-
-    String payload6 =
-        "{\"InstanceChange\" : { \"SwapInstances\" : {\" nonExistInstanceName \" : \""
-            + disabledInstance +"\"} }} ";
-    post(urlBase, null, Entity.entity(payload6, MediaType.APPLICATION_JSON_TYPE),
         Response.Status.BAD_REQUEST.getStatusCode(), true);
 
     System.out.println("End test :" + TestHelper.getTestMethodName());


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1849 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR changes the keyword add/remove instances to activate/deactivateInstances in partitionAssignment. 

### Tests

- [X] The following tests are written for this issue:

TestResourceAssignmentOptimizerAccessor

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Results:
[INFO] 
[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /Users/xialu/Documents/WorkSpace/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 79 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  05:34 min
[INFO] Finished at: 2021-08-23T19:10:18-07:00
[INFO] ------------------------------------------------------------------------
```



### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
