### PR TITLE
Use final remaining capacity when computing weighted score

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
  * "hard constraints"
  */
 class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
+  private static final float DIV_GUARD = 0.01f;
   private static final Logger LOG = LoggerFactory.getLogger(ConstraintBasedAlgorithm.class);
   private final List<HardConstraint> _hardConstraints;
   private final Map<SoftConstraint, Float> _softConstraints;
@@ -81,10 +82,10 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
             .format("The cluster does not have enough %s capacity for all partitions. ",
                 capacityKey), HelixRebalanceException.Type.FAILED_TO_CALCULATE);
       }
-      // estimate remain capacity after assignment + %1 of current cluster remain capacity before assignment
+      // estimate remain capacity after assignment + %1 of current cluster capacity before assignment
       positiveEstimateClusterRemainCap.put(capacityKey,
            clusterModel.getContext().getEstimateUtilizationMap().get(capacityKey) +
-          (clusterModel.getContext().getClusterRemainCapacityMap().get(capacityKey) * 0.01f));
+          (clusterModel.getContext().getClusterCapacityMap().get(capacityKey) * DIV_GUARD));
     }
 
     // Create a wrapper for each AssignableReplica.

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -200,8 +200,11 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
         if (resourceCapacity.getValue() == 0) {
           continue;
         }
-        score = score + (float) resourceCapacity.getValue() / (overallClusterRemainingCapMap
-            .get(capacityKey));
+        score = (overallClusterRemainingCapMap.get(capacityKey) == 0
+            || resourceCapacity.getValue() > (overallClusterRemainingCapMap
+            .get(capacityKey))) ? Float.MAX_VALUE
+            : score + (float) resourceCapacity.getValue() / (overallClusterRemainingCapMap
+                .get(capacityKey));
         if (Float.compare(score, Float.MAX_VALUE) == 0) {
           break;
         }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -285,9 +285,10 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
           int finalRemainCapacity =
               utilizationMap.get(resourceUsage.getKey()) - resourceUsage.getValue();
           if (finalRemainCapacity < 0) {
+            // all replicas' assignment will fail if there is one dimension's remain capacity <0.
             String errorMessage = String.format(
-                "Unable to find any available candidate node for partition %s; There is no enough capacity ",
-                replica.getPartitionName());
+                "The cluster does not have enough %s capacity for all partitions. ",
+                resourceUsage.getKey());
             throw new HelixRebalanceException(errorMessage,
                 HelixRebalanceException.Type.FAILED_TO_CALCULATE);
           }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
