### PR TITLE
Enable HelixManager as an event listener

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
@@ -190,7 +190,7 @@ public class HelixCloudProperty {
     return _isCloudEventCallbackEnabled;
   }
 
-  public void enableCloudEventCallback(boolean enabled) {
+  public void setCloudEventCallbackEnabled(boolean enabled) {
     _isCloudEventCallbackEnabled = enabled;
   }
 

--- a/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import org.apache.helix.cloud.constants.CloudProvider;
+import org.apache.helix.cloud.event.helix.CloudEventCallbackProperty;
 import org.apache.helix.model.CloudConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,6 +69,10 @@ public class HelixCloudProperty {
 
   // Other customized properties that may be used.
   private Properties _customizedCloudProperties = new Properties();
+
+  private boolean _isCloudEventCallbackEnabled;
+
+  private CloudEventCallbackProperty _cloudEventCallbackProperty;
 
   /**
    * Initialize Helix Cloud Property based on the provider
@@ -179,5 +184,21 @@ public class HelixCloudProperty {
 
   public void setCustomizedCloudProperties(Properties customizedCloudProperties) {
     _customizedCloudProperties.putAll(customizedCloudProperties);
+  }
+
+  public boolean isCloudEventCallbackEnabled() {
+    return _isCloudEventCallbackEnabled;
+  }
+
+  public void enableCloudEventCallback(boolean enabled) {
+    _isCloudEventCallbackEnabled = enabled;
+  }
+
+  public CloudEventCallbackProperty getCloudEventCallbackProperty() {
+    return _cloudEventCallbackProperty;
+  }
+
+  public void setCloudEventCallbackProperty(CloudEventCallbackProperty cloudEventCallbackProperty) {
+    _cloudEventCallbackProperty = cloudEventCallbackProperty;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/CloudEventHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/CloudEventHandler.java
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory;
 public class CloudEventHandler {
   private static final Logger LOG = LoggerFactory.getLogger(CloudEventHandler.class.getName());
   private List<CloudEventListener> _unorderedEventListenerList = new ArrayList<>();
-  private Optional<CloudEventListener> _preEventHandlerCallback;
-  private Optional<CloudEventListener> _postEventHandlerCallback;
+  private Optional<CloudEventListener> _preEventHandlerCallback = Optional.empty();
+  private Optional<CloudEventListener> _postEventHandlerCallback = Optional.empty();
 
   /**
    * Register an event listener to the event handler.

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/CloudEventHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/CloudEventHandler.java
@@ -70,28 +70,12 @@ public class CloudEventHandler {
   }
 
   /**
-   * Trigger the callback / listeners in order of
-   * 1. PreEventHandlerCallback
-   * 2. Unordered CloudEventListener list
-   * 3. PostEventHandlerCallback
-   * @param eventInfo the object contains any information about the incoming event
+   * Trigger the registered listeners in order,
+   * and trigger the corresponding callback registered in the listeners for a certain type of event.
    */
-  public void onPause(Object eventInfo) {
-    _preEventHandlerCallback.ifPresent(callback -> callback.onPause(eventInfo));
-    _unorderedEventListenerList.parallelStream().forEach(listener -> listener.onPause(eventInfo));
-    _postEventHandlerCallback.ifPresent(callback -> callback.onPause(eventInfo));
-  }
-
-  /**
-   * Trigger the callback / listeners in order of
-   * 1. PreEventHandlerCallback
-   * 2. Unordered CloudEventListener list
-   * 3. PostEventHandlerCallback
-   * @param eventInfo the object contains any information about the incoming event
-   */
-  public void onResume(Object eventInfo) {
-    _preEventHandlerCallback.ifPresent(callback -> callback.onResume(eventInfo));
-    _unorderedEventListenerList.parallelStream().forEach(listener -> listener.onResume(eventInfo));
-    _postEventHandlerCallback.ifPresent(callback -> callback.onResume(eventInfo));
+  public void performAction(Object eventType, Object eventInfo) {
+    _preEventHandlerCallback.ifPresent(callback -> callback.performAction(eventType, eventInfo));
+    _unorderedEventListenerList.parallelStream().forEach(listener -> listener.performAction(eventType, eventInfo));
+    _postEventHandlerCallback.ifPresent(callback -> callback.performAction(eventType, eventInfo));
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/CloudEventListener.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/CloudEventListener.java
@@ -24,15 +24,27 @@ package org.apache.helix.cloud.event;
  * The listeners can be registered to {@link CloudEventHandler}.
  */
 public interface CloudEventListener {
+  /**
+   * Defines different listener types
+   * It determines the position this listener being triggered in {@link CloudEventHandler}
+   * Order being: PRE_EVENT_HANDLER -> UNORDERED (in parallel) -> POST_EVENT_HANDLER
+   */
   enum ListenerType {
-    PRE_EVENT_HANDLER, UNORDERED, POST_EVENT_HANDLER
+    PRE_EVENT_HANDLER,
+    UNORDERED,
+    POST_EVENT_HANDLER
   }
 
+  /**
+   * Perform action to react the the event
+   * @param eventType Type of the event
+   * @param eventInfo Detailed information about the event
+   */
   void performAction(Object eventType, Object eventInfo);
 
   /**
    * Get the listener type of a listener
-   * @return the type of the listener
+   * @return The type of the listener
    */
   ListenerType getListenerType();
 }

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/CloudEventListener.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/CloudEventListener.java
@@ -28,17 +28,7 @@ public interface CloudEventListener {
     PRE_EVENT_HANDLER, UNORDERED, POST_EVENT_HANDLER
   }
 
-  /**
-   * Callback for when a pause event is incoming
-   * @param eventInfo the info of the incoming event
-   */
-  void onPause(Object eventInfo);
-
-  /**
-   * Callback for when a pause event finishes
-   * @param eventInfo the info of the incoming event
-   */
-  void onResume(Object eventInfo);
+  void performAction(Object eventType, Object eventInfo);
 
   /**
    * Get the listener type of a listener

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/helix/AbstractCloudEventCallbackImpl.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/helix/AbstractCloudEventCallbackImpl.java
@@ -1,0 +1,46 @@
+package org.apache.helix.cloud.event.helix;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.HelixManager;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+public abstract class AbstractCloudEventCallbackImpl {
+
+  public void onPauseDefaultHelixOperation(HelixManager manager, Object eventInfo) {
+    // To be implemented
+    throw new NotImplementedException();
+  }
+
+  public void onResumeDefaultHelixOperation(HelixManager manager, Object eventInfo) {
+    // To be implemented
+    throw new NotImplementedException();
+  }
+
+  public void onPauseMaintenanceMode(HelixManager manager, Object eventInfo) {
+    // To be implemented
+    throw new NotImplementedException();
+  }
+
+  public void onResumeMaintenanceMode(HelixManager manager, Object eventInfo) {
+    // To be implemented
+    throw new NotImplementedException();
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/helix/CloudEventCallbackProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/helix/CloudEventCallbackProperty.java
@@ -19,8 +19,10 @@ package org.apache.helix.cloud.event.helix;
  * under the License.
  */
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Set;
 import java.util.function.BiConsumer;
 
 import org.apache.helix.HelixManager;
@@ -29,35 +31,34 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A property for users to customize the behavior of a Helix manager as a cloud event listener
- * Use this
  */
 public class CloudEventCallbackProperty {
   private static final Logger LOG =
       LoggerFactory.getLogger(CloudEventCallbackProperty.class.getName());
 
-  // The key for user to pass in callback impl class name in the constructor
-  public static final String CALLBACK_IMPL_CLASS_NAME = "callbackImplClassName";
-  private Map<OnPauseOperations, BiConsumer<HelixManager, Object>>
-      _onPauseOperationMap;
-  private Map<OnResumeOperations, BiConsumer<HelixManager, Object>>
-      _onResumeOperationMap;
-  private final String _callbackImplClassName;
+  private Set<HelixOperation> _enabledHelixOperation;
+  private Map<UserDefinedCallbackType, BiConsumer<HelixManager, Object>> _userDefinedCallbackMap;
+  private final Map<String, String> _userArgs;
 
   /**
    * Constructor
    * @param userArgs A map contains information that users pass in
    */
   public CloudEventCallbackProperty(Map<String, String> userArgs) {
-    _callbackImplClassName = userArgs.get(CALLBACK_IMPL_CLASS_NAME);
-    _onPauseOperationMap = new ConcurrentHashMap<>();
-    _onResumeOperationMap = new ConcurrentHashMap<>();
+    _enabledHelixOperation = new HashSet<>();
+    _userDefinedCallbackMap = new HashMap<>();
+    _userArgs = userArgs;
+  }
+
+  public static class UserArgsInputKey {
+    public static final String CALLBACK_IMPL_CLASS_NAME = "callbackImplClassName";
   }
 
   /**
-   * A collection of types of optional Helix-supported operations
+   * A collection of types of Helix operations
    */
-  public enum OptionalHelixOperation {
-    MAINTENANCE_MODE
+  public enum HelixOperation {
+    ENABLE_DISABLE_INSTANCE, MAINTENANCE_MODE
   }
 
   /**
@@ -67,128 +68,33 @@ public class CloudEventCallbackProperty {
     PRE_ON_PAUSE, POST_ON_PAUSE, PRE_ON_RESUME, POST_ON_RESUME,
   }
 
-  private enum OnPauseOperations {
-    PRE_ON_PAUSE, MAINTENANCE_MODE, DEFAULT_HELIX_OPERATION, POST_ON_PAUSE
-  }
-
-  private enum OnResumeOperations {
-    PRE_ON_RESUME, DEFAULT_HELIX_OPERATION, MAINTENANCE_MODE, POST_ON_RESUME,
-  }
-
   /**
-   * Trigger the registered onPause callbacks one by one
-   * Order:
-   * 1. PRE onPause
-   * 2. Helix optional: Maintenance Mode
-   * 3. Helix default
-   * 4. POST onPause
-   * @param helixManager Helix manager to perform operations
-   * @param eventInfo Information of the event provided by upsteam
-   * @param callbackImplClass Implementation class for Helix default and optional operations
-   */
-  public void onPause(HelixManager helixManager, Object eventInfo,
-      AbstractCloudEventCallbackImpl callbackImplClass) {
-    for (OnPauseOperations operation : OnPauseOperations.values()) {
-      switch (operation) {
-        case DEFAULT_HELIX_OPERATION:
-          callbackImplClass.onPauseDefaultHelixOperation(helixManager, eventInfo);
-          break;
-        case MAINTENANCE_MODE:
-          callbackImplClass.onPauseMaintenanceMode(helixManager, eventInfo);
-          break;
-        default:
-          _onPauseOperationMap.getOrDefault(operation, (manager, info) -> {
-          }).accept(helixManager, eventInfo);
-      }
-    }
-  }
-
-  /**
-   * Trigger the registered onResume callbacks one by one
-   * Order:
-   * 1. PRE onResume
-   * 2. Helix default
-   * 3. Helix optional: Maintenance Mode
-   * 4. POST onResume
-   * @param helixManager Helix manager to perform operations
-   * @param eventInfo Information of the event provided by upsteam
-   * @param callbackImplClass Implementation class for Helix default and optional operations
-   */
-  public void onResume(HelixManager helixManager, Object eventInfo,
-      AbstractCloudEventCallbackImpl callbackImplClass) {
-    for (OnResumeOperations operation : OnResumeOperations.values()) {
-      switch (operation) {
-        case DEFAULT_HELIX_OPERATION:
-          callbackImplClass.onResumeDefaultHelixOperation(helixManager, eventInfo);
-          break;
-        case MAINTENANCE_MODE:
-          callbackImplClass.onResumeMaintenanceMode(helixManager, eventInfo);
-          break;
-        default:
-          _onResumeOperationMap.getOrDefault(operation, (manager, info) -> {
-          }).accept(helixManager, eventInfo);
-      }
-    }
-  }
-
-  /**
-   * Enable an Helix-supported optional operation
-   * The operation is implemented in the callback impl class loaded in Helix manager
+   * Enable an Helix-supported operation
+   * The operation is implemented in the callback impl class
    * @param operation operation type
    */
-  public void enableOptionalHelixOperation(OptionalHelixOperation operation) {
-    LOG.info("Enabling {} type optional Helix operation...", operation.name());
-    if (operation == OptionalHelixOperation.MAINTENANCE_MODE) {
-      // Put a place holder first, it will be replaced with implementations from the loaded
-      // callback impl class at call time
-      _onPauseOperationMap.put(OnPauseOperations.MAINTENANCE_MODE, (manager, info) -> {
-      });
-      _onResumeOperationMap.put(OnResumeOperations.MAINTENANCE_MODE, (manager, info) -> {
-      });
-    }
-  }
-
-  /**
-   * Disable an Helix-supported optional operation
-   * @param operation operation type
-   */
-  public void disableOptionalHelixOperation(OptionalHelixOperation operation) {
-    LOG.info("Disabling {} type optional Helix operation...", operation.name());
-    if (operation == OptionalHelixOperation.MAINTENANCE_MODE) {
-      _onPauseOperationMap.remove(OnPauseOperations.MAINTENANCE_MODE);
-      _onResumeOperationMap.remove(OnResumeOperations.MAINTENANCE_MODE);
+  public void setHelixOperationEnabled(HelixOperation operation, boolean enabled) {
+    if (enabled) {
+      _enabledHelixOperation.add(operation);
+    } else {
+      _enabledHelixOperation.remove(operation);
     }
   }
 
   /**
    * Register a user defined callback at a user specified position
-   * The position is relative to Helix-supported logic (Helix default operation + Helix optional operation)
+   * The position is relative to Helix operations
    * There are two options for each type (onPause or onResume):
-   * 1. PRE: The user defined callback will be called before Helix-supported logic
-   * 2. POST: The user defined callback will be called after Helix-supported logic finishes
+   * 1. PRE: The user defined callback will be the first callback being called in the listener
+   * 2. POST: The user defined callback will be the last callback being called in the listener
    * @param callbackType The type and position for registering the callback
-   * @param callback The actual implementation of the callback
+   * @param callback The implementation of the callback
    */
   public void registerUserDefinedCallback(UserDefinedCallbackType callbackType,
       BiConsumer<HelixManager, Object> callback) {
     LOG.info("Registering callback {} as {} type user defined callback...", callback,
         callbackType.name());
-    switch (callbackType) {
-      case PRE_ON_PAUSE:
-        _onPauseOperationMap.put(OnPauseOperations.PRE_ON_PAUSE, callback);
-        break;
-      case POST_ON_PAUSE:
-        _onPauseOperationMap.put(OnPauseOperations.POST_ON_PAUSE, callback);
-        break;
-      case PRE_ON_RESUME:
-        _onResumeOperationMap.put(OnResumeOperations.PRE_ON_RESUME, callback);
-        break;
-      case POST_ON_RESUME:
-        _onResumeOperationMap.put(OnResumeOperations.POST_ON_RESUME, callback);
-        break;
-      default:
-        break;
-    }
+    _userDefinedCallbackMap.put(callbackType, callback);
   }
 
   /**
@@ -197,31 +103,18 @@ public class CloudEventCallbackProperty {
    */
   public void unregisterUserDefinedCallback(UserDefinedCallbackType callbackType) {
     LOG.info("Unregistering {} type user defined callback...", callbackType.name());
-    switch (callbackType) {
-      case PRE_ON_PAUSE:
-        _onPauseOperationMap.remove(OnPauseOperations.PRE_ON_PAUSE);
-        break;
-      case POST_ON_PAUSE:
-        _onPauseOperationMap.remove(OnPauseOperations.POST_ON_PAUSE);
-        break;
-      case PRE_ON_RESUME:
-        _onResumeOperationMap.remove(OnResumeOperations.PRE_ON_RESUME);
-        break;
-      case POST_ON_RESUME:
-        _onResumeOperationMap.remove(OnResumeOperations.POST_ON_RESUME);
-        break;
-      default:
-        break;
-    }
+    _userDefinedCallbackMap.remove(callbackType);
   }
 
-  /**
-   * Get the user specified class name for the implementation class of Helix-supported callbacks
-   * @return The user defined class name if not null;
-   *         if null, return AbstractCloudEventCallbackImpl class name
-   */
-  public String getCallbackImplClassName() {
-    return _callbackImplClassName == null ? AbstractCloudEventCallbackImpl.class.getCanonicalName()
-        : _callbackImplClassName;
+  public Map<String, String> getUserArgs() {
+    return _userArgs;
+  }
+
+  public Map<UserDefinedCallbackType, BiConsumer<HelixManager, Object>> getUserDefinedCallbackMap() {
+    return _userDefinedCallbackMap;
+  }
+
+  public Set<HelixOperation> getEnabledHelixOperation() {
+    return _enabledHelixOperation;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/helix/CloudEventCallbackProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/helix/CloudEventCallbackProperty.java
@@ -19,8 +19,6 @@ package org.apache.helix.cloud.event.helix;
  * under the License.
  */
 
-import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
@@ -39,11 +37,11 @@ public class CloudEventCallbackProperty {
 
   // The key for user to pass in callback impl class name in the constructor
   public static final String CALLBACK_IMPL_CLASS_NAME = "callbackImplClassName";
-  private ConcurrentHashMap<OnPauseOperations, BiConsumer<HelixManager, Object>>
+  private Map<OnPauseOperations, BiConsumer<HelixManager, Object>>
       _onPauseOperationMap;
-  private ConcurrentHashMap<OnResumeOperations, BiConsumer<HelixManager, Object>>
+  private Map<OnResumeOperations, BiConsumer<HelixManager, Object>>
       _onResumeOperationMap;
-  private String _callbackImplClassName;
+  private final String _callbackImplClassName;
 
   /**
    * Constructor
@@ -90,9 +88,7 @@ public class CloudEventCallbackProperty {
    */
   public void onPause(HelixManager helixManager, Object eventInfo,
       AbstractCloudEventCallbackImpl callbackImplClass) {
-    Iterator<OnPauseOperations> iterator = Arrays.stream(OnPauseOperations.values()).iterator();
-    while (iterator.hasNext()) {
-      OnPauseOperations operation = iterator.next();
+    for (OnPauseOperations operation : OnPauseOperations.values()) {
       switch (operation) {
         case DEFAULT_HELIX_OPERATION:
           callbackImplClass.onPauseDefaultHelixOperation(helixManager, eventInfo);
@@ -120,9 +116,7 @@ public class CloudEventCallbackProperty {
    */
   public void onResume(HelixManager helixManager, Object eventInfo,
       AbstractCloudEventCallbackImpl callbackImplClass) {
-    Iterator<OnResumeOperations> iterator = Arrays.stream(OnResumeOperations.values()).iterator();
-    while (iterator.hasNext()) {
-      OnResumeOperations operation = iterator.next();
+    for (OnResumeOperations operation : OnResumeOperations.values()) {
       switch (operation) {
         case DEFAULT_HELIX_OPERATION:
           callbackImplClass.onResumeDefaultHelixOperation(helixManager, eventInfo);

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/helix/CloudEventCallbackProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/helix/CloudEventCallbackProperty.java
@@ -19,6 +19,7 @@ package org.apache.helix.cloud.event.helix;
  * under the License.
  */
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -50,6 +51,9 @@ public class CloudEventCallbackProperty {
     _userArgs = userArgs;
   }
 
+  /**
+   * Keys for retrieve information from the map users pass in
+   */
   public static class UserArgsInputKey {
     public static final String CALLBACK_IMPL_CLASS_NAME = "callbackImplClassName";
   }
@@ -58,14 +62,18 @@ public class CloudEventCallbackProperty {
    * A collection of types of Helix operations
    */
   public enum HelixOperation {
-    ENABLE_DISABLE_INSTANCE, MAINTENANCE_MODE
+    ENABLE_DISABLE_INSTANCE,
+    MAINTENANCE_MODE
   }
 
   /**
-   * A collection of types and positions for user to plugin customized callback
+   * A collection of types and positions for user to plug in customized callback
    */
   public enum UserDefinedCallbackType {
-    PRE_ON_PAUSE, POST_ON_PAUSE, PRE_ON_RESUME, POST_ON_RESUME,
+    PRE_ON_PAUSE,
+    POST_ON_PAUSE,
+    PRE_ON_RESUME,
+    POST_ON_RESUME,
   }
 
   /**
@@ -106,14 +114,24 @@ public class CloudEventCallbackProperty {
     _userDefinedCallbackMap.remove(callbackType);
   }
 
+  /**
+   * Get the user passed-in information
+   * @return Empty map if not defined; an unmodified map otherwise
+   */
   public Map<String, String> getUserArgs() {
-    return _userArgs;
+    return _userArgs == null ? Collections.emptyMap() : Collections.unmodifiableMap(_userArgs);
   }
 
+  /**
+   * Get the map where user defined callbacks are stored
+   */
   public Map<UserDefinedCallbackType, BiConsumer<HelixManager, Object>> getUserDefinedCallbackMap() {
     return _userDefinedCallbackMap;
   }
 
+  /**
+   * Get the set where enabled Helix operations are stored
+   */
   public Set<HelixOperation> getEnabledHelixOperation() {
     return _enabledHelixOperation;
   }

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/helix/CloudEventCallbackProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/helix/CloudEventCallbackProperty.java
@@ -1,0 +1,233 @@
+package org.apache.helix.cloud.event.helix;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+
+import org.apache.helix.HelixManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A property for users to customize the behavior of a Helix manager as a cloud event listener
+ * Use this
+ */
+public class CloudEventCallbackProperty {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CloudEventCallbackProperty.class.getName());
+
+  // The key for user to pass in callback impl class name in the constructor
+  public static final String CALLBACK_IMPL_CLASS_NAME = "callbackImplClassName";
+  private ConcurrentHashMap<OnPauseOperations, BiConsumer<HelixManager, Object>>
+      _onPauseOperationMap;
+  private ConcurrentHashMap<OnResumeOperations, BiConsumer<HelixManager, Object>>
+      _onResumeOperationMap;
+  private String _callbackImplClassName;
+
+  /**
+   * Constructor
+   * @param userArgs A map contains information that users pass in
+   */
+  public CloudEventCallbackProperty(Map<String, String> userArgs) {
+    _callbackImplClassName = userArgs.get(CALLBACK_IMPL_CLASS_NAME);
+    _onPauseOperationMap = new ConcurrentHashMap<>();
+    _onResumeOperationMap = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * A collection of types of optional Helix-supported operations
+   */
+  public enum OptionalHelixOperation {
+    MAINTENANCE_MODE
+  }
+
+  /**
+   * A collection of types and positions for user to plugin customized callback
+   */
+  public enum UserDefinedCallbackType {
+    PRE_ON_PAUSE, POST_ON_PAUSE, PRE_ON_RESUME, POST_ON_RESUME,
+  }
+
+  private enum OnPauseOperations {
+    PRE_ON_PAUSE, MAINTENANCE_MODE, DEFAULT_HELIX_OPERATION, POST_ON_PAUSE
+  }
+
+  private enum OnResumeOperations {
+    PRE_ON_RESUME, DEFAULT_HELIX_OPERATION, MAINTENANCE_MODE, POST_ON_RESUME,
+  }
+
+  /**
+   * Trigger the registered onPause callbacks one by one
+   * Order:
+   * 1. PRE onPause
+   * 2. Helix optional: Maintenance Mode
+   * 3. Helix default
+   * 4. POST onPause
+   * @param helixManager Helix manager to perform operations
+   * @param eventInfo Information of the event provided by upsteam
+   * @param callbackImplClass Implementation class for Helix default and optional operations
+   */
+  public void onPause(HelixManager helixManager, Object eventInfo,
+      AbstractCloudEventCallbackImpl callbackImplClass) {
+    Iterator<OnPauseOperations> iterator = Arrays.stream(OnPauseOperations.values()).iterator();
+    while (iterator.hasNext()) {
+      OnPauseOperations operation = iterator.next();
+      switch (operation) {
+        case DEFAULT_HELIX_OPERATION:
+          callbackImplClass.onPauseDefaultHelixOperation(helixManager, eventInfo);
+          break;
+        case MAINTENANCE_MODE:
+          callbackImplClass.onPauseMaintenanceMode(helixManager, eventInfo);
+          break;
+        default:
+          _onPauseOperationMap.getOrDefault(operation, (manager, info) -> {
+          }).accept(helixManager, eventInfo);
+      }
+    }
+  }
+
+  /**
+   * Trigger the registered onResume callbacks one by one
+   * Order:
+   * 1. PRE onResume
+   * 2. Helix default
+   * 3. Helix optional: Maintenance Mode
+   * 4. POST onResume
+   * @param helixManager Helix manager to perform operations
+   * @param eventInfo Information of the event provided by upsteam
+   * @param callbackImplClass Implementation class for Helix default and optional operations
+   */
+  public void onResume(HelixManager helixManager, Object eventInfo,
+      AbstractCloudEventCallbackImpl callbackImplClass) {
+    Iterator<OnResumeOperations> iterator = Arrays.stream(OnResumeOperations.values()).iterator();
+    while (iterator.hasNext()) {
+      OnResumeOperations operation = iterator.next();
+      switch (operation) {
+        case DEFAULT_HELIX_OPERATION:
+          callbackImplClass.onResumeDefaultHelixOperation(helixManager, eventInfo);
+          break;
+        case MAINTENANCE_MODE:
+          callbackImplClass.onResumeMaintenanceMode(helixManager, eventInfo);
+          break;
+        default:
+          _onResumeOperationMap.getOrDefault(operation, (manager, info) -> {
+          }).accept(helixManager, eventInfo);
+      }
+    }
+  }
+
+  /**
+   * Enable an Helix-supported optional operation
+   * The operation is implemented in the callback impl class loaded in Helix manager
+   * @param operation operation type
+   */
+  public void enableOptionalHelixOperation(OptionalHelixOperation operation) {
+    LOG.info("Enabling {} type optional Helix operation...", operation.name());
+    if (operation == OptionalHelixOperation.MAINTENANCE_MODE) {
+      // Put a place holder first, it will be replaced with implementations from the loaded
+      // callback impl class at call time
+      _onPauseOperationMap.put(OnPauseOperations.MAINTENANCE_MODE, (manager, info) -> {
+      });
+      _onResumeOperationMap.put(OnResumeOperations.MAINTENANCE_MODE, (manager, info) -> {
+      });
+    }
+  }
+
+  /**
+   * Disable an Helix-supported optional operation
+   * @param operation operation type
+   */
+  public void disableOptionalHelixOperation(OptionalHelixOperation operation) {
+    LOG.info("Disabling {} type optional Helix operation...", operation.name());
+    if (operation == OptionalHelixOperation.MAINTENANCE_MODE) {
+      _onPauseOperationMap.remove(OnPauseOperations.MAINTENANCE_MODE);
+      _onResumeOperationMap.remove(OnResumeOperations.MAINTENANCE_MODE);
+    }
+  }
+
+  /**
+   * Register a user defined callback at a user specified position
+   * The position is relative to Helix-supported logic (Helix default operation + Helix optional operation)
+   * There are two options for each type (onPause or onResume):
+   * 1. PRE: The user defined callback will be called before Helix-supported logic
+   * 2. POST: The user defined callback will be called after Helix-supported logic finishes
+   * @param callbackType The type and position for registering the callback
+   * @param callback The actual implementation of the callback
+   */
+  public void registerUserDefinedCallback(UserDefinedCallbackType callbackType,
+      BiConsumer<HelixManager, Object> callback) {
+    LOG.info("Registering callback {} as {} type user defined callback...", callback,
+        callbackType.name());
+    switch (callbackType) {
+      case PRE_ON_PAUSE:
+        _onPauseOperationMap.put(OnPauseOperations.PRE_ON_PAUSE, callback);
+        break;
+      case POST_ON_PAUSE:
+        _onPauseOperationMap.put(OnPauseOperations.POST_ON_PAUSE, callback);
+        break;
+      case PRE_ON_RESUME:
+        _onResumeOperationMap.put(OnResumeOperations.PRE_ON_RESUME, callback);
+        break;
+      case POST_ON_RESUME:
+        _onResumeOperationMap.put(OnResumeOperations.POST_ON_RESUME, callback);
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Unregister a user defined callback at a user specified position
+   * @param callbackType The type and position for registering the callback
+   */
+  public void unregisterUserDefinedCallback(UserDefinedCallbackType callbackType) {
+    LOG.info("Unregistering {} type user defined callback...", callbackType.name());
+    switch (callbackType) {
+      case PRE_ON_PAUSE:
+        _onPauseOperationMap.remove(OnPauseOperations.PRE_ON_PAUSE);
+        break;
+      case POST_ON_PAUSE:
+        _onPauseOperationMap.remove(OnPauseOperations.POST_ON_PAUSE);
+        break;
+      case PRE_ON_RESUME:
+        _onResumeOperationMap.remove(OnResumeOperations.PRE_ON_RESUME);
+        break;
+      case POST_ON_RESUME:
+        _onResumeOperationMap.remove(OnResumeOperations.POST_ON_RESUME);
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Get the user specified class name for the implementation class of Helix-supported callbacks
+   * @return The user defined class name if not null;
+   *         if null, return AbstractCloudEventCallbackImpl class name
+   */
+  public String getCallbackImplClassName() {
+    return _callbackImplClassName == null ? AbstractCloudEventCallbackImpl.class.getCanonicalName()
+        : _callbackImplClassName;
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/helix/DefaultCloudEventCallbackImpl.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/helix/DefaultCloudEventCallbackImpl.java
@@ -22,23 +22,46 @@ package org.apache.helix.cloud.event.helix;
 import org.apache.helix.HelixManager;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
+/**
+ * A default callback implementation class to be used in {@link HelixCloudEventListener}
+ */
 public class DefaultCloudEventCallbackImpl {
 
+  /**
+   * Disable the instance
+   * @param manager The helix manager associated with the listener
+   * @param eventInfo Detailed information about the event
+   */
   public void disableInstance(HelixManager manager, Object eventInfo) {
     // To be implemented
     throw new NotImplementedException();
   }
 
+  /**
+   * Enable the instance
+   * @param manager The helix manager associated with the listener
+   * @param eventInfo Detailed information about the event
+   */
   public void enableInstance(HelixManager manager, Object eventInfo) {
     // To be implemented
     throw new NotImplementedException();
   }
 
+  /**
+   *
+   * @param manager The helix manager associated with the listener
+   * @param eventInfo Detailed information about the event
+   */
   public void enterMaintenanceMode(HelixManager manager, Object eventInfo) {
     // To be implemented
     throw new NotImplementedException();
   }
 
+  /**
+   *
+   * @param manager The helix manager associated with the listener
+   * @param eventInfo Detailed information about the event
+   */
   public void exitMaintenanceMode(HelixManager manager, Object eventInfo) {
     // To be implemented
     throw new NotImplementedException();

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/helix/DefaultCloudEventCallbackImpl.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/helix/DefaultCloudEventCallbackImpl.java
@@ -22,24 +22,24 @@ package org.apache.helix.cloud.event.helix;
 import org.apache.helix.HelixManager;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
-public abstract class AbstractCloudEventCallbackImpl {
+public class DefaultCloudEventCallbackImpl {
 
-  public void onPauseDefaultHelixOperation(HelixManager manager, Object eventInfo) {
+  public void disableInstance(HelixManager manager, Object eventInfo) {
     // To be implemented
     throw new NotImplementedException();
   }
 
-  public void onResumeDefaultHelixOperation(HelixManager manager, Object eventInfo) {
+  public void enableInstance(HelixManager manager, Object eventInfo) {
     // To be implemented
     throw new NotImplementedException();
   }
 
-  public void onPauseMaintenanceMode(HelixManager manager, Object eventInfo) {
+  public void enterMaintenanceMode(HelixManager manager, Object eventInfo) {
     // To be implemented
     throw new NotImplementedException();
   }
 
-  public void onResumeMaintenanceMode(HelixManager manager, Object eventInfo) {
+  public void exitMaintenanceMode(HelixManager manager, Object eventInfo) {
     // To be implemented
     throw new NotImplementedException();
   }

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/helix/HelixCloudEventListener.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/helix/HelixCloudEventListener.java
@@ -1,0 +1,150 @@
+package org.apache.helix.cloud.event.helix;
+
+import java.util.Set;
+
+import org.apache.helix.HelixManager;
+import org.apache.helix.cloud.event.CloudEventListener;
+import org.apache.helix.util.HelixUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HelixCloudEventListener implements CloudEventListener {
+  private static Logger LOG = LoggerFactory.getLogger(HelixCloudEventListener.class);
+
+  private final CloudEventCallbackProperty _property;
+  private final DefaultCloudEventCallbackImpl _callbackImplClass;
+  private final HelixManager _helixManager;
+
+  public HelixCloudEventListener(CloudEventCallbackProperty property, HelixManager helixManager)
+      throws InstantiationException, IllegalAccessException {
+    this._property = property;
+    this._helixManager = helixManager;
+    this._callbackImplClass = loadCloudEventCallbackImplClass(property.getUserArgs()
+        .getOrDefault(CloudEventCallbackProperty.UserArgsInputKey.CALLBACK_IMPL_CLASS_NAME,
+            DefaultCloudEventCallbackImpl.class.getCanonicalName()));
+  }
+
+  public enum EventType {
+    ON_PAUSE, ON_RESUME
+  }
+
+  /**
+   * Below are enums defining the sequence of callbacks for each type of events
+   */
+  private enum OnPauseOperations {
+    PRE_ON_PAUSE {
+      @Override
+      public CloudEventCallbackProperty.UserDefinedCallbackType toUserDefinedCallbackType() {
+        return CloudEventCallbackProperty.UserDefinedCallbackType.PRE_ON_PAUSE;
+      }
+    }, MAINTENANCE_MODE, ENABLE_DISABLE_INSTANCE, POST_ON_PAUSE {
+      @Override
+      public CloudEventCallbackProperty.UserDefinedCallbackType toUserDefinedCallbackType() {
+        return CloudEventCallbackProperty.UserDefinedCallbackType.POST_ON_PAUSE;
+      }
+    };
+
+    public CloudEventCallbackProperty.UserDefinedCallbackType toUserDefinedCallbackType() {
+      return null;
+    }
+  }
+
+  private enum OnResumeOperations {
+    PRE_ON_RESUME {
+      @Override
+      public CloudEventCallbackProperty.UserDefinedCallbackType toUserDefinedCallbackType() {
+        return CloudEventCallbackProperty.UserDefinedCallbackType.PRE_ON_RESUME;
+      }
+    }, ENABLE_DISABLE_INSTANCE, MAINTENANCE_MODE, POST_ON_RESUME {
+      @Override
+      public CloudEventCallbackProperty.UserDefinedCallbackType toUserDefinedCallbackType() {
+        return CloudEventCallbackProperty.UserDefinedCallbackType.POST_ON_RESUME;
+      }
+    };
+
+    public CloudEventCallbackProperty.UserDefinedCallbackType toUserDefinedCallbackType() {
+      return null;
+    }
+  }
+
+  @Override
+  public void performAction(Object eventType, Object eventInfo) {
+    LOG.info("Received {} event, event info {}, timestamp {}. Acting on the event... "
+            + "Actor {}, based on callback implementation class {}.", ((EventType) eventType).name(),
+        eventInfo == null ? "N/A" : eventInfo.toString(), System.currentTimeMillis(), _helixManager,
+        _callbackImplClass.getClass().getCanonicalName());
+    Set<CloudEventCallbackProperty.HelixOperation> enabledHelixOperationSet =
+        _property.getEnabledHelixOperation();
+
+    if (eventType == EventType.ON_PAUSE) {
+      for (OnPauseOperations operation : OnPauseOperations.values()) {
+        switch (operation) {
+          case ENABLE_DISABLE_INSTANCE:
+            if (enabledHelixOperationSet
+                .contains(CloudEventCallbackProperty.HelixOperation.ENABLE_DISABLE_INSTANCE)) {
+              _callbackImplClass.disableInstance(_helixManager, eventInfo);
+            }
+            break;
+          case MAINTENANCE_MODE:
+            if (enabledHelixOperationSet
+                .contains(CloudEventCallbackProperty.HelixOperation.MAINTENANCE_MODE)) {
+              _callbackImplClass.enterMaintenanceMode(_helixManager, eventInfo);
+            }
+            break;
+          default:
+            if (operation.toUserDefinedCallbackType() != null) {
+              _property.getUserDefinedCallbackMap()
+                  .getOrDefault(operation.toUserDefinedCallbackType(), (manager, info) -> {
+                  }).accept(_helixManager, eventInfo);
+            }
+        }
+      }
+    } else if (eventType == EventType.ON_RESUME) {
+      for (OnResumeOperations operation : OnResumeOperations.values()) {
+        switch (operation) {
+          case ENABLE_DISABLE_INSTANCE:
+            if (enabledHelixOperationSet
+                .contains(CloudEventCallbackProperty.HelixOperation.ENABLE_DISABLE_INSTANCE)) {
+              _callbackImplClass.enableInstance(_helixManager, eventInfo);
+            }
+            break;
+          case MAINTENANCE_MODE:
+            if (enabledHelixOperationSet
+                .contains(CloudEventCallbackProperty.HelixOperation.MAINTENANCE_MODE)) {
+              _callbackImplClass.exitMaintenanceMode(_helixManager, eventInfo);
+            }
+            break;
+          default:
+            if (operation.toUserDefinedCallbackType() != null) {
+              _property.getUserDefinedCallbackMap()
+                  .getOrDefault(operation.toUserDefinedCallbackType(), (manager, info) -> {
+                  }).accept(_helixManager, eventInfo);
+            }
+        }
+      }
+    }
+  }
+
+  @Override
+  public CloudEventListener.ListenerType getListenerType() {
+    return CloudEventListener.ListenerType.UNORDERED;
+  }
+
+  private DefaultCloudEventCallbackImpl loadCloudEventCallbackImplClass(String implClassName)
+      throws IllegalAccessException, InstantiationException {
+    DefaultCloudEventCallbackImpl implClass;
+    try {
+      LOG.info("Loading class: " + implClassName);
+      implClass = (DefaultCloudEventCallbackImpl) HelixUtil.loadClass(getClass(), implClassName)
+          .newInstance();
+    } catch (Exception e) {
+      implClass = DefaultCloudEventCallbackImpl.class.newInstance();
+      LOG.error(
+          "No cloud event callback implementation class found for: {}. message: {}. Using default callback impl class instead.",
+          implClassName, e.getMessage());
+    }
+    LOG.info("Using {} as cloud event callback impl class.",
+        implClass.getClass().getCanonicalName());
+    return implClass;
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/cloud/event/MockCloudEventCallbackImpl.java
+++ b/helix-core/src/test/java/org/apache/helix/cloud/event/MockCloudEventCallbackImpl.java
@@ -1,0 +1,61 @@
+package org.apache.helix.cloud.event;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.helix.HelixManager;
+import org.apache.helix.cloud.event.helix.AbstractCloudEventCallbackImpl;
+
+public class MockCloudEventCallbackImpl extends AbstractCloudEventCallbackImpl {
+  public enum OperationType {
+    ON_PAUSE_DEFAULT_HELIX,
+    ON_RESUME_DEFAULT_HELIX,
+    ON_PAUSE_MAINTENANCE_MODE,
+    ON_RESUME_MAINTENANCE_MODE,
+    PRE_ON_PAUSE,
+    POST_ON_PAUSE,
+    PRE_ON_RESUME,
+    POST_ON_RESUME
+  }
+
+  public static Set<OperationType> triggeredOperation = new HashSet<>();
+
+  @Override
+  public void onPauseDefaultHelixOperation(HelixManager manager, Object eventInfo) {
+    triggeredOperation.add(OperationType.ON_PAUSE_DEFAULT_HELIX);
+  }
+
+  @Override
+  public void onResumeDefaultHelixOperation(HelixManager manager, Object eventInfo) {
+    triggeredOperation.add(OperationType.ON_RESUME_DEFAULT_HELIX);
+  }
+
+  @Override
+  public void onPauseMaintenanceMode(HelixManager manager, Object eventInfo) {
+    triggeredOperation.add(OperationType.ON_PAUSE_MAINTENANCE_MODE);
+  }
+
+  @Override
+  public void onResumeMaintenanceMode(HelixManager manager, Object eventInfo) {
+    triggeredOperation.add(OperationType.ON_RESUME_MAINTENANCE_MODE);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/cloud/event/MockCloudEventCallbackImpl.java
+++ b/helix-core/src/test/java/org/apache/helix/cloud/event/MockCloudEventCallbackImpl.java
@@ -23,12 +23,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.helix.HelixManager;
-import org.apache.helix.cloud.event.helix.AbstractCloudEventCallbackImpl;
+import org.apache.helix.cloud.event.helix.DefaultCloudEventCallbackImpl;
 
-public class MockCloudEventCallbackImpl extends AbstractCloudEventCallbackImpl {
+public class MockCloudEventCallbackImpl extends DefaultCloudEventCallbackImpl {
   public enum OperationType {
-    ON_PAUSE_DEFAULT_HELIX,
-    ON_RESUME_DEFAULT_HELIX,
+    ON_PAUSE_DISABLE_INSTANCE,
+    ON_RESUME_ENABLE_INSTANCE,
     ON_PAUSE_MAINTENANCE_MODE,
     ON_RESUME_MAINTENANCE_MODE,
     PRE_ON_PAUSE,
@@ -40,22 +40,22 @@ public class MockCloudEventCallbackImpl extends AbstractCloudEventCallbackImpl {
   public static Set<OperationType> triggeredOperation = new HashSet<>();
 
   @Override
-  public void onPauseDefaultHelixOperation(HelixManager manager, Object eventInfo) {
-    triggeredOperation.add(OperationType.ON_PAUSE_DEFAULT_HELIX);
+  public void disableInstance(HelixManager manager, Object eventInfo) {
+    triggeredOperation.add(OperationType.ON_PAUSE_DISABLE_INSTANCE);
   }
 
   @Override
-  public void onResumeDefaultHelixOperation(HelixManager manager, Object eventInfo) {
-    triggeredOperation.add(OperationType.ON_RESUME_DEFAULT_HELIX);
+  public void enableInstance(HelixManager manager, Object eventInfo) {
+    triggeredOperation.add(OperationType.ON_RESUME_ENABLE_INSTANCE);
   }
 
   @Override
-  public void onPauseMaintenanceMode(HelixManager manager, Object eventInfo) {
+  public void enterMaintenanceMode(HelixManager manager, Object eventInfo) {
     triggeredOperation.add(OperationType.ON_PAUSE_MAINTENANCE_MODE);
   }
 
   @Override
-  public void onResumeMaintenanceMode(HelixManager manager, Object eventInfo) {
+  public void exitMaintenanceMode(HelixManager manager, Object eventInfo) {
     triggeredOperation.add(OperationType.ON_RESUME_MAINTENANCE_MODE);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/cloud/event/TestCloudEventCallbackProperty.java
+++ b/helix-core/src/test/java/org/apache/helix/cloud/event/TestCloudEventCallbackProperty.java
@@ -48,7 +48,7 @@ public class TestCloudEventCallbackProperty {
     // Cloud property
     HelixCloudProperty cloudProperty =
         new HelixCloudProperty(new CloudConfig(new ZNRecord("test")));
-    cloudProperty.enableCloudEventCallback(true);
+    cloudProperty.setCloudEventCallbackEnabled(true);
     cloudProperty.setCloudEventCallbackProperty(property);
 
     // Helix manager property
@@ -103,7 +103,7 @@ public class TestCloudEventCallbackProperty {
     // Cloud property
     HelixCloudProperty cloudProperty =
         new HelixCloudProperty(new CloudConfig(new ZNRecord("test")));
-    cloudProperty.enableCloudEventCallback(true);
+    cloudProperty.setCloudEventCallbackEnabled(true);
     cloudProperty.setCloudEventCallbackProperty(property);
 
     // Helix manager property

--- a/helix-core/src/test/java/org/apache/helix/cloud/event/TestCloudEventCallbackProperty.java
+++ b/helix-core/src/test/java/org/apache/helix/cloud/event/TestCloudEventCallbackProperty.java
@@ -1,0 +1,171 @@
+package org.apache.helix.cloud.event;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+
+import org.apache.helix.HelixCloudProperty;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.HelixManagerProperty;
+import org.apache.helix.InstanceType;
+import org.apache.helix.cloud.event.helix.CloudEventCallbackProperty;
+import org.apache.helix.cloud.event.helix.CloudEventCallbackProperty.OptionalHelixOperation;
+import org.apache.helix.cloud.event.helix.CloudEventCallbackProperty.UserDefinedCallbackType;
+import org.apache.helix.manager.zk.HelixManagerStateListener;
+import org.apache.helix.model.CloudConfig;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestCloudEventCallbackProperty {
+
+  @Test
+  public void testOptionalHelixOperation() {
+    // Cloud event callback property
+    CloudEventCallbackProperty property = new CloudEventCallbackProperty(Collections
+        .singletonMap(CloudEventCallbackProperty.CALLBACK_IMPL_CLASS_NAME,
+            MockCloudEventCallbackImpl.class.getCanonicalName()));
+    property.enableOptionalHelixOperation(OptionalHelixOperation.MAINTENANCE_MODE);
+
+    // Cloud property
+    HelixCloudProperty cloudProperty =
+        new HelixCloudProperty(new CloudConfig(new ZNRecord("test")));
+    cloudProperty.enableCloudEventCallback(true);
+    cloudProperty.setCloudEventCallbackProperty(property);
+
+    // Helix manager property
+    HelixManagerProperty.Builder managerPropertyBuilder = new HelixManagerProperty.Builder();
+    managerPropertyBuilder.setHelixCloudProperty(cloudProperty);
+    HelixManagerProperty managerProperty = managerPropertyBuilder.build();
+    HelixManager helixManager = HelixManagerFactory
+        .getZKHelixManager("clusterName", "instanceName", InstanceType.PARTICIPANT,
+            new HelixManagerStateListener() {
+              @Override
+              public void onConnected(HelixManager helixManager) throws Exception {
+
+              }
+
+              @Override
+              public void onDisconnected(HelixManager helixManager, Throwable error)
+                  throws Exception {
+
+              }
+            }, managerProperty);
+
+    CloudEventHandlerFactory.getInstance().onPause(null);
+    Assert.assertTrue(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.ON_PAUSE_DEFAULT_HELIX));
+    Assert.assertTrue(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.ON_PAUSE_MAINTENANCE_MODE));
+    Assert.assertFalse(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.ON_RESUME_DEFAULT_HELIX));
+    Assert.assertFalse(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.ON_RESUME_MAINTENANCE_MODE));
+
+    MockCloudEventCallbackImpl.triggeredOperation.clear();
+
+    CloudEventHandlerFactory.getInstance().onResume(null);
+    Assert.assertFalse(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.ON_PAUSE_DEFAULT_HELIX));
+    Assert.assertFalse(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.ON_PAUSE_MAINTENANCE_MODE));
+    Assert.assertTrue(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.ON_RESUME_DEFAULT_HELIX));
+    Assert.assertTrue(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.ON_RESUME_MAINTENANCE_MODE));
+  }
+
+  @Test
+  public void testUserDefinedCallback() {
+    // Cloud event callback property
+    CloudEventCallbackProperty property = new CloudEventCallbackProperty(Collections
+        .singletonMap(CloudEventCallbackProperty.CALLBACK_IMPL_CLASS_NAME,
+            MockCloudEventCallbackImpl.class.getCanonicalName()));
+
+    // Cloud property
+    HelixCloudProperty cloudProperty =
+        new HelixCloudProperty(new CloudConfig(new ZNRecord("test")));
+    cloudProperty.enableCloudEventCallback(true);
+    cloudProperty.setCloudEventCallbackProperty(property);
+
+    // Helix manager property
+    HelixManagerProperty.Builder managerPropertyBuilder = new HelixManagerProperty.Builder();
+    managerPropertyBuilder.setHelixCloudProperty(cloudProperty);
+    HelixManagerProperty managerProperty = managerPropertyBuilder.build();
+    HelixManager helixManager = HelixManagerFactory
+        .getZKHelixManager("clusterName", "instanceName", InstanceType.PARTICIPANT,
+            new HelixManagerStateListener() {
+              @Override
+              public void onConnected(HelixManager helixManager) throws Exception {
+
+              }
+
+              @Override
+              public void onDisconnected(HelixManager helixManager, Throwable error)
+                  throws Exception {
+
+              }
+            }, managerProperty);
+
+    property
+        .registerUserDefinedCallback(UserDefinedCallbackType.PRE_ON_PAUSE, (manager, eventInfo) -> {
+          MockCloudEventCallbackImpl.triggeredOperation
+              .add(MockCloudEventCallbackImpl.OperationType.PRE_ON_PAUSE);
+        });
+    property.registerUserDefinedCallback(UserDefinedCallbackType.POST_ON_PAUSE,
+        (manager, eventInfo) -> {
+          MockCloudEventCallbackImpl.triggeredOperation
+              .add(MockCloudEventCallbackImpl.OperationType.POST_ON_PAUSE);
+        });
+    property.registerUserDefinedCallback(UserDefinedCallbackType.PRE_ON_RESUME,
+        (manager, eventInfo) -> {
+          MockCloudEventCallbackImpl.triggeredOperation
+              .add(MockCloudEventCallbackImpl.OperationType.PRE_ON_RESUME);
+        });
+    property.registerUserDefinedCallback(UserDefinedCallbackType.POST_ON_RESUME,
+        (manager, eventInfo) -> {
+          MockCloudEventCallbackImpl.triggeredOperation
+              .add(MockCloudEventCallbackImpl.OperationType.POST_ON_RESUME);
+        });
+
+    CloudEventHandlerFactory.getInstance().onPause(null);
+    Assert.assertTrue(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.PRE_ON_PAUSE));
+    Assert.assertTrue(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.POST_ON_PAUSE));
+    Assert.assertFalse(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.PRE_ON_RESUME));
+    Assert.assertFalse(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.POST_ON_RESUME));
+
+    MockCloudEventCallbackImpl.triggeredOperation.clear();
+
+    CloudEventHandlerFactory.getInstance().onResume(null);
+    Assert.assertFalse(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.PRE_ON_PAUSE));
+    Assert.assertFalse(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.POST_ON_PAUSE));
+    Assert.assertTrue(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.PRE_ON_RESUME));
+    Assert.assertTrue(MockCloudEventCallbackImpl.triggeredOperation
+        .contains(MockCloudEventCallbackImpl.OperationType.POST_ON_RESUME));
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1982.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Added class: 
1. CloudEventCallbackProperty (A property specified for customizing Helix manager as event listener)
2. HelixCloudEventListener
Modified classes:
1. HelixManagerProperty -> **HelixCloudProperty**(**modified**) -> CloudEventCallbackProperty
3. ZKHelixManager

### Tests

- [x] The following tests are written for this issue:

TestCloudEventCallbackProperty

- The following is the result of the "mvn test" command on the appropriate module:
Ran helix-core cloud module tests.
===============================================
Default Suite
Total tests run: 7, Failures: 0, Skips: 0
===============================================

Will run the whole helix-core tests when merging this feature branch into master branch.
### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
