### PR TITLE
Fix test failure TestInstancesAccessor

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -95,7 +95,7 @@ public class TestInstancesAccessor extends AbstractTestClass {
         new BestPossibleExternalViewVerifier.Builder(STOPPABLE_CLUSTER).setZkAddr(ZK_ADDR).build();
     Assert.assertTrue(verifier.verifyByPolling());
 
-    Entity entity = Entity.entity("", MediaType.APPLICATION_JSON_TYPE);
+    Entity entity = Entity.entity("\"{}\"", MediaType.APPLICATION_JSON_TYPE);
     Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/stoppable")
         .format(STOPPABLE_CLUSTER, instance).post(this, entity);
     JsonNode jsonResult = OBJECT_MAPPER.readTree(response.readEntity(String.class));
@@ -109,7 +109,7 @@ public class TestInstancesAccessor extends AbstractTestClass {
     _configAccessor.setInstanceConfig(STOPPABLE_CLUSTER, instance, instanceConfig);
     Assert.assertTrue(verifier.verifyByPolling());
 
-    entity = Entity.entity("", MediaType.APPLICATION_JSON_TYPE);
+    entity = Entity.entity("\"{}\"", MediaType.APPLICATION_JSON_TYPE);
     response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/stoppable")
         .format(STOPPABLE_CLUSTER, instance).post(this, entity);
     jsonResult = OBJECT_MAPPER.readTree(response.readEntity(String.class));


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

fixes #1880 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Test input is changed due to change API behavior

### Tests

- [ ] The following tests are written for this issue:


- The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 221.526 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /Users/jxue/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 79 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 03:52 min
[INFO] Finished at: 2021-09-24T15:39:14-07:00
[INFO] Final Memory: 45M/570M
[INFO] ------------------------------------------------------------------------

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:


### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
