### PR TITLE
Fix TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit.testWithOfflineInstancesLimit - auto Exit MM for auto EMM test

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit.java
@@ -99,6 +99,7 @@ public class TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit exten
     ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
     ClusterConfig clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
     clusterConfig.setMaxOfflineInstancesAllowed(_maxOfflineInstancesAllowed);
+    clusterConfig.setNumOfflineInstancesForAutoExit(0);
     configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
 
     for (int i = 0; i < 3; i++) {
@@ -190,7 +191,7 @@ public class TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit exten
       return ms != null && ms.getReason() != null;
     }, TestHelper.WAIT_DURATION);
     Assert.assertTrue(result);
-    
+
     // Verify there is rebalance error logged
     checkForRebalanceError(true);
   }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2002 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit is failing because of a race condition:
The cluster is set to enter MM when >4 instances are offline. In the test, the cluster is manually exit MM mode.
It is possible that when cluster manually exit MM, pipeline cache still has old data and thinks there are >4 instances disabled, so it auto enter MM.

Fix it to add a config to auto exit MM when there are no disabled instances.

### Tests

- [X] The following tests are written for this issue:

TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit.testWithOfflineInstancesLimit

- The following is the result of the "mvn test" command on the appropriate module:
CI result: TestDropResourceMetricsReset.testDropWithNoCurrentState:153 expected:<true> but was:<false>
Existing issue: #1980 

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
