### PR TITLE
Support disable fault zone as an entity and code refactoring

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -38,7 +38,6 @@ import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.util.ConfigStringUtil;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.api.config.ViewClusterSourceConfig;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
 /**
  * Cluster configurations
@@ -91,6 +90,8 @@ public class ClusterConfig extends HelixProperty {
     VIEW_CLUSTER_SOURCES, // Map field, key is the name of source cluster, value is
     // ViewClusterSourceConfig JSON string
     VIEW_CLUSTER_REFRESH_PERIOD, // In second
+    // The disabled zones
+    DISABLED_ZONES,
     // Specifies job types and used for quota allocation
     QUOTA_TYPES,
 
@@ -853,6 +854,33 @@ public class ClusterConfig extends HelixProperty {
       return Collections.emptyList();
     }
     return capacityKeys;
+  }
+
+  public Map<String, String> getDisabledZones() {
+    Map<String, String> disabledZones = _record.getMapField(ClusterConfigProperty.DISABLED_ZONES.name());
+    return disabledZones == null ? Collections.emptyMap() : ImmutableMap.copyOf(disabledZones);
+  }
+
+  public void addDisabledZone(String zoneId) {
+    Map<String, String> disabledZones = new HashMap<>();
+    if (_record.getMapField(ClusterConfigProperty.DISABLED_ZONES.name()) != null) {
+      disabledZones.putAll(_record.getMapField(ClusterConfigProperty.DISABLED_ZONES.name()));
+    }
+    disabledZones.put(zoneId, String.valueOf(System.currentTimeMillis()));
+    setDisabledZones(disabledZones);
+  }
+
+  public void removeDisabledZone(String zoneId) {
+    Map<String, String> disabledZones = new HashMap<>();
+    if (_record.getMapField(ClusterConfigProperty.DISABLED_ZONES.name()) != null) {
+      disabledZones.putAll(_record.getMapField(ClusterConfigProperty.DISABLED_ZONES.name()));
+    }
+    disabledZones.remove(zoneId);
+    setDisabledZones(disabledZones);
+  }
+
+  public void setDisabledZones(Map<String, String> zones) {
+    _record.setMapField(ClusterConfigProperty.DISABLED_ZONES.name(), zones);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
@@ -128,9 +128,28 @@ public class InstanceValidationUtil {
     if (clusterConfig == null) {
       return enabledInInstanceConfig;
     }
-    boolean enabledInClusterConfig =
-        !clusterConfig.getDisabledInstances().containsKey(instanceConfig.getInstanceName());
-    return enabledInClusterConfig && enabledInInstanceConfig;
+    Map<String, String> disabledInstancesFromClusterConfig = clusterConfig.getDisabledInstances();
+    boolean enabledInClusterConfig = disabledInstancesFromClusterConfig == null
+        || !disabledInstancesFromClusterConfig.containsKey(instanceConfig.getInstanceName());
+
+    boolean disabledInZone = isInstanceInDisabledZones(instanceConfig, clusterConfig);
+    return enabledInClusterConfig && enabledInInstanceConfig && !disabledInZone;
+  }
+
+  /**
+   * Check if an instance is in disabled zone of a cluster
+   * @param instanceConfig instance config
+   * @param clusterConfig cluster config
+   * @return True if the instance is in a disabled zone of the cluster
+   */
+  private static boolean isInstanceInDisabledZones(InstanceConfig instanceConfig, ClusterConfig clusterConfig) {
+    if (clusterConfig == null) {
+      return false;
+    }
+    Map<String, String> disabledZones = clusterConfig.getDisabledZones();
+    String faultZoneType = clusterConfig.getFaultZoneType();
+    return instanceConfig.getDomainAsMap().containsKey(faultZoneType)
+        && disabledZones.containsKey(instanceConfig.getDomainAsMap().get(faultZoneType));
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.Set;
 import org.apache.helix.controller.rebalancer.constraint.MockAbnormalStateResolver;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.testng.Assert;
@@ -395,6 +396,22 @@ public class TestClusterConfig {
     resolverMap.clear();
     resolverMap.put(MasterSlaveSMD.name, "");
     trySetInvalidAbnormalStatesResolverMap(testConfig, resolverMap);
+  }
+
+  @Test
+  public void testSetDisabledZones() {
+    ClusterConfig testConfig = new ClusterConfig("testConfig");
+    Assert.assertTrue(testConfig.getDisabledZones().isEmpty());
+    testConfig.addDisabledZone("zone1");
+    testConfig.addDisabledZone("zone2");
+    testConfig.addDisabledZone("zone1");
+    Assert.assertEquals(testConfig.getDisabledZones().size(), 2);
+    Assert.assertTrue(testConfig.getDisabledZones().containsKey("zone1"));
+    Assert.assertTrue(testConfig.getDisabledZones().containsKey("zone2"));
+
+    testConfig.removeDisabledZone("zone1");
+    Assert.assertEquals(testConfig.getDisabledZones().size(), 1);
+    Assert.assertTrue(testConfig.getDisabledZones().containsKey("zone2"));
   }
 
   private void trySetInvalidAbnormalStatesResolverMap(ClusterConfig testConfig,

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ZoneAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ZoneAccessor.java
@@ -1,0 +1,101 @@
+package org.apache.helix.rest.server.resources.helix;
+
+import com.codahale.metrics.annotation.ResponseMetered;
+import com.codahale.metrics.annotation.Timed;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+import org.apache.helix.AccessOption;
+import org.apache.helix.BaseDataAccessor;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixException;
+import org.apache.helix.PropertyPathBuilder;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.rest.common.HttpConstants;
+import org.apache.helix.rest.server.filters.ClusterAuth;
+import org.apache.helix.rest.server.filters.NamespaceAuth;
+import org.apache.helix.rest.server.json.cluster.ClusterTopology;
+import org.apache.helix.rest.server.service.ClusterService;
+import org.apache.helix.rest.server.service.ClusterServiceImpl;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.zkclient.DataUpdater;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@ClusterAuth
+@Path("/clusters/{clusterId}/zones")
+public class ZoneAccessor extends AbstractHelixResource {
+  private final static Logger LOG = LoggerFactory.getLogger(ZoneAccessor.class);
+
+  @NamespaceAuth
+  @ResponseMetered(name = HttpConstants.READ_REQUEST)
+  @Timed(name = HttpConstants.READ_REQUEST)
+  @GET
+  public Response getZones(@PathParam("clusterId") String clusterId) {
+    ClusterService clusterService =
+        new ClusterServiceImpl(getDataAccssor(clusterId), getConfigAccessor());
+    ClusterTopology clusterTopology = clusterService.getClusterTopology(clusterId);
+    Set<String> zones = clusterTopology.getZones().stream()
+        .map(ClusterTopology.Zone::getId)
+        .collect(Collectors.toSet());
+    return JSONRepresentation(zones);
+  }
+
+  @NamespaceAuth
+  @ResponseMetered(name = HttpConstants.READ_REQUEST)
+  @Timed(name = HttpConstants.READ_REQUEST)
+  @GET
+  @Path("disabledZones")
+  public Response getDisabledZones(@PathParam("clusterId") String clusterId) {
+    ConfigAccessor accessor = getConfigAccessor();
+    ClusterConfig clusterConfig = accessor.getClusterConfig(clusterId);
+    return JSONRepresentation(clusterConfig.getDisabledZones());
+  }
+
+  @ClusterAuth
+  @ResponseMetered(name = HttpConstants.WRITE_REQUEST)
+  @Timed(name = HttpConstants.WRITE_REQUEST)
+  @POST
+  @Path("{zoneId}")
+  public Response update(@PathParam("clusterId") String clusterId, @PathParam("zoneId") String zoneId,
+      @QueryParam("command") String commandStr) {
+    Command command;
+    try {
+      command = getCommand(commandStr);
+    } catch (HelixException ex) {
+      return badRequest(ex.getMessage());
+    }
+    HelixDataAccessor accessor = getDataAccssor(clusterId);
+    BaseDataAccessor<ZNRecord> baseDataAccessor = accessor.getBaseDataAccessor();
+    String path = PropertyPathBuilder.clusterConfig(clusterId);
+
+    baseDataAccessor.update(path, currentData -> {
+      if (currentData == null) {
+        throw new HelixException("Cluster: " + clusterId + ": cluster config is null");
+      }
+      ClusterConfig clusterConfig = new ClusterConfig(currentData);
+      switch (command) {
+        case enable:
+          LOG.info("Enable zone {} in cluster {}.", zoneId, clusterId);
+          clusterConfig.removeDisabledZone(zoneId);
+          break;
+        case disable:
+          LOG.info("Disable zone {} in cluster {}.", zoneId, clusterId);
+          clusterConfig.addDisabledZone(zoneId);
+          break;
+        default:
+          throw new HelixException("Illegal command: " + commandStr);
+      }
+      return clusterConfig.getRecord();
+    }, AccessOption.PERSISTENT);
+
+    return OK();
+  }
+}

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestZoneAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestZoneAccessor.java
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
 public class TestZoneAccessor extends AbstractTestClass  {
 
   private HelixDataAccessor _helixDataAccessor;
-  private static final String TEST_CLUSTER = "TestCluster_0";
+  private static final String TEST_CLUSTER = "TestCluster_zoneAccessor";
   private final String _instance1 = TEST_CLUSTER + "localhost_12918";
   private final String _instance2 = TEST_CLUSTER + "localhost_12922";
   private final String _instance3 = TEST_CLUSTER + "localhost_12923";
@@ -37,11 +37,15 @@ public class TestZoneAccessor extends AbstractTestClass  {
 
   @BeforeTest
   public void beforeTest() {
-    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(TEST_CLUSTER);
+    _gSetupTool.addCluster(TEST_CLUSTER, true);
+    _clusters.add(TEST_CLUSTER);
+    Set<String> instances = createInstances(TEST_CLUSTER, 10);
+    ClusterConfig clusterConfig = new ClusterConfig(TEST_CLUSTER);
     clusterConfig.setTopology("/zone/instance");
     clusterConfig.setFaultZoneType("zone");
     clusterConfig.setTopologyAwareEnabled(true);
-    _configAccessor.updateClusterConfig(TEST_CLUSTER, clusterConfig);
+    _configAccessor.setClusterConfig(TEST_CLUSTER, clusterConfig);
+    _clusterControllerManagers.add(startController(TEST_CLUSTER));
 
     _helixDataAccessor = new ZKHelixDataAccessor(TEST_CLUSTER, _baseAccessor);
     // setup up 10 instances across 5 zones
@@ -52,6 +56,7 @@ public class TestZoneAccessor extends AbstractTestClass  {
       instanceConfig.setDomain("zone=zone_" + i / 2 + ",instance=" + instanceName);
       _helixDataAccessor.setProperty(_helixDataAccessor.keyBuilder().instanceConfig(instanceName), instanceConfig);
     }
+    startInstances(TEST_CLUSTER, instances, 10);
   }
 
   @Test

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestZoneAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestZoneAccessor.java
@@ -1,0 +1,147 @@
+package org.apache.helix.rest.server;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.InstanceConfig;
+import org.junit.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+
+public class TestZoneAccessor extends AbstractTestClass  {
+
+  private HelixDataAccessor _helixDataAccessor;
+  private static final String TEST_CLUSTER = "TestCluster_0";
+  private final String _instance1 = TEST_CLUSTER + "localhost_12918";
+  private final String _instance2 = TEST_CLUSTER + "localhost_12922";
+  private final String _instance3 = TEST_CLUSTER + "localhost_12923";
+  private final String _instanceUrl1 =
+      String.format("clusters/%s/instances/%s", TEST_CLUSTER, _instance1);
+  private final String _instanceUrl2 =
+      String.format("clusters/%s/instances/%s", TEST_CLUSTER, _instance2);
+  private final String _instanceUrl3 =
+      String.format("clusters/%s/instances/%s", TEST_CLUSTER, _instance3);
+
+  @BeforeTest
+  public void beforeTest() {
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(TEST_CLUSTER);
+    clusterConfig.setTopology("/zone/instance");
+    clusterConfig.setFaultZoneType("zone");
+    clusterConfig.setTopologyAwareEnabled(true);
+    _configAccessor.updateClusterConfig(TEST_CLUSTER, clusterConfig);
+
+    _helixDataAccessor = new ZKHelixDataAccessor(TEST_CLUSTER, _baseAccessor);
+    // setup up 10 instances across 5 zones
+    for (int i = 0; i < 10; i++) {
+      String instanceName = TEST_CLUSTER + "localhost_" + (12918 + i);
+      InstanceConfig instanceConfig =
+          _helixDataAccessor.getProperty(_helixDataAccessor.keyBuilder().instanceConfig(instanceName));
+      instanceConfig.setDomain("zone=zone_" + i / 2 + ",instance=" + instanceName);
+      _helixDataAccessor.setProperty(_helixDataAccessor.keyBuilder().instanceConfig(instanceName), instanceConfig);
+    }
+  }
+
+  @Test
+  public void testDisabledZones() throws JsonProcessingException {
+    String zonesUrl = String.format("clusters/%s/zones", TEST_CLUSTER);
+    String disableUrl = String.format("clusters/%s/zones/disabledZones", TEST_CLUSTER);
+
+    Set<String> zones = getSetFromRest(zonesUrl);
+    Assert.assertEquals(zones.size(), 5);
+
+    Set<String> disabledZones = getMapFromRest(disableUrl).keySet();
+    Assert.assertTrue(disabledZones.isEmpty());
+
+    post(zonesUrl + "/zone_2",
+        ImmutableMap.of("command", "disable"),
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.OK.getStatusCode());
+
+    disabledZones = getMapFromRest(disableUrl).keySet();
+    Assert.assertEquals(disabledZones.size(), 1);
+    Assert.assertTrue(disabledZones.contains("zone_2"));
+
+    post(zonesUrl + "/zone_1",
+        ImmutableMap.of("command", "disable"),
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.OK.getStatusCode());
+    post(zonesUrl + "/zone_2",
+        ImmutableMap.of("command", "enable"),
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.OK.getStatusCode());
+    post(zonesUrl + "/zone_3",
+        ImmutableMap.of("command", "disable"),
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.OK.getStatusCode());
+    post(zonesUrl + "/zone_4",
+        ImmutableMap.of("command", "enable"),
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.OK.getStatusCode());
+    disabledZones = getMapFromRest(disableUrl).keySet();
+    Assert.assertEquals(disabledZones.size(), 2);
+    Assert.assertTrue(disabledZones.contains("zone_1"));
+    Assert.assertTrue(disabledZones.contains("zone_3"));
+
+    post(zonesUrl + "/zone_1",
+        ImmutableMap.of("command", "enable"),
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.OK.getStatusCode());
+    post(zonesUrl + "/zone_3",
+        ImmutableMap.of("command", "enable"),
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.OK.getStatusCode());
+  }
+
+  @Test(dependsOnMethods = "testDisabledZones")
+  public void testDisabledInstancesFromCache() {
+    BaseControllerDataProvider cache = new BaseControllerDataProvider(TEST_CLUSTER, "test-pipeline");
+    String zonesUrl = String.format("clusters/%s/zones", TEST_CLUSTER);
+
+    post(zonesUrl + "/zone_2",
+        ImmutableMap.of("command", "disable"),
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.OK.getStatusCode());
+    post(_instanceUrl1,
+        ImmutableMap.of("command", "disable"),
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.OK.getStatusCode());
+    post(_instanceUrl2,
+        ImmutableMap.of("command", "disable"),
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.OK.getStatusCode());
+    post(_instanceUrl3,
+        ImmutableMap.of("command", "enable"),
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.OK.getStatusCode());
+
+    cache.refresh(_helixDataAccessor);
+    Set<String> disabledInstancesFromCache = cache.getDisabledInstances();
+    Assert.assertEquals(disabledInstancesFromCache.size(), 3);
+    Assert.assertTrue(disabledInstancesFromCache.contains(_instance1));
+    Assert.assertTrue(disabledInstancesFromCache.contains(_instance2));
+    Assert.assertTrue(disabledInstancesFromCache.contains(_instance3));
+  }
+
+  private Map<String, String> getMapFromRest(String url) throws JsonProcessingException {
+    String response = get(url, null, Response.Status.OK.getStatusCode(), true);
+    return OBJECT_MAPPER.readValue(response, new TypeReference<HashMap<String, String>>() { });
+  }
+
+  private Set<String> getSetFromRest(String url) throws JsonProcessingException {
+    String response = get(url, null, Response.Status.OK.getStatusCode(), true);
+    return OBJECT_MAPPER.readValue(response, new TypeReference<HashSet<String>>() { });
+  }
+}


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Resolve https://github.com/apache/helix/issues/2022 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

We introduce a set of REST API to enable/disable fault zone as an entity. Store the disabled zone info with cluster config.

Get all fault zones in the cluster
`GET: clusters/{clusterId}/zones`
Get disabled zones in the cluster
`GET: clusters/{clusterId}/zones/disabledZones`
Set status of a zone in a cluster
`POST: clusters/{clusterId}/zones/{zoneId}?command={enable, disable}`


An instance is disabled if any of the following is true:
- Disabled in cluster config (clusterConfig.getDisabledInstances())
- Disabled in instance config
- Belongs to a disabled fault zone

Above logic is implemented with [helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java](https://github.com/apache/helix/compare/master...qqu0127:disable-fault-zone?expand=1#diff-9e6a0144cb83407580269ee8fe7bf98fb51c82a927e6aa83c0372d89e4a6d59f) and integrated with all client side code.

### Tests

- [X] The following tests are written for this issue:

[helix-rest/src/test/java/org/apache/helix/rest/server/TestZoneAccessor.java](https://github.com/apache/helix/compare/master...qqu0127:disable-fault-zone?expand=1#diff-64fb8a0ba86233d3d4ccd71ba3c54174b85e17d22fad734f5da94b172b08fea0)

New test cases in
[helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java](https://github.com/apache/helix/compare/master...qqu0127:disable-fault-zone?expand=1#diff-27d08a56c5892883c5af6283feffeaa12d6ecfcb03c062305c27e603d62841da)
and 
[helix-core/src/test/java/org/apache/helix/util/TestInstanceValidationUtil.java](https://github.com/apache/helix/compare/master...qqu0127:disable-fault-zone?expand=1#diff-00c2d85b89dacf8b7f46cda1777b32d969415df2a79080f35fbc5dcb2468b071)

- The following is the result of the "mvn test" command on the appropriate module:

helix-rest
[INFO] Tests run: 208, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 269.443 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 208, Failures: 0, Errors: 0, Skipped: 0

### Documentation (Optional)

TODO: Will link when ready

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
