### PR TITLE
Add separate ZK serializer configuration to active ZNRecord compression when size exceeds a threshold.

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/constant/ZkSystemPropertyKeys.java
@@ -37,6 +37,15 @@ public class ZkSystemPropertyKeys {
       "zk.serializer.znrecord.auto-compress.enabled";
 
   /**
+   * This property defines a threshold of ZNRecord size in bytes that the ZK serializer starts to auto compress
+   * the ZNRecord for write requests if it's size exceeds the threshold.
+   * If the threshold is not configured or exceed ZKRecord write size limit, default value
+   * {@value ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES} will be applied.
+   */
+  public static final String ZK_SERIALIZER_ZNRECORD_AUTO_COMPRESS_THRESHOLD_BYTES =
+      "zk.serializer.znrecord.auto-compress.threshold.bytes";
+
+  /**
    * This is property that defines the maximum write size in bytes for ZKRecord's two serializers
    * before serialized data is ready to be written to ZK. This property applies to
    * 1. {@link org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer}

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/ZNRecordUtil.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/util/ZNRecordUtil.java
@@ -45,7 +45,25 @@ public class ZNRecordUtil {
         .getProperty(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_AUTO_COMPRESS_ENABLED,
             ZNRecord.ZK_SERIALIZER_ZNRECORD_AUTO_COMPRESS_DEFAULT));
 
-    return autoCompressEnabled && serializedLength > getSerializerWriteSizeLimit();
+    return autoCompressEnabled && serializedLength > getSerializerCompressThreshold();
+  }
+
+  /**
+   * Returns the threshold in bytes that ZNRecord serializer should compress a ZNRecord with larger size.
+   * If threshold is configured to be less than or equal to 0, the serializer will always compress ZNRecords as long as
+   * auto-compression is enabled.
+   * If threshold is not configured or the threshold is larger than ZNRecord write size limit, the default value
+   * ZNRecord write size limit will be used instead.
+   */
+  private static int getSerializerCompressThreshold() {
+    Integer autoCompressThreshold =
+        Integer.getInteger(ZkSystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_AUTO_COMPRESS_THRESHOLD_BYTES);
+
+    if (autoCompressThreshold == null || autoCompressThreshold > getSerializerWriteSizeLimit()) {
+      return getSerializerWriteSizeLimit();
+    }
+
+    return autoCompressThreshold;
   }
 
   /**


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1616

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Add separate ZK serializer configuration to active ZNRecord compression even the node size is smaller than the write size limit.

The property zk.serializer.znrecord.auto-compress.threshold.bytes defines a threshold of ZNRecord size in bytes that the ZK serializer starts to auto compress the ZNRecord for write requests if its size exceeds the threshold.
If the threshold is not configured or exceed ZKRecord write size limit, default value zk.serializer.znrecord.write.size.limit.bytes (if configured) or 1MB (if no configuration) will be applied.

### Tests

- [x] The following tests are written for this issue:

TestZNRecordSizeLimit

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
