### PR TITLE
Fix inconsistent behavior beween batch stoppable and single stoppable API

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -163,8 +163,21 @@ public class PerInstanceAccessor extends AbstractHelixResource {
             continueOnFailures, getNamespace());
     StoppableCheck stoppableCheck;
     try {
+      JsonNode node = null;
+      if (jsonContent.length() != 0) {
+        node = OBJECT_MAPPER.readTree(jsonContent);
+      }
+      if (node == null) {
+        return badRequest("Invalid input for content : " + jsonContent);
+      }
+
+      String customizedInput = null;
+      if (node.get(InstancesAccessor.InstancesProperties.customized_values.name()) != null) {
+        customizedInput = node.get(InstancesAccessor.InstancesProperties.customized_values.name()).textValue();
+      }
+
       stoppableCheck =
-          instanceService.getInstanceStoppableCheck(clusterId, instanceName, jsonContent);
+          instanceService.getInstanceStoppableCheck(clusterId, instanceName, customizedInput);
     } catch (HelixException e) {
       LOG.error("Current cluster: {}, instance: {} has issue with health checks!", clusterId,
           instanceName, e);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

fixes #1878 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Fix inconsistent behavior beween batch stoppable and single stoppable API

### Tests

- [ ] The following tests are written for this issue:



- The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 243.25 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /Users/jxue/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 79 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 04:19 min
[INFO] Finished at: 2021-09-22T13:35:01-07:00
[INFO] Final Memory: 44M/555M
[INFO] ------------------------------------------------------------------------
### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
