### PR TITLE
Fix input for stoppable rest API

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -211,7 +211,7 @@ public class InstancesAccessor extends AbstractHelixResource {
       List<String> orderOfZone = null;
       String customizedInput = null;
       if (node.get(InstancesAccessor.InstancesProperties.customized_values.name()) != null) {
-        customizedInput = node.get(InstancesAccessor.InstancesProperties.customized_values.name()).textValue();
+        customizedInput = node.get(InstancesAccessor.InstancesProperties.customized_values.name()).toString();
       }
 
       if (node.get(InstancesAccessor.InstancesProperties.zone_order.name()) != null) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -46,7 +46,6 @@ import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
-import org.apache.helix.PropertyKey;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.Error;
@@ -173,7 +172,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
 
       String customizedInput = null;
       if (node.get(InstancesAccessor.InstancesProperties.customized_values.name()) != null) {
-        customizedInput = node.get(InstancesAccessor.InstancesProperties.customized_values.name()).textValue();
+        customizedInput = node.get(InstancesAccessor.InstancesProperties.customized_values.name()).toString();
       }
 
       stoppableCheck =

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceServiceImpl.java
@@ -318,6 +318,9 @@ public class InstanceServiceImpl implements InstanceService {
 
   private Map<String, String> getCustomPayLoads(String jsonContent) throws IOException {
     Map<String, String> result = new HashMap<>();
+    if (jsonContent == null) {
+      return result;
+    }
     JsonNode jsonNode = OBJECT_MAPPER.readTree(jsonContent);
     // parsing the inputs as string key value pairs
     jsonNode.fields().forEachRemaining(kv -> result.put(kv.getKey(), kv.getValue().asText()));


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1903

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

User will hit a 500 error when passing the following input to stoppable API.
`instance_name/stoppable -d '{"customized_values": {"keys" : "cc"}}'` or
`instance_name/stoppable -d '{}'`

Reason:

```
String customizedInput = null;                 <------------- <1>
if (node.get(InstancesAccessor.InstancesProperties.customized_values.name()) != null) {
  customizedInput = node.get(InstancesAccessor.InstancesProperties.customized_values.name()).textValue();   <<<----- <2>
}
```
This is shared code that reads user input Json payload.

<1> is the cause of this problem. If there is no "customized_values" defined in the payload, "customizedInput" will be null and cause nullptr exception.

<2> is another problem we have. JsonNode.textValue() will only convert Textual value this node contains, iff it is a textual JSON node (comes from JSON String value entry). (https://fasterxml.github.io/jackson-databind/javadoc/2.7/com/fasterxml/jackson/databind/JsonNode.html#textValue()).

It will return null is user provide a KV map, witch is a container node instead of a textual node. We should use toString() here.

### Tests

- [X] The following tests are written for this issue:
NA
We already have test that has empty(no customized_values key)/non-empty(customized_values has {k:v} values) input. The test will fail after refactor PR #1902. No new test need to be added. 

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 412.328 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /Users/xialu/Documents/WorkSpace/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 83 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  06:58 min
[INFO] Finished at: 2021-11-16T16:41:05-08:00
[INFO] ------------------------------------------------------------------------

```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
