### PR TITLE
Fix a potential race condition in MBean unregister logic.

### DIFF
--- a/metrics-common/src/main/java/org/apache/helix/monitoring/mbeans/MBeanRegistrar.java
+++ b/metrics-common/src/main/java/org/apache/helix/monitoring/mbeans/MBeanRegistrar.java
@@ -21,6 +21,7 @@ package org.apache.helix.monitoring.mbeans;
 
 import java.lang.management.ManagementFactory;
 import javax.management.InstanceAlreadyExistsException;
+import javax.management.InstanceNotFoundException;
 import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
@@ -84,10 +85,13 @@ public class MBeanRegistrar {
   }
 
   public static void unregister(ObjectName objectName) {
-    if (objectName != null && _beanServer.isRegistered(objectName)) {
+    if (objectName != null) {
       try {
         _beanServer.unregisterMBean(objectName);
         LOG.info("MBean {} has been un-registered.", objectName.getCanonicalName());
+      } catch (InstanceNotFoundException ex) {
+        LOG.warn("MBean {} does not exist. It might have been removed already.",
+            objectName.getCanonicalName());
       } catch (JMException e) {
         LOG.warn("Error in un-registering: " + objectName.getCanonicalName(), e);
       }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1763

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

The unregister method should rely on the MBeanServer class to validate if the target MBean has been unregistered or not to avoid race conditions. This PR fixes this potential problem.

### Tests

- [X] The following tests are written for this issue:

This PR aims to stabilize testClusterStatusMonitorLifecycle

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
