### PR TITLE
Daemonize ZkBucketDataAccessor GC_THREAD

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
@@ -67,7 +67,11 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
   // Note that newScheduledThreadPool(1) may not work. newSingleThreadScheduledExecutor guarantees
   // sequential execution, which is what we want for implementing TTL & GC here
   private static final ScheduledExecutorService GC_THREAD =
-      Executors.newSingleThreadScheduledExecutor();
+      Executors.newSingleThreadScheduledExecutor((runnable) -> {
+        Thread thread = new Thread(runnable, "ZkBucketDataAccessorGcThread");
+        thread.setDaemon(true);
+        return thread;
+      });
 
   private final int _bucketSize;
   private final long _versionTTLms;


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1915

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Daemonize ZkBucketDataAccessor GC_THREAD so it doesn't prevent application shutdown.

### Tests

- [x] The following tests are written for this issue:

No new tests. 

Three failing tests, however these fail in `master` as well.

```
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestNoThrottleDisabledPartitions.testDisablingTopStateReplicaByDisablingInstance:98 expected:<false> but was:<true>
[ERROR]   TestP2PNoDuplicatedMessage.testP2PStateTransitionEnabled:180 expected:<true> but was:<false>
[ERROR]   TestResourceThreadpoolSize.testBatchMessageThreadPoolSize:206 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1287, Failures: 3, Errors: 0, Skipped: 0
```

### Changes that Break Backward Compatibility (Optional)

No breaking changes

### Documentation (Optional)

No new functionality

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
