### PR TITLE
Avoid NPE when getting property store through Helix-rest API.

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPropertyStoreAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPropertyStoreAccessor.java
@@ -49,6 +49,8 @@ public class TestPropertyStoreAccessor extends AbstractTestClass {
   private static final ZNRecord TEST_ZNRECORD = new ZNRecord("TestContent");
   private static final String CUSTOM_PATH =
       PropertyPathBuilder.propertyStore(TEST_CLUSTER) + "/NonZnRecord";
+  private static final String EMPTY_PATH =
+      PropertyPathBuilder.propertyStore(TEST_CLUSTER) + "/EmptyNode";
   private static final String TEST_CONTENT = "TestContent";
   private static final String CONTENT_KEY = "content";
 
@@ -71,6 +73,7 @@ public class TestPropertyStoreAccessor extends AbstractTestClass {
     Assert
         .assertTrue(_customDataAccessor.create(CUSTOM_PATH, TEST_CONTENT, AccessOption.PERSISTENT));
     Assert.assertTrue(_baseAccessor.create(ZNRECORD_PATH, TEST_ZNRECORD, AccessOption.PERSISTENT));
+    Assert.assertTrue(_baseAccessor.create(EMPTY_PATH, null, AccessOption.EPHEMERAL));
   }
 
   @AfterClass
@@ -78,6 +81,13 @@ public class TestPropertyStoreAccessor extends AbstractTestClass {
     if (_customDataAccessor != null) {
       _customDataAccessor.close();
     }
+  }
+
+  @Test
+  public void testGetPropertyStoreWithEmptyContent() {
+    String data = new JerseyUriRequestBuilder("clusters/{}/propertyStore/EmptyNode").format(TEST_CLUSTER)
+            .expectedReturnStatusCode(Response.Status.NO_CONTENT.getStatusCode()).get(this);
+    Assert.assertTrue(data.isEmpty());
   }
 
   @Test
@@ -91,9 +101,9 @@ public class TestPropertyStoreAccessor extends AbstractTestClass {
 
   @Test
   public void testGetPropertyStoreWithTestStringData() throws IOException {
-    String actual =
-        new JerseyUriRequestBuilder("clusters/{}/propertyStore/NonZnRecord").format(TEST_CLUSTER)
-            .isBodyReturnExpected(true).get(this);
+    String actual = new JerseyUriRequestBuilder("clusters/{}/propertyStore/NonZnRecord").format(TEST_CLUSTER)
+        .isBodyReturnExpected(true)
+        .get(this);
     JsonNode jsonNode = OBJECT_MAPPER.readTree(actual);
     String payLoad = jsonNode.get(CONTENT_KEY).textValue();
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/util/JerseyUriRequestBuilder.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/util/JerseyUriRequestBuilder.java
@@ -94,13 +94,15 @@ public class JerseyUriRequestBuilder {
 
     Assert.assertEquals(response.getStatus(), _expectedStatusCode);
 
-    // NOT_FOUND will throw text based html
-    if (_expectedStatusCode != Response.Status.NOT_FOUND.getStatusCode()
-        && _expectedStatusCode != Response.Status.BAD_REQUEST.getStatusCode()) {
-      Assert.assertEquals(response.getMediaType().getType(), "application");
-    } else {
-      Assert.assertEquals(response.getMediaType().getType(), "text");
-    }
+    if (_expectedStatusCode != Response.Status.NO_CONTENT.getStatusCode()) {
+      // NOT_FOUND will throw text based html
+      if (_expectedStatusCode != Response.Status.NOT_FOUND.getStatusCode()
+          && _expectedStatusCode != Response.Status.BAD_REQUEST.getStatusCode()) {
+        Assert.assertEquals(response.getMediaType().getType(), "application");
+      } else {
+        Assert.assertEquals(response.getMediaType().getType(), "text");
+      }
+    } // else, NO_CONTENT should not return any content, so no need to check the type.
 
     String body = response.readEntity(String.class);
     if (_isBodyReturnExpected) {


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1928 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR aims to fix the ambiguous error return message when user request to get an empty ZK node through the Helix-rest property store access API.
This PR changes the server behavior to response NO_CONTENT instead of internal_server_error in the scenarios described above.

### Tests

- [X] The following tests are written for this issue:

TestPropertyStoreAccessor.testGetPropertyStoreWithEmptyContent

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
