### PR TITLE
Fix input for stoppable rest API

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -209,10 +209,8 @@ public class InstancesAccessor extends AbstractHelixResource {
               OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, String.class));
 
       List<String> orderOfZone = null;
-      String customizedInput = null;
-      if (node.get(InstancesAccessor.InstancesProperties.customized_values.name()) != null) {
-        customizedInput = node.get(InstancesAccessor.InstancesProperties.customized_values.name()).textValue();
-      }
+      Map<String, String> customizedInput = InstanceServiceImpl.getMapFromJsonNode(
+          node.get(InstancesAccessor.InstancesProperties.customized_values.name()));
 
       if (node.get(InstancesAccessor.InstancesProperties.zone_order.name()) != null) {
         orderOfZone = OBJECT_MAPPER

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -157,7 +157,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       @QueryParam("skipZKRead") boolean skipZKRead,
       @QueryParam("continueOnFailures") boolean continueOnFailures) throws IOException {
     HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
-    InstanceServiceImpl instanceService =
+    InstanceService instanceService =
         new InstanceServiceImpl((ZKHelixDataAccessor) dataAccessor, getConfigAccessor(), skipZKRead,
             continueOnFailures, getNamespace());
     StoppableCheck stoppableCheck;
@@ -170,10 +170,8 @@ public class PerInstanceAccessor extends AbstractHelixResource {
         return badRequest("Invalid input for content : " + jsonContent);
       }
 
-      String customizedInput = null;
-      if (node.get(InstancesAccessor.InstancesProperties.customized_values.name()) != null) {
-        customizedInput = node.get(InstancesAccessor.InstancesProperties.customized_values.name()).textValue();
-      }
+      Map<String, String> customizedInput = InstanceServiceImpl.getMapFromJsonNode(
+          node.get(InstancesAccessor.InstancesProperties.customized_values.name()));
 
       stoppableCheck =
           instanceService.getInstanceStoppableCheck(clusterId, instanceName, customizedInput);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -46,7 +46,6 @@ import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
-import org.apache.helix.PropertyKey;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.Error;
@@ -158,7 +157,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       @QueryParam("skipZKRead") boolean skipZKRead,
       @QueryParam("continueOnFailures") boolean continueOnFailures) throws IOException {
     HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
-    InstanceService instanceService =
+    InstanceServiceImpl instanceService =
         new InstanceServiceImpl((ZKHelixDataAccessor) dataAccessor, getConfigAccessor(), skipZKRead,
             continueOnFailures, getNamespace());
     StoppableCheck stoppableCheck;

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceService.java
@@ -108,6 +108,6 @@ public interface InstanceService {
      * @return A map contains the instance as key and the StoppableCheck as the value
      * @throws IOException in case of network failure
      */
-    Map<String, StoppableCheck> batchGetInstancesStoppableChecks(String clusterId, List<String> instances, String jsonContent)
-            throws IOException;
+    Map<String, StoppableCheck> batchGetInstancesStoppableChecks(String clusterId,
+        List<String> instances, String jsonContent) throws IOException;
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceService.java
@@ -100,6 +100,18 @@ public interface InstanceService {
                                              String jsonContent) throws IOException;
 
     /**
+     * Get the current instance stoppable checks
+     *
+     * @param clusterId    The cluster id
+     * @param instanceName The instance name
+     * @param customizedInput  The Map of payload from client side
+     * @return An instance of {@link StoppableCheck} easily convertible to JSON
+     * @throws IOException in case of network failure
+     */
+    StoppableCheck getInstanceStoppableCheck(String clusterId, String instanceName,
+        Map<String, String> customizedInput) throws IOException;
+
+    /**
      * Batch get StoppableCheck results for a list of instances in one cluster
      *
      * @param clusterId   The cluster id
@@ -110,4 +122,16 @@ public interface InstanceService {
      */
     Map<String, StoppableCheck> batchGetInstancesStoppableChecks(String clusterId,
         List<String> instances, String jsonContent) throws IOException;
+
+    /**
+     * Batch get StoppableCheck results for a list of instances in one cluster
+     *
+     * @param clusterId   The cluster id
+     * @param instances   The list of instances
+     * @param customizedInput  The Map of payload from client side
+     * @return A map contains the instance as key and the StoppableCheck as the value
+     * @throws IOException in case of network failure
+     */
+    Map<String, StoppableCheck> batchGetInstancesStoppableChecks(String clusterId,
+        List<String> instances, Map<String, String> customizedInput) throws IOException;
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
@@ -195,13 +196,13 @@ public class InstanceServiceImpl implements InstanceService {
     return finalStoppableChecks;
   }
 
-  protected StoppableCheck getInstanceStoppableCheck(String clusterId, String instanceName,
+  public StoppableCheck getInstanceStoppableCheck(String clusterId, String instanceName,
       Map<String, String> customizedValues) throws IOException {
     return batchGetInstancesStoppableChecks(clusterId, ImmutableList.of(instanceName),
         customizedValues).get(instanceName);
   }
 
-  protected Map<String, StoppableCheck> batchGetInstancesStoppableChecks(String clusterId,
+  public Map<String, StoppableCheck> batchGetInstancesStoppableChecks(String clusterId,
       List<String> instances, Map<String, String> customizedValues) throws IOException {
     Map<String, StoppableCheck> finalStoppableChecks = new HashMap<>();
     // helix instance check
@@ -357,14 +358,13 @@ public class InstanceServiceImpl implements InstanceService {
     return result;
   }
 
-  public static Map<String, String> getMapFromJsonPayload(String jsonContent) throws IOException {
-    if (jsonContent == null) {
-      return null;
-    }
+  public static Map<String, String> getMapFromJsonNode(JsonNode jsonContent) throws IOException {
     Map<String, String> result = new HashMap<>();
-    JsonNode jsonNode = OBJECT_MAPPER.readTree(jsonContent);
-    // parsing the inputs as string key value pairs
-    jsonNode.fields().forEachRemaining(kv -> result.put(kv.getKey(), kv.getValue().asText()));
+    if (jsonContent == null) {
+      return result;
+    }
+    result = OBJECT_MAPPER.convertValue(jsonContent, new TypeReference<Map<String, String>>() {
+    });
     return result;
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
@@ -21,6 +21,7 @@ package org.apache.helix.rest.server.service;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -185,35 +186,48 @@ public class InstanceServiceImpl implements InstanceService {
   public Map<String, StoppableCheck> batchGetInstancesStoppableChecks(String clusterId,
       List<String> instances, String jsonContent) throws IOException {
     Map<String, StoppableCheck> finalStoppableChecks = new HashMap<>();
-    Map<String, Future<StoppableCheck>> helixInstanceChecks =
-        instances.stream().collect(Collectors.toMap(Function.identity(),
-            instance -> POOL.submit(() -> performHelixOwnInstanceCheck(clusterId, instance))));
+    // helix instance check
     List<String> instancesForCustomInstanceLevelChecks =
-        filterInstancesForNextCheck(helixInstanceChecks, finalStoppableChecks);
-    if (instancesForCustomInstanceLevelChecks.isEmpty()) {
-      // if all instances failed at helix custom level checks and all checks are not required
-      return finalStoppableChecks;
-    }
+        batchHelixInstanceStoppableCheck(clusterId, instances, finalStoppableChecks);
+    // custom check
+    batchCustomInstanceStoppableCheck(clusterId, instancesForCustomInstanceLevelChecks,
+        finalStoppableChecks, getCustomPayLoads(jsonContent));
+    return finalStoppableChecks;
+  }
 
+  private List<String> batchHelixInstanceStoppableCheck(String clusterId,
+      Collection<String> instances, Map<String, StoppableCheck> finalStoppableChecks) {
+    Map<String, Future<StoppableCheck>> helixInstanceChecks = instances.stream().collect(Collectors
+        .toMap(Function.identity(),
+            instance -> POOL.submit(() -> performHelixOwnInstanceCheck(clusterId, instance))));
+    // finalStoppableChecks only contains instances that does not pass this health check
+    return filterInstancesForNextCheck(helixInstanceChecks, finalStoppableChecks);
+  }
+
+  private void batchCustomInstanceStoppableCheck(String clusterId, List<String> instances,
+      Map<String, StoppableCheck> finalStoppableChecks, Map<String, String> customPayLoads) {
+    if (instances.isEmpty() ) {
+      // if all instances failed at previous checks, then all following checks are not required.
+      return;
+    }
     RESTConfig restConfig = _configAccessor.getRESTConfig(clusterId);
     if (restConfig == null) {
-      String errorMessage =
-          String.format("The cluster %s hasn't enabled client side health checks yet, "
+      String errorMessage = String.format(
+          "The cluster %s hasn't enabled client side health checks yet, "
               + "thus the stoppable check result is inaccurate", clusterId);
       LOG.error(errorMessage);
       throw new HelixException(errorMessage);
     }
-    Map<String, String> customPayLoads = getCustomPayLoads(jsonContent);
-    Map<String, Future<StoppableCheck>> customInstanceLevelChecks =
-        instancesForCustomInstanceLevelChecks.stream()
-            .collect(Collectors.toMap(Function.identity(),
-                instance -> POOL.submit(() -> performCustomInstanceCheck(clusterId, instance,
-                    restConfig.getBaseUrl(instance), customPayLoads))));
+    Map<String, Future<StoppableCheck>> customInstanceLevelChecks = instances.stream().collect(
+        Collectors.toMap(Function.identity(), instance -> POOL.submit(
+            () -> performCustomInstanceCheck(clusterId, instance, restConfig.getBaseUrl(instance),
+                customPayLoads))));
     List<String> instancesForCustomPartitionLevelChecks =
         filterInstancesForNextCheck(customInstanceLevelChecks, finalStoppableChecks);
     if (!instancesForCustomPartitionLevelChecks.isEmpty()) {
-      Map<String, StoppableCheck> instancePartitionLevelChecks = performPartitionsCheck(
-          instancesForCustomPartitionLevelChecks, restConfig, customPayLoads);
+      Map<String, StoppableCheck> instancePartitionLevelChecks =
+          performPartitionsCheck(instancesForCustomPartitionLevelChecks, restConfig,
+              customPayLoads);
       for (Map.Entry<String, StoppableCheck> instancePartitionStoppableCheckEntry : instancePartitionLevelChecks
           .entrySet()) {
         String instance = instancePartitionStoppableCheckEntry.getKey();
@@ -221,8 +235,6 @@ public class InstanceServiceImpl implements InstanceService {
         addStoppableCheck(finalStoppableChecks, instance, stoppableCheck);
       }
     }
-
-    return finalStoppableChecks;
   }
 
   private void addStoppableCheck(Map<String, StoppableCheck> stoppableChecks, String instance,
@@ -318,6 +330,9 @@ public class InstanceServiceImpl implements InstanceService {
 
   private Map<String, String> getCustomPayLoads(String jsonContent) throws IOException {
     Map<String, String> result = new HashMap<>();
+    if (jsonContent == null) {
+      return result;
+    }
     JsonNode jsonNode = OBJECT_MAPPER.readTree(jsonContent);
     // parsing the inputs as string key value pairs
     jsonNode.fields().forEachRemaining(kv -> result.put(kv.getKey(), kv.getValue().asText()));


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1903 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change fixes the inout problem for stoppable rest API.
Adds 2 public functions that takes Map<String, String> as input in InstanceService for single instance and batched instance stoppable check. 

This PR is dependent on PR #1902.

### Tests

- [X] The following tests are written for this issue:
NA


- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
