### PR TITLE
Issue #1970: allow clients to prevent HelixProperty from cloning the ZNRecord

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixProperty.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * A wrapper class for ZNRecord. Used as a base class for IdealState, CurrentState, etc.
  */
 public class HelixProperty {
-  private static Logger LOG = LoggerFactory.getLogger(HelixProperty.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HelixProperty.class);
 
   public enum HelixPropertyAttribute {
     BUCKET_SIZE, BATCH_MESSAGE_MODE
@@ -156,25 +156,50 @@ public class HelixProperty {
    * @param id
    */
   public HelixProperty(String id) {
-    this(new ZNRecord(id), id);
+    this(new ZNRecord(id), id, false);
+  }
+
+  /**
+   * Initialize the property with an existing ZNRecord
+   * @param record a deep copy of the record is made, updates to this record will not be reflected
+   *               by the HelixProperty
+   */
+  public HelixProperty(ZNRecord record) {
+    this(record, true);
   }
 
   /**
    * Initialize the property with an existing ZNRecord
    * @param record
+   * @param deepCopyRecord set to true to make a copy of the ZNRecord, false otherwise
    */
-  public HelixProperty(ZNRecord record) {
-    this(record, record.getId());
+  public HelixProperty(ZNRecord record, boolean deepCopyRecord) {
+    this(record, record.getId(), deepCopyRecord);
+  }
+
+  /**
+   * Initialize the property with an existing ZNRecord with new record id
+   * @param record a deep copy of the record is made, updates to this record will not be reflected by the HelixProperty
+   * @param id
+   */
+  public HelixProperty(ZNRecord record, String id) {
+    this(record, id, true);
   }
 
   /**
    * Initialize the property with an existing ZNRecord with new record id
    * @param record
    * @param id
+   * @param deepCopyRecord whether to deep copy the ZNRecord, set to true if subsequent changes to
+   *                       the ZNRecord should not affect this HelixProperty and vice versa, or false
    */
-  public HelixProperty(ZNRecord record, String id) {
-    _record = (record instanceof SessionAwareZNRecord) ? new SessionAwareZNRecord(record, id)
-        : new ZNRecord(record, id);
+  public HelixProperty(ZNRecord record, String id, boolean deepCopyRecord) {
+    if (deepCopyRecord) {
+      _record = record instanceof SessionAwareZNRecord ? new SessionAwareZNRecord(record, id)
+          : new ZNRecord(record, id);
+    } else {
+      _record = record;
+    }
     _stat = new Stat(_record.getVersion(), _record.getCreationTime(), _record.getModifiedTime(),
         _record.getEphemeralOwner());
   }


### PR DESCRIPTION
…ZNRecord

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #1970

### Description

In Apache Pinot, we first deserialize `ZNRecord`s and then construct `HelixProperty`s from them, and never use the `ZNRecord` again. `HelixProperty` makes a defensive copy of the `ZNRecord`, which is actually expensive enough to show up prominently in profiles of our helix threads. This change adds constructors to `HelixConstructor` which do not clone the `ZNRecord`. Backward compatibility is maintained, and all existing code will continue to clone the `ZNRecord`, but new code can be written to set the `clone` to false to avoid the expensive copy.

### Tests

No tests have been added as this change is trivial.

### Changes that Break Backward Compatibility (Optional)

Backward compatibility has been maintained. Existing code continues to clone the `ZNRecord`.