### PR TITLE
support common input for operational input on Maintenance Management API 

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
@@ -377,7 +377,7 @@ public class MaintenanceManagementService {
                 ? Collections.emptyMap()
                 : getMapFromJsonPayload(operationConfig.get(operationClassName));
         commonOperationConfig
-            .forEach((key, value) -> singleOperationConfig.merge(key, value, (v1, v2) -> v1));
+            .forEach(singleOperationConfig::putIfAbsent);
         operationConfigSet.put(operationClassName, singleOperationConfig);
         boolean continueOnFailures =
             singleOperationConfig.containsKey(continueOnFailuresName) && getBooleanFromJsonPayload(

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
@@ -78,6 +78,9 @@ public class MaintenanceManagementService {
   private static final String CUSTOM_INSTANCE_CHECK_HTTP_REQUESTS_DURATION =
       MetricRegistry.name(InstanceService.class, "custom_instance_check_http_requests_duration");
   public static final String ALL_HEALTH_CHECK_NONBLOCK = "allHealthCheckNonBlock";
+  public static final String HELIX_INSTANCE_STOPPABLE_CHECK = "HelixInstanceStoppableCheck";
+  public static final String HELIX_CUSTOM_STOPPABLE_CHECK = "CustomInstanceStoppableCheck";
+  public static final String OPERATION_CONFIG_SHARED_INPUT = "OperationConfigSharedInput";
 
   private final ConfigAccessor _configAccessor;
   private final CustomRestClient _customRestClient;
@@ -361,6 +364,11 @@ public class MaintenanceManagementService {
           PerInstanceAccessor.PerInstanceProperties.continueOnFailures.name();
       Map<String, Map<String, String>> operationConfigSet = new HashMap<>();
 
+      Map<String, String> commonOperationConfig =
+          (operationConfig == null || !operationConfig.containsKey(OPERATION_CONFIG_SHARED_INPUT))
+              ? Collections.emptyMap()
+              : getMapFromJsonPayload(operationConfig.get(OPERATION_CONFIG_SHARED_INPUT));
+
       // perform operation check
       for (OperationInterface operationClass : operationAbstractClassList) {
         String operationClassName = operationClass.getClass().getName();
@@ -368,6 +376,8 @@ public class MaintenanceManagementService {
             (operationConfig == null || !operationConfig.containsKey(operationClassName))
                 ? Collections.emptyMap()
                 : getMapFromJsonPayload(operationConfig.get(operationClassName));
+        commonOperationConfig
+            .forEach((key, value) -> singleOperationConfig.merge(key, value, (v1, v2) -> v1));
         operationConfigSet.put(operationClassName, singleOperationConfig);
         boolean continueOnFailures =
             singleOperationConfig.containsKey(continueOnFailuresName) && getBooleanFromJsonPayload(
@@ -468,14 +478,15 @@ public class MaintenanceManagementService {
     // CostumeInstanceStoppableCheck. We should add finer grain check groups to choose from
     // i.e. HELIX:INSTANCE_NOT_ENABLED, CUSTOM_PARTITION_HEALTH_FAILURE:PARTITION_INITIAL_STATE_FAIL etc.
     for (String healthCheck : healthChecks) {
-      if (healthCheck.equals("HelixInstanceStoppableCheck")) {
+      if (healthCheck.equals(HELIX_INSTANCE_STOPPABLE_CHECK)) {
         // this is helix own check
         instancesForNext =
             batchHelixInstanceStoppableCheck(clusterId, instancesForNext, finalStoppableChecks);
-      } else if (healthCheck.equals("CustomInstanceStoppableCheck")) {
+      } else if (healthCheck.equals(HELIX_CUSTOM_STOPPABLE_CHECK)) {
         // custom check, includes custom Instance check and partition check.
-        instancesForNext = batchCustomInstanceStoppableCheck(clusterId, instancesForNext, finalStoppableChecks,
-            healthCheckConfig);
+        instancesForNext =
+            batchCustomInstanceStoppableCheck(clusterId, instancesForNext, finalStoppableChecks,
+                healthCheckConfig);
       } else {
         throw new UnsupportedOperationException(healthCheck + " is not supported yet!");
       }

--- a/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
@@ -176,6 +176,7 @@ public class TestMaintenanceManagementService {
     Assert.assertEquals(actual.getFailedChecks().size(), expectedFailedChecksSize);
     Assert.assertEquals(actual.getFailedChecks().get(0), expectedFailedCheck);
   }
+
   @Test
   public void testCustomPartitionCheckWithSkipZKRead() throws IOException {
     // Let ZK result is health, but http request is unhealthy.
@@ -256,7 +257,7 @@ public class TestMaintenanceManagementService {
     Assert.assertEquals(instanceInfo2.getOperationResult(), "DummyTakeOperationResult");
   }
 
-    /*
+  /*
    * Tests stoppable check api when all checks query is enabled. After helix own check fails,
    * the subsequent checks should be performed.
    */
@@ -294,6 +295,7 @@ public class TestMaintenanceManagementService {
     verify(_customRestClient, times(2))
         .getPartitionStoppableCheck(anyString(), nullable(List.class), anyMap());
   }
+
   // TODO re-enable the test when partition health checks get decoupled
   @Test(enabled = false)
   public void testGetInstanceStoppableCheckWhenPartitionsCheckFail() throws IOException {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -193,6 +193,24 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
   }
 
   @Test(dependsOnMethods = "testTakeInstanceOperationCheckFailure")
+  public void testTakeInstanceOperationCheckFailureCommonInput() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String payload = "{ \"operation_list\" : [\"org.apache.helix.rest.server.TestOperationImpl\"],"
+        + "\"operation_config\": { \"OperationConfigSharedInput\" :"
+        + " {\"instance0\": true, \"instance2\": true, "
+        + "\"instance3\": true, \"instance4\": true, \"instance5\": true, "
+        + " \"value\" : \"i001\", \"list_value\" : [\"list1\"]}}} ";
+    Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/takeInstance")
+        .format(STOPPABLE_CLUSTER, "instance0")
+        .post(this, Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE));
+    String takeInstanceResult = response.readEntity(String.class);
+
+    Map<String, Object> actualMap = OBJECT_MAPPER.readValue(takeInstanceResult, Map.class);
+    Assert.assertFalse((boolean)actualMap.get("successful"));
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testTakeInstanceOperationCheckFailureCommonInput")
   public void testTakeInstanceOperationCheckFailureNonBlocking() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String payload = "{ \"operation_list\" : [\"org.apache.helix.rest.server.TestOperationImpl\"],"


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2034

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change adds a common input field for operational check input on Maintenance Management API. 

### Tests

- [X] The following tests are written for this issue:

testTakeInstanceOperationCheckFailureCommonInput

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
