### PR TITLE
Fix incompatible issue for clusterConfig mapfields disabledInstances

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
@@ -139,10 +139,10 @@ public class DelayedRebalanceUtil {
     // check the time instance got disabled.
     if (!InstanceValidationUtil.isInstanceEnabled(instanceConfig, clusterConfig)) {
       long disabledTime = instanceConfig.getInstanceEnabledTime();
-      Map<String, String> disabledInstances = clusterConfig.getDisabledInstances();
-      if (disabledInstances.containsKey(instance)) {
+      String batchedDisabledTime = clusterConfig.getInstanceHelixDisabledTimeStamp(instance);
+      if (batchedDisabledTime != null && !batchedDisabledTime.isEmpty()) {
         // Update batch disable time
-        long batchDisableTime = Long.parseLong(clusterConfig.getInstanceHelixDisabledTimeStamp(instance));
+        long batchDisableTime = Long.parseLong(batchedDisabledTime);
         if (disabledTime == -1 || disabledTime > batchDisableTime) {
           disabledTime = batchDisableTime;
         }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1940,6 +1940,8 @@ public class ZKHelixAdmin implements HelixAdmin {
         } else {
           for (String disabledInstance : instances) {
             // We allow user to override disabledType and reason for an already disabled instance.
+            // TODO: we are updating both DISABLED_INSTANCES and DISABLED_INSTANCES_W_INFO for
+            // backward compatible. Deprecate DISABLED_INSTANCES in the future.
             // TODO: update the history ZNode
             String timeStamp = String.valueOf(System.currentTimeMillis());
             disabledInstances.put(disabledInstance, timeStamp);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1933,17 +1933,22 @@ public class ZKHelixAdmin implements HelixAdmin {
 
         ClusterConfig clusterConfig = new ClusterConfig(currentData);
         Map<String, String> disabledInstances = new TreeMap<>(clusterConfig.getDisabledInstances());
+        Map<String, String> disabledInstancesWithInfo = new TreeMap<>(clusterConfig.getDisabledInstancesWithInfo());
         if (enabled) {
           disabledInstances.keySet().removeAll(instances);
+          disabledInstancesWithInfo.keySet().removeAll(instances);
         } else {
           for (String disabledInstance : instances) {
             // We allow user to override disabledType and reason for an already disabled instance.
             // TODO: update the history ZNode
-            disabledInstances
-                .put(disabledInstance, assembleInstanceBatchedDisabledInfo(disabledType, reason));
+            String timeStamp = String.valueOf(System.currentTimeMillis());
+            disabledInstances.put(disabledInstance, timeStamp);
+            disabledInstancesWithInfo
+                .put(disabledInstance, assembleInstanceBatchedDisabledInfo(disabledType, reason, timeStamp));
           }
         }
         clusterConfig.setDisabledInstances(disabledInstances);
+        clusterConfig.setDisabledInstancesWithInfo(disabledInstancesWithInfo);
 
         return clusterConfig.getRecord();
       }
@@ -1951,10 +1956,10 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   public static String assembleInstanceBatchedDisabledInfo(
-      InstanceConstants.InstanceDisabledType disabledType, String reason) {
+      InstanceConstants.InstanceDisabledType disabledType, String reason, String timeStamp) {
     Map<String, String> disableInfo = new TreeMap<>();
     disableInfo.put(ClusterConfig.ClusterConfigProperty.HELIX_ENABLED_DISABLE_TIMESTAMP.toString(),
-        String.valueOf(System.currentTimeMillis()));
+        timeStamp);
     if (disabledType != null) {
       disableInfo.put(ClusterConfig.ClusterConfigProperty.HELIX_DISABLED_TYPE.toString(),
           disabledType.toString());

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -76,8 +76,8 @@ public class ClusterConfig extends HelixProperty {
 
     TARGET_EXTERNALVIEW_ENABLED,
     @Deprecated // ERROR_OR_RECOVERY_PARTITION_THRESHOLD_FOR_LOAD_BALANCE will take
-        // precedence if it is set
-        ERROR_PARTITION_THRESHOLD_FOR_LOAD_BALANCE, // Controller won't execute load balance state
+    // precedence if it is set
+    ERROR_PARTITION_THRESHOLD_FOR_LOAD_BALANCE, // Controller won't execute load balance state
     // transition if the number of partitons that need
     // recovery exceeds this limitation
     ERROR_OR_RECOVERY_PARTITION_THRESHOLD_FOR_LOAD_BALANCE, // Controller won't execute load balance
@@ -87,6 +87,7 @@ public class ClusterConfig extends HelixProperty {
     DISABLED_INSTANCES,
     DISABLED_INSTANCES_W_INFO,
     // disabled instances and disabled instances with info are for storing batch disabled instances.
+    // disabled instances will write into both 2 fields for backward compatibility.
 
     VIEW_CLUSTER, // Set to "true" to indicate this is a view cluster
     VIEW_CLUSTER_SOURCES, // Map field, key is the name of source cluster, value is
@@ -774,8 +775,8 @@ public class ClusterConfig extends HelixProperty {
   }
 
   /**
-   * Set the disabled instance list
-   disabledInstancesWithInfo   */
+   * Set the disabled instance list with concatenated Info
+   */
   public void setDisabledInstancesWithInfo(Map<String, String> disabledInstancesWithInfo) {
     _record.setMapField(ClusterConfigProperty.DISABLED_INSTANCES_W_INFO.name(), disabledInstancesWithInfo);
   }
@@ -792,7 +793,7 @@ public class ClusterConfig extends HelixProperty {
 
   /**
    * Get current disabled instance map of
-   * <instance, disabledReason = res, disabledType = typ, disabledTimeStamp = time>
+   * <instance, disabledReason = "res, disabledType = typ, disabledTimeStamp = time">
    * @return a non-null map of disabled instances in cluster config
    */
   public Map<String, String> getDisabledInstancesWithInfo() {
@@ -1142,7 +1143,8 @@ public class ClusterConfig extends HelixProperty {
   }
 
   public String getInstanceHelixDisabledType(String instanceName) {
-    if (!getDisabledInstancesWithInfo().containsKey(instanceName) && !getDisabledInstances().containsKey(instanceName)) {
+    if (!getDisabledInstancesWithInfo().containsKey(instanceName) &&
+        !getDisabledInstances().containsKey(instanceName)) {
       return InstanceConstants.INSTANCE_NOT_DISABLED;
     }
     return ConfigStringUtil.parseConcatenatedConfig(getDisabledInstancesWithInfo().get(instanceName))
@@ -1150,13 +1152,20 @@ public class ClusterConfig extends HelixProperty {
             InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE.toString());
   }
 
-  // return null if instance is not disabled in batch mode or do not have disabled reason
+  /**
+   * @return a String representing reason.
+   * null if instance is not disabled in batch mode or do not have disabled reason
+   */
   public String getInstanceHelixDisabledReason(String instanceName) {
     return ConfigStringUtil.parseConcatenatedConfig(getDisabledInstancesWithInfo().get(instanceName))
         .get(ClusterConfigProperty.HELIX_DISABLED_REASON.toString());
   }
 
-  // return null if instance is not disabled in batch mode
+  /**
+   * @param instanceName
+   * @return a String representation of unix time
+   * null if the instance is not disabled in batch mode.
+   */
   public String getInstanceHelixDisabledTimeStamp(String instanceName) {
     if (getDisabledInstancesWithInfo().containsKey(instanceName)) {
       return ConfigStringUtil.parseConcatenatedConfig(

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -76,8 +76,8 @@ public class ClusterConfig extends HelixProperty {
 
     TARGET_EXTERNALVIEW_ENABLED,
     @Deprecated // ERROR_OR_RECOVERY_PARTITION_THRESHOLD_FOR_LOAD_BALANCE will take
-    // precedence if it is set
-    ERROR_PARTITION_THRESHOLD_FOR_LOAD_BALANCE, // Controller won't execute load balance state
+        // precedence if it is set
+        ERROR_PARTITION_THRESHOLD_FOR_LOAD_BALANCE, // Controller won't execute load balance state
     // transition if the number of partitons that need
     // recovery exceeds this limitation
     ERROR_OR_RECOVERY_PARTITION_THRESHOLD_FOR_LOAD_BALANCE, // Controller won't execute load balance
@@ -85,12 +85,13 @@ public class ClusterConfig extends HelixProperty {
     // partitons that need recovery or in
     // error exceeds this limitation
     DISABLED_INSTANCES,
-    DISABLED_INSTANCES_W_INFO,
+    DISABLED_INSTANCES_WITH_INFO,
     // disabled instances and disabled instances with info are for storing batch disabled instances.
     // disabled instances will write into both 2 fields for backward compatibility.
 
     VIEW_CLUSTER, // Set to "true" to indicate this is a view cluster
-    VIEW_CLUSTER_SOURCES, // Map field, key is the name of source cluster, value is
+    VIEW_CLUSTER_SOURCES, // Map field, key is the name of source clust:1175
+    // er, value is
     // ViewClusterSourceConfig JSON string
     VIEW_CLUSTER_REFRESH_PERIOD, // In second
     // Specifies job types and used for quota allocation
@@ -778,7 +779,8 @@ public class ClusterConfig extends HelixProperty {
    * Set the disabled instance list with concatenated Info
    */
   public void setDisabledInstancesWithInfo(Map<String, String> disabledInstancesWithInfo) {
-    _record.setMapField(ClusterConfigProperty.DISABLED_INSTANCES_W_INFO.name(), disabledInstancesWithInfo);
+    _record.setMapField(ClusterConfigProperty.DISABLED_INSTANCES_WITH_INFO.name(),
+        disabledInstancesWithInfo);
   }
 
   /**
@@ -798,7 +800,7 @@ public class ClusterConfig extends HelixProperty {
    */
   public Map<String, String> getDisabledInstancesWithInfo() {
     Map<String, String> disabledInstances =
-        _record.getMapField(ClusterConfigProperty.DISABLED_INSTANCES_W_INFO.name());
+        _record.getMapField(ClusterConfigProperty.DISABLED_INSTANCES_WITH_INFO.name());
     return disabledInstances == null ? Collections.emptyMap() : disabledInstances;
   }
 
@@ -1168,11 +1170,10 @@ public class ClusterConfig extends HelixProperty {
    */
   public String getInstanceHelixDisabledTimeStamp(String instanceName) {
     if (getDisabledInstancesWithInfo().containsKey(instanceName)) {
-      return ConfigStringUtil.parseConcatenatedConfig(
-          getDisabledInstancesWithInfo().get(instanceName))
+      return ConfigStringUtil
+          .parseConcatenatedConfig(getDisabledInstancesWithInfo().get(instanceName))
           .get(ClusterConfigProperty.HELIX_ENABLED_DISABLE_TIMESTAMP.toString());
-    } else {
-      return getDisabledInstances().get(instanceName);
     }
+    return getDisabledInstances().get(instanceName);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -76,8 +76,8 @@ public class ClusterConfig extends HelixProperty {
 
     TARGET_EXTERNALVIEW_ENABLED,
     @Deprecated // ERROR_OR_RECOVERY_PARTITION_THRESHOLD_FOR_LOAD_BALANCE will take
-        // precedence if it is set
-        ERROR_PARTITION_THRESHOLD_FOR_LOAD_BALANCE, // Controller won't execute load balance state
+    // precedence if it is set
+    ERROR_PARTITION_THRESHOLD_FOR_LOAD_BALANCE, // Controller won't execute load balance state
     // transition if the number of partitons that need
     // recovery exceeds this limitation
     ERROR_OR_RECOVERY_PARTITION_THRESHOLD_FOR_LOAD_BALANCE, // Controller won't execute load balance
@@ -90,8 +90,7 @@ public class ClusterConfig extends HelixProperty {
     // disabled instances will write into both 2 fields for backward compatibility.
 
     VIEW_CLUSTER, // Set to "true" to indicate this is a view cluster
-    VIEW_CLUSTER_SOURCES, // Map field, key is the name of source clust:1175
-    // er, value is
+    VIEW_CLUSTER_SOURCES, // Map field, key is the name of source cluster, value is
     // ViewClusterSourceConfig JSON string
     VIEW_CLUSTER_REFRESH_PERIOD, // In second
     // Specifies job types and used for quota allocation

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
@@ -129,7 +129,8 @@ public class InstanceValidationUtil {
       return enabledInInstanceConfig;
     }
     boolean enabledInClusterConfig =
-        !clusterConfig.getDisabledInstances().containsKey(instanceConfig.getInstanceName());
+        !clusterConfig.getDisabledInstances().containsKey(instanceConfig.getInstanceName())
+        && !clusterConfig.getDisabledInstancesWithInfo().containsKey(instanceConfig.getInstanceName());
     return enabledInClusterConfig && enabledInInstanceConfig;
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestBatchEnableInstances.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestBatchEnableInstances.java
@@ -61,6 +61,12 @@ public class TestBatchEnableInstances extends TaskTestBase {
     for (Map<String, String> stateMap : externalView.getRecord().getMapFields().values()) {
       Assert.assertTrue(!stateMap.keySet().contains(_participants[0].getInstanceName()));
     }
+    HelixDataAccessor dataAccessor =
+        new ZKHelixDataAccessor(CLUSTER_NAME, new ZkBaseDataAccessor<>(_gZkClient));
+    ClusterConfig clusterConfig = dataAccessor.getProperty(dataAccessor.keyBuilder().clusterConfig());
+    Assert.assertEquals(Long.parseLong(
+        clusterConfig.getInstanceHelixDisabledTimeStamp(_participants[0].getInstanceName())),
+        Long.parseLong(clusterConfig.getDisabledInstances().get(_participants[0].getInstanceName())));
     _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME,
         _participants[0].getInstanceName(), true);
   }
@@ -79,9 +85,18 @@ public class TestBatchEnableInstances extends TaskTestBase {
       Assert.assertTrue(!stateMap.keySet().contains(_participants[0].getInstanceName()));
       Assert.assertTrue(!stateMap.keySet().contains(_participants[1].getInstanceName()));
     }
+    HelixDataAccessor dataAccessor =
+        new ZKHelixDataAccessor(CLUSTER_NAME, new ZkBaseDataAccessor<>(_gZkClient));
+    ClusterConfig clusterConfig = dataAccessor.getProperty(dataAccessor.keyBuilder().clusterConfig());
+    Assert.assertEquals(Long.parseLong(
+        clusterConfig.getInstanceHelixDisabledTimeStamp(_participants[1].getInstanceName())),
+        Long.parseLong(clusterConfig.getDisabledInstances().get(_participants[1].getInstanceName())));
     _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME,
         Arrays.asList(_participants[0].getInstanceName(), _participants[1].getInstanceName()),
         true);
+    Assert.assertEquals(Long.parseLong(
+        clusterConfig.getInstanceHelixDisabledTimeStamp(_participants[0].getInstanceName())),
+        Long.parseLong(clusterConfig.getDisabledInstances().get(_participants[0].getInstanceName())));
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -319,18 +319,23 @@ public class MockHelixAdmin implements HelixAdmin {
     ClusterConfig clusterConfig = new ClusterConfig(record);
 
     Map<String, String> disabledInstances = new TreeMap<>();
+    Map<String, String> disabledInstancesWithInfo = new TreeMap<>();
     if (clusterConfig.getDisabledInstances() != null) {
       disabledInstances.putAll(clusterConfig.getDisabledInstances());
+      disabledInstancesWithInfo.putAll(clusterConfig.getDisabledInstancesWithInfo());
     }
     if (enabled) {
       disabledInstances.keySet().removeAll(instances);
     } else {
       for (String disabledInstance : instances) {
+        String timeStamp = String.valueOf(System.currentTimeMillis());
+        disabledInstances.put(disabledInstance, timeStamp);
         disabledInstances
-            .put(disabledInstance, assembleInstanceBatchedDisabledInfo(disabledType, reason));
+            .put(disabledInstance, assembleInstanceBatchedDisabledInfo(disabledType, reason, timeStamp));
       }
     }
     clusterConfig.setDisabledInstances(disabledInstances);
+    clusterConfig.setDisabledInstancesWithInfo(disabledInstancesWithInfo);
   }
 
   @Override

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -175,6 +175,9 @@ public class TestInstancesAccessor extends AbstractTestClass {
         new HashSet<>(Arrays.asList(CLUSTER_NAME + "localhost_12919")));
     Assert.assertEquals(clusterConfig.getDisabledInstancesWithInfo().keySet(),
         new HashSet<>(Arrays.asList(CLUSTER_NAME + "localhost_12919")));
+    Assert.assertEquals(Long.parseLong(
+        clusterConfig.getInstanceHelixDisabledTimeStamp(CLUSTER_NAME + "localhost_12919")),
+        Long.parseLong(clusterConfig.getDisabledInstances().get(CLUSTER_NAME + "localhost_12919")));
     Assert
         .assertEquals(clusterConfig.getInstanceHelixDisabledType(CLUSTER_NAME + "localhost_12918"),
             "INSTANCE_NOT_DISABLED");

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -154,6 +154,8 @@ public class TestInstancesAccessor extends AbstractTestClass {
     ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
     Assert.assertEquals(clusterConfig.getDisabledInstances().keySet(),
         new HashSet<>(instancesToDisable));
+    Assert.assertEquals(clusterConfig.getDisabledInstancesWithInfo().keySet(),
+        new HashSet<>(instancesToDisable));
     Assert
         .assertEquals(clusterConfig.getInstanceHelixDisabledType(CLUSTER_NAME + "localhost_12918"),
             "USER_OPERATION");
@@ -170,6 +172,8 @@ public class TestInstancesAccessor extends AbstractTestClass {
             "reason_1"), entity, Response.Status.OK.getStatusCode());
     clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
     Assert.assertEquals(clusterConfig.getDisabledInstances().keySet(),
+        new HashSet<>(Arrays.asList(CLUSTER_NAME + "localhost_12919")));
+    Assert.assertEquals(clusterConfig.getDisabledInstancesWithInfo().keySet(),
         new HashSet<>(Arrays.asList(CLUSTER_NAME + "localhost_12919")));
     Assert
         .assertEquals(clusterConfig.getInstanceHelixDisabledType(CLUSTER_NAME + "localhost_12918"),


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
#2000


### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Batch enable/disable instance now will update 2 map fields, DISABLED_INSTANCES, and DISABLED_INSTANCES_W_INFO.
Keep the format for DISABLED_INSTANCES the same as before. 


### Tests

- [X] The following tests are written for this issue:
Updated  TestBatchEnableInstances and TestInstancesAccessor

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
