### PR TITLE
Upgrading Zookeeper version to 3.6.13 to enanle zk client SSL/TLS

### DIFF
--- a/helix-admin-webapp/pom.xml
+++ b/helix-admin-webapp/pom.xml
@@ -40,7 +40,7 @@
       org.slf4j*;version="[1.7,2)",
       org.apache.logging.log4j*;version="[2.17,3)",
       org.apache.logging.slf4j*;version="[2.17,3)",
-      org.apache.zookeeper*;version="[3.4,4)",
+      org.apache.zookeeper*;version="[3.6,3)",
       *
     </osgi.import>
     <osgi.export>org.apache.helix.webapp*;version="${project.version};-noimport:=true</osgi.export>

--- a/helix-core/src/main/java/org/apache/helix/tools/commandtools/ZKLogFormatter.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/commandtools/ZKLogFormatter.java
@@ -49,6 +49,7 @@ import org.apache.zookeeper.server.persistence.FileSnap;
 import org.apache.zookeeper.server.persistence.FileTxnLog;
 import org.apache.zookeeper.server.util.SerializeUtils;
 import org.apache.zookeeper.txn.TxnHeader;
+import org.apache.zookeeper.server.TxnLogEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -248,13 +249,12 @@ public class ZKLogFormatter {
       if (crcValue != crc.getValue()) {
         throw new IOException("CRC doesn't match " + crcValue + " vs " + crc.getValue());
       }
-      TxnHeader hdr = new TxnHeader();
-      Record txn = SerializeUtils.deserializeTxn(bytes, hdr);
+      TxnLogEntry txnLogEntry =  SerializeUtils.deserializeTxn(bytes);
       if (bw != null) {
-        bw.write(formatTransaction(hdr, txn));
+        bw.write(formatTransaction(txnLogEntry.getHeader(), txnLogEntry.getTxn()));
         bw.newLine();
       } else {
-        System.out.println(formatTransaction(hdr, txn));
+        System.out.println(formatTransaction(txnLogEntry.getHeader(), txnLogEntry.getTxn()));
       }
 
       if (logStream.readByte("EOR") != 'B') {

--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -37,7 +37,7 @@
       org.slf4j*;version="[1.7,2)",
       org.apache.logging.log4j*;version="[2.17,3)",
       org.apache.logging.slf4j*;version="[2.17,3)",
-      org.apache.zookeeper*;version="[3.4,13)",
+      org.apache.zookeeper*;version="[3.6,3)",
       org.apache.commons.io*;version="[1.4,2)",
       *
     </osgi.import>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -37,7 +37,7 @@
       org.apache.zookeeper.server.persistence*;resolution:=optional,
       org.apache.zookeeper.server.util*;resolution:=optional,
       org.apache.zookeeper.txn*;resolution:=optional,
-      org.apache.zookeeper*;version="[3.4,13)",
+      org.apache.zookeeper*;version="[3.6,3)",
       *
     </osgi.import>
     <osgi.export>org.apache.helix.zookeeper*;version="${project.version};-noimport:=true</osgi.export>
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.13</version>
+      <version>3.6.3</version>
       <exclusions>
         <exclusion>
           <groupId>junit</groupId>


### PR DESCRIPTION

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1971 by upgrading ZooKeeper version to 3.6.3

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR upgrades the Zookeeper version to 3.6.3 which allows Helix to to talk to Zookeeper to secured port.
Zookeeper has enabled SSL/TLS version from 3.5.6+. 

WIth Zookeeper 3.6.3, there are changes in signature of one of the methods of SerializeUtils class. Added a 
fix to support that. 

### Tests

- [] The following tests are written for this issue:

(List the names of added unit/integration tests)
No new tests added but dependent on CI tests.
- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
