### PR TITLE
Let logging framework format exception stack traces

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -904,8 +904,8 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
         pipeline.finish();
       } catch (Exception e) {
         logger.error(
-            "Exception while executing {} pipeline: {} for cluster {}. Will not continue to next pipeline",
-            dataProvider.getPipelineName(), _clusterName, Arrays.toString(e.getStackTrace()));
+            "Exception while executing {} pipeline for cluster {}. Will not continue to next pipeline",
+            dataProvider.getPipelineName(), _clusterName, e);
         if (e instanceof HelixMetaDataAccessException) {
           helixMetaDataAccessRebalanceFail = true;
           // If pipeline failed due to read/write fails to zookeeper, retry the pipeline.

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalancePartitionLimit.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalancePartitionLimit.java
@@ -225,7 +225,7 @@ public class TestAutoRebalancePartitionLimit extends ZkStandAloneCMTestBase {
             numberOfPartitions, masterValue, replicas, cache.getLiveInstances().size(),
             cache.getIdealState(_resourceName).getMaxPartitionsPerInstance());
       } catch (Exception e) {
-        LOG.debug("Verify failed due to {}", e.getStackTrace());
+        LOG.debug("Verify failed", e);
         return false;
       }
     }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
@@ -147,12 +147,11 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
     } catch (JsonProcessingException e) {
       return badRequest("Invalid input: Input can not be parsed into a KV map." + e.getMessage());
     } catch (OutOfMemoryError e) {
-      LOG.error("OutOfMemoryError while calling partitionAssignment" + Arrays
-          .toString(e.getStackTrace()));
+      LOG.error("OutOfMemoryError while calling partitionAssignment", e);
       return badRequest(
           "Response size is too large to serialize. Please query by resources or instance filter");
     } catch (Exception e) {
-      LOG.error("Failed to compute partition assignment:" + Arrays.toString(e.getStackTrace()));
+      LOG.error("Failed to compute partition assignment", e);
       return badRequest("Failed to compute partition assignment: " + e);
     }
   }


### PR DESCRIPTION
Fixes #1953

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#1953 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Where possible, logging calls are changed so that logging framework handles exception formatting instead of stack trace being manually formatted using `Throwable#getStackTrace`

### Tests

- [x] The following tests are written for this issue:

Logging only change, no tests

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
