### PR TITLE
Fix a string operation for custom health check and update test

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
@@ -548,9 +548,9 @@ public class MaintenanceManagementService {
         // "CUSTOM_PARTITION_HEALTH_FAILURE:PARTITION_INITIAL_STATE_FAIL:partition_name"
         // we want to keep the first 2 parts as failed test name.
         String[] checks = failedCheck.split(":", 3);
-        failedCheck = checks[0] + checks[1];
+        failedCheck = checks[0] + ":" + checks[1];
       }
-      // Helix own health check name wil be in this pattern "HELIX:INSTANCE_NOT_ALIVE",
+      // Helix own health check name will be in this pattern "HELIX:INSTANCE_NOT_ALIVE",
       // no need to preprocess.
       if (!_nonBlockingHealthChecks.contains(failedCheck)) {
         return false;

--- a/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
@@ -236,7 +236,7 @@ public class TestMaintenanceManagementService {
     stoppableCheck = instanceServiceWithoutReadZK.getInstanceStoppableCheck(TEST_CLUSTER, TEST_INSTANCE, jsonContent);
     Assert.assertFalse(stoppableCheck.isStoppable());
 
-       // Test take instance with same setting.
+    // Test take instance with same setting.
     MaintenanceManagementInstanceInfo instanceInfo =
         instanceServiceWithoutReadZK.takeInstance(TEST_CLUSTER, TEST_INSTANCE, Collections.singletonList("CustomInstanceStoppableCheck"),
             MaintenanceManagementService.getMapFromJsonPayload(jsonContent), Collections.singletonList("org.apache.helix.rest.server.TestOperationImpl"),
@@ -244,7 +244,7 @@ public class TestMaintenanceManagementService {
     Assert.assertFalse(instanceInfo.isSuccessful());
     Assert.assertEquals(instanceInfo.getMessages().get(0), "CUSTOM_PARTITION_HEALTH_FAILURE:UNHEALTHY_PARTITION:PARTITION_0");
 
-    // Even ZK data is valid. Skip ZK read should fail the test.
+    // Operation should finish even with check failed.
     MockMaintenanceManagementService instanceServiceSkipFailure =
         new MockMaintenanceManagementService(zkHelixDataAccessor, _configAccessor, _customRestClient, true,
             ImmutableSet.of("CUSTOM_PARTITION_HEALTH_FAILURE:UNHEALTHY_PARTITION"), HelixRestNamespace.DEFAULT_NAMESPACE_NAME);

--- a/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
@@ -103,6 +104,7 @@ public class TestMaintenanceManagementService {
       return Collections.emptyMap();
     }
   }
+
 
   @Test
   public void testGetInstanceStoppableCheckWhenHelixOwnCheckFail() throws IOException {
@@ -233,8 +235,28 @@ public class TestMaintenanceManagementService {
             false, HelixRestNamespace.DEFAULT_NAMESPACE_NAME);
     stoppableCheck = instanceServiceWithoutReadZK.getInstanceStoppableCheck(TEST_CLUSTER, TEST_INSTANCE, jsonContent);
     Assert.assertFalse(stoppableCheck.isStoppable());
+
+       // Test take instance with same setting.
+    MaintenanceManagementInstanceInfo instanceInfo =
+        instanceServiceWithoutReadZK.takeInstance(TEST_CLUSTER, TEST_INSTANCE, Collections.singletonList("CustomInstanceStoppableCheck"),
+            MaintenanceManagementService.getMapFromJsonPayload(jsonContent), Collections.singletonList("org.apache.helix.rest.server.TestOperationImpl"),
+            Collections.EMPTY_MAP, true);
+    Assert.assertFalse(instanceInfo.isSuccessful());
+    Assert.assertEquals(instanceInfo.getMessages().get(0), "CUSTOM_PARTITION_HEALTH_FAILURE:UNHEALTHY_PARTITION:PARTITION_0");
+
+    // Even ZK data is valid. Skip ZK read should fail the test.
+    MockMaintenanceManagementService instanceServiceSkipFailure =
+        new MockMaintenanceManagementService(zkHelixDataAccessor, _configAccessor, _customRestClient, true,
+            ImmutableSet.of("CUSTOM_PARTITION_HEALTH_FAILURE:UNHEALTHY_PARTITION"), HelixRestNamespace.DEFAULT_NAMESPACE_NAME);
+    MaintenanceManagementInstanceInfo instanceInfo2 =
+        instanceServiceSkipFailure.takeInstance(TEST_CLUSTER, TEST_INSTANCE, Collections.singletonList("CustomInstanceStoppableCheck"),
+            MaintenanceManagementService.getMapFromJsonPayload(jsonContent), Collections.singletonList("org.apache.helix.rest.server.TestOperationImpl"),
+            Collections.EMPTY_MAP, true);
+    Assert.assertTrue(instanceInfo2.isSuccessful());
+    Assert.assertEquals(instanceInfo2.getOperationResult(), "DummyTakeOperationResult");
   }
-  /*
+
+    /*
    * Tests stoppable check api when all checks query is enabled. After helix own check fails,
    * the subsequent checks should be performed.
    */


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1896

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

When setting nonBlocking customized health check for take/free instance, there is one ":" missing when parsing the string. This change fix the bug and add a unit test case.

### Tests

- [X] The following tests are written for this issue:

Updated test TestMaintenanceManagementService.testCustomPartitionCheckWithSkipZKRead

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
