### PR TITLE
Disable delayed rebalance as default for partitionAssignment

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
@@ -220,7 +220,14 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
       }
     }
 
-    clusterState.clusterConfig = cfgAccessor.getClusterConfig(clusterId);
+    // We will not consider delayed rebalance. The current implementation of
+    // 'getIdealAssignmentForFullAuto' for ChrushEd resources will not consider delayed rebalancer
+    // but `getImmediateAssignmentForWagedFullAuto` will honor current timestamp and delayed
+    // rebalance window. We are disabling delayed rebalance for now. Could add a cluster option to
+    // honor delayed rebalance window in the future.
+    ClusterConfig clusterConfig = cfgAccessor.getClusterConfig(clusterId);
+    clusterConfig.setDelayRebalaceEnabled(false);
+    clusterState.clusterConfig = clusterConfig;
     clusterState.liveInstances = new ArrayList<>(liveInstancesSet);
     clusterState.instanceConfigs.addAll(instanceConfigMap.values());
     return clusterState;

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
@@ -61,6 +61,7 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
     liveInstances =  helixDataAccessor.getChildNames(helixDataAccessor.keyBuilder().liveInstances());
     Assert.assertFalse(resources.isEmpty() || liveInstances.isEmpty());
 
+    // set up instances, we need too deactivate one instance
     toDeactivatedInstance = liveInstances.get(0);
     toEnabledInstance = liveInstances.get(2);
     InstanceConfig config = _gSetupTool.getClusterManagementTool()
@@ -68,6 +69,16 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
     config.setInstanceEnabled(false);
     _gSetupTool.getClusterManagementTool()
         .setInstanceConfig(cluster, toEnabledInstance, config);
+
+    // set all resource to FULL_AUTO
+    for (String resource : resources) {
+      IdealState idealState =
+          _gSetupTool.getClusterManagementTool().getResourceIdealState(cluster, resource);
+      idealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+      idealState.setDelayRebalanceEnabled(true);
+      idealState.setRebalanceDelay(360000);
+      _gSetupTool.getClusterManagementTool().setResourceIdealState(cluster, resource, idealState);
+    }
 
   }
 
@@ -91,15 +102,6 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
   public void testComputePartitionAssignment() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
 
-    // set all resource to FULL_AUTO except one
-    for (int i = 0; i < resources.size() - 1; ++i) {
-      String resource = resources.get(i);
-      IdealState idealState =
-          _gSetupTool.getClusterManagementTool().getResourceIdealState(cluster, resource);
-      idealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
-      _gSetupTool.getClusterManagementTool().setResourceIdealState(cluster, resource, idealState);
-    }
-
     // Test AddInstances, RemoveInstances and SwapInstances
     String payload = "{\"InstanceChange\" : {  \"ActivateInstances\" : [\"" + toEnabledInstance + "\"],"
         + "\"DeactivateInstances\" : [ \"" + toDeactivatedInstance + "\"] }}  ";
@@ -111,6 +113,7 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
             });
     Set<String> hostSet = new HashSet<>();
     resourceAssignments.forEach((k, v) -> v.forEach((kk, vv) -> hostSet.addAll(vv.keySet())));
+    resourceAssignments.forEach((k, v) -> v.forEach((kk, vv) -> Assert.assertEquals(vv.size(), 2)));
     Assert.assertTrue(hostSet.contains(toEnabledInstance));
     Assert.assertFalse(hostSet.contains(toDeactivatedInstance));
     // Validate header
@@ -243,6 +246,8 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
         });
     Set<String> hostSet = new HashSet<>();
     resourceAssignments.forEach((k, v) -> v.forEach((kk, vv) -> hostSet.addAll(vv.keySet())));
+    // Assert the
+    resourceAssignments.forEach((k, v) -> v.forEach((kk, vv) -> Assert.assertEquals(vv.size(), 2)));
     Assert.assertTrue(hostSet.contains(toEnabledInstance));
     Assert.assertFalse(hostSet.contains(toDeactivatedInstance));
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
@@ -246,7 +246,8 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
         });
     Set<String> hostSet = new HashSet<>();
     resourceAssignments.forEach((k, v) -> v.forEach((kk, vv) -> hostSet.addAll(vv.keySet())));
-    // Assert the
+    // Assert every partition has 2 replicas. Indicating we ignore the delayed rebalance when
+    // recomputing partition assignment.
     resourceAssignments.forEach((k, v) -> v.forEach((kk, vv) -> Assert.assertEquals(vv.size(), 2)));
     Assert.assertTrue(hostSet.contains(toEnabledInstance));
     Assert.assertFalse(hostSet.contains(toDeactivatedInstance));


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1851

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Helix has 2 functions to return potential cluster partition assignment for any cluster state change. getIdealAssignmentForFullAuto for ChrushEd resources and getImmediateAssignmentForWagedFullAuto for Waged resources.
When recomputing assignment, getIdealAssignmentForFullAuto will not consider delayed rebalance but getImmediateAssignmentForWagedFullAuto will.
In rest API partitionAssignment is a single enter point for cluster assignment, it called these 2 functions for different resource types. The behavior is inconsistent for these two.

This change disabled delayed rebalance for partitionAssignment. Could add a cluster option to honor delayed rebalance window in the future.

### Tests

- [X] The following tests are written for this issue:

N/A

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 208.805 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /Users/xialu/Documents/WorkSpace/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 79 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:34 min
[INFO] Finished at: 2021-08-24T16:58:00-07:00
[INFO] ------------------------------------------------------------------------

```

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
