### PR TITLE
Improve ZkClientMonitor and ZkClientPathMonitor performance

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/metric/ZkClientPathMonitor.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/metric/ZkClientPathMonitor.java
@@ -42,16 +42,16 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
   private final PredefinedPath _path;
 
   public enum PredefinedPath {
-    IdealStates(".*/IDEALSTATES/.*"),
-    Instances(".*/INSTANCES/.*"),
-    Configs(".*/CONFIGS/.*"),
-    Controller(".*/CONTROLLER/.*"),
-    ExternalView(".*/EXTERNALVIEW/.*"),
-    LiveInstances(".*/LIVEINSTANCES/.*"),
-    PropertyStore(".*/PROPERTYSTORE/.*"),
-    CurrentStates(".*/CURRENTSTATES/.*"),
-    Messages(".*/MESSAGES/.*"),
-    Root(".*");
+    IdealStates("/IDEALSTATES/"),
+    Instances("/INSTANCES/"),
+    Configs("/CONFIGS/"),
+    Controller("/CONTROLLER/"),
+    ExternalView("/EXTERNALVIEW/"),
+    LiveInstances("/LIVEINSTANCES/"),
+    PropertyStore("/PROPERTYSTORE/"),
+    CurrentStates("/CURRENTSTATES/"),
+    Messages("/MESSAGES/"),
+    Root("");
 
     private final String _matchString;
 
@@ -60,7 +60,7 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
     }
 
     public boolean match(String path) {
-      return path.matches(this._matchString);
+      return path.contains(this._matchString);
     }
   }
 
@@ -135,27 +135,27 @@ public class ZkClientPathMonitor extends DynamicMBeanProvider {
             path.name());
 
     _writeTotalLatencyCounter =
-        new SimpleDynamicMetric(PredefinedMetricDomains.WriteTotalLatencyCounter.name(), 0l);
+        new SimpleDynamicMetric<>(PredefinedMetricDomains.WriteTotalLatencyCounter.name(), 0L);
     _readTotalLatencyCounter =
-        new SimpleDynamicMetric(PredefinedMetricDomains.ReadTotalLatencyCounter.name(), 0l);
+        new SimpleDynamicMetric<>(PredefinedMetricDomains.ReadTotalLatencyCounter.name(), 0L);
     _writeFailureCounter =
-        new SimpleDynamicMetric(PredefinedMetricDomains.WriteFailureCounter.name(), 0l);
+        new SimpleDynamicMetric<>(PredefinedMetricDomains.WriteFailureCounter.name(), 0L);
     _readFailureCounter =
-        new SimpleDynamicMetric(PredefinedMetricDomains.ReadFailureCounter.name(), 0l);
+        new SimpleDynamicMetric<>(PredefinedMetricDomains.ReadFailureCounter.name(), 0L);
     _writeAsyncFailureCounter =
-        new SimpleDynamicMetric(PredefinedMetricDomains.WriteAsyncFailureCounter.name(), 0l);
+        new SimpleDynamicMetric<>(PredefinedMetricDomains.WriteAsyncFailureCounter.name(), 0L);
     _readAsyncFailureCounter =
-        new SimpleDynamicMetric(PredefinedMetricDomains.ReadAsyncFailureCounter.name(), 0l);
+        new SimpleDynamicMetric<>(PredefinedMetricDomains.ReadAsyncFailureCounter.name(), 0L);
     _writeBytesCounter =
-        new SimpleDynamicMetric(PredefinedMetricDomains.WriteBytesCounter.name(), 0l);
+        new SimpleDynamicMetric<>(PredefinedMetricDomains.WriteBytesCounter.name(), 0L);
     _readBytesCounter =
-        new SimpleDynamicMetric(PredefinedMetricDomains.ReadBytesCounter.name(), 0l);
-    _writeCounter = new SimpleDynamicMetric(PredefinedMetricDomains.WriteCounter.name(), 0l);
-    _readCounter = new SimpleDynamicMetric(PredefinedMetricDomains.ReadCounter.name(), 0l);
+        new SimpleDynamicMetric<>(PredefinedMetricDomains.ReadBytesCounter.name(), 0L);
+    _writeCounter = new SimpleDynamicMetric<>(PredefinedMetricDomains.WriteCounter.name(), 0L);
+    _readCounter = new SimpleDynamicMetric<>(PredefinedMetricDomains.ReadCounter.name(), 0L);
     _writeAsyncCounter =
-        new SimpleDynamicMetric(PredefinedMetricDomains.WriteAsyncCounter.name(), 0l);
+        new SimpleDynamicMetric<>(PredefinedMetricDomains.WriteAsyncCounter.name(), 0L);
     _readAsyncCounter =
-        new SimpleDynamicMetric(PredefinedMetricDomains.ReadAsyncCounter.name(), 0l);
+        new SimpleDynamicMetric<>(PredefinedMetricDomains.ReadAsyncCounter.name(), 0L);
 
     _readLatencyGauge = new HistogramDynamicMetric(PredefinedMetricDomains.ReadLatencyGauge.name(),
         new Histogram(


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #2020

### Description

- Replace `String#matches` with more efficient `String#contains` in `ZkClientPathMonitor`
- Refactor `record*` methods in `ZkClientMonitor` to avoid repetition and simplify matching logic


### Tests

Covered by existing tests, in particular
- org.apache.helix.zookeeper.impl.client.TestRawZkClient
- org.apache.helix.monitoring.mbeans.TestZkClientMonitor

The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestNoThrottleDisabledPartitions.testDisablingTopStateReplicaByDisablingInstance:98 expected:<false> but was:<true>
[ERROR]   TestNoThrottleDisabledPartitions.testNoThrottleOnDisabledInstance:231->setupEnvironment:317->setupCluster:436 » ZkClient
[ERROR]   TestP2PNoDuplicatedMessage.testP2PStateTransitionEnabled:180 expected:<true> but was:<false>
[ERROR]   TestRecurringJobQueue.testDeletingRecurrentQueueWithHistory:298 expected:<true> but was:<false>
[ERROR]   TestResourceThreadpoolSize.testBatchMessageThreadPoolSize:206 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1300, Failures: 5, Errors: 0, Skipped: 0

```
All of the failures appear to be unrelated

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
