### PR TITLE
Read cloud config from zk and propagate to HelixManagerProperty in ZkHelixManager constructor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
@@ -69,6 +69,10 @@ public class HelixManagerProperty {
     return _helixCloudProperty;
   }
 
+  public void setHelixCloudProperty(CloudConfig cloudConfig) {
+    _helixCloudProperty = new HelixCloudProperty(cloudConfig);
+  }
+
   public String getVersion() {
     return _version;
   }

--- a/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
@@ -84,7 +84,7 @@ public final class HelixPropertyFactory {
    * @param clusterName
    * @return
    */
-  private CloudConfig getCloudConfig(String zkAddress, String clusterName) {
+  public static CloudConfig getCloudConfig(String zkAddress, String clusterName) {
     CloudConfig cloudConfig;
     RealmAwareZkClient dedicatedZkClient = null;
     try {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -122,7 +122,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
   private final List<PreConnectCallback> _preConnectCallbacks;
   protected final List<CallbackHandler> _handlers;
   private final HelixManagerProperties _properties;
-  private final HelixManagerProperty _helixManagerProperty;
+  protected final HelixManagerProperty _helixManagerProperty;
   private final HelixManagerStateListener _stateListener;
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -269,7 +269,10 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     }
 
     _stateListener = stateListener;
+    // read cloud config from ZK and set cloudConfig in HelixManagerProperty
     _helixManagerProperty = helixManagerProperty;
+    _helixManagerProperty
+        .setHelixCloudProperty(HelixPropertyFactory.getCloudConfig(_zkAddress, _clusterName));
 
     /**
      * use system property if available


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#1985 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Helix user notice that when ZooScalability is enabled, property configured helix cloud participant could not auto register in cluster. This is because when ZooScalability is enabled, Helix need user to pass a cloudConfig object when initiating ZkHelixManager. When user did not set cloudConfig, it will cause nullptr error when reading cloudConfig in ParticipantManager.autoJoin().
This change reads cloudConfig from Zookeeper in ZkHelixManager constructor and propagate to HelixManagerProperty in ZkHelixManager constructor.


### Tests

- [x] The following tests are written for this issue:

NA

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
