### PR TITLE
Add take/free instance implementation and test

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementInstanceInfo.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementInstanceInfo.java
@@ -83,9 +83,9 @@ public class MaintenanceManagementInstanceInfo {
     mergeResultForOperationCheck(info, false);
   }
 
-  public void mergeResultForOperationCheck(MaintenanceManagementInstanceInfo info, boolean continueOnFailure) {
+  public void mergeResultForOperationCheck(MaintenanceManagementInstanceInfo info, boolean nonBlockingFailure) {
     messages.addAll(info.getMessages());
-    status = (info.isSuccessful() || continueOnFailure) && isSuccessful() ? OperationalStatus.SUCCESS
+    status = (info.isSuccessful() || nonBlockingFailure) && isSuccessful() ? OperationalStatus.SUCCESS
         : OperationalStatus.FAILURE;
     if (info.hasOperationResult()) {
       operationResult =

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementInstanceInfo.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementInstanceInfo.java
@@ -80,13 +80,14 @@ public class MaintenanceManagementInstanceInfo {
   }
 
   public void mergeResult(MaintenanceManagementInstanceInfo info) {
-    mergeResultForOperationCheck(info, false);
+    mergeResult(info, false);
   }
 
-  public void mergeResultForOperationCheck(MaintenanceManagementInstanceInfo info, boolean nonBlockingFailure) {
+  public void mergeResult(MaintenanceManagementInstanceInfo info, boolean nonBlockingFailure) {
     messages.addAll(info.getMessages());
-    status = (info.isSuccessful() || nonBlockingFailure) && isSuccessful() ? OperationalStatus.SUCCESS
-        : OperationalStatus.FAILURE;
+    status =
+        (info.isSuccessful() || nonBlockingFailure) && isSuccessful() ? OperationalStatus.SUCCESS
+            : OperationalStatus.FAILURE;
     if (info.hasOperationResult()) {
       operationResult =
           this.hasOperationResult() ? operationResult + "," + info.getOperationResult()

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementInstanceInfo.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementInstanceInfo.java
@@ -68,8 +68,11 @@ public class MaintenanceManagementInstanceInfo {
     operationResult = result;
   }
 
-  public void addFailureMessage(List<String> msg) {
+  public void addMessages(List<String> msg) {
     messages.addAll(msg);
+  }
+  public void addMessage(String meg) {
+    messages.add(meg);
   }
 
   public boolean isSuccessful() {
@@ -77,8 +80,12 @@ public class MaintenanceManagementInstanceInfo {
   }
 
   public void mergeResult(MaintenanceManagementInstanceInfo info) {
+    mergeResultForOperationCheck(info, false);
+  }
+
+  public void mergeResultForOperationCheck(MaintenanceManagementInstanceInfo info, boolean continueOnFailure) {
     messages.addAll(info.getMessages());
-    status = info.isSuccessful() && isSuccessful() ? OperationalStatus.SUCCESS
+    status = (info.isSuccessful() || continueOnFailure) && isSuccessful() ? OperationalStatus.SUCCESS
         : OperationalStatus.FAILURE;
     if (info.hasOperationResult()) {
       operationResult =

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementInstanceInfo.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementInstanceInfo.java
@@ -76,7 +76,7 @@ public class MaintenanceManagementInstanceInfo {
     return status.equals(OperationalStatus.SUCCESS);
   }
 
-  public void mergeResultStatus(MaintenanceManagementInstanceInfo info) {
+  public void mergeResult(MaintenanceManagementInstanceInfo info) {
     messages.addAll(info.getMessages());
     status = info.isSuccessful() && isSuccessful() ? OperationalStatus.SUCCESS
         : OperationalStatus.FAILURE;

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
@@ -464,6 +464,9 @@ public class MaintenanceManagementService {
     List<String> instancesForNext = new ArrayList<>(instances);
     Map<String, MaintenanceManagementInstanceInfo> instanceInfos = new HashMap<>();
     Map<String, StoppableCheck> finalStoppableChecks = new HashMap<>();
+    // TODO: Right now user can only choose from HelixInstanceStoppableCheck and
+    // CostumeInstanceStoppableCheck. We should add finer grain check groups to choose from
+    // i.e. HELIX:INSTANCE_NOT_ENABLED, CUSTOM_PARTITION_HEALTH_FAILURE:PARTITION_INITIAL_STATE_FAIL etc.
     for (String healthCheck : healthChecks) {
       if (healthCheck.equals("HelixInstanceStoppableCheck")) {
         // this is helix own check

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
@@ -472,7 +472,7 @@ public class MaintenanceManagementService {
         // this is helix own check
         instancesForNext =
             batchHelixInstanceStoppableCheck(clusterId, instancesForNext, finalStoppableChecks);
-      } else if (healthCheck.equals("CostumeInstanceStoppableCheck")) {
+      } else if (healthCheck.equals("CustomInstanceStoppableCheck")) {
         // custom check, includes custom Instance check and partition check.
         instancesForNext = batchCustomInstanceStoppableCheck(clusterId, instancesForNext, finalStoppableChecks,
             healthCheckConfig);

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
@@ -132,7 +132,7 @@ public class MaintenanceManagementService {
    * @param healthChecks       A list of healthChecks to perform
    * @param healthCheckConfig The input for health Checks
    * @param operations         A list of operation checks or operations to execute
-   *  @param operationConfig    A map of config. Key is the operation name value if a Json
+   * @param operationConfig    A map of config. Key is the operation name value if a Json
    *                            representation of a map
    * @param performOperation   If this param is set to false, the function will only do a dry run
    * @return MaintenanceManagementInstanceInfo
@@ -292,8 +292,9 @@ public class MaintenanceManagementService {
                 .newInstance();
         operationAbstractClassList.add(userOperation);
       } catch (Exception e) {
-        LOG.error("No operation class found for: " + operationClassName + ". message: ", e);
-        throw new HelixException("No operation class found for: " + operationClassName + ". message: ", e);
+        LOG.error("No operation class found for: {}. message: ", operationClassName, e);
+        throw new HelixException(
+            String.format("No operation class found for: %s. message: %s", operationClassName, e));
       }
     }
     return operationAbstractClassList;
@@ -390,8 +391,8 @@ public class MaintenanceManagementService {
       }
 
       // operation execution
-      for (OperationInterface operationClass : operationAbstractClassList) {
-        if (instanceInfo.isSuccessful() && performOperation) {
+      if (performOperation && instanceInfo.isSuccessful()) {
+        for (OperationInterface operationClass : operationAbstractClassList) {
           Map<String, String> singleOperationConfig =
               operationConfigSet.get(operationClass.getClass().getName());
           boolean continueOnFailures =
@@ -625,7 +626,8 @@ public class MaintenanceManagementService {
     }
     JsonNode jsonNode = OBJECT_MAPPER.readTree(jsonContent);
     // parsing the inputs as string key value pairs
-    jsonNode.fields().forEachRemaining(kv -> result.put(kv.getKey(), kv.getValue().toString()));
+    jsonNode.fields().forEachRemaining(kv -> result.put(kv.getKey(),
+        kv.getValue().isValueNode() ? kv.getValue().asText() : kv.getValue().toString()));
     return result;
   }
 
@@ -633,7 +635,8 @@ public class MaintenanceManagementService {
       throws IllegalArgumentException {
     Map<String, String> result = new HashMap<>();
     if (jsonNode != null) {
-      jsonNode.fields().forEachRemaining(kv -> result.put(kv.getKey(), kv.getValue().toString()));
+      jsonNode.fields().forEachRemaining(kv -> result.put(kv.getKey(),
+          kv.getValue().isValueNode() ? kv.getValue().asText() : kv.getValue().toString()));
     }
     return result;
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/common/HelixDataAccessorWrapper.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/common/HelixDataAccessorWrapper.java
@@ -39,7 +39,7 @@ import org.apache.helix.HelixProperty;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyType;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
-import org.apache.helix.model.IdealState;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.RESTConfig;
 import org.apache.helix.rest.client.CustomRestClient;
 import org.apache.helix.rest.client.CustomRestClientFactory;
@@ -241,7 +241,7 @@ public class HelixDataAccessorWrapper extends ZKHelixDataAccessor {
 
     for (String resourceName : resources) {
       getProperty(propertyKeyBuilder.idealStates(resourceName));
-      IdealState externalView = getProperty(propertyKeyBuilder.externalView(resourceName));
+      ExternalView externalView = getProperty(propertyKeyBuilder.externalView(resourceName));
       if (externalView != null) {
         String stateModeDef = externalView.getStateModelDefRef();
         getProperty(propertyKeyBuilder.stateModelDef(stateModeDef));

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceService.java
@@ -47,7 +47,6 @@ public interface InstanceService {
      * @return An instance of {@link StoppableCheck} easily convertible to JSON
      * @throws IOException in case of network failure
      */
-    @Deprecated
     StoppableCheck getInstanceStoppableCheck(String clusterId, String instanceName,
                                              String jsonContent) throws IOException;
 
@@ -60,7 +59,6 @@ public interface InstanceService {
      * @return A map contains the instance as key and the StoppableCheck as the value
      * @throws IOException in case of network failure
      */
-    @Deprecated
     Map<String, StoppableCheck> batchGetInstancesStoppableChecks(String clusterId, List<String> instances, String jsonContent)
             throws IOException;
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/InstanceService.java
@@ -28,8 +28,6 @@ import org.apache.helix.rest.server.json.instance.InstanceInfo;
 import org.apache.helix.rest.server.json.instance.StoppableCheck;
 
 public interface InstanceService {
-
-
     /**
      * Get the overall status of the instance
      *
@@ -38,7 +36,7 @@ public interface InstanceService {
      * @return An instance of {@link InstanceInfo} easily convertible to JSON
      */
     InstanceInfo getInstanceInfo(String clusterId, String instanceName,
-                                 List<HealthCheck> healthChecks);
+        List<HealthCheck> healthChecks);
 
     /**
      * Get the current instance stoppable checks
@@ -49,6 +47,7 @@ public interface InstanceService {
      * @return An instance of {@link StoppableCheck} easily convertible to JSON
      * @throws IOException in case of network failure
      */
+    @Deprecated
     StoppableCheck getInstanceStoppableCheck(String clusterId, String instanceName,
                                              String jsonContent) throws IOException;
 
@@ -61,6 +60,7 @@ public interface InstanceService {
      * @return A map contains the instance as key and the StoppableCheck as the value
      * @throws IOException in case of network failure
      */
+    @Deprecated
     Map<String, StoppableCheck> batchGetInstancesStoppableChecks(String clusterId, List<String> instances, String jsonContent)
             throws IOException;
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
@@ -18,12 +18,15 @@ package org.apache.helix.rest.clusterMaintenanceService;
  * specific language governing permissions and limitations
  * under the License.
  */
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.AccessOption;
@@ -46,6 +49,7 @@ import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
@@ -77,12 +81,22 @@ public class TestMaintenanceManagementService {
   }
 
   class MockMaintenanceManagementService extends MaintenanceManagementService {
+
     public MockMaintenanceManagementService(ZKHelixDataAccessor dataAccessor,
         ConfigAccessor configAccessor, CustomRestClient customRestClient, boolean skipZKRead,
-        boolean continueOnFailures, String namespace) {
-      super(dataAccessor, configAccessor, customRestClient, skipZKRead, continueOnFailures,
+        boolean continueOnFailure, String namespace) {
+      super(dataAccessor, configAccessor, customRestClient, skipZKRead,
+          continueOnFailure ? Collections.singleton(ALL_HEALTH_CHECK_NONBLOCK)
+              : Collections.emptySet(), namespace);
+    }
+
+    public MockMaintenanceManagementService(ZKHelixDataAccessor dataAccessor,
+        ConfigAccessor configAccessor, CustomRestClient customRestClient, boolean skipZKRead,
+        Set<String> nonBlockingHealthChecks, String namespace) {
+      super(dataAccessor, configAccessor, customRestClient, skipZKRead, nonBlockingHealthChecks,
           namespace);
     }
+
     @Override
     protected Map<String, Boolean> getInstanceHealthStatus(String clusterId, String instanceName,
         List<HealthCheck> healthChecks) {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestOperationImpl.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestOperationImpl.java
@@ -1,0 +1,148 @@
+package org.apache.helix.rest.server;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.helix.HelixException;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.StateModelDefinition;
+import org.apache.helix.rest.clusterMaintenanceService.MaintenanceManagementInstanceInfo;
+import org.apache.helix.rest.clusterMaintenanceService.api.OperationInterface;
+import org.apache.helix.rest.common.RestSnapShotSimpleImpl;
+import org.apache.helix.rest.common.datamodel.RestSnapShot;
+import org.apache.helix.task.TaskConstants;
+import org.apache.helix.util.InstanceValidationUtil;
+
+
+public class TestOperationImpl implements OperationInterface {
+
+  @Override
+  public MaintenanceManagementInstanceInfo operationCheckForTakeSingleInstance(String instanceName, Map<String, String> operationConfig, RestSnapShot sn) {
+    Map<String, Boolean> isInstanceOnHoldCache = new HashMap<>();
+    for (Map.Entry<String, String> entry : operationConfig.entrySet()) {
+      isInstanceOnHoldCache.put(entry.getKey(), Boolean.parseBoolean(entry.getValue()));
+    }
+    try {
+      String unHealthyPartition =
+          siblingNodesActiveReplicaCheck(sn, instanceName, isInstanceOnHoldCache);
+      if (unHealthyPartition == null) {
+        return new MaintenanceManagementInstanceInfo(
+            MaintenanceManagementInstanceInfo.OperationalStatus.SUCCESS);
+      } else {
+        return new MaintenanceManagementInstanceInfo(
+            MaintenanceManagementInstanceInfo.OperationalStatus.FAILURE,
+            Collections.singletonList(unHealthyPartition));
+      }
+    } catch (Exception ex) {
+      return new MaintenanceManagementInstanceInfo(
+          MaintenanceManagementInstanceInfo.OperationalStatus.FAILURE,
+          Collections.singletonList(ex.getMessage()));
+    }
+  }
+
+  @Override
+  public MaintenanceManagementInstanceInfo operationCheckForFreeSingleInstance(String instanceName, Map<String, String> operationConfig, RestSnapShot sn) {
+    return new MaintenanceManagementInstanceInfo(
+        MaintenanceManagementInstanceInfo.OperationalStatus.SUCCESS);
+  }
+
+  @Override
+  public Map<String, MaintenanceManagementInstanceInfo> operationCheckForTakeInstances(Collection<String> instances, Map<String, String> operationConfig, RestSnapShot sn) {
+    return null;
+  }
+
+  @Override
+  public Map<String, MaintenanceManagementInstanceInfo> operationCheckForFreeInstances(Collection<String> instances, Map<String, String> operationConfig, RestSnapShot sn) {
+    return null;
+  }
+
+  @Override
+  public MaintenanceManagementInstanceInfo operationExecForTakeSingleInstance(String instanceName,
+      Map<String, String> operationConfig, RestSnapShot sn) {
+    return new MaintenanceManagementInstanceInfo(
+        MaintenanceManagementInstanceInfo.OperationalStatus.SUCCESS,
+        "DummyTakeOperationResult");
+  }
+
+  @Override
+  public MaintenanceManagementInstanceInfo operationExecForFreeSingleInstance(String instanceName,
+      Map<String, String> operationConfig, RestSnapShot sn) {
+    return new MaintenanceManagementInstanceInfo(
+        MaintenanceManagementInstanceInfo.OperationalStatus.SUCCESS,
+        "DummyFreeOperationResult");
+  }
+
+  @Override
+  public Map<String, MaintenanceManagementInstanceInfo> operationExecForTakeInstances(Collection<String> instances, Map<String, String> operationConfig, RestSnapShot sn) {
+    return null;
+  }
+
+  @Override
+  public Map<String, MaintenanceManagementInstanceInfo> operationExecForFreeInstances(Collection<String> instances, Map<String, String> operationConfig, RestSnapShot sn) {
+    return null;
+  }
+
+  public String siblingNodesActiveReplicaCheck(RestSnapShot snapShot, String instanceName,
+      Map<String, Boolean> isInstanceOnHoldCache) throws HelixException {
+    String clusterName = snapShot.getClusterName();
+    if (!(snapShot instanceof RestSnapShotSimpleImpl)) {
+      throw new HelixException("Passed in Snapshot is not an instance of RestSnapShotSimpleImpl");
+    } RestSnapShotSimpleImpl restSnapShotSimple = (RestSnapShotSimpleImpl) snapShot;
+
+    PropertyKey.Builder propertyKeyBuilder = new PropertyKey.Builder(clusterName);
+    List<String> resources = restSnapShotSimple.getChildNames(propertyKeyBuilder.idealStates());
+
+    for (String resourceName : resources) {
+      IdealState idealState =
+          restSnapShotSimple.getProperty(propertyKeyBuilder.idealStates(resourceName));
+      if (idealState == null || !idealState.isEnabled() || !idealState.isValid()
+          || TaskConstants.STATE_MODEL_NAME.equals(idealState.getStateModelDefRef())) {
+        continue;
+      }
+      ExternalView externalView =
+          restSnapShotSimple.getProperty(propertyKeyBuilder.externalView(resourceName));
+      if (externalView == null) {
+        throw new HelixException(
+            String.format("Resource %s does not have external view!", resourceName));
+      }
+      // Get the minActiveReplicas constraint for the resource
+      int minActiveReplicas = externalView.getMinActiveReplicas();
+      if (minActiveReplicas == -1) {
+        continue;
+      }
+      String stateModeDef = externalView.getStateModelDefRef();
+      StateModelDefinition stateModelDefinition =
+          restSnapShotSimple.getProperty(propertyKeyBuilder.stateModelDef(stateModeDef));
+      Set<String> unhealthyStates = new HashSet<>(InstanceValidationUtil.UNHEALTHY_STATES);
+      if (stateModelDefinition != null) {
+        unhealthyStates.add(stateModelDefinition.getInitialState());
+      }
+      for (String partition : externalView.getPartitionSet()) {
+        Map<String, String> stateByInstanceMap = externalView.getStateMap(partition);
+        // found the resource hosted on the instance
+        if (stateByInstanceMap.containsKey(instanceName)) {
+          int numHealthySiblings = 0;
+          for (Map.Entry<String, String> entry : stateByInstanceMap.entrySet()) {
+            if (!entry.getKey().equals(instanceName) && !unhealthyStates.contains(entry.getValue())
+                && !isInstanceOnHoldCache.get(entry.getKey())) {
+              numHealthySiblings++;
+            }
+          }
+          if (numHealthySiblings < minActiveReplicas) {
+            return partition;
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+}
+

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -126,7 +126,6 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/takeInstance")
         .format(STOPPABLE_CLUSTER, "instance1").post(this, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
     String takeInstanceResult = response.readEntity(String.class);
-    System.out.println("testTakeInstanceNonBlockingCheck: " + takeInstanceResult);
 
     Map<String, Object> actualMap = OBJECT_MAPPER.readValue(takeInstanceResult, Map.class);
     List<String> errorMsg = Arrays

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -176,8 +176,9 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
   public void testTakeInstanceOperationCheckFailure() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String payload = "{ \"operation_list\" : [\"org.apache.helix.rest.server.TestOperationImpl\"],"
-        + "\"operation_config\": {\"instance0\": \"true\", \"instance2\": \"true\", "
-        + "\"instance3\": \"true\", \"instance4\": \"true\", \"instance5\": \"true\"} } ";
+        + "\"operation_config\": { \"org.apache.helix.rest.server.TestOperationImpl\" :"
+        + " {\"instance0\": \"true\", \"instance2\": \"true\", "
+        + "\"instance3\": \"true\", \"instance4\": \"true\", \"instance5\": \"true\"}} } ";
     Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/takeInstance")
         .format(STOPPABLE_CLUSTER, "instance0")
         .post(this, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
@@ -192,9 +193,11 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
   public void testTakeInstanceOperationCheckFailureNonBlocking() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String payload = "{ \"operation_list\" : [\"org.apache.helix.rest.server.TestOperationImpl\"],"
-        + "\"operation_config\": {\"instance0\": \"true\", \"instance2\": \"true\", "
-        + "\"instance3\": \"true\", \"instance4\": \"true\", \"instance5\": \"true\", "
-        + "\"continueOnFailures\" : [\"org.apache.helix.rest.server.TestOperationImpl\"]} } ";
+        + "\"operation_config\": { \"org.apache.helix.rest.server.TestOperationImpl\" : "
+        + "{\"instance0\": true, \"instance2\": true, "
+        + "\"instance3\": true, \"instance4\": true, \"instance5\": true, "
+        + "\"continueOnFailures\" : true} } } ";
+
     Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/takeInstance")
         .format(STOPPABLE_CLUSTER, "instance0")
         .post(this, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
@@ -213,7 +216,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
   public void testTakeInstanceCheckOnly() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String payload = "{ \"operation_list\" : [\"org.apache.helix.rest.server.TestOperationImpl\"],"
-        + "\"operation_config\": {\"performOperation\": \"false\"} } ";
+        + "\"operation_config\": {\"performOperation\": false} } ";
     Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/takeInstance")
         .format(STOPPABLE_CLUSTER, "instance1")
         .post(this, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -64,7 +63,6 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/stoppable")
         .format(STOPPABLE_CLUSTER, "instance1").post(this, entity);
     String stoppableCheckResult = response.readEntity(String.class);
-
     Map<String, Object> actualMap = OBJECT_MAPPER.readValue(stoppableCheckResult, Map.class);
     List<String> failedChecks = Arrays
         .asList("HELIX:EMPTY_RESOURCE_ASSIGNMENT", "HELIX:INSTANCE_NOT_ENABLED",
@@ -78,7 +76,6 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
   @Test(dependsOnMethods = "testIsInstanceStoppable")
   public void testTakeInstanceNegInput() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
-
     post("clusters/TestCluster_0/instances/instance1/takeInstance", null,
         Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
         Response.Status.BAD_REQUEST.getStatusCode(), true);
@@ -86,6 +83,108 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
   }
 
   @Test(dependsOnMethods = "testTakeInstanceNegInput")
+  public void testTakeInstanceNegInput2() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/takeInstance")
+        .format(STOPPABLE_CLUSTER, "instance1").post(this, Entity.entity("{}", MediaType.APPLICATION_JSON_TYPE));
+    String takeInstanceResult = response.readEntity(String.class);
+
+    Map<String, Object> actualMap = OBJECT_MAPPER.readValue(takeInstanceResult, Map.class);
+    List<String> errorMsg = Arrays.asList("Invalid input. Please provide at least one health check or operation.");
+    Map<String, Object> expectedMap =
+        ImmutableMap.of("successful", false, "messages", errorMsg, "operationResult", "");
+    Assert.assertEquals(actualMap, expectedMap);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testTakeInstanceNegInput2")
+  public void testTakeInstanceHealthCheck() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String payload = "{ \"health_check_list\" : [\"HelixInstanceStoppableCheck\", \"CostumeInstanceStoppableCheck\"],"
+        + "\"health_check_config\" : { \"client\" : \"espresso\" }} ";
+    Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/takeInstance")
+        .format(STOPPABLE_CLUSTER, "instance1").post(this, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
+    String takeInstanceResult = response.readEntity(String.class);
+
+    Map<String, Object> actualMap = OBJECT_MAPPER.readValue(takeInstanceResult, Map.class);
+    List<String> errorMsg = Arrays
+        .asList("HELIX:EMPTY_RESOURCE_ASSIGNMENT", "HELIX:INSTANCE_NOT_ENABLED",
+            "HELIX:INSTANCE_NOT_STABLE");
+    Map<String, Object> expectedMap =
+        ImmutableMap.of("successful", false, "messages", errorMsg, "operationResult", "");
+    Assert.assertEquals(actualMap, expectedMap);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testTakeInstanceHealthCheck")
+  public void testTakeInstanceOperationSuccess() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String payload =
+        "{ \"operation_list\" : [\"org.apache.helix.rest.server.TestOperationImpl\"]} ";
+    Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/takeInstance")
+        .format(STOPPABLE_CLUSTER, "instance1")
+        .post(this, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
+    String takeInstanceResult = response.readEntity(String.class);
+
+    Map<String, Object> actualMap = OBJECT_MAPPER.readValue(takeInstanceResult, Map.class);
+    Map<String, Object> expectedMap = ImmutableMap
+        .of("successful", true, "messages", new ArrayList<>(), "operationResult", "DummyTakeOperationResult");
+    Assert.assertEquals(actualMap, expectedMap);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testTakeInstanceOperationSuccess")
+  public void testFreeInstanceOperationSuccess() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String payload =
+        "{ \"operation_list\" : [\"org.apache.helix.rest.server.TestOperationImpl\"]} ";
+    Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/freeInstance")
+        .format(STOPPABLE_CLUSTER, "instance1")
+        .post(this, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
+    String takeInstanceResult = response.readEntity(String.class);
+
+    Map<String, Object> actualMap = OBJECT_MAPPER.readValue(takeInstanceResult, Map.class);
+    Map<String, Object> expectedMap = ImmutableMap
+        .of("successful", true, "messages", new ArrayList<>(), "operationResult",
+            "DummyFreeOperationResult");
+    Assert.assertEquals(actualMap, expectedMap);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testFreeInstanceOperationSuccess")
+  public void testTakeInstanceOperationCheckFailure() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String payload = "{ \"operation_list\" : [\"org.apache.helix.rest.server.TestOperationImpl\"],"
+        + "\"operation_config\": {\"instance0\": \"true\", \"instance2\": \"true\", "
+        + "\"instance3\": \"true\", \"instance4\": \"true\", \"instance5\": \"true\"} } ";
+    Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/takeInstance")
+        .format(STOPPABLE_CLUSTER, "instance0")
+        .post(this, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
+    String takeInstanceResult = response.readEntity(String.class);
+
+    Map<String, Object> actualMap = OBJECT_MAPPER.readValue(takeInstanceResult, Map.class);
+    Assert.assertFalse((boolean)actualMap.get("successful"));
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testFreeInstanceOperationSuccess")
+  public void testTakeInstanceCheckOnly() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String payload = "{ \"operation_list\" : [\"org.apache.helix.rest.server.TestOperationImpl\"],"
+        + "\"operation_config\": {\"performOperation\": \"false\"} } ";
+    Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/takeInstance")
+        .format(STOPPABLE_CLUSTER, "instance1")
+        .post(this, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
+    String takeInstanceResult = response.readEntity(String.class);
+    System.out.println("testTakeInstanceCheckOnly: "+ takeInstanceResult);
+
+    Map<String, Object> actualMap = OBJECT_MAPPER.readValue(takeInstanceResult, Map.class);
+    Assert.assertTrue((boolean)actualMap.get("successful"));
+    Assert.assertTrue(actualMap.get("operationResult").equals(""));
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testTakeInstanceCheckOnly")
   public void testGetAllMessages() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String testInstance = CLUSTER_NAME + "localhost_12926"; //Non-live instance

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -177,8 +177,9 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String payload = "{ \"operation_list\" : [\"org.apache.helix.rest.server.TestOperationImpl\"],"
         + "\"operation_config\": { \"org.apache.helix.rest.server.TestOperationImpl\" :"
-        + " {\"instance0\": \"true\", \"instance2\": \"true\", "
-        + "\"instance3\": \"true\", \"instance4\": \"true\", \"instance5\": \"true\"}} } ";
+        + " {\"instance0\": true, \"instance2\": true, "
+        + "\"instance3\": true, \"instance4\": true, \"instance5\": true, "
+        + " \"value\" : \"i001\", \"list_value\" : [\"list1\"]}} } ";
     Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/takeInstance")
         .format(STOPPABLE_CLUSTER, "instance0")
         .post(this, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
@@ -189,7 +190,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
-  @Test(dependsOnMethods = "testFreeInstanceOperationSuccess")
+  @Test(dependsOnMethods = "testTakeInstanceOperationCheckFailure")
   public void testTakeInstanceOperationCheckFailureNonBlocking() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String payload = "{ \"operation_list\" : [\"org.apache.helix.rest.server.TestOperationImpl\"],"

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -100,7 +100,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
   @Test(dependsOnMethods = "testTakeInstanceNegInput2")
   public void testTakeInstanceHealthCheck() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
-    String payload = "{ \"health_check_list\" : [\"HelixInstanceStoppableCheck\", \"CostumeInstanceStoppableCheck\"],"
+    String payload = "{ \"health_check_list\" : [\"HelixInstanceStoppableCheck\", \"CustomInstanceStoppableCheck\"],"
         + "\"health_check_config\" : { \"client\" : \"espresso\" }} ";
     Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/takeInstance")
         .format(STOPPABLE_CLUSTER, "instance1").post(this, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1896 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change add take and free single instance implementation and corresponding tests. 

### Tests

- [X] The following tests are written for this issue:

Unit tests added to TestPerInstanceAccessor.java and TestOperationImpl.java. 

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
