### PR TITLE
Improve Purge Offline Instances API

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -231,8 +231,11 @@ public class ZKHelixAdmin implements HelixAdmin {
     // delete config path
     String instanceConfigsPath = PropertyPathBuilder.instanceConfig(clusterName);
     ZKUtil.dropChildren(_zkClient, instanceConfigsPath, instanceConfig.getRecord());
-
     // delete instance path
+    dropInstancePathRecursively(instancePath, instanceConfig.getInstanceName());
+  }
+
+  private void dropInstancePathRecursively(String instancePath, String instanceName) {
     int retryCnt = 0;
     while (true) {
       try {
@@ -244,12 +247,12 @@ public class ZKHelixAdmin implements HelixAdmin {
           // Racing condition with controller's persisting node history, retryable.
           // We don't need to backoff here as this racing condition only happens once (controller
           // does not repeatedly write instance history)
-          logger.warn("Retrying dropping instance {} with exception {}",
-              instanceConfig.getInstanceName(), e.getCause().getMessage());
+          logger.warn("Retrying dropping instance {} with exception {}", instanceName,
+              e.getCause().getMessage());
           retryCnt++;
         } else {
-          String errorMessage = "Failed to drop instance: " + instanceConfig.getInstanceName()
-              + ". Retry times: " + retryCnt;
+          String errorMessage =
+              "Failed to drop instance: " + instanceName + ". Retry times: " + retryCnt;
           logger.error(errorMessage, e);
           throw new HelixException(errorMessage, e);
         }
@@ -268,20 +271,33 @@ public class ZKHelixAdmin implements HelixAdmin {
    */
   @Override
   public void purgeOfflineInstances(String clusterName, long offlineDuration) {
-    Map<String, InstanceConfig> timeoutOfflineInstances =
-        findTimeoutOfflineInstances(clusterName, offlineDuration);
     List<String> failToPurgeInstances = new ArrayList<>();
-    timeoutOfflineInstances.values().forEach(instance -> {
+    findTimeoutOfflineInstances(clusterName, offlineDuration).forEach(instance -> {
       try {
-        dropInstance(clusterName, instance);
+        purgeInstance(clusterName, instance);
       } catch (HelixException e) {
-        failToPurgeInstances.add(instance.getInstanceName());
+        failToPurgeInstances.add(instance);
       }
     });
     if (failToPurgeInstances.size() > 0) {
       LOG.error("ZKHelixAdmin::purgeOfflineInstances(): failed to drop the following instances: "
           + failToPurgeInstances);
     }
+  }
+
+  private void purgeInstance(String clusterName, String instanceName) {
+    logger.info("Purge instance {} from cluster {}.", instanceName, clusterName);
+
+    String liveInstancePath = PropertyPathBuilder.liveInstance(clusterName, instanceName);
+    if (_zkClient.exists(liveInstancePath)) {
+      throw new HelixException(
+          "Node " + instanceName + " is still alive for cluster " + clusterName + ", can't purge.");
+    }
+
+    String instanceConfigPath = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
+    _zkClient.delete(instanceConfigPath);
+    String instancePath = PropertyPathBuilder.instance(clusterName, instanceName);
+    dropInstancePathRecursively(instancePath, instanceName);
   }
 
   @Override
@@ -2176,36 +2192,40 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
   }
 
-  private Map<String, InstanceConfig> findTimeoutOfflineInstances(String clusterName,
-      long offlineDuration) {
-    Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
+  private Set<String> findTimeoutOfflineInstances(String clusterName, long offlineDuration) {
     // in case there is no customized timeout value, use the one defined in cluster config
     if (offlineDuration == ClusterConfig.OFFLINE_DURATION_FOR_PURGE_NOT_SET) {
       offlineDuration =
           _configAccessor.getClusterConfig(clusterName).getOfflineDurationForPurge();
       if (offlineDuration == ClusterConfig.OFFLINE_DURATION_FOR_PURGE_NOT_SET) {
-        return instanceConfigMap;
+        return Collections.emptySet();
       }
     }
 
     HelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<ZNRecord>(_zkClient));
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
-    instanceConfigMap = accessor.getChildValuesMap(keyBuilder.instanceConfigs(), true);
+    List<String> instanceConfigNames = accessor.getChildNames(keyBuilder.instanceConfigs());
+    List<String> instancePathNames = accessor.getChildNames(keyBuilder.instances());
     List<String> liveNodes = accessor.getChildNames(keyBuilder.liveInstances());
-    instanceConfigMap.keySet().removeAll(liveNodes);
 
-    Set<String> toRemoveInstances = new HashSet<>();
-    for (String instanceName : instanceConfigMap.keySet()) {
+    Set<String> timeoutOfflineInstanceNames = new HashSet<>();
+    timeoutOfflineInstanceNames.addAll(instanceConfigNames);
+    timeoutOfflineInstanceNames.addAll(instancePathNames);
+    liveNodes.forEach(timeoutOfflineInstanceNames::remove);
+    for (String instanceName : timeoutOfflineInstanceNames) {
       ParticipantHistory participantHistory =
           accessor.getProperty(keyBuilder.participantHistory(instanceName));
-      long lastOfflineTime = participantHistory.getLastOfflineTime();
-      if (lastOfflineTime == ClusterConfig.OFFLINE_DURATION_FOR_PURGE_NOT_SET
-          || System.currentTimeMillis() - lastOfflineTime < offlineDuration) {
-        toRemoveInstances.add(instanceName);
+
+      // If participant history is null, a race condition happened and should be cleaned up
+      // Otherwise, if the participant has not been offline for more than the duration, no clean up
+      if (participantHistory != null
+          && (participantHistory.getLastOfflineTime() == ParticipantHistory.ONLINE
+          || System.currentTimeMillis() - participantHistory.getLastOfflineTime()
+          < offlineDuration)) {
+        timeoutOfflineInstanceNames.remove(instanceName);
       }
     }
-    instanceConfigMap.keySet().removeAll(toRemoveInstances);
-    return instanceConfigMap;
+    return timeoutOfflineInstanceNames;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -1067,17 +1067,18 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     tool.purgeOfflineInstances(clusterName, 10000L);
     assertInstanceDropped(keyBuilder, instanceName);
 
-    // Set config again, without instancePath or history
-    _baseAccessor.set(PropertyPathBuilder.instanceConfig(clusterName, instanceName),
-        new ZNRecord(instanceName), 1);
-    tool.purgeOfflineInstances(clusterName, 10000L);
-    assertInstanceDropped(keyBuilder, instanceName);
-
-    // Set message without config, mimicking race condition
+    // Set message without config or history, mimicking race condition
     _baseAccessor.set(PropertyPathBuilder.instanceMessage(clusterName, instanceName, "testId"),
         new ZNRecord("testId"), 1);
     tool.purgeOfflineInstances(clusterName, 10000L);
     assertInstanceDropped(keyBuilder, instanceName);
+
+    // Set config again, without instancePath or history, mimicking new instance joining
+    _baseAccessor.set(PropertyPathBuilder.instanceConfig(clusterName, instanceName),
+        new ZNRecord(instanceName), 1);
+    tool.purgeOfflineInstances(clusterName, 10000L);
+    Assert.assertTrue(_gZkClient.exists(keyBuilder.instanceConfig(instanceName).getPath()),
+        "Instance should still be there");
 
     tool.dropCluster(clusterName);
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1869

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The `purgeOfflineInstances` API is used to clean up the instance metadata in ZK that is left by offline instances. The API is only used during special use cases where a large amount of instance metadata is left uncleaned; instance metadata should usually be cleaned up manually. 

As a cleanup API, `purgeOfflineInstances` has limitations: it cannot handle the case when participantHistory is missing. This is because `purgeOfflineInstances` uses the same underlying code as `dropInstance`. That means after one round of purging, race conditions could write unwanted data (such as messages) back to ZK, and they will never be cleaned up because participantHistory is no longer present. 

This PR improves the API such that it will also purge any incomplete instance data, such as instance path without InstanceConfig or ParticipantHistory. 

### Tests

- [x] The following tests are written for this issue:

Modified TestZkHelixAdmin.testPurgeOfflineInstances

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 1283, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,709.742 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1283, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /home/nesun/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 909 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:35 h
[INFO] Finished at: 2021-09-10T19:14:54-07:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
