### PR TITLE
Clean up after TestAuthValidator --  fix TestClusterAccessor

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestAuthValidator.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestAuthValidator.java
@@ -44,6 +44,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -54,9 +55,18 @@ public class TestAuthValidator extends AbstractTestClass {
   private String _mockBaseUri;
   private CloseableHttpClient _httpClient;
 
+  private static String CLASSNAME_TEST_DEFAULT_AUTH = "testDefaultAuthValidator";
+  private static String CLASSNAME_TEST_CST_AUTH = "testCustomAuthValidator";
+
+  @AfterClass
+  public void afterClass() {
+    _gZkClient.deleteRecursively("/" + CLASSNAME_TEST_DEFAULT_AUTH);
+    _gZkClient.deleteRecursively("/" + CLASSNAME_TEST_CST_AUTH);
+  }
+
   @Test
   public void testDefaultAuthValidator() throws JsonProcessingException {
-    String testClusterName = "testDefaultAuthValidator";
+    String testClusterName = CLASSNAME_TEST_DEFAULT_AUTH;
     put("clusters/" + testClusterName, null, Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
         Response.Status.CREATED.getStatusCode());
     String body = get("clusters/", null, Response.Status.OK.getStatusCode(), true);
@@ -67,7 +77,7 @@ public class TestAuthValidator extends AbstractTestClass {
 
   @Test(dependsOnMethods = "testDefaultAuthValidator")
   public void testCustomAuthValidator() throws IOException, InterruptedException {
-    String testClusterName = "testCustomAuthValidator";
+    String testClusterName = CLASSNAME_TEST_CST_AUTH;
     int newPort = getBaseUri().getPort() + 1;
 
     // Start a second server for testing Distributed Leader Election for writes

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestAuthValidator.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestAuthValidator.java
@@ -66,18 +66,16 @@ public class TestAuthValidator extends AbstractTestClass {
 
   @Test
   public void testDefaultAuthValidator() throws JsonProcessingException {
-    String testClusterName = CLASSNAME_TEST_DEFAULT_AUTH;
-    put("clusters/" + testClusterName, null, Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
+    put("clusters/" + CLASSNAME_TEST_DEFAULT_AUTH, null, Entity.entity("", MediaType.APPLICATION_JSON_TYPE),
         Response.Status.CREATED.getStatusCode());
     String body = get("clusters/", null, Response.Status.OK.getStatusCode(), true);
     JsonNode node = OBJECT_MAPPER.readTree(body);
     String clustersStr = node.get(ClusterAccessor.ClusterProperties.clusters.name()).toString();
-    Assert.assertTrue(clustersStr.contains(testClusterName));
+    Assert.assertTrue(clustersStr.contains(CLASSNAME_TEST_DEFAULT_AUTH));
   }
 
   @Test(dependsOnMethods = "testDefaultAuthValidator")
   public void testCustomAuthValidator() throws IOException, InterruptedException {
-    String testClusterName = CLASSNAME_TEST_CST_AUTH;
     int newPort = getBaseUri().getPort() + 1;
 
     // Start a second server for testing Distributed Leader Election for writes
@@ -101,9 +99,9 @@ public class TestAuthValidator extends AbstractTestClass {
     server.start();
 
     HttpUriRequest request =
-        buildRequest("/clusters/" + testClusterName, HttpConstants.RestVerbs.PUT, "");
+        buildRequest("/clusters/" + CLASSNAME_TEST_CST_AUTH, HttpConstants.RestVerbs.PUT, "");
     sendRequestAndValidate(request, Response.Status.CREATED.getStatusCode());
-    request = buildRequest("/clusters/" + testClusterName, HttpConstants.RestVerbs.GET, "");
+    request = buildRequest("/clusters/" + CLASSNAME_TEST_CST_AUTH, HttpConstants.RestVerbs.GET, "");
     sendRequestAndValidate(request, Response.Status.FORBIDDEN.getStatusCode());
 
     server.shutdown();
@@ -117,7 +115,7 @@ public class TestAuthValidator extends AbstractTestClass {
     server.start();
     _httpClient = HttpClients.createDefault();
 
-    request = buildRequest("/clusters/" + testClusterName, HttpConstants.RestVerbs.GET, "");
+    request = buildRequest("/clusters/" + CLASSNAME_TEST_CST_AUTH, HttpConstants.RestVerbs.GET, "");
     sendRequestAndValidate(request, Response.Status.OK.getStatusCode());
     request = buildRequest("/clusters", HttpConstants.RestVerbs.GET, "");
     sendRequestAndValidate(request, Response.Status.FORBIDDEN.getStatusCode());

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestAuthValidator.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestAuthValidator.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.helix.TestHelper;
 import org.apache.helix.rest.common.HelixRestNamespace;
 import org.apache.helix.rest.common.HttpConstants;
 import org.apache.helix.rest.server.authValidator.AuthValidator;
@@ -60,8 +61,8 @@ public class TestAuthValidator extends AbstractTestClass {
 
   @AfterClass
   public void afterClass() {
-    _gZkClient.deleteRecursively("/" + CLASSNAME_TEST_DEFAULT_AUTH);
-    _gZkClient.deleteRecursively("/" + CLASSNAME_TEST_CST_AUTH);
+    TestHelper.dropCluster(CLASSNAME_TEST_DEFAULT_AUTH, _gZkClient);
+    TestHelper.dropCluster(CLASSNAME_TEST_CST_AUTH, _gZkClient);
   }
 
   @Test


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2096
#2093 


### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

TestAuthValidator create 2 clusters testDefaultAuthValidator and testCustomAuthValidator. These 2 clusters are not cleaned up causing TestClusterAccessor. testGetClusters to fail.


### Tests

- [X] The following tests are written for this issue:

NA

- The following is the result of the "mvn test" command on the appropriate module:
CU result:
testHelixViewAggregator(org.apache.helix.view.integration.TestHelixViewAggregator)
Link to issue: #2049
local run:
```
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 183.686 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-view-aggregator ---
[INFO] Loading execution data file /Users/xialu/Documents/WorkSpace/helix/helix-view-aggregator/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: View Aggregator' with 15 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:09 min
[INFO] Finished at: 2022-05-27T22:28:57-07:00
[INFO] ------------------------------------------------------------------------

```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
