### PR TITLE
Populate helix cloud property using cloud config

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
@@ -69,42 +69,56 @@ public class HelixCloudProperty {
   // Other customized properties that may be used.
   private Properties _customizedCloudProperties = new Properties();
 
+  public static final HelixCloudProperty EMPTY_HELIX_CLOUD_PROPERTY = new HelixCloudProperty();
+
+  private HelixCloudProperty() {
+    setCloudEnabled(false);
+  }
+
   /**
    * Initialize Helix Cloud Property based on the provider
    * @param
    */
   public HelixCloudProperty(CloudConfig cloudConfig) {
+    this();
+    populateFieldsWithCloudConfig(cloudConfig);
+  }
+
+  public void populateFieldsWithCloudConfig(CloudConfig cloudConfig) {
+    if (cloudConfig == null) {
+      return;
+    }
     setCloudEnabled(cloudConfig.isCloudEnabled());
     if (cloudConfig.isCloudEnabled()) {
       setCloudId(cloudConfig.getCloudID());
       setCloudProvider(cloudConfig.getCloudProvider());
       switch (CloudProvider.valueOf(cloudConfig.getCloudProvider())) {
-      case AZURE:
-        Properties azureProperties = new Properties();
-        try {
-          InputStream stream = Thread.currentThread().getContextClassLoader()
-              .getResourceAsStream(AZURE_CLOUD_PROPERTY_FILE);
-          azureProperties.load(stream);
-        } catch (IOException e) {
-          String errMsg =
-              "failed to open Helix Azure cloud properties file: " + AZURE_CLOUD_PROPERTY_FILE;
-          throw new IllegalArgumentException(errMsg, e);
-        }
-        LOG.info("Successfully loaded Helix Azure cloud properties: {}", azureProperties);
-        setCloudInfoSources(
-            Collections.singletonList(azureProperties.getProperty(CLOUD_INFO_SOURCE)));
-        setCloudInfoProcessorName(azureProperties.getProperty(CLOUD_INFO_PROCESSOR_NAME));
-        setCloudMaxRetry(Integer.valueOf(azureProperties.getProperty(CLOUD_MAX_RETRY)));
-        setCloudConnectionTimeout(Long.valueOf(azureProperties.getProperty(CONNECTION_TIMEOUT_MS)));
-        setCloudRequestTimeout(Long.valueOf(azureProperties.getProperty(REQUEST_TIMEOUT_MS)));
-        break;
-      case CUSTOMIZED:
-        setCloudInfoSources(cloudConfig.getCloudInfoSources());
-        setCloudInfoProcessorName(cloudConfig.getCloudInfoProcessorName());
-        break;
-      default:
-        throw new HelixException(
-            String.format("Unsupported cloud provider: %s", cloudConfig.getCloudProvider()));
+        case AZURE:
+          Properties azureProperties = new Properties();
+          try {
+            InputStream stream = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream(AZURE_CLOUD_PROPERTY_FILE);
+            azureProperties.load(stream);
+          } catch (IOException e) {
+            String errMsg =
+                "failed to open Helix Azure cloud properties file: " + AZURE_CLOUD_PROPERTY_FILE;
+            throw new IllegalArgumentException(errMsg, e);
+          }
+          LOG.info("Successfully loaded Helix Azure cloud properties: {}", azureProperties);
+          setCloudInfoSources(
+              Collections.singletonList(azureProperties.getProperty(CLOUD_INFO_SOURCE)));
+          setCloudInfoProcessorName(azureProperties.getProperty(CLOUD_INFO_PROCESSOR_NAME));
+          setCloudMaxRetry(Integer.valueOf(azureProperties.getProperty(CLOUD_MAX_RETRY)));
+          setCloudConnectionTimeout(Long.valueOf(azureProperties.getProperty(CONNECTION_TIMEOUT_MS)));
+          setCloudRequestTimeout(Long.valueOf(azureProperties.getProperty(REQUEST_TIMEOUT_MS)));
+          break;
+        case CUSTOMIZED:
+          setCloudInfoSources(cloudConfig.getCloudInfoSources());
+          setCloudInfoProcessorName(cloudConfig.getCloudInfoProcessorName());
+          break;
+        default:
+          throw new HelixException(
+              String.format("Unsupported cloud provider: %s", cloudConfig.getCloudProvider()));
       }
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
@@ -79,7 +79,7 @@ public class HelixCloudProperty {
 
   public void populateFieldsWithCloudConfig(CloudConfig cloudConfig) {
     if (cloudConfig == null) {
-      cloudConfig = CloudConfig.buildEmptyCloudConfig();
+      cloudConfig = new CloudConfig();
     }
     setCloudEnabled(cloudConfig.isCloudEnabled());
     setCloudId(cloudConfig.getCloudID());

--- a/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
@@ -69,9 +69,7 @@ public class HelixCloudProperty {
   // Other customized properties that may be used.
   private Properties _customizedCloudProperties = new Properties();
 
-  public static final HelixCloudProperty EMPTY_HELIX_CLOUD_PROPERTY = new HelixCloudProperty();
-
-  private HelixCloudProperty() {
+  public HelixCloudProperty() {
     setCloudEnabled(false);
   }
 
@@ -85,41 +83,40 @@ public class HelixCloudProperty {
   }
 
   public void populateFieldsWithCloudConfig(CloudConfig cloudConfig) {
-    if (cloudConfig == null) {
+    if (cloudConfig == null || !cloudConfig.isCloudEnabled()) {
+      reset();
       return;
     }
     setCloudEnabled(cloudConfig.isCloudEnabled());
-    if (cloudConfig.isCloudEnabled()) {
-      setCloudId(cloudConfig.getCloudID());
-      setCloudProvider(cloudConfig.getCloudProvider());
-      switch (CloudProvider.valueOf(cloudConfig.getCloudProvider())) {
-        case AZURE:
-          Properties azureProperties = new Properties();
-          try {
-            InputStream stream = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream(AZURE_CLOUD_PROPERTY_FILE);
-            azureProperties.load(stream);
-          } catch (IOException e) {
-            String errMsg =
-                "failed to open Helix Azure cloud properties file: " + AZURE_CLOUD_PROPERTY_FILE;
-            throw new IllegalArgumentException(errMsg, e);
-          }
-          LOG.info("Successfully loaded Helix Azure cloud properties: {}", azureProperties);
-          setCloudInfoSources(
-              Collections.singletonList(azureProperties.getProperty(CLOUD_INFO_SOURCE)));
-          setCloudInfoProcessorName(azureProperties.getProperty(CLOUD_INFO_PROCESSOR_NAME));
-          setCloudMaxRetry(Integer.valueOf(azureProperties.getProperty(CLOUD_MAX_RETRY)));
-          setCloudConnectionTimeout(Long.valueOf(azureProperties.getProperty(CONNECTION_TIMEOUT_MS)));
-          setCloudRequestTimeout(Long.valueOf(azureProperties.getProperty(REQUEST_TIMEOUT_MS)));
-          break;
-        case CUSTOMIZED:
-          setCloudInfoSources(cloudConfig.getCloudInfoSources());
-          setCloudInfoProcessorName(cloudConfig.getCloudInfoProcessorName());
-          break;
-        default:
-          throw new HelixException(
-              String.format("Unsupported cloud provider: %s", cloudConfig.getCloudProvider()));
-      }
+    setCloudId(cloudConfig.getCloudID());
+    setCloudProvider(cloudConfig.getCloudProvider());
+    switch (CloudProvider.valueOf(cloudConfig.getCloudProvider())) {
+      case AZURE:
+        Properties azureProperties = new Properties();
+        try {
+          InputStream stream = Thread.currentThread().getContextClassLoader()
+              .getResourceAsStream(AZURE_CLOUD_PROPERTY_FILE);
+          azureProperties.load(stream);
+        } catch (IOException e) {
+          String errMsg =
+              "failed to open Helix Azure cloud properties file: " + AZURE_CLOUD_PROPERTY_FILE;
+          throw new IllegalArgumentException(errMsg, e);
+        }
+        LOG.info("Successfully loaded Helix Azure cloud properties: {}", azureProperties);
+        setCloudInfoSources(
+            Collections.singletonList(azureProperties.getProperty(CLOUD_INFO_SOURCE)));
+        setCloudInfoProcessorName(azureProperties.getProperty(CLOUD_INFO_PROCESSOR_NAME));
+        setCloudMaxRetry(Integer.valueOf(azureProperties.getProperty(CLOUD_MAX_RETRY)));
+        setCloudConnectionTimeout(Long.valueOf(azureProperties.getProperty(CONNECTION_TIMEOUT_MS)));
+        setCloudRequestTimeout(Long.valueOf(azureProperties.getProperty(REQUEST_TIMEOUT_MS)));
+        break;
+      case CUSTOMIZED:
+        setCloudInfoSources(cloudConfig.getCloudInfoSources());
+        setCloudInfoProcessorName(cloudConfig.getCloudInfoProcessorName());
+        break;
+      default:
+        throw new HelixException(
+            String.format("Unsupported cloud provider: %s", cloudConfig.getCloudProvider()));
     }
   }
 
@@ -193,5 +190,19 @@ public class HelixCloudProperty {
 
   public void setCustomizedCloudProperties(Properties customizedCloudProperties) {
     _customizedCloudProperties.putAll(customizedCloudProperties);
+  }
+
+  /**
+   * This method will reset all the fields that are included in CloudConfig
+   */
+  private void reset() {
+    setCloudEnabled(false);
+    setCloudId(null);
+    setCloudProvider(null);
+    setCloudInfoSources(null);
+    setCloudInfoProcessorName(null);
+    setCloudMaxRetry(0);
+    setCloudConnectionTimeout(0L);
+    setCloudRequestTimeout(0L);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
@@ -66,7 +66,10 @@ public class HelixManagerProperty {
   }
 
   public HelixCloudProperty getHelixCloudProperty() {
-    return _helixCloudProperty == null ? new HelixCloudProperty() : _helixCloudProperty;
+    if (_helixCloudProperty == null) {
+      _helixCloudProperty = new HelixCloudProperty(CloudConfig.buildEmptyCloudConfig());
+    }
+    return _helixCloudProperty;
   }
 
   public String getVersion() {

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
@@ -67,7 +67,7 @@ public class HelixManagerProperty {
 
   public HelixCloudProperty getHelixCloudProperty() {
     if (_helixCloudProperty == null) {
-      _helixCloudProperty = new HelixCloudProperty(CloudConfig.buildEmptyCloudConfig());
+      _helixCloudProperty = new HelixCloudProperty(new CloudConfig());
     }
     return _helixCloudProperty;
   }

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
@@ -66,11 +66,8 @@ public class HelixManagerProperty {
   }
 
   public HelixCloudProperty getHelixCloudProperty() {
-    return _helixCloudProperty;
-  }
-
-  public void setHelixCloudProperty(CloudConfig cloudConfig) {
-    _helixCloudProperty = new HelixCloudProperty(cloudConfig);
+    return _helixCloudProperty == null ? HelixCloudProperty.EMPTY_HELIX_CLOUD_PROPERTY
+        : _helixCloudProperty;
   }
 
   public String getVersion() {

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
@@ -66,8 +66,7 @@ public class HelixManagerProperty {
   }
 
   public HelixCloudProperty getHelixCloudProperty() {
-    return _helixCloudProperty == null ? HelixCloudProperty.EMPTY_HELIX_CLOUD_PROPERTY
-        : _helixCloudProperty;
+    return _helixCloudProperty == null ? new HelixCloudProperty() : _helixCloudProperty;
   }
 
   public String getVersion() {

--- a/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
@@ -109,8 +109,10 @@ public final class HelixPropertyFactory {
       // The try-catch logic is for backward compatibility reason only. Even if the cluster is not set
       // up yet, constructing a new ZKHelixManager should not throw an exception
       try {
-        cloudConfig = configAccessor.getCloudConfig(clusterName) == null ? new CloudConfig()
-            : configAccessor.getCloudConfig(clusterName);
+        cloudConfig = configAccessor.getCloudConfig(clusterName);
+        if (cloudConfig == null) {
+          cloudConfig = new CloudConfig();
+        }
       } catch (HelixException e) {
         cloudConfig = new CloudConfig();
       }

--- a/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
@@ -109,10 +109,10 @@ public final class HelixPropertyFactory {
       // The try-catch logic is for backward compatibility reason only. Even if the cluster is not set
       // up yet, constructing a new ZKHelixManager should not throw an exception
       try {
-        cloudConfig = configAccessor.getCloudConfig(clusterName) == null ? CloudConfig.buildEmptyCloudConfig()
+        cloudConfig = configAccessor.getCloudConfig(clusterName) == null ? new CloudConfig()
             : configAccessor.getCloudConfig(clusterName);
       } catch (HelixException e) {
-        cloudConfig = CloudConfig.buildEmptyCloudConfig();
+        cloudConfig = new CloudConfig();
       }
     } finally {
       // Use a try-finally to make sure zkclient connection is closed properly

--- a/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
@@ -70,10 +70,6 @@ public final class HelixPropertyFactory {
     return new HelixManagerProperty(properties, cloudConfig);
   }
 
-  private static CloudConfig buildEmptyCloudConfig() {
-    return new CloudConfig.Builder().setCloudEnabled(false).build();
-  }
-
   /**
    * Retrieve the CloudConfig of the cluster if available.
    * Note: the reason we create a dedicated zk client here is because we need an isolated access to
@@ -113,10 +109,10 @@ public final class HelixPropertyFactory {
       // The try-catch logic is for backward compatibility reason only. Even if the cluster is not set
       // up yet, constructing a new ZKHelixManager should not throw an exception
       try {
-        cloudConfig = configAccessor.getCloudConfig(clusterName) == null ? buildEmptyCloudConfig()
+        cloudConfig = configAccessor.getCloudConfig(clusterName) == null ? CloudConfig.buildEmptyCloudConfig()
             : configAccessor.getCloudConfig(clusterName);
       } catch (HelixException e) {
-        cloudConfig = buildEmptyCloudConfig();
+        cloudConfig = CloudConfig.buildEmptyCloudConfig();
       }
     } finally {
       // Use a try-finally to make sure zkclient connection is closed properly

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -271,8 +271,8 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     _stateListener = stateListener;
     // read cloud config from ZK and set cloudConfig in HelixManagerProperty
     _helixManagerProperty = helixManagerProperty;
-    _helixManagerProperty
-        .setHelixCloudProperty(HelixPropertyFactory.getCloudConfig(_zkAddress, _clusterName));
+    _helixManagerProperty.getHelixCloudProperty().populateFieldsWithCloudConfig(
+        HelixPropertyFactory.getCloudConfig(_zkAddress, _clusterName));
 
     /**
      * use system property if available

--- a/helix-core/src/main/java/org/apache/helix/model/CloudConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/CloudConfig.java
@@ -94,6 +94,10 @@ public class CloudConfig extends HelixProperty {
     }
   }
 
+  public static CloudConfig buildEmptyCloudConfig() {
+    return new CloudConfig.Builder().setCloudEnabled(false).build();
+  }
+
   /**
    * Enable/Disable the CLOUD_ENABLED field.
    * @param enabled

--- a/helix-core/src/main/java/org/apache/helix/model/CloudConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/CloudConfig.java
@@ -58,8 +58,9 @@ public class CloudConfig extends HelixProperty {
   /**
    * Instantiate the CloudConfig for the cloud
    */
-  private CloudConfig() {
+  public CloudConfig() {
     super(CLOUD_CONFIG_KW);
+    setCloudEnabled(false);
   }
 
   /**
@@ -92,10 +93,6 @@ public class CloudConfig extends HelixProperty {
         _record.setListField(CloudConfigProperty.CLOUD_INFO_SOURCE.name(), cloudInfoSource);
       }
     }
-  }
-
-  public static CloudConfig buildEmptyCloudConfig() {
-    return new CloudConfig.Builder().setCloudEnabled(false).build();
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixJavaApis.java
@@ -474,7 +474,7 @@ public class TestMultiZkHelixJavaApis {
     CloudConfig cloudConfig = cloudConfigBuilder.build();
     HelixManagerProperty helixManagerProperty =
         propertyBuilder.setRealmAWareZkConnectionConfig(validZkConnectionConfig).build();
-    helixManagerProperty.setHelixCloudProperty(cloudConfig);
+    helixManagerProperty.getHelixCloudProperty().populateFieldsWithCloudConfig(cloudConfig);
 
     class TestZKHelixManager extends ZKHelixManager {
       public TestZKHelixManager(String clusterName, String participantName,


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1985

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This is a fix based on a previous [PR](https://github.com/apache/helix/pull/1986). The previous PR retrieves cloud config from zk and replace entire HelixCloudProperty object, which may cause some fields that user pass in in HelixCloudProperty that are not  included in cloud config get missing. This commit changes the logic to only populate fields in HelixCloudProperty with values that are present in cloud config, and leave other fields unchanged.

### Tests

- [x] The following tests are written for this issue:

TestMultiZkHelixJavaApis.testZKHelixManagerCloudConfig

- The following is the result of the "mvn test" command on the appropriate module:

[info] ./helix-core/target/surefire-reports/TestSuite.txt: Tests run: 1296, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,863.791 s - in TestSuite

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
