### PR TITLE
Fixed size history for Scheduled Workflow tasks

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowContext.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowContext.java
@@ -58,7 +58,7 @@ public class WorkflowContext extends HelixProperty {
   private boolean isModified;
 
   // Have fixed size history of Scheduled Workflow Tasks
-  private final static int SCHEDULED_WORKFLOW_HISTORY_SIZE = 100;
+  private final static int SCHEDULED_WORKFLOW_HISTORY_SIZE = 20;
 
   public WorkflowContext(ZNRecord record) {
     super(record);

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowContext.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowContext.java
@@ -57,6 +57,9 @@ public class WorkflowContext extends HelixProperty {
   // Otherwise, the context will not be written to ZK by the controller.
   private boolean isModified;
 
+  // Have fixed size history of Scheduled Workflow Tasks
+  private final static int SCHEDULED_WORKFLOW_HISTORY_SIZE = 100;
+
   public WorkflowContext(ZNRecord record) {
     super(record);
     isModified = false;
@@ -234,6 +237,10 @@ public class WorkflowContext extends HelixProperty {
           scheduledWorkflows);
     }
     if (!scheduledWorkflows.contains(workflow)) {
+      // This while loop is to cleanup existing scheduled workflows
+      while (scheduledWorkflows.size() >= SCHEDULED_WORKFLOW_HISTORY_SIZE) {
+        scheduledWorkflows.remove(0);
+      }
       scheduledWorkflows.add(workflow);
       markWorkflowContextAsModified();
     }


### PR DESCRIPTION
Once we execute scheduled workflow task, we append entry to history.
Each entry is of the format "taskname-timestamp"
But we never purged old entries.

This will result in hitting size limit of Znode.
    
Introducing fixed size history of 20 and purge all the previous entries
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

### Description

- [] Here are some details about my PR, including screenshots of any UI changes:


### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