@@ -55,7 +55,7 @@ public class ClusterContext {
   private final Map<String, ResourceAssignment> _bestPossibleAssignment;
   // Estimate remaining capacity after assignment. Used to compute score when sorting replicas.
   private final Map<String, Integer> _estimateUtilizationMap;
-  // current cluster remaining capacity. Used to compute score when sorting replicas.
+  // Cluster total capacity. Used to compute score when sorting replicas.
   private final Map<String, Integer> _clusterCapacityMap;
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
@@ -183,7 +183,7 @@ public class ClusterContext {
     _assignmentForFaultZoneMap = assignmentForFaultZoneMap;
   }
 
-  private int estimateAvgReplicaCount(int replicaCount, int instanceCount) {
+  private static int estimateAvgReplicaCount(int replicaCount, int instanceCount) {
     // Use the floor to ensure evenness.
     // Note if we calculate estimation based on ceil, we might have some low usage participants.
     // For example, if the evaluation is between 1 and 2. While we use 2, many participants will be
@@ -193,7 +193,7 @@ public class ClusterContext {
     return (int) Math.floor((float) replicaCount / instanceCount);
   }
 
-  private float estimateMaxUtilization(Map<String, Integer> totalCapacity,
+  private static float estimateMaxUtilization(Map<String, Integer> totalCapacity,
       Map<String, Integer> totalUsage) {
     float estimatedMaxUsage = 0;
     for (String capacityKey : totalCapacity.keySet()) {
@@ -206,7 +206,7 @@ public class ClusterContext {
     return estimatedMaxUsage;
   }
 
-  private Map<String, Integer> estimateUtilization(Map<String, Integer> totalCapacity,
+  private static Map<String, Integer> estimateUtilization(Map<String, Integer> totalCapacity,
       Map<String, Integer> totalUsage) {
     Map<String, Integer> estimateUtilization = new HashMap<>();
     for (String capacityKey : totalCapacity.keySet()) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
@@ -109,7 +109,7 @@ public class ClusterContext {
       _estimatedMaxUtilization = estimateMaxUtilization(totalCapacity, totalUsage);
       _estimatedTopStateMaxUtilization = estimateMaxUtilization(totalCapacity, totalTopStateUsage);
       _estimateUtilizationMap = estimateUtilization(totalCapacity, totalUsage);
-      _clusterRemainCapacityMap = totalCapacity;
+      _clusterRemainCapacityMap = Collections.unmodifiableMap(totalCapacity);
     }
     _estimatedMaxPartitionCount = estimateAvgReplicaCount(totalReplicas, instanceCount);
     _estimatedMaxTopStateCount = estimateAvgReplicaCount(totalTopStateReplicas, instanceCount);
@@ -212,10 +212,9 @@ public class ClusterContext {
     for (String capacityKey : totalCapacity.keySet()) {
       int maxCapacity = totalCapacity.get(capacityKey);
       int usage = totalUsage.getOrDefault(capacityKey, 0);
-      estimateUtilization.put(capacityKey, maxCapacity-usage) ;
+      estimateUtilization.put(capacityKey, maxCapacity - usage);
     }
 
-    return estimateUtilization;
+    return Collections.unmodifiableMap(estimateUtilization);
   }
-
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
@@ -54,7 +54,7 @@ public class ClusterContext {
   // <ResourceName, ResourceAssignment contains the best possible assignment>
   private final Map<String, ResourceAssignment> _bestPossibleAssignment;
   // This estimation helps to compute score when sorting replicas.
-  private Map<String, Integer> _estimateUtilizationMap;
+  private final Map<String, Integer> _estimateUtilizationMap;
 
   /**
    * Construct the cluster context based on the current instance status.
@@ -101,7 +101,7 @@ public class ClusterContext {
       // If no capacity is configured, we treat the cluster as fully utilized.
       _estimatedMaxUtilization = 1f;
       _estimatedTopStateMaxUtilization = 1f;
-      _estimateUtilizationMap = new HashMap<>();
+      _estimateUtilizationMap = Collections.emptyMap();
     } else {
       _estimatedMaxUtilization = estimateMaxUtilization(totalCapacity, totalUsage);
       _estimatedTopStateMaxUtilization = estimateMaxUtilization(totalCapacity, totalTopStateUsage);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
@@ -53,9 +53,9 @@ public class ClusterContext {
   private final Map<String, ResourceAssignment> _baselineAssignment;
   // <ResourceName, ResourceAssignment contains the best possible assignment>
   private final Map<String, ResourceAssignment> _bestPossibleAssignment;
-  // This estimation helps to compute score when sorting replicas.
+  // Estimate remaining capacity after assignment. Used to compute score when sorting replicas.
   private final Map<String, Integer> _estimateUtilizationMap;
-  // This estimation helps to compute score when sorting replicas.
+  // current cluster remaining capacity. Used to compute score when sorting replicas.
   private final Map<String, Integer> _clusterRemainCapacityMap;
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
@@ -55,6 +55,8 @@ public class ClusterContext {
   private final Map<String, ResourceAssignment> _bestPossibleAssignment;
   // This estimation helps to compute score when sorting replicas.
   private final Map<String, Integer> _estimateUtilizationMap;
+  // This estimation helps to compute score when sorting replicas.
+  private final Map<String, Integer> _clusterRemainCapacityMap;
 
   /**
    * Construct the cluster context based on the current instance status.
@@ -102,10 +104,12 @@ public class ClusterContext {
       _estimatedMaxUtilization = 1f;
       _estimatedTopStateMaxUtilization = 1f;
       _estimateUtilizationMap = Collections.emptyMap();
+      _clusterRemainCapacityMap = Collections.emptyMap();
     } else {
       _estimatedMaxUtilization = estimateMaxUtilization(totalCapacity, totalUsage);
       _estimatedTopStateMaxUtilization = estimateMaxUtilization(totalCapacity, totalTopStateUsage);
       _estimateUtilizationMap = estimateUtilization(totalCapacity, totalUsage);
+      _clusterRemainCapacityMap = totalCapacity;
     }
     _estimatedMaxPartitionCount = estimateAvgReplicaCount(totalReplicas, instanceCount);
     _estimatedMaxTopStateCount = estimateAvgReplicaCount(totalTopStateReplicas, instanceCount);
@@ -148,6 +152,10 @@ public class ClusterContext {
 
   public Map<String, Integer> getEstimateUtilizationMap() {
     return _estimateUtilizationMap;
+  }
+
+  public Map<String, Integer> getClusterRemainCapacityMap() {
+    return _clusterRemainCapacityMap;
   }
 
   public Set<String> getPartitionsForResourceAndFaultZone(String resourceName, String faultZoneId) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
@@ -56,7 +56,7 @@ public class ClusterContext {
   // Estimate remaining capacity after assignment. Used to compute score when sorting replicas.
   private final Map<String, Integer> _estimateUtilizationMap;
   // current cluster remaining capacity. Used to compute score when sorting replicas.
-  private final Map<String, Integer> _clusterRemainCapacityMap;
+  private final Map<String, Integer> _clusterCapacityMap;
 
   /**
    * Construct the cluster context based on the current instance status.
@@ -104,12 +104,12 @@ public class ClusterContext {
       _estimatedMaxUtilization = 1f;
       _estimatedTopStateMaxUtilization = 1f;
       _estimateUtilizationMap = Collections.emptyMap();
-      _clusterRemainCapacityMap = Collections.emptyMap();
+      _clusterCapacityMap = Collections.emptyMap();
     } else {
       _estimatedMaxUtilization = estimateMaxUtilization(totalCapacity, totalUsage);
       _estimatedTopStateMaxUtilization = estimateMaxUtilization(totalCapacity, totalTopStateUsage);
       _estimateUtilizationMap = estimateUtilization(totalCapacity, totalUsage);
-      _clusterRemainCapacityMap = Collections.unmodifiableMap(totalCapacity);
+      _clusterCapacityMap = Collections.unmodifiableMap(totalCapacity);
     }
     _estimatedMaxPartitionCount = estimateAvgReplicaCount(totalReplicas, instanceCount);
     _estimatedMaxTopStateCount = estimateAvgReplicaCount(totalTopStateReplicas, instanceCount);
@@ -154,8 +154,8 @@ public class ClusterContext {
     return _estimateUtilizationMap;
   }
 
-  public Map<String, Integer> getClusterRemainCapacityMap() {
-    return _clusterRemainCapacityMap;
+  public Map<String, Integer> getClusterCapacityMap() {
+    return _clusterCapacityMap;
   }
 
   public Set<String> getPartitionsForResourceAndFaultZone(String resourceName, String faultZoneId) {

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
@@ -98,4 +98,24 @@ public class TestConstraintBasedAlgorithm {
 
     Assert.assertFalse(optimalAssignment.hasAnyFailure());
   }
+
+  // Add capacity related hard/soft constrain to test sorting algorithm in ConstraintBasedAlgorithm.
+  @Test
+  public void testSortingEarlyQuitLackCapacity() throws IOException, HelixRebalanceException {
+    HardConstraint nodeCapacityConstraint = new NodeCapacityConstraint();
+    SoftConstraint soft1 = new MaxCapacityUsageInstanceConstraint();
+    SoftConstraint soft2 = new InstancePartitionsCountConstraint();
+    ConstraintBasedAlgorithm algorithm =
+        new ConstraintBasedAlgorithm(ImmutableList.of(nodeCapacityConstraint),
+            ImmutableMap.of(soft1, 1f, soft2, 1f));
+    ClusterModel clusterModel =
+        new ClusterModelTestHelper().getMultiNodeClusterModelNegativeSetup();
+    try {
+      OptimalAssignment optimalAssignment = algorithm.calculate(clusterModel);
+    } catch (HelixRebalanceException ex) {
+      Assert.assertEquals(ex.getFailureType(), HelixRebalanceException.Type.FAILED_TO_CALCULATE);
+      Assert.assertEquals(ex.getMessage(),
+          "The cluster does not have enough item1 capacity for all partitions.  Failure Type: FAILED_TO_CALCULATE");
+    }
+  }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
@@ -84,7 +84,7 @@ public class TestConstraintBasedAlgorithm {
         }));
   }
 
-  // Add capacity related hard/soft constrain to test sorting algorithm in ConstraintBasedAlgorithm.
+  // Add capacity related hard/soft constraint to test sorting algorithm in ConstraintBasedAlgorithm.
   @Test
   public void testSortingByResourceCapacity() throws IOException, HelixRebalanceException {
     HardConstraint nodeCapacityConstraint = new NodeCapacityConstraint();
@@ -99,7 +99,7 @@ public class TestConstraintBasedAlgorithm {
     Assert.assertFalse(optimalAssignment.hasAnyFailure());
   }
 
-  // Add capacity related hard/soft constrain to test sorting algorithm in ConstraintBasedAlgorithm.
+  // Add neg test for error handling in ConstraintBasedAlgorithm replica sorting.
   @Test
   public void testSortingEarlyQuitLackCapacity() throws IOException, HelixRebalanceException {
     HardConstraint nodeCapacityConstraint = new NodeCapacityConstraint();

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelTestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelTestHelper.java
@@ -48,7 +48,16 @@ public class ClusterModelTestHelper extends AbstractTestClusterModel {
 
   public ClusterModel getMultiNodeClusterModel() throws IOException {
     initialize();
-    ResourceControllerDataProvider testCache = setupClusterDataCacheForNearFullUtil();
+    return getClusterHelper(setupClusterDataCacheForNearFullUtil());
+  }
+
+  public ClusterModel getMultiNodeClusterModelNegativeSetup() throws IOException {
+    initialize();
+    return getClusterHelper(setupClusterDataCacheForNoFitUtil());
+  }
+
+  private ClusterModel getClusterHelper(ResourceControllerDataProvider testCache)
+      throws IOException {
     InstanceConfig testInstanceConfig1 = createMockInstanceConfig(TEST_INSTANCE_ID_1);
     InstanceConfig testInstanceConfig2 = createMockInstanceConfig(TEST_INSTANCE_ID_2);
     Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
@@ -59,7 +68,8 @@ public class ClusterModelTestHelper extends AbstractTestClusterModel {
     Set<AssignableNode> assignableNodes = generateNodes(testCache);
 
     ClusterContext context =
-        new ClusterContext(assignableReplicas, assignableNodes, Collections.emptyMap(), Collections.emptyMap());
+        new ClusterContext(assignableReplicas, assignableNodes, Collections.emptyMap(),
+            Collections.emptyMap());
     return new ClusterModel(context, assignableReplicas, assignableNodes);
   }
 }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1960

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Use the final cluster's remaining capacity when computing weight for replicas.

### Tests

- [X] The following tests are written for this issue:

TestConstraintBasedAlgorithm.testSortingEarlyQuitLackCapacity

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 1288, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,563.591 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1288, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /home/xialu/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 910 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:32 h
[INFO] Finished at: 2022-02-16T12:42:18-08:00
[INFO] ------------------------------------------------------------------------
```
2nd from last commit has CI pass https://github.com/apache/helix/actions/runs/1854611254. 
last commit is comment wording change.  


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
