### PR TITLE
Add rest endpoint for virtual topology group

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -59,6 +59,7 @@ public class AbstractResource {
   public enum Command {
     activate,
     addInstanceTag,
+    addVirtualTopologyGroup,
     expand,
     enable,
     disable,

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -70,6 +70,7 @@ import org.apache.helix.rest.common.HttpConstants;
 import org.apache.helix.rest.server.json.cluster.ClusterTopology;
 import org.apache.helix.rest.server.service.ClusterService;
 import org.apache.helix.rest.server.service.ClusterServiceImpl;
+import org.apache.helix.rest.server.service.VirtualTopologyGroupService;
 import org.apache.helix.tools.ClusterSetup;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -235,6 +236,21 @@ public class ClusterAccessor extends AbstractHelixResource {
         }
         break;
 
+      case addVirtualTopologyGroup:
+        try {
+          addVirtualTopologyGroup(clusterId, content);
+        } catch (JsonProcessingException ex) {
+          LOG.error("Failed to parse json string: {}", content, ex);
+          return badRequest("Invalid payload json body: " + content);
+        } catch (IllegalArgumentException ex) {
+          LOG.error("Illegal input {} for command {}.", content, command, ex);
+          return badRequest(String.format("Illegal input %s for command %s", content, command));
+        } catch (Exception ex) {
+          LOG.error("Failed to add virtual topology group to cluster {}", clusterId);
+          return serverError(ex);
+        }
+        break;
+
       case expand:
         try {
           clusterSetup.expandCluster(clusterId);
@@ -303,6 +319,15 @@ public class ClusterAccessor extends AbstractHelixResource {
     }
 
     return OK();
+  }
+
+  private void addVirtualTopologyGroup(String clusterId, String content) throws JsonProcessingException {
+    ClusterService clusterService = new ClusterServiceImpl(getDataAccssor(clusterId), getConfigAccessor());
+    VirtualTopologyGroupService service = new VirtualTopologyGroupService(
+        getHelixAdmin(), clusterService, getConfigAccessor(), getDataAccssor(clusterId));
+    Map<String, String> customFieldsMap =
+        OBJECT_MAPPER.readValue(content, new TypeReference<HashMap<String, String>>() { });
+    service.addVirtualTopologyGroup(clusterId, customFieldsMap);
   }
 
   @ResponseMetered(name = HttpConstants.READ_REQUEST)

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -246,7 +246,7 @@ public class ClusterAccessor extends AbstractHelixResource {
           LOG.error("Illegal input {} for command {}.", content, command, ex);
           return badRequest(String.format("Illegal input %s for command %s", content, command));
         } catch (Exception ex) {
-          LOG.error("Failed to add virtual topology group to cluster {}", clusterId);
+          LOG.error("Failed to add virtual topology group to cluster {}", clusterId, ex);
           return serverError(ex);
         }
         break;


### PR DESCRIPTION
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We introduce the REST endpoint for virtual topology group at `clusters/{}` with command `addVirtualTopologyGroup`. 
It invokes the java endpoint introduced in https://github.com/apache/helix/pull/1935.
It's expected to be called every time we setup or change virtual topology group, or adding new instances to the cluster.

### Tests

- [x] The following tests are written for this issue:

New tests in `TestClusterAccessor`

- The following is the result of the "mvn test" command on the appropriate module:
[INFO] Tests run: 203, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 123.527 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 203, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /home/qqu/workspace/qqu-helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 88 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:10 min
[INFO] Finished at: 2022-02-10T12:43:50-08:00
[INFO] ------------------------------------------------------------------------

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
