### PR TITLE
fix bug where generateJobList would iterate until the parallelism is reached

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/RuntimeJobDag.java
+++ b/helix-core/src/main/java/org/apache/helix/task/RuntimeJobDag.java
@@ -198,12 +198,14 @@ public class RuntimeJobDag extends JobDag {
     resetJobListAndDependencyMaps();
     computeIndependentNodes();
     _readyJobList.addAll(_independentNodes);
-    if (_isJobQueue && _readyJobList.size() > 0) {
+    if (_isJobQueue && !_readyJobList.isEmpty()) {
       // For job queue, only get number of parallel jobs to run in the ready list.
       for (int i = 1; i < _numParallelJobs; i++) {
-        if (_parentsToChildren.containsKey(_readyJobList.peekLast())) {
-          _readyJobList.offer(_parentsToChildren.get(_readyJobList.peekLast()).iterator().next());
+        Set<String> children = _parentsToChildren.get(_readyJobList.peekLast());
+        if (children == null) {
+          break;
         }
+        _readyJobList.offer(children.iterator().next());
       }
     }
     _hasDagChanged = false;

--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestRuntimeJobDag.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestRuntimeJobDag.java
@@ -24,11 +24,25 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.helix.task.JobDag;
 import org.apache.helix.task.RuntimeJobDag;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class TestRuntimeJobDag {
+
+  @Test
+  public void testBuildJobQueueWithParallelismExceedingJobCount() {
+    JobDag jobDag = new JobDag();
+    jobDag.addNode("parent");
+    jobDag.addParentToChild("parent", "child");
+    jobDag.addParentToChild("child", "grandchild");
+    RuntimeJobDag runtimeJobDag = new RuntimeJobDag(jobDag, true, Integer.MAX_VALUE, 1);
+    Assert.assertEquals(runtimeJobDag.getNextJob(), "parent");
+    Assert.assertEquals(runtimeJobDag.getNextJob(), "child");
+    Assert.assertEquals(runtimeJobDag.getNextJob(), "grandchild");
+  }
+
   private Set<String> actualJobs;
   private Set<String> expectedJobs;
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #2064

### Description

When there is a high level of parallelism configured and the JobDag is a job queue, building the ready job list would take a long time because the loop iterates until the level of parallelism is reached, and doesn't terminate when all the jobs have been processed

### Tests

`TestRuntimeJobDag#testBuildJobQueueWithParallelismExceedingJobCount` was added to verify that the correct job order is still produced. It is not a performance test, but before the fix it took 22 seconds to complete, afterwards it takes ~1ms.

### Changes that Break Backward Compatibility (Optional)

None.

### Documentation (Optional)

This is a bug fix, no documentation required.
