### PR TITLE
Code refactor and cleanup on instance validation

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
@@ -32,6 +32,7 @@ import org.apache.helix.HelixException;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ClusterTopologyConfig;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.util.InstanceValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -168,7 +169,7 @@ public class Topology {
         }
         addEndNode(root, instanceName, instanceTopologyMap, weight, _liveInstances);
       } catch (IllegalArgumentException e) {
-        if (isInstanceEnabled(clusterConfig, instanceName, insConfig)) {
+        if (InstanceValidationUtil.isInstanceEnabled(insConfig, clusterConfig)) {
           throw e;
         } else {
           logger.warn("Topology setting {} for instance {} is unset or invalid, ignore the instance!",
@@ -177,12 +178,6 @@ public class Topology {
       }
     }
     return root;
-  }
-
-  private static boolean isInstanceEnabled(ClusterConfig clusterConfig, String instanceName,
-      InstanceConfig instanceConfig) {
-    return (instanceConfig.getInstanceEnabled() && (clusterConfig.getDisabledInstances() == null
-        || !clusterConfig.getDisabledInstances().containsKey(instanceName)));
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
@@ -32,6 +32,7 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.util.ConfigStringUtil;
+import org.apache.helix.util.InstanceValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,14 +138,13 @@ public class DelayedRebalanceUtil {
     }
 
     // check the time instance got disabled.
-    if (!instanceConfig.getInstanceEnabled() || (clusterConfig.getDisabledInstances() != null
-        && clusterConfig.getDisabledInstances().containsKey(instance))) {
+    if (!InstanceValidationUtil.isInstanceEnabled(instanceConfig, clusterConfig)) {
       long disabledTime = instanceConfig.getInstanceEnabledTime();
-      if (clusterConfig.getDisabledInstances() != null && clusterConfig.getDisabledInstances()
-          .containsKey(instance)) {
+      Map<String, String> disabledInstances = clusterConfig.getDisabledInstances();
+      if (disabledInstances.containsKey(instance)) {
         // Update batch disable time
         long batchDisableTime = Long.parseLong(ConfigStringUtil
-            .parseConcatenatedConfig(clusterConfig.getDisabledInstances().get(instance))
+            .parseConcatenatedConfig(disabledInstances.get(instance))
             .get(ClusterConfig.ClusterConfigProperty.HELIX_ENABLED_DISABLE_TIMESTAMP.toString()));
         if (disabledTime == -1 || disabledTime > batchDisableTime) {
           disabledTime = batchDisableTime;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
@@ -31,7 +31,6 @@ import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.ResourceConfig;
-import org.apache.helix.util.ConfigStringUtil;
 import org.apache.helix.util.InstanceValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,9 +142,7 @@ public class DelayedRebalanceUtil {
       Map<String, String> disabledInstances = clusterConfig.getDisabledInstances();
       if (disabledInstances.containsKey(instance)) {
         // Update batch disable time
-        long batchDisableTime = Long.parseLong(ConfigStringUtil
-            .parseConcatenatedConfig(disabledInstances.get(instance))
-            .get(ClusterConfig.ClusterConfigProperty.HELIX_ENABLED_DISABLE_TIMESTAMP.toString()));
+        long batchDisableTime = Long.parseLong(clusterConfig.getInstanceHelixDisabledTimeStamp(instance));
         if (disabledTime == -1 || disabledTime > batchDisableTime) {
           disabledTime = batchDisableTime;
         }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -41,6 +41,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
 import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
+import org.apache.helix.util.InstanceValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,8 +92,7 @@ public class ReadClusterDataStage extends AbstractBaseStage {
                 instanceMessageMap.put(instanceName,
                     Sets.newHashSet(dataProvider.getMessages(instanceName).values()));
               }
-              if (!config.getInstanceEnabled() || (clusterConfig.getDisabledInstances() != null
-                  && clusterConfig.getDisabledInstances().containsKey(instanceName))) {
+              if (!InstanceValidationUtil.isInstanceEnabled(config, clusterConfig)) {
                 disabledInstanceSet.add(instanceName);
               }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1928,10 +1928,7 @@ public class ZKHelixAdmin implements HelixAdmin {
         }
 
         ClusterConfig clusterConfig = new ClusterConfig(currentData);
-        Map<String, String> disabledInstances = new TreeMap<>();
-        if (clusterConfig.getDisabledInstances() != null) {
-          disabledInstances.putAll(clusterConfig.getDisabledInstances());
-        }
+        Map<String, String> disabledInstances = new TreeMap<>(clusterConfig.getDisabledInstances());
         if (enabled) {
           disabledInstances.keySet().removeAll(instances);
         } else {

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -774,10 +774,11 @@ public class ClusterConfig extends HelixProperty {
 
   /**
    * Get current disabled instance map of <instance, disabledTimeStamp>
-   * @return
+   * @return a non-null map of disabled instances in cluster config
    */
   public Map<String, String> getDisabledInstances() {
-    return _record.getMapField(ClusterConfigProperty.DISABLED_INSTANCES.name());
+    Map<String, String> disabledInstances = _record.getMapField(ClusterConfigProperty.DISABLED_INSTANCES.name());
+    return disabledInstances == null ? Collections.emptyMap() : disabledInstances;
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterSetup.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterSetup.java
@@ -68,6 +68,7 @@ import org.apache.helix.model.builder.ConstraintItemBuilder;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.util.HelixUtil;
+import org.apache.helix.util.InstanceValidationUtil;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -308,8 +309,7 @@ public class ClusterSetup {
 
     ClusterConfig clusterConfig = accessor.getProperty(keyBuilder.clusterConfig());
     // ensure node is disabled, otherwise fail
-    if (config.getInstanceEnabled() && (clusterConfig.getDisabledInstances() == null
-        || !clusterConfig.getDisabledInstances().containsKey(instanceId))) {
+    if (InstanceValidationUtil.isInstanceEnabled(config, clusterConfig)) {
       String error = "Node " + instanceId + " is enabled, cannot drop";
       _logger.warn(error);
       throw new HelixException(error);

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -398,9 +398,10 @@ public final class HelixUtil {
         idealState.getMaxPartitionsPerInstance());
 
     // Remove all disabled instances so that Helix will not consider them live.
-    List<String> disabledInstance =
-        instanceConfigs.stream().filter(enabled -> !enabled.getInstanceEnabled())
-            .map(InstanceConfig::getInstanceName).collect(Collectors.toList());
+    List<String> disabledInstance = instanceConfigs.stream()
+        .filter(instanceConfig -> !InstanceValidationUtil.isInstanceEnabled(instanceConfig, clusterConfig))
+        .map(InstanceConfig::getInstanceName)
+        .collect(Collectors.toList());
     liveInstances.removeAll(disabledInstance);
 
     Map<String, List<String>> preferenceLists = strategy

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
@@ -114,11 +114,22 @@ public class InstanceValidationUtil {
         : instanceConfig.getInstanceDisabledType();
   }
 
-  private  static boolean isInstanceEnabled(InstanceConfig instanceConfig, ClusterConfig clusterConfig) {
+  /**
+   * Check if the instance is enabled by configuration
+   * @param instanceConfig
+   * @param clusterConfig
+   * @return
+   */
+  public static boolean isInstanceEnabled(InstanceConfig instanceConfig, ClusterConfig clusterConfig) {
+    if (instanceConfig == null) {
+      throw new HelixException("InstanceConfig is NULL");
+    }
     boolean enabledInInstanceConfig = instanceConfig.getInstanceEnabled();
-    Map<String, String> disabledInstances = clusterConfig.getDisabledInstances();
+    if (clusterConfig == null) {
+      return enabledInInstanceConfig;
+    }
     boolean enabledInClusterConfig =
-        disabledInstances == null || !disabledInstances.keySet().contains(instanceConfig.getInstanceName());
+        !clusterConfig.getDisabledInstances().containsKey(instanceConfig.getInstanceName());
     return enabledInClusterConfig && enabledInInstanceConfig;
   }
 
@@ -138,12 +149,10 @@ public class InstanceValidationUtil {
    * Method to check if the instance is assigned at least 1 resource, not in a idle state;
    * Independent of the instance alive/enabled status
    * @param dataAccessor
-   * @param clusterId
    * @param instanceName
    * @return
    */
-  public static boolean hasResourceAssigned(HelixDataAccessor dataAccessor, String clusterId,
-      String instanceName) {
+  public static boolean hasResourceAssigned(HelixDataAccessor dataAccessor, String instanceName) {
     PropertyKey.Builder propertyKeyBuilder = dataAccessor.keyBuilder();
     LiveInstance liveInstance = dataAccessor.getProperty(propertyKeyBuilder.liveInstance(instanceName));
     if (liveInstance != null) {

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
@@ -146,13 +146,22 @@ public class InstanceValidationUtil {
   }
 
   /**
+   * Deprecated. Please use {@link #isResourceAssigned} instead.
+   */
+  @Deprecated
+  public static boolean hasResourceAssigned(HelixDataAccessor dataAccessor, String clusterId,
+      String instanceName) {
+    return isResourceAssigned(dataAccessor, instanceName);
+  }
+
+  /**
    * Method to check if the instance is assigned at least 1 resource, not in a idle state;
    * Independent of the instance alive/enabled status
    * @param dataAccessor
    * @param instanceName
    * @return
    */
-  public static boolean hasResourceAssigned(HelixDataAccessor dataAccessor, String instanceName) {
+  public static boolean isResourceAssigned(HelixDataAccessor dataAccessor, String instanceName) {
     PropertyKey.Builder propertyKeyBuilder = dataAccessor.keyBuilder();
     LiveInstance liveInstance = dataAccessor.getProperty(propertyKeyBuilder.liveInstance(instanceName));
     if (liveInstance != null) {

--- a/helix-core/src/test/java/org/apache/helix/util/TestInstanceValidationUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestInstanceValidationUtil.java
@@ -136,7 +136,7 @@ public class TestInstanceValidationUtil {
         .getProperty(argThat(new PropertyKeyArgument(PropertyType.CURRENTSTATES)));
 
     Assert.assertTrue(
-        InstanceValidationUtil.hasResourceAssigned(mock.dataAccessor, TEST_CLUSTER, TEST_INSTANCE));
+        InstanceValidationUtil.hasResourceAssigned(mock.dataAccessor, TEST_INSTANCE));
   }
 
   @Test
@@ -156,7 +156,7 @@ public class TestInstanceValidationUtil {
         .getProperty(argThat(new PropertyKeyArgument(PropertyType.CURRENTSTATES)));
 
     Assert.assertFalse(
-        InstanceValidationUtil.hasResourceAssigned(mock.dataAccessor, TEST_CLUSTER, TEST_INSTANCE));
+        InstanceValidationUtil.hasResourceAssigned(mock.dataAccessor, TEST_INSTANCE));
   }
 
   @Test
@@ -166,7 +166,7 @@ public class TestInstanceValidationUtil {
         .getProperty(argThat(new PropertyKeyArgument(PropertyType.LIVEINSTANCES)));
 
     Assert.assertFalse(
-        InstanceValidationUtil.hasResourceAssigned(mock.dataAccessor, TEST_CLUSTER, TEST_INSTANCE));
+        InstanceValidationUtil.hasResourceAssigned(mock.dataAccessor, TEST_INSTANCE));
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/util/TestInstanceValidationUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestInstanceValidationUtil.java
@@ -136,7 +136,7 @@ public class TestInstanceValidationUtil {
         .getProperty(argThat(new PropertyKeyArgument(PropertyType.CURRENTSTATES)));
 
     Assert.assertTrue(
-        InstanceValidationUtil.hasResourceAssigned(mock.dataAccessor, TEST_INSTANCE));
+        InstanceValidationUtil.isResourceAssigned(mock.dataAccessor, TEST_INSTANCE));
   }
 
   @Test
@@ -156,7 +156,7 @@ public class TestInstanceValidationUtil {
         .getProperty(argThat(new PropertyKeyArgument(PropertyType.CURRENTSTATES)));
 
     Assert.assertFalse(
-        InstanceValidationUtil.hasResourceAssigned(mock.dataAccessor, TEST_INSTANCE));
+        InstanceValidationUtil.isResourceAssigned(mock.dataAccessor, TEST_INSTANCE));
   }
 
   @Test
@@ -166,7 +166,7 @@ public class TestInstanceValidationUtil {
         .getProperty(argThat(new PropertyKeyArgument(PropertyType.LIVEINSTANCES)));
 
     Assert.assertFalse(
-        InstanceValidationUtil.hasResourceAssigned(mock.dataAccessor, TEST_INSTANCE));
+        InstanceValidationUtil.isResourceAssigned(mock.dataAccessor, TEST_INSTANCE));
   }
 
   @Test

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
@@ -699,7 +699,7 @@ public class MaintenanceManagementService {
           break;
         case EMPTY_RESOURCE_ASSIGNMENT:
           healthStatus.put(HealthCheck.EMPTY_RESOURCE_ASSIGNMENT.name(),
-              InstanceValidationUtil.hasResourceAssigned(_dataAccessor, instanceName));
+              InstanceValidationUtil.isResourceAssigned(_dataAccessor, instanceName));
           break;
         case MIN_ACTIVE_REPLICA_CHECK_FAILED:
           healthStatus.put(HealthCheck.MIN_ACTIVE_REPLICA_CHECK_FAILED.name(),

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
@@ -699,7 +699,7 @@ public class MaintenanceManagementService {
           break;
         case EMPTY_RESOURCE_ASSIGNMENT:
           healthStatus.put(HealthCheck.EMPTY_RESOURCE_ASSIGNMENT.name(),
-              InstanceValidationUtil.hasResourceAssigned(_dataAccessor, clusterId, instanceName));
+              InstanceValidationUtil.hasResourceAssigned(_dataAccessor, instanceName));
           break;
         case MIN_ACTIVE_REPLICA_CHECK_FAILED:
           healthStatus.put(HealthCheck.MIN_ACTIVE_REPLICA_CHECK_FAILED.name(),

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -56,6 +56,7 @@ import org.apache.helix.rest.server.json.instance.StoppableCheck;
 import org.apache.helix.rest.server.resources.exceptions.HelixHealthException;
 import org.apache.helix.rest.server.service.ClusterService;
 import org.apache.helix.rest.server.service.ClusterServiceImpl;
+import org.apache.helix.util.InstanceValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,8 +121,7 @@ public class InstancesAccessor extends AbstractHelixResource {
         InstanceConfig instanceConfig =
             accessor.getProperty(accessor.keyBuilder().instanceConfig(instanceName));
         if (instanceConfig != null) {
-          if (!instanceConfig.getInstanceEnabled() || (clusterConfig.getDisabledInstances() != null
-              && clusterConfig.getDisabledInstances().containsKey(instanceName))) {
+          if (!InstanceValidationUtil.isInstanceEnabled(instanceConfig, clusterConfig)) {
             disabledNode.add(JsonNodeFactory.instance.textNode(instanceName));
           }
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
https://github.com/apache/helix/issues/2022 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Cleanup the usage in checking instance enable/disable using InstanceValidationUtil

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 59.725 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-view-aggregator ---
[INFO] Loading execution data file /home/qqu/workspace/qqu-helix/helix-view-aggregator/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: View Aggregator' with 15 classes
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Helix 1.0.3-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  1.235 s]
[INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  4.014 s]
[INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [ 14.624 s]
[INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [02:28 min]
[INFO] Apache Helix :: Helix Common ....................... SUCCESS [  2.168 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [  01:47 h]
[INFO] Apache Helix :: Admin Webapp ....................... SUCCESS [  0.932 s]
[INFO] Apache Helix :: Restful Interface .................. SUCCESS [02:49 min]
[INFO] Apache Helix :: Distributed Lock ................... SUCCESS [ 56.694 s]
[INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  0.556 s]
[INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.015 s]
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  1.859 s]
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  2.003 s]
[INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  1.975 s]
[INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  1.756 s]
[INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  1.842 s]
[INFO] Apache Helix :: View Aggregator .................... SUCCESS [01:01 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:55 h
[INFO] Finished at: 2022-04-11T17:25:03-07:00
[INFO] ------------------------------------------------------------------------


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
