### PR TITLE
specify known working nodejs and npm versions in package.json

### DIFF
--- a/helix-front/package.json
+++ b/helix-front/package.json
@@ -21,6 +21,10 @@
     "e2e": "ng e2e",
     "smoke": "ng lint && ng test -sr && npm run build"
   },
+  "engines": {
+    "node": "8.9.4",
+    "npm": "5.5.1"
+  },
   "dependencies": {
     "@angular/animations": "^5.1.1",
     "@angular/cdk": "^5.0.1",
@@ -81,9 +85,6 @@
     "protractor": "~5.1.0",
     "ts-node": "~2.0.0",
     "tslint": "^5.8.0",
-    "typescript": "2.4.2"
-  },
-  "volta": {
-    "node": "8.9.4"
+    "typescript": "^2.4.2"
   }
 }

--- a/helix-front/package.json
+++ b/helix-front/package.json
@@ -82,5 +82,8 @@
     "ts-node": "~2.0.0",
     "tslint": "^5.8.0",
     "typescript": "2.4.2"
+  },
+  "volta": {
+    "node": "8.9.4"
   }
 }


### PR DESCRIPTION
This PR specifies a compatible version of nodejs for the current Angular version, based on this table of compatible versions: https://gist.github.com/LayZeeDK/c822cc812f75bb07b7c55d07ba2719b3

highly upvoted stackoverflow answer with the same table: https://stackoverflow.com/questions/60248452/is-there-a-compatibility-list-for-angular-angular-cli-and-node-js

An incremental approach to #2053 