### PR TITLE
Fix TestCloudEventCallbackProperty by bypassing connecting to zk

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/cloud/event/MockCloudEventAwareHelixManager.java
+++ b/helix-core/src/test/java/org/apache/helix/cloud/event/MockCloudEventAwareHelixManager.java
@@ -1,0 +1,378 @@
+package org.apache.helix.cloud.event;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.helix.ClusterMessagingService;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixCloudProperty;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerProperties;
+import org.apache.helix.HelixManagerProperty;
+import org.apache.helix.InstanceType;
+import org.apache.helix.LiveInstanceInfoProvider;
+import org.apache.helix.PreConnectCallback;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.api.listeners.ClusterConfigChangeListener;
+import org.apache.helix.api.listeners.ConfigChangeListener;
+import org.apache.helix.api.listeners.ControllerChangeListener;
+import org.apache.helix.api.listeners.CurrentStateChangeListener;
+import org.apache.helix.api.listeners.CustomizedStateChangeListener;
+import org.apache.helix.api.listeners.CustomizedStateConfigChangeListener;
+import org.apache.helix.api.listeners.CustomizedStateRootChangeListener;
+import org.apache.helix.api.listeners.CustomizedViewChangeListener;
+import org.apache.helix.api.listeners.CustomizedViewRootChangeListener;
+import org.apache.helix.api.listeners.ExternalViewChangeListener;
+import org.apache.helix.api.listeners.IdealStateChangeListener;
+import org.apache.helix.api.listeners.InstanceConfigChangeListener;
+import org.apache.helix.api.listeners.LiveInstanceChangeListener;
+import org.apache.helix.api.listeners.MessageListener;
+import org.apache.helix.api.listeners.ResourceConfigChangeListener;
+import org.apache.helix.api.listeners.ScopedConfigChangeListener;
+import org.apache.helix.cloud.constants.CloudProvider;
+import org.apache.helix.cloud.event.helix.HelixCloudEventListener;
+import org.apache.helix.controller.pipeline.Pipeline;
+import org.apache.helix.healthcheck.ParticipantHealthReportCollector;
+import org.apache.helix.model.CloudConfig;
+import org.apache.helix.model.HelixConfigScope;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+
+public class MockCloudEventAwareHelixManager implements HelixManager {
+  private final HelixManagerProperty _helixManagerProperty;
+  private CloudEventListener _cloudEventListener;
+
+  /**
+   * Use a mock zk helix manager to avoid the need to connect to zk
+   * Change the cloud event related logic here every time the real logic is modified in ZKHelixManager
+   */
+  public MockCloudEventAwareHelixManager(HelixManagerProperty helixManagerProperty) {
+    _helixManagerProperty = helixManagerProperty;
+    _helixManagerProperty.getHelixCloudProperty().populateFieldsWithCloudConfig(
+        new CloudConfig.Builder().setCloudEnabled(true).setCloudProvider(CloudProvider.AZURE)
+            .build());
+  }
+
+  public void connect() throws IllegalAccessException, InstantiationException {
+    if (_helixManagerProperty != null) {
+      HelixCloudProperty helixCloudProperty = _helixManagerProperty.getHelixCloudProperty();
+      if (helixCloudProperty != null && helixCloudProperty.isCloudEventCallbackEnabled()) {
+        _cloudEventListener =
+            new HelixCloudEventListener(helixCloudProperty.getCloudEventCallbackProperty(), this);
+        CloudEventHandlerFactory.getInstance().registerCloudEventListener(_cloudEventListener);
+      }
+    }
+  }
+
+  public void disconnect() {
+    if (_cloudEventListener != null) {
+      CloudEventHandlerFactory.getInstance().unregisterCloudEventListener(_cloudEventListener);
+      _cloudEventListener = null;
+    }
+  }
+
+  @Override
+  public boolean isConnected() {
+    return false;
+  }
+
+  @Override
+  public void addIdealStateChangeListener(IdealStateChangeListener listener) throws Exception {
+
+  }
+
+  @Override
+  public void addIdealStateChangeListener(org.apache.helix.IdealStateChangeListener listener)
+      throws Exception {
+
+  }
+
+  @Override
+  public void addLiveInstanceChangeListener(LiveInstanceChangeListener listener) throws Exception {
+
+  }
+
+  @Override
+  public void addLiveInstanceChangeListener(org.apache.helix.LiveInstanceChangeListener listener)
+      throws Exception {
+
+  }
+
+  @Override
+  public void addConfigChangeListener(ConfigChangeListener listener) throws Exception {
+
+  }
+
+  @Override
+  public void addInstanceConfigChangeListener(InstanceConfigChangeListener listener)
+      throws Exception {
+
+  }
+
+  @Override
+  public void addInstanceConfigChangeListener(
+      org.apache.helix.InstanceConfigChangeListener listener) throws Exception {
+
+  }
+
+  @Override
+  public void addResourceConfigChangeListener(ResourceConfigChangeListener listener)
+      throws Exception {
+
+  }
+
+  @Override
+  public void addCustomizedStateConfigChangeListener(CustomizedStateConfigChangeListener listener)
+      throws Exception {
+
+  }
+
+  @Override
+  public void addClusterfigChangeListener(ClusterConfigChangeListener listener) throws Exception {
+
+  }
+
+  @Override
+  public void addConfigChangeListener(ScopedConfigChangeListener listener,
+      HelixConfigScope.ConfigScopeProperty scope) throws Exception {
+
+  }
+
+  @Override
+  public void addConfigChangeListener(org.apache.helix.ScopedConfigChangeListener listener,
+      HelixConfigScope.ConfigScopeProperty scope) throws Exception {
+
+  }
+
+  @Override
+  public void addMessageListener(MessageListener listener, String instanceName) throws Exception {
+
+  }
+
+  @Override
+  public void addMessageListener(org.apache.helix.MessageListener listener, String instanceName)
+      throws Exception {
+
+  }
+
+  @Override
+  public void addCurrentStateChangeListener(CurrentStateChangeListener listener,
+      String instanceName, String sessionId) throws Exception {
+
+  }
+
+  @Override
+  public void addCurrentStateChangeListener(org.apache.helix.CurrentStateChangeListener listener,
+      String instanceName, String sessionId) throws Exception {
+
+  }
+
+  @Override
+  public void addTaskCurrentStateChangeListener(CurrentStateChangeListener listener,
+      String instanceName, String sessionId) throws Exception {
+
+  }
+
+  @Override
+  public void addCustomizedStateRootChangeListener(CustomizedStateRootChangeListener listener,
+      String instanceName) throws Exception {
+
+  }
+
+  @Override
+  public void addCustomizedStateChangeListener(CustomizedStateChangeListener listener,
+      String instanceName, String stateName) throws Exception {
+
+  }
+
+  @Override
+  public void addExternalViewChangeListener(ExternalViewChangeListener listener) throws Exception {
+
+  }
+
+  @Override
+  public void addCustomizedViewChangeListener(CustomizedViewChangeListener listener,
+      String customizedStateType) throws Exception {
+
+  }
+
+  @Override
+  public void addCustomizedViewRootChangeListener(CustomizedViewRootChangeListener listener)
+      throws Exception {
+
+  }
+
+  @Override
+  public void addTargetExternalViewChangeListener(ExternalViewChangeListener listener)
+      throws Exception {
+
+  }
+
+  @Override
+  public void addExternalViewChangeListener(org.apache.helix.ExternalViewChangeListener listener)
+      throws Exception {
+
+  }
+
+  @Override
+  public void addControllerListener(ControllerChangeListener listener) {
+
+  }
+
+  @Override
+  public void addControllerListener(org.apache.helix.ControllerChangeListener listener) {
+
+  }
+
+  @Override
+  public void addControllerMessageListener(MessageListener listener) {
+
+  }
+
+  @Override
+  public void addControllerMessageListener(org.apache.helix.MessageListener listener) {
+
+  }
+
+  @Override
+  public void setEnabledControlPipelineTypes(Set<Pipeline.Type> types) {
+
+  }
+
+  @Override
+  public boolean removeListener(PropertyKey key, Object listener) {
+    return false;
+  }
+
+  @Override
+  public HelixDataAccessor getHelixDataAccessor() {
+    return null;
+  }
+
+  @Override
+  public ConfigAccessor getConfigAccessor() {
+    return null;
+  }
+
+  @Override
+  public String getClusterName() {
+    return null;
+  }
+
+  @Override
+  public String getMetadataStoreConnectionString() {
+    return null;
+  }
+
+  @Override
+  public String getInstanceName() {
+    return null;
+  }
+
+  @Override
+  public String getSessionId() {
+    return null;
+  }
+
+  @Override
+  public long getLastNotificationTime() {
+    return 0;
+  }
+
+  @Override
+  public HelixAdmin getClusterManagmentTool() {
+    return null;
+  }
+
+  @Override
+  public ZkHelixPropertyStore<ZNRecord> getHelixPropertyStore() {
+    return null;
+  }
+
+  @Override
+  public ClusterMessagingService getMessagingService() {
+    return null;
+  }
+
+  @Override
+  public InstanceType getInstanceType() {
+    return null;
+  }
+
+  @Override
+  public String getVersion() {
+    return null;
+  }
+
+  @Override
+  public HelixManagerProperties getProperties() {
+    return null;
+  }
+
+  @Override
+  public StateMachineEngine getStateMachineEngine() {
+    return null;
+  }
+
+  @Override
+  public Long getSessionStartTime() {
+    return null;
+  }
+
+  @Override
+  public Optional<String> getSessionIdIfLead() {
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean isLeader() {
+    return false;
+  }
+
+  @Override
+  public void startTimerTasks() {
+
+  }
+
+  @Override
+  public void stopTimerTasks() {
+
+  }
+
+  @Override
+  public void addPreConnectCallback(PreConnectCallback callback) {
+
+  }
+
+  @Override
+  public void setLiveInstanceInfoProvider(LiveInstanceInfoProvider liveInstanceInfoProvider) {
+
+  }
+
+  @Override
+  public ParticipantHealthReportCollector getHealthReportCollector() {
+    return null;
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes #1982

Due to logical change in ZKHelixManager constructor in a [previous commit](https://github.com/apache/helix/pull/1986), TestCloudEventCallbackProperty broke because in this test it doesn't connect to zookeeper server.
To fix this test, we separated MockCloudEventAwareHelixManager （previously called MockEventAwareZKHelixManager, nested inside TestCloudEventCallbackProperty）into a class, and include all and only the logics related to cloud events in MockCloudEventAwareHelixManager. More detailed, we mock a cloud config object retrieved from zk to bypass connection to zk.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Modified: TestCloudEventCallbackProperty
Added: MockCloudEventAwareHelixManager

### Tests

- [x] The following tests are written for this issue:

N/A

- The following is the result of the "mvn test" command on the appropriate module:


Default Suite
Total tests run: 3, Failures: 0, Skips: 0


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
