### PR TITLE
Implement deactivate rest API

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1255,6 +1255,9 @@ public class ZKHelixAdmin implements HelixAdmin {
   @Override
   public void dropResource(String clusterName, String resourceName) {
     logger.info("Drop resource {} from cluster {}", resourceName, clusterName);
+    if (!ZKUtil.isClusterSetup(clusterName, _zkClient)) {
+      throw new HelixException("Cluster " + clusterName + " is not setup yet");
+    }
     HelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<ZNRecord>(_zkClient));
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
@@ -297,8 +297,10 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
   @Test
   public void testChangeIdealStateWithPendingMsg() throws Exception {
     String clusterName = "CLUSTER_" + _className + "_pending";
-    System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
 
+    System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+    admin.addCluster(clusterName);
     HelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_gZkClient));
     HelixManager manager =
@@ -356,7 +358,6 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
 
     // round2: drop resource, but keep the
     // message, make sure controller should not send O->DROPPED until O->S is done
-    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
     admin.dropResource(clusterName, resourceName);
     List<IdealState> idealStates = accessor.getChildValues(accessor.keyBuilder().idealStates(), true);
     cache.setIdealStates(idealStates);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -58,6 +58,7 @@ public class AbstractResource {
 
   public enum Command {
     activate,
+    deactivate,
     addInstanceTag,
     addVirtualTopologyGroup,
     expand,

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -243,6 +243,18 @@ public class ClusterAccessor extends AbstractHelixResource {
         }
         break;
 
+      case deactivate:
+        if (superCluster == null) {
+          return badRequest("Super Cluster name is missing!");
+        }
+        try {
+          clusterSetup.activateCluster(clusterId, superCluster, false);
+        } catch (Exception ex) {
+          LOG.error("Failed to deactivate cluster {} from super cluster {}.", clusterId, superCluster);
+          return serverError(ex);
+        }
+        break;
+
       case addVirtualTopologyGroup:
         try {
           addVirtualTopologyGroup(clusterId, content);


### PR DESCRIPTION
Fixes #1987, add functionality to deactivate helix cluster in helix-rest.

### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixes #1987

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Add new rest endpoint at `clusters/{clusterId}?command=deactivate` to deactivate cluster from supercluster.

### Tests

- [X] The following tests are written for this issue:
Added test in `TestClusterAccessor.testActivateSuperCluster`

- The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 205, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 264.021 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 205, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /Users/qqu/workspace/qqu-helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 91 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:29 min
[INFO] Finished at: 2022-03-16T16:23:56-07:00
[INFO] ------------------------------------------------------------------------

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
