### PR TITLE
MaintenanceManagementService  improvement - Allow implementation of OperationInterface to return null

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementInstanceInfo.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementInstanceInfo.java
@@ -30,54 +30,54 @@ public class MaintenanceManagementInstanceInfo {
     FAILURE
   }
 
-  private String operationResult;
-  private OperationalStatus status;
-  private List<String> messages;
+  private String _operationResult;
+  private OperationalStatus _status;
+  private List<String> _messages;
 
   public MaintenanceManagementInstanceInfo(OperationalStatus status) {
-    this.status = status;
-    this.messages = new ArrayList<>();
-    this.operationResult = "";
+    this._status = status;
+    this._messages = new ArrayList<>();
+    this._operationResult = "";
   }
 
   public MaintenanceManagementInstanceInfo(OperationalStatus status, List<String> messages) {
-    this.status = status;
-    this.messages = messages;
-    this.operationResult = "";
+    this._status = status;
+    this._messages = messages;
+    this._operationResult = "";
   }
 
   public MaintenanceManagementInstanceInfo(OperationalStatus status, String newOperationResult) {
-    this.status = status;
-    this.operationResult = newOperationResult;
-    this.messages = new ArrayList<>();
+    this._status = status;
+    this._operationResult = newOperationResult;
+    this._messages = new ArrayList<>();
   }
 
   public List<String> getMessages() {
-    return messages;
+    return _messages;
   }
 
   public String getOperationResult() {
-    return operationResult;
+    return _operationResult;
   }
 
   public boolean hasOperationResult() {
-    return !operationResult.isEmpty();
+    return !_operationResult.isEmpty();
   }
 
   public void setOperationResult(String result) {
-    operationResult = result;
+    _operationResult = result;
   }
 
   public void addMessages(List<String> msg) {
-    messages.addAll(msg);
+    _messages.addAll(msg);
   }
 
   public void addMessage(String meg) {
-    messages.add(meg);
+    _messages.add(meg);
   }
 
   public boolean isSuccessful() {
-    return status.equals(OperationalStatus.SUCCESS);
+    return _status.equals(OperationalStatus.SUCCESS);
   }
 
   public void mergeResult(MaintenanceManagementInstanceInfo info) {
@@ -85,14 +85,16 @@ public class MaintenanceManagementInstanceInfo {
   }
 
   public void mergeResult(MaintenanceManagementInstanceInfo info, boolean nonBlockingFailure) {
-    if (info != null) {
-      messages.addAll(info.getMessages());
+    if (info == null) {
+      return;
     }
-    status = ((info == null || info.isSuccessful() || nonBlockingFailure) && isSuccessful())
-        ? OperationalStatus.SUCCESS : OperationalStatus.FAILURE;
-    if (info != null && info.hasOperationResult()) {
-      operationResult =
-          this.hasOperationResult() ? operationResult + "," + info.getOperationResult()
+    _messages.addAll(info.getMessages());
+    _status =
+        ((info.isSuccessful() || nonBlockingFailure) && isSuccessful()) ? OperationalStatus.SUCCESS
+            : OperationalStatus.FAILURE;
+    if (info.hasOperationResult()) {
+      _operationResult =
+          this.hasOperationResult() ? _operationResult + "," + info.getOperationResult()
               : info.getOperationResult();
     }
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementInstanceInfo.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementInstanceInfo.java
@@ -71,6 +71,7 @@ public class MaintenanceManagementInstanceInfo {
   public void addMessages(List<String> msg) {
     messages.addAll(msg);
   }
+
   public void addMessage(String meg) {
     messages.add(meg);
   }
@@ -84,11 +85,12 @@ public class MaintenanceManagementInstanceInfo {
   }
 
   public void mergeResult(MaintenanceManagementInstanceInfo info, boolean nonBlockingFailure) {
-    messages.addAll(info.getMessages());
-    status =
-        (info.isSuccessful() || nonBlockingFailure) && isSuccessful() ? OperationalStatus.SUCCESS
-            : OperationalStatus.FAILURE;
-    if (info.hasOperationResult()) {
+    if (info != null) {
+      messages.addAll(info.getMessages());
+    }
+    status = ((info == null || info.isSuccessful() || nonBlockingFailure) && isSuccessful())
+        ? OperationalStatus.SUCCESS : OperationalStatus.FAILURE;
+    if (info != null && info.hasOperationResult()) {
       operationResult =
           this.hasOperationResult() ? operationResult + "," + info.getOperationResult()
               : info.getOperationResult();

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestOperationImpl.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestOperationImpl.java
@@ -49,8 +49,7 @@ public class TestOperationImpl implements OperationInterface {
 
   @Override
   public MaintenanceManagementInstanceInfo operationCheckForFreeSingleInstance(String instanceName, Map<String, String> operationConfig, RestSnapShot sn) {
-    return new MaintenanceManagementInstanceInfo(
-        MaintenanceManagementInstanceInfo.OperationalStatus.SUCCESS);
+    return null;
   }
 
   @Override


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2034 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Maintenance Management service fails silently when user provided OperationInterface returns null in take/freeInstance API.
We should allow user provided OperationInterface to return null.

### Tests

- [X] The following tests are written for this issue:

Modified TestOperationImpl.java.
TestInstanceAccessor will cover null case.

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
