### PR TITLE
Code cleanup: addListenersToController is not used at all

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/HelixControllerMain.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/HelixControllerMain.java
@@ -130,24 +130,6 @@ public class HelixControllerMain {
     return null;
   }
 
-  public static void addListenersToController(HelixManager manager,
-      GenericHelixController controller) {
-    try {
-      manager.addControllerListener(controller);
-      manager.addInstanceConfigChangeListener(controller);
-      manager.addResourceConfigChangeListener(controller);
-      manager.addClusterfigChangeListener(controller);
-      manager.addLiveInstanceChangeListener(controller);
-      manager.addIdealStateChangeListener(controller);
-    } catch (ZkInterruptedException e) {
-      logger
-          .warn("zk connection is interrupted during HelixManagerMain.addListenersToController(). "
-              + e);
-    } catch (Exception e) {
-      logger.error("Error when creating HelixManagerContollerMonitor", e);
-    }
-  }
-
   public static HelixManager startHelixController(final String zkConnectString,
       final String clusterName, final String controllerName, final String controllerMode) {
     HelixManager manager = null;


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:



### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Code cleanup is a basic hygiene and great way to learn about code. Starting with finding some dead-code. I have searched within our code base and no one is using this method. I am hoping that in-general community is also not using this.

Please review it carefully and confirm.

### Tests

- [ ] The following tests are written for this issue:


- The following is the result of the "mvn test" command on the appropriate module:

No test fails

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

This is a public method of - helix/helix-core/src/main/java/org/apache/helix/controller/HelixControllerMain.java

method signature is: public static void addListenersToController(HelixManager manager,  GenericHelixController controller)

Please do look at and see if there are any consumers.



### Documentation (Optional)


(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
