### PR TITLE
Do not proceed with cluster creation if addCluster() fails.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterSetup.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterSetup.java
@@ -223,7 +223,11 @@ public class ClusterSetup {
 
   public void addCluster(String clusterName, boolean overwritePrevious, CloudConfig cloudConfig)
       throws HelixException {
-    _admin.addCluster(clusterName, overwritePrevious);
+    if (!_admin.addCluster(clusterName, overwritePrevious)) {
+      String error = "Cluster creation failed for " + clusterName;
+      _logger.error(error);
+      throw new HelixException(error);
+    }
     for (BuiltInStateModelDefinitions def : BuiltInStateModelDefinitions.values()) {
       addStateModelDef(clusterName, def.getStateModelDefinition().getId(),
           def.getStateModelDefinition(), overwritePrevious);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #2066 

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

In Helix-Tools - ClusterSetup::addCluster() doesn't check return value
of HelixAdmin::addCluster() method. It proceeds even when the call
returns failure.
The change will throw exception to indicate creation failed.

Added a unit-test to verify.
### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)
- testAddClusterWithFailure

- The following is the result of the "mvn test" command on the appropriate module:
START TestClusterSetup testAddClusterWithFailure at Wed Apr 27 11:09:26 PDT 2022
END TestClusterSetup testAddClusterWithFailure at Wed Apr 27 11:09:27 PDT 2022, took: 674ms.
...
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 109.472 s - in org.apache.helix.tools.TestClusterSetup
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0
[INFO] 

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

https://github.com/apache/helix/issues/2052 - this test case failed as part of CI

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
