### PR TITLE
Use ZooKeeper 3.5.9 in zookeeper-api instead

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/tools/commandtools/ZKLogFormatter.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/commandtools/ZKLogFormatter.java
@@ -49,7 +49,6 @@ import org.apache.zookeeper.server.persistence.FileSnap;
 import org.apache.zookeeper.server.persistence.FileTxnLog;
 import org.apache.zookeeper.server.util.SerializeUtils;
 import org.apache.zookeeper.txn.TxnHeader;
-import org.apache.zookeeper.server.TxnLogEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -249,12 +248,13 @@ public class ZKLogFormatter {
       if (crcValue != crc.getValue()) {
         throw new IOException("CRC doesn't match " + crcValue + " vs " + crc.getValue());
       }
-      TxnLogEntry txnLogEntry =  SerializeUtils.deserializeTxn(bytes);
+      TxnHeader hdr = new TxnHeader();
+      Record txn = SerializeUtils.deserializeTxn(bytes, hdr);
       if (bw != null) {
-        bw.write(formatTransaction(txnLogEntry.getHeader(), txnLogEntry.getTxn()));
+        bw.write(formatTransaction(hdr, txn));
         bw.newLine();
       } else {
-        System.out.println(formatTransaction(txnLogEntry.getHeader(), txnLogEntry.getTxn()));
+        System.out.println(formatTransaction(hdr, txn));
       }
 
       if (logStream.readByte("EOR") != 'B') {

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -32,11 +32,6 @@
   <properties>
     <osgi.import>
       org.slf4j*;version="[1.7,2)",
-      org.apache.logging.log4j*;version="[2.17,3)",
-      org.apache.logging.slf4j*;version="[2.17,3)",
-      org.apache.zookeeper.server.persistence*;resolution:=optional,
-      org.apache.zookeeper.server.util*;resolution:=optional,
-      org.apache.zookeeper.txn*;resolution:=optional,
       org.apache.zookeeper*;version="[3.6,3)",
       *
     </osgi.import>
@@ -106,6 +101,12 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>1.1.7</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <osgi.import>
       org.slf4j*;version="[1.7,2)",
-      org.apache.zookeeper*;version="[3.6,3)",
+      org.apache.zookeeper*;version="[3.5,9)",
       *
     </osgi.import>
     <osgi.export>org.apache.helix.zookeeper*;version="${project.version};-noimport:=true</osgi.export>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.6.3</version>
+      <version>3.5.9</version>
       <exclusions>
         <exclusion>
           <groupId>junit</groupId>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1973

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

With the upgrade of apache zookeeper version, snappy-java was missing in the dependency. This commit adds snappy-java and removes unused imports in osgi declaration. Also, using ZooKeeper 3.5.9 in zookeeper-api instead because 3.6.0+ causes some tests to fail in zookeeper-api.

### Tests

- [ ] The following tests are written for this issue:

N/A

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
