### PR TITLE
Declare dependency to Zookeeper in zookeeper-api-*.ivy

### DIFF
--- a/zookeeper-api/zookeeper-api-1.0.3-SNAPSHOT.ivy
+++ b/zookeeper-api/zookeeper-api-1.0.3-SNAPSHOT.ivy
@@ -43,6 +43,7 @@ under the License.
     <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.7.14" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)">
         <artifact name="slf4j-log4j12" ext="jar"/>
     </dependency>
+    <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.4.13" conf="compile->compile(default);runtime->runtime(default);default->default"/>
 		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.11.0" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.11.0" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.13" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>


### PR DESCRIPTION
Adds dependency to Zookeeper in the ivy file in zookeeper-api module.

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1925 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR declares dependency to Zookeeper in the ivy file of the zookeeper-api module. Since zookeeper-api needs classes from Zookeeper, the absence of this dependency in the ivy file causes compilation error on some systems. By adding this dependency, the compilation error is resolved.

### Tests

- [x] The following tests are written for this issue:

None

- The following is the result of the "mvn test" command on the appropriate module:

No changes to the code were made.

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
