### PR TITLE
Fix flaky test testClusterFreezeMode

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -1292,7 +1292,7 @@ public class TestClusterAccessor extends AbstractTestClass {
 
   @Test
   public void testClusterFreezeMode() throws Exception {
-    String cluster = _clusters.iterator().next();
+    String cluster = "TestCluster_0";
     HelixDataAccessor dataAccessor =
         new ZKHelixDataAccessor(cluster, new ZkBaseDataAccessor<>(_gZkClient));
     // Pause not existed


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1832 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The test fails randomly. Root cause is the test used a random cluster from the clusters set which has super clusters and task cluster, so the cluster could be a task cluster and then the test fails. Freeze mode does not apply to task framework.

This PR fixes it by changing the test cluster name with a fixed name `TestClusters_0`.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

Ran TestClusterAccessor 50 times. All passed
```
21:58:58,307 [INFO] Tests run: 35, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 27.071 s - in org.apache.helix.rest.server.TestClusterAccessor
21:58:58,759 [INFO]
21:58:58,760 [INFO] Results:
21:58:58,760 [INFO]
21:58:58,761 [INFO] Tests run: 35, Failures: 0, Errors: 0, Skipped: 0
21:58:58,761 [INFO]
21:58:58,767 [INFO]
21:58:58,767 [INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
21:58:58,802 [INFO] Loading execution data file /home/hulu/Projects/helix/helix-rest/target/jacoco.exec
21:58:58,998 [INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 79 classes
21:58:59,273 [INFO] ------------------------------------------------------------------------
21:58:59,274 [INFO] BUILD SUCCESS
21:58:59,274 [INFO] ------------------------------------------------------------------------
21:58:59,276 [INFO] Total time:  32.249 s
21:58:59,277 [INFO] Finished at: 2021-09-13T21:58:59-07:00
21:58:59,277 [INFO] ------------------------------------------------------------------------
```

Helix rest
```
22:05:21,721 [INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 106.319 s - in TestSuite
22:05:22,234 [INFO]
22:05:22,234 [INFO] Results:
22:05:22,234 [INFO]
22:05:22,234 [INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
22:05:22,235 [INFO]
22:05:22,240 [INFO]
22:05:22,240 [INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
22:05:22,287 [INFO] Loading execution data file /home/hulu/Projects/helix/helix-rest/target/jacoco.exec
22:05:22,476 [INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 79 classes
22:05:22,761 [INFO] ------------------------------------------------------------------------
22:05:22,762 [INFO] BUILD SUCCESS
22:05:22,763 [INFO] ------------------------------------------------------------------------
22:05:22,765 [INFO] Total time:  01:51 min
22:05:22,766 [INFO] Finished at: 2021-09-13T22:05:22-07:00
22:05:22,767 [INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
