### PR TITLE
add new error message for customized partition check host connection error 

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
@@ -259,13 +259,13 @@ public class InstanceValidationUtil {
             }
 
             // If we failed to get partition assignment for one sibling instance, we add the
-            // nstance name in return error for debugability
+            // instance name in return error for debuggability.
             if (!globalPartitionHealthStatus.containsKey(siblingInstance)
                 || globalPartitionHealthStatus.get(siblingInstance).isEmpty()) {
               unhealthyPartitions.computeIfAbsent(partition, list -> new ArrayList<>())
                   .add(HOST_NO_STATE_ERROR + siblingInstance);
-            } else if (!globalPartitionHealthStatus.get(siblingInstance).containsKey(partition)
-                || !globalPartitionHealthStatus.get(siblingInstance).get(partition)) {
+            } else if (globalPartitionHealthStatus.get(siblingInstance)
+                .getOrDefault(partition, false)) {
               // We are checking sibling partition healthy status. So if partition health does not
               // exist or it is not healthy. We should mark this partition is unhealthy.
               unhealthyPartitions.computeIfAbsent(partition, list -> new ArrayList<>())

--- a/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
@@ -242,12 +242,12 @@ public class TestMaintenanceManagementService {
             MaintenanceManagementService.getMapFromJsonPayload(jsonContent), Collections.singletonList("org.apache.helix.rest.server.TestOperationImpl"),
             Collections.EMPTY_MAP, true);
     Assert.assertFalse(instanceInfo.isSuccessful());
-    Assert.assertEquals(instanceInfo.getMessages().get(0), "CUSTOM_PARTITION_HEALTH_FAILURE:UNHEALTHY_PARTITION:PARTITION_0");
+    Assert.assertEquals(instanceInfo.getMessages().get(0), "CUSTOM_PARTITION_HEALTH_FAILURE:HOST_NO_STATE_ERROR:INSTANCE0.LINKEDIN.COM_1236:PARTITION_0");
 
     // Operation should finish even with check failed.
     MockMaintenanceManagementService instanceServiceSkipFailure =
         new MockMaintenanceManagementService(zkHelixDataAccessor, _configAccessor, _customRestClient, true,
-            ImmutableSet.of("CUSTOM_PARTITION_HEALTH_FAILURE:UNHEALTHY_PARTITION"), HelixRestNamespace.DEFAULT_NAMESPACE_NAME);
+            ImmutableSet.of("CUSTOM_PARTITION_HEALTH_FAILURE:HOST_NO_STATE_ERROR"), HelixRestNamespace.DEFAULT_NAMESPACE_NAME);
     MaintenanceManagementInstanceInfo instanceInfo2 =
         instanceServiceSkipFailure.takeInstance(TEST_CLUSTER, TEST_INSTANCE, Collections.singletonList("CustomInstanceStoppableCheck"),
             MaintenanceManagementService.getMapFromJsonPayload(jsonContent), Collections.singletonList("org.apache.helix.rest.server.TestOperationImpl"),


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1983 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Helix user will get "UNHEALTHY_PARTITION:PARTITION_XX" error for customized partition health check failure when
1. There is not enough partition in healthy state, or
2. Helix failed to get partition status from a particular host.

User need to search Helix log to differentiate these two cases. It is hard to debug when there are hundreds of instances in cluster.

This change adds a new error case when Helix gets an empty map for partition status.

### Tests

- [X] The following tests are written for this issue:
TestMaintenanceManagementService.
Existing test changed as behavior changed. 


- The following is the result of the "mvn test" command on the appropriate module:
```
[ERROR] Tests run: 1294, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 6,122.559 s <<< FAILURE! - in TestSuite
[ERROR] testDropWithNoCurrentState(org.apache.helix.monitoring.mbeans.TestDropResourceMetricsReset)  Time elapsed: 30.948 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
        at org.apache.helix.monitoring.mbeans.TestDropResourceMetricsReset.testDropWithNoCurrentState(TestDropResourceMetricsReset.java:153)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestDropResourceMetricsReset.testDropWithNoCurrentState:153 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1294, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:42 h
[INFO] Finished at: 2022-03-28T18:14:29-07:00
[INFO] ------------------------------------------------------------------------


testDropWithNoCurrentState is a known failing test, issue: #1980

```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
