### PR TITLE
Cleanup messages intended for instances that are no longer in cluster

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -193,7 +193,7 @@ public class MessageGenerationPhase extends AbstractBaseStage {
           }
         }
 
-        if (pendingMessage != null && shouldCleanUpPendingMessage(pendingMessage, currentState,
+        if (shouldCleanUpPendingMessage(pendingMessage, sessionIdMap, instanceName, currentState,
             currentStateOutput.getEndTime(resourceName, partition, instanceName))) {
           logAndAddToCleanUp(messagesToCleanUp, pendingMessage, instanceName, resourceName,
               partition, currentState, PENDING_MESSAGE);
@@ -203,7 +203,8 @@ public class MessageGenerationPhase extends AbstractBaseStage {
           // staleMessage can be simple or batch mode
           if ((System.currentTimeMillis() - currentStateOutput
               .getEndTime(resourceName, partition, instanceName) > DEFAULT_OBSELETE_MSG_PURGE_DELAY)
-              && staleMessage.getResourceName().equals(resourceName) && (
+              && staleMessage.getResourceName().equals(resourceName) && sessionIdMap
+              .containsKey(instanceName) && (
               staleMessage.getPartitionName().equals(partition.getPartitionName()) || (
                   staleMessage.getBatchMessageMode() && staleMessage.getPartitionNames()
                       .contains(partition.getPartitionName())))) {
@@ -404,9 +405,9 @@ public class MessageGenerationPhase extends AbstractBaseStage {
     });
   }
 
-  private boolean shouldCleanUpPendingMessage(Message pendingMsg, String currentState,
-      Long currentStateTransitionEndTime) {
-    if (pendingMsg == null) {
+  private boolean shouldCleanUpPendingMessage(Message pendingMsg, Map<String, String> sessionIdMap,
+      String instanceName, String currentState, Long currentStateTransitionEndTime) {
+    if (pendingMsg == null || !sessionIdMap.containsKey(instanceName)) {
       return false;
     }
     if (currentState.equalsIgnoreCase(pendingMsg.getToState())) {


### PR DESCRIPTION
Cleanup messages intended for instances that are no longer in the cluster
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Resolves #1802 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In MessageGenerationPhase.java, - process() method populates the list of live instances from cache.

But while generateMessage() method has the sessionIdMap information, it still goes through partition/resource/instance map without checking if instance is still part of the cluster or not. 

It is possible that cache has stale entry but that logic needs to be worked separately. But while generating message, we should check if the instance is still there. 

So this is a simple change. We need to still look further if cache is getting invalidated properly.

To make sure that the cache properly is handled/refreshed under instance being replaced or deletion - have filled another bug: https://github.com/apache/helix/issues/1956


### Tests

- [ ] The following tests are written for this issue:



- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)
[INFO] Results:
[INFO]
[INFO] Tests run: 1287, Failures: 0, Errors: 0, Skipped: 0
[INFO]

### Changes that Break Backward Compatibility (Optional)

- This is a simple bug fix and no APIs have been modified.

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
