### PR TITLE
Throw exception when query partition assignment in Maintenance mode

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
@@ -322,8 +322,9 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
       InputFields inputFields, ClusterState clusterState, String clusterId,
       AssignmentResult result) {
 
-    // If the cluster is in M mode, throw an exception
-    // TODO: we should return the partitionAssignment regardless of the cluster is in Mmode or not
+    // If the cluster is in Maintenance mode, throw an exception
+    // TODO: we should return the partitionAssignment regardless of the cluster is in Maintenance
+    // mode or not
     if (getHelixAdmin().isInMaintenanceMode(clusterId)) {
       throw new UnsupportedOperationException(
           "Can not query potential Assignment when cluster is in Maintenance mode.");

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
@@ -322,6 +322,13 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
       InputFields inputFields, ClusterState clusterState, String clusterId,
       AssignmentResult result) {
 
+    // If the cluster is in M mode, throw an exception
+    // TODO: we should return the partitionAssignment regardless of the cluster is in Mmode or not
+    if (getHelixAdmin().isInMaintenanceMode(clusterId)) {
+      throw new UnsupportedOperationException(
+          "Can not query potential Assignment when cluster is in Maintenance mode.");
+    }
+
     // Use getTargetAssignmentForWagedFullAuto for Waged resources.
     ConfigAccessor cfgAccessor = getConfigAccessor();
     List<ResourceConfig> wagedResourceConfigs = new ArrayList<>();

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
@@ -289,6 +289,12 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
     post(urlBase, null, Entity.entity(payload5, MediaType.APPLICATION_JSON_TYPE),
         Response.Status.BAD_REQUEST.getStatusCode(), true);
 
+    // Currently we do not support maintenance mode
+    _gSetupTool.getClusterManagementTool().enableMaintenanceMode(cluster, true, TestHelper.getTestMethodName());
+    String payload6 = "{}";
+    post(urlBase, null, Entity.entity(payload6, MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.BAD_REQUEST.getStatusCode(), true);
+
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
@@ -82,9 +82,9 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
     InstanceConfig config = _gSetupTool.getClusterManagementTool()
         .getInstanceConfig(cluster, toEnabledInstance);
     config.setInstanceEnabled(true);
+    _gSetupTool.getClusterManagementTool().setInstanceConfig(cluster, toEnabledInstance, config);
     _gSetupTool.getClusterManagementTool()
-        .setInstanceConfig(cluster, toEnabledInstance, config);
-
+        .enableMaintenanceMode(cluster, false, TestHelper.getTestMethodName());
   }
 
   @Test
@@ -285,12 +285,13 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
 
     String payload5 =
         "{\"InstanceChange\" : {  { \"ActivateInstances\" : [\"" + toDeactivatedInstance
-            + "\"], \"DeactivateInstances\" : [\"" +  toDeactivatedInstance + "\"] }} ";
+            + "\"], \"DeactivateInstances\" : [\"" + toDeactivatedInstance + "\"] }} ";
     post(urlBase, null, Entity.entity(payload5, MediaType.APPLICATION_JSON_TYPE),
         Response.Status.BAD_REQUEST.getStatusCode(), true);
 
     // Currently we do not support maintenance mode
-    _gSetupTool.getClusterManagementTool().enableMaintenanceMode(cluster, true, TestHelper.getTestMethodName());
+    _gSetupTool.getClusterManagementTool()
+        .enableMaintenanceMode(cluster, true, TestHelper.getTestMethodName());
     String payload6 = "{}";
     post(urlBase, null, Entity.entity(payload6, MediaType.APPLICATION_JSON_TYPE),
         Response.Status.BAD_REQUEST.getStatusCode(), true);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1854

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

API GetIdealAssignmentForFullAuto will return the potential partition assignment regardless of the cluster state. If the cluster is in maintenance mode, this API will returns potential assignment considering the input change.
However, GetImmediateAssignmentForWagedFullAuto will honor the cluster state. If the cluster is in maintenance mode, this API will use maintenance rebalancer.

### Tests

- [X] The following tests are written for this issue:

TestResourceAssignmentOptimizerAccessor

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
