### PR TITLE
Add instance disable reason 

### DIFF
--- a/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
+++ b/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
@@ -1,0 +1,8 @@
+package org.apache.helix.constants;
+
+public class InstanceConstants {
+  public enum InstanceDisabledType {
+    CLOUD_EVENT,
+    USER_OPERATION
+  }
+}

--- a/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
+++ b/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
@@ -4,7 +4,7 @@ public class InstanceConstants {
   public enum InstanceDisabledType {
     CLOUD_EVENT,
     USER_OPERATION,
-    DEFAULT_INSTANCE_DISABLE_REASON,
+    DEFAULT_INSTANCE_DISABLE_TYPE,
     INSTANCE_NOT_DISABLED
   }
 }

--- a/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
+++ b/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
@@ -3,6 +3,8 @@ package org.apache.helix.constants;
 public class InstanceConstants {
   public enum InstanceDisabledType {
     CLOUD_EVENT,
-    USER_OPERATION
+    USER_OPERATION,
+    DEFAULT_INSTANCE_DISABLE_REASON,
+    INSTANCE_NOT_DISABLED
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.helix.api.status.ClusterManagementMode;
 import org.apache.helix.api.status.ClusterManagementModeRequest;
 import org.apache.helix.api.topology.ClusterTopology;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.ClusterConstraints;
 import org.apache.helix.model.ClusterConstraints.ConstraintType;
@@ -279,6 +280,16 @@ public interface HelixAdmin {
    * @param enabled
    */
   void enableInstance(String clusterName, String instanceName, boolean enabled);
+
+  /**
+   * @param clusterName
+   * @param instanceName
+   * @param enabled
+   * @param reason set additional string description on why the instance is disabled when
+   *          <code>enabled</code> is false.
+   */
+  void enableInstance(String clusterName, String instanceName, boolean enabled,
+      InstanceConstants.InstanceDisabledType disabledType, String reason);
 
   /**
    * Batch enable/disable instances in a cluster

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -56,6 +56,7 @@ import org.apache.helix.api.exceptions.HelixConflictException;
 import org.apache.helix.api.status.ClusterManagementMode;
 import org.apache.helix.api.status.ClusterManagementModeRequest;
 import org.apache.helix.api.topology.ClusterTopology;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
 import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
@@ -341,10 +342,16 @@ public class ZKHelixAdmin implements HelixAdmin {
   @Override
   public void enableInstance(final String clusterName, final String instanceName,
       final boolean enabled) {
+    enableInstance(clusterName, instanceName, enabled, null, null);
+  }
+
+  @Override
+  public void enableInstance(final String clusterName, final String instanceName,
+      final boolean enabled, InstanceConstants.InstanceDisabledType disabledType, String reason) {
     logger.info("{} instance {} in cluster {}.", enabled ? "Enable" : "Disable", instanceName,
         clusterName);
     BaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<>(_zkClient);
-    enableSingleInstance(clusterName, instanceName, enabled, baseAccessor);
+    enableSingleInstance(clusterName, instanceName, enabled, baseAccessor, disabledType, reason);
     // TODO: Reenable this after storage node bug fixed.
     // enableBatchInstances(clusterName, Collections.singletonList(instanceName), enabled, baseAccessor);
 
@@ -352,6 +359,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   @Override
   public void enableInstance(String clusterName, List<String> instances, boolean enabled) {
+    // TODO: Considering adding another batched API with  disabled type and reason.
     // TODO: Reenable this after storage node bug fixed.
     if (true) {
       throw new HelixException("Current batch enable/disable instances are temporarily disabled!");
@@ -361,7 +369,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     BaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<>(_zkClient);
     if (enabled) {
       for (String instance : instances) {
-        enableSingleInstance(clusterName, instance, enabled, baseAccessor);
+        enableSingleInstance(clusterName, instance, enabled, baseAccessor, null, null);
       }
     }
     enableBatchInstances(clusterName, instances, enabled, baseAccessor);
@@ -1858,7 +1866,8 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   private void enableSingleInstance(final String clusterName, final String instanceName,
-      final boolean enabled, BaseDataAccessor<ZNRecord> baseAccessor) {
+      final boolean enabled, BaseDataAccessor<ZNRecord> baseAccessor,
+      InstanceConstants.InstanceDisabledType disabledType, String reason) {
     String path = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
 
     if (!baseAccessor.exists(path, 0)) {
@@ -1876,6 +1885,14 @@ public class ZKHelixAdmin implements HelixAdmin {
 
         InstanceConfig config = new InstanceConfig(currentData);
         config.setInstanceEnabled(enabled);
+        if (!enabled) {
+          if (reason!=null) {
+            config.setInstanceDisabledReason(reason);
+          }
+          if (disabledType != null) {
+            config.setInstanceDisabledType(disabledType);
+          }
+        }
         return config.getRecord();
       }
     }, AccessOption.PERSISTENT);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1886,7 +1886,7 @@ public class ZKHelixAdmin implements HelixAdmin {
         InstanceConfig config = new InstanceConfig(currentData);
         config.setInstanceEnabled(enabled);
         if (!enabled) {
-          if (reason!=null) {
+          if (reason != null) {
             config.setInstanceDisabledReason(reason);
           }
           if (disabledType != null) {

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.rebalancer.topology.Topology;
 import org.apache.helix.util.HelixUtil;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -50,6 +51,8 @@ public class InstanceConfig extends HelixProperty {
     HELIX_ZONE_ID,
     HELIX_ENABLED,
     HELIX_ENABLED_TIMESTAMP,
+    HELIX_DISABLED_REASON,
+    HELIX_DISABLED_TYPE,
     HELIX_DISABLED_PARTITION,
     TAG_LIST,
     INSTANCE_WEIGHT,
@@ -275,6 +278,7 @@ public class InstanceConfig extends HelixProperty {
 
   /**
    * Set the enabled state of the instance
+   * If user enables the instance, HELIX_DISABLED_REASON filed will be removed.
    *
    * @param enabled true to enable, false to disable
    */
@@ -282,6 +286,47 @@ public class InstanceConfig extends HelixProperty {
     _record.setBooleanField(InstanceConfigProperty.HELIX_ENABLED.toString(), enabled);
     _record.setLongField(InstanceConfigProperty.HELIX_ENABLED_TIMESTAMP.name(),
         System.currentTimeMillis());
+    if (enabled) {
+      _record.getSimpleFields().remove(InstanceConfigProperty.HELIX_DISABLED_REASON.toString());
+      _record.getSimpleFields().remove(InstanceConfigProperty.HELIX_DISABLED_TYPE.toString());
+    }
+  }
+
+  /**
+   * Set the instance disabled reason when instance is disabled.
+   * It will be a no-op when instance is enabled.
+   */
+  public void setInstanceDisabledReason(String disabledReason) {
+     if (!getInstanceEnabled()) {
+     _record.setSimpleField(InstanceConfigProperty.HELIX_DISABLED_REASON.toString(), disabledReason);
+     }
+  }
+
+  /**
+   * Set the instance disabled type when instance is disabled.
+   * It will be a no-op when instance is enabled.
+   */
+  public void setInstanceDisabledType(InstanceConstants.InstanceDisabledType disabledType) {
+    if (!getInstanceEnabled()) {
+      _record.setSimpleField(InstanceConfigProperty.HELIX_DISABLED_TYPE.toString(),
+          disabledType.toString());
+    }
+  }
+
+  /**
+   * @return Return instance disabled reason. Default is am empty string.
+   */
+  public String getInstanceDisabledReason() {
+    return _record.getStringField(InstanceConfigProperty.HELIX_DISABLED_REASON.toString(), "");
+  }
+
+  /**
+   *
+   * @return Return instance disabled type (org.apache.helix.constants.InstanceConstants.InstanceDisabledType)
+   *         Default is am empty string.
+   */
+  public String getInstanceDisabledType() {
+    return _record.getStringField(InstanceConfigProperty.HELIX_DISABLED_TYPE.toString(), "");
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -330,7 +330,7 @@ public class InstanceConfig extends HelixProperty {
       return InstanceConstants.InstanceDisabledType.INSTANCE_NOT_DISABLED.toString();
     }
     return _record.getStringField(InstanceConfigProperty.HELIX_DISABLED_TYPE.toString(),
-        InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_REASON.toString());
+        InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE.toString());
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -326,7 +326,11 @@ public class InstanceConfig extends HelixProperty {
    *         Default is am empty string.
    */
   public String getInstanceDisabledType() {
-    return _record.getStringField(InstanceConfigProperty.HELIX_DISABLED_TYPE.toString(), "");
+    if (getInstanceEnabled()) {
+      return InstanceConstants.InstanceDisabledType.INSTANCE_NOT_DISABLED.toString();
+    }
+    return _record.getStringField(InstanceConfigProperty.HELIX_DISABLED_TYPE.toString(),
+        InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_REASON.toString());
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -47,8 +47,10 @@ import org.apache.helix.TestHelper;
 import org.apache.helix.ZkUnitTestBase;
 import org.apache.helix.api.exceptions.HelixConflictException;
 import org.apache.helix.api.status.ClusterManagementMode;
+import org.apache.helix.api.status.ClusterManagementModeRequest;
 import org.apache.helix.api.topology.ClusterTopology;
 import org.apache.helix.cloud.constants.CloudProvider;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.examples.MasterSlaveStateModelFactory;
 import org.apache.helix.integration.manager.ClusterControllerManager;
@@ -73,7 +75,6 @@ import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.model.builder.ConstraintItemBuilder;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
-import org.apache.helix.api.status.ClusterManagementModeRequest;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.tools.StateModelConfigGenerator;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
@@ -175,6 +176,21 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     } catch (HelixException e) {
       // OK
     }
+
+    Assert.assertTrue(
+        tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledReason().isEmpty());
+    String disableReason = "Reason";
+    tool.enableInstance(clusterName, instanceName, false,
+        InstanceConstants.InstanceDisabledType.CLOUD_EVENT, disableReason);
+    Assert.assertTrue(tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledReason()
+        .equals(disableReason));
+    tool.enableInstance(clusterName, instanceName, true,
+        InstanceConstants.InstanceDisabledType.CLOUD_EVENT, disableReason);
+    Assert.assertTrue(
+        tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledReason().isEmpty());
+    Assert.assertTrue(
+        tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledType().isEmpty());
+
 
     dummyList.remove("bar");
     dummyList.add("baz");

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -188,9 +188,8 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
         InstanceConstants.InstanceDisabledType.CLOUD_EVENT, disableReason);
     Assert.assertTrue(
         tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledReason().isEmpty());
-    Assert.assertTrue(
-        tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledType().isEmpty());
-
+    Assert.assertEquals(tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledType(),
+        InstanceConstants.InstanceDisabledType.INSTANCE_NOT_DISABLED.toString());
 
     dummyList.remove("bar");
     dummyList.add("baz");

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -284,8 +284,8 @@ public class MockHelixAdmin implements HelixAdmin {
     ZNRecord record = (ZNRecord) _baseDataAccessor.get(instanceConfigPath, null, 0);
     InstanceConfig instanceConfig = new InstanceConfig(record);
     instanceConfig.setInstanceEnabled(enabled);
-    if (!enabled ) {
-      if (reason!=null) {
+    if (!enabled) {
+      if (reason != null) {
         instanceConfig.setInstanceDisabledReason(reason);
       }
       if (disabledType != null) {

--- a/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
@@ -23,17 +23,11 @@ import java.util.Collections;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-/**
- * Created with IntelliJ IDEA.
- * User: zzhang
- * Date: 3/19/13
- * Time: 5:28 PM
- * To change this template use File | Settings | File Templates.
- */
 public class TestInstanceConfig {
   @Test
   public void testNotCheckingHostPortExistence() {
@@ -45,11 +39,39 @@ public class TestInstanceConfig {
   @Test
   public void testGetParsedDomain() {
     InstanceConfig instanceConfig = new InstanceConfig(new ZNRecord("id"));
-    instanceConfig.setDomain("cluster=myCluster,zone=myZone1,rack=myRack,host=hostname,instance=instance001");
+    instanceConfig
+        .setDomain("cluster=myCluster,zone=myZone1,rack=myRack,host=hostname,instance=instance001");
 
     Map<String, String> parsedDomain = instanceConfig.getDomainAsMap();
     Assert.assertEquals(parsedDomain.size(), 5);
     Assert.assertEquals(parsedDomain.get("zone"), "myZone1");
+  }
+
+  @Test
+  public void testSetInstanceEnableWithReason() {
+    InstanceConfig instanceConfig = new InstanceConfig(new ZNRecord("id"));
+    instanceConfig.setInstanceEnabled(true);
+    instanceConfig.setInstanceDisabledReason("NoShowReason");
+    instanceConfig.setInstanceDisabledType(InstanceConstants.InstanceDisabledType.USER_OPERATION);
+
+    Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
+        .get(InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.toString()), "true");
+    Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
+        .get(InstanceConfig.InstanceConfigProperty.HELIX_DISABLED_REASON.toString()), null);
+    Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
+        .get(InstanceConfig.InstanceConfigProperty.HELIX_DISABLED_TYPE.toString()), null);
+
+    instanceConfig.setInstanceEnabled(false);
+    String reasonCode = "ReasonCode";
+    instanceConfig.setInstanceDisabledReason(reasonCode);
+    instanceConfig.setInstanceDisabledType(InstanceConstants.InstanceDisabledType.USER_OPERATION);
+    Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
+        .get(InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.toString()), "false");
+    Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
+        .get(InstanceConfig.InstanceConfigProperty.HELIX_DISABLED_REASON.toString()), reasonCode);
+    Assert.assertEquals(instanceConfig.getInstanceDisabledReason(), reasonCode);
+    Assert.assertEquals(instanceConfig.getInstanceDisabledType(),
+        InstanceConstants.InstanceDisabledType.USER_OPERATION.toString());
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
@@ -61,6 +61,7 @@ public class TestInstanceConfig {
     Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
         .get(InstanceConfig.InstanceConfigProperty.HELIX_DISABLED_TYPE.toString()), null);
 
+
     instanceConfig.setInstanceEnabled(false);
     String reasonCode = "ReasonCode";
     instanceConfig.setInstanceDisabledReason(reasonCode);

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -367,7 +367,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
         _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceEnabled());
     Assert.assertEquals(
         _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledType(),
-        InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_REASON.toString());
+        InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE.toString());
     Assert.assertEquals(
         _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledReason(),
         "reason1");

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -360,14 +360,14 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     Entity entity = Entity.entity("", MediaType.APPLICATION_JSON_TYPE);
 
     new JerseyUriRequestBuilder(
-        "clusters/{}/instances/{}?command=disable&instanceDisabledType=USER_OPERATION&instanceDisabledReason=reason1")
+        "clusters/{}/instances/{}?command=disable&instanceDisabledReason=reason1")
         .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
 
     Assert.assertFalse(
         _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceEnabled());
     Assert.assertEquals(
         _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledType(),
-        InstanceConstants.InstanceDisabledType.USER_OPERATION.toString());
+        InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_REASON.toString());
     Assert.assertEquals(
         _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledReason(),
         "reason1");
@@ -379,9 +379,11 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     Assert.assertTrue(
         _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceEnabled());
     Assert.assertEquals(
-        _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledType(), "");
+        _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledType(),
+        InstanceConstants.InstanceDisabledType.INSTANCE_NOT_DISABLED.toString());
     Assert.assertEquals(
-        _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledReason(), "");
+        _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledReason(),
+        "");
 
     // disable instance with no reason input
     new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=disable")


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
 #1992

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
This change adds an API for Disabling instance with optional disabling type and reason.
Added a new api in HelixAdmin
Added 2 optional query param in Rest API PerInstanceAccessor

### Tests

- [X] The following tests are written for this issue:
Expanded these following test class to include the new API
   TestZkHelixAdmin.testZkHelixAdmin()
   TestPerInstanceAccessor.updateInstance()
New test:
   TestInstanceConfig.testSetInstanceEnableWithReason()


- The following is the result of the "mvn test" command on the appropriate module:

```
2022-03-23T01:22:45.9122191Z ##[endgroup]
2022-03-23T01:22:45.9706391Z [info] ./helix-core/target/surefire-reports/TestSuite.txt: Tests run: 1295, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,466.689 s - in TestSuite
2022-03-23T01:22:45.9709873Z [info] ./zookeeper-api/target/surefire-reports/TestSuite.txt: Tests run: 54, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 107.346 s - in TestSuite
2022-03-23T01:22:45.9714987Z [info] ./metrics-common/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.365 s - in TestSuite
2022-03-23T01:22:45.9717685Z [info] ./helix-lock/target/surefire-reports/TestSuite.txt: Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 57.3 s - in TestSuite
2022-03-23T01:22:45.9722084Z [info] ./metadata-store-directory-common/target/surefire-reports/TestSuite.txt: Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.495 s - in TestSuite
2022-03-23T01:22:45.9725027Z [info] ./helix-rest/target/surefire-reports/TestSuite.txt: Tests run: 205, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 141.08 s - in TestSuite
2022-03-23T01:22:45.9727725Z [info] ./recipes/rsync-replicated-file-system/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.495 s - in TestSuite
2022-03-23T01:22:45.9730328Z [info] ./recipes/rabbitmq-consumer-group/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.51 s - in TestSuite
2022-03-23T01:22:45.9732681Z [info] ./recipes/distributed-lock-manager/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.505 s - in TestSuite
2022-03-23T01:22:45.9735031Z [info] ./recipes/service-discovery/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.48 s - in TestSuite
2022-03-23T01:22:45.9737402Z [info] ./recipes/task-execution/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.396 s - in TestSuite
2022-03-23T01:22:45.9742030Z [info] ./helix-common/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.24 s - in TestSuite
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
