### PR TITLE
Reduce helix controller log and minor code improve

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -138,7 +138,7 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
       String resourceName = message.getResourceName();
       Resource resource = resourceMap.get(resourceName);
       if (resource == null) {
-        LogUtil.logInfo(LOG, _eventId, String.format(
+        LogUtil.logDebug(LOG, _eventId, String.format(
             "Ignore a pending relay message %s for a non-exist resource %s and partition %s",
             message.getMsgId(), resourceName, message.getPartitionName()));
         continue;
@@ -156,7 +156,7 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
             cache.addStaleMessage(instanceName, message);
           }
         } else {
-          LogUtil.logInfo(LOG, _eventId, String
+          LogUtil.logDebug(LOG, _eventId, String
               .format("Ignore a pending message %s for a non-exist resource %s and partition %s",
                   message.getMsgId(), resourceName, message.getPartitionName()));
         }
@@ -168,7 +168,7 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
             if (partition != null) {
               setMessageState(currentStateOutput, resourceName, partition, instanceName, message);
             } else {
-              LogUtil.logInfo(LOG, _eventId, String.format(
+              LogUtil.logDebug(LOG, _eventId, String.format(
                   "Ignore a pending message %s for a non-exist resource %s and partition %s",
                   message.getMsgId(), resourceName, message.getPartitionName()));
             }
@@ -193,7 +193,7 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
       String resourceName = message.getResourceName();
       Resource resource = resourceMap.get(resourceName);
       if (resource == null) {
-        LogUtil.logInfo(LOG, _eventId, String.format(
+        LogUtil.logDebug(LOG, _eventId, String.format(
             "Ignore a pending relay message %s for a non-exist resource %s and partition %s",
             message.getMsgId(), resourceName, message.getPartitionName()));
         continue;
@@ -205,7 +205,7 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
         if (partition != null) {
           currentStateOutput.setPendingRelayMessage(resourceName, partition, instanceName, message);
         } else {
-          LogUtil.logInfo(LOG, _eventId, String.format(
+          LogUtil.logDebug(LOG, _eventId, String.format(
               "Ignore a pending relay message %s for a non-exist resource %s and partition %s",
               message.getMsgId(), resourceName, message.getPartitionName()));
         }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -320,18 +320,18 @@ public class MessageGenerationPhase extends AbstractBaseStage {
     if (pendingMessage != null) {
       String pendingState = pendingMessage.getToState();
       if (nextState.equalsIgnoreCase(pendingState)) {
-        LogUtil.logInfo(logger, _eventId,
+        LogUtil.logDebug(logger, _eventId,
             "Message already exists for " + instanceName + " to transit " + resource
                 .getResourceName() + "." + partition.getPartitionName() + " from " + currentState
                 + " to " + nextState + ", isRelay: " + pendingMessage.isRelayMessage());
       } else if (currentState.equalsIgnoreCase(pendingState)) {
-        LogUtil.logInfo(logger, _eventId,
+        LogUtil.logDebug(logger, _eventId,
             "Message hasn't been removed for " + instanceName + " to transit " + resource
                 .getResourceName() + "." + partition.getPartitionName() + " to " + pendingState
                 + ", desiredState: " + desiredState + ", isRelay: " + pendingMessage
                 .isRelayMessage());
       } else {
-        LogUtil.logInfo(logger, _eventId,
+        LogUtil.logDebug(logger, _eventId,
             "IdealState changed before state transition completes for " + resource.getResourceName()
                 + "." + partition.getPartitionName() + " on " + instanceName + ", pendingState: "
                 + pendingState + ", currentState: " + currentState + ", nextState: " + nextState

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -320,7 +320,7 @@ public class MessageGenerationPhase extends AbstractBaseStage {
     if (pendingMessage != null) {
       String pendingState = pendingMessage.getToState();
       if (nextState.equalsIgnoreCase(pendingState)) {
-        LogUtil.logDebug(logger, _eventId,
+        LogUtil.logInfo(logger, _eventId,
             "Message already exists for " + instanceName + " to transit " + resource
                 .getResourceName() + "." + partition.getPartitionName() + " from " + currentState
                 + " to " + nextState + ", isRelay: " + pendingMessage.isRelayMessage());

--- a/helix-core/src/main/java/org/apache/helix/task/AssignableInstanceManager.java
+++ b/helix-core/src/main/java/org/apache/helix/task/AssignableInstanceManager.java
@@ -178,6 +178,9 @@ public class AssignableInstanceManager {
     }
     LOG.info(
         "AssignableInstanceManager built AssignableInstances from scratch based on contexts in TaskDataCache due to Controller switch or ClusterConfig change.");
+    if (_assignableInstanceMap.isEmpty()) {
+      LOG.warn("No assignable instance!");
+    }
     computeGlobalThreadBasedCapacity();
   }
 
@@ -273,6 +276,9 @@ public class AssignableInstanceManager {
     }
     LOG.info(
         "AssignableInstanceManager built AssignableInstances from scratch based on CurrentState.");
+    if (_assignableInstanceMap.isEmpty()) {
+      LOG.warn("No assignable instance!");
+    }
     computeGlobalThreadBasedCapacity();
   }
 
@@ -419,7 +425,9 @@ public class AssignableInstanceManager {
     }
     LOG.info(
         "AssignableInstanceManager updated AssignableInstances due to LiveInstance/InstanceConfig change.");
-
+    if (_assignableInstanceMap.isEmpty()) {
+      LOG.warn("No assignable instance!");
+    }
     computeGlobalThreadBasedCapacity();
   }
 

--- a/helix-core/src/main/java/org/apache/helix/task/AssignableInstanceManager.java
+++ b/helix-core/src/main/java/org/apache/helix/task/AssignableInstanceManager.java
@@ -178,9 +178,6 @@ public class AssignableInstanceManager {
     }
     LOG.info(
         "AssignableInstanceManager built AssignableInstances from scratch based on contexts in TaskDataCache due to Controller switch or ClusterConfig change.");
-    if (_assignableInstanceMap.isEmpty()) {
-      LOG.warn("No assignable instance!");
-    }
     computeGlobalThreadBasedCapacity();
   }
 
@@ -276,9 +273,6 @@ public class AssignableInstanceManager {
     }
     LOG.info(
         "AssignableInstanceManager built AssignableInstances from scratch based on CurrentState.");
-    if (_assignableInstanceMap.isEmpty()) {
-      LOG.warn("No assignable instance!");
-    }
     computeGlobalThreadBasedCapacity();
   }
 
@@ -425,9 +419,6 @@ public class AssignableInstanceManager {
     }
     LOG.info(
         "AssignableInstanceManager updated AssignableInstances due to LiveInstance/InstanceConfig change.");
-    if (_assignableInstanceMap.isEmpty()) {
-      LOG.warn("No assignable instance!");
-    }
     computeGlobalThreadBasedCapacity();
   }
 

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowDispatcher.java
@@ -149,12 +149,9 @@ public class WorkflowDispatcher extends AbstractTaskDispatcher {
     // For workflows that have already reached final states, STOP should not take into effect.
     if (!TaskConstants.FINAL_STATES.contains(workflowCtx.getWorkflowState())
         && TargetState.STOP.equals(targetState)) {
-      if (workflowCtx.getWorkflowState() == TaskState.STOPPED) {
-        return;
-      }
-      LOG.debug("Workflow {} is marked as stopped. Workflow state is {}", workflow,
-          workflowCtx.getWorkflowState());
-      if (isWorkflowStopped(workflowCtx, workflowCfg)) {
+      if (isWorkflowStopped(workflowCtx, workflowCfg) && workflowCtx.getWorkflowState() != TaskState.STOPPED) {
+        LOG.debug("Workflow {} is marked as stopped. Workflow state is {}", workflow,
+            workflowCtx.getWorkflowState());
         workflowCtx.setWorkflowState(TaskState.STOPPED);
         _clusterDataCache.updateWorkflowContext(workflow, workflowCtx);
       }

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowDispatcher.java
@@ -21,7 +21,6 @@ package org.apache.helix.task;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -75,7 +74,7 @@ public class WorkflowDispatcher extends AbstractTaskDispatcher {
     // Clean up if workflow marked for deletion
     TargetState targetState = workflowCfg.getTargetState();
     if (targetState == TargetState.DELETE) {
-      LOG.info("Workflow is marked as deleted {} cleaning up the workflow context.", workflow);
+      LOG.debug("Workflow is marked as deleted {} cleaning up the workflow context.", workflow);
       updateInflightJobs(workflow, workflowCtx, currentStateOutput, bestPossibleOutput);
       cleanupWorkflow(workflow);
       return;
@@ -119,7 +118,7 @@ public class WorkflowDispatcher extends AbstractTaskDispatcher {
 
     // Step 4: Handle finished workflows
     if (workflowCtx.getFinishTime() != WorkflowContext.UNFINISHED) {
-      LOG.info("Workflow {} is finished.", workflow);
+      LOG.debug("Workflow {} is finished.", workflow);
       updateInflightJobs(workflow, workflowCtx, currentStateOutput, bestPossibleOutput);
       long expiryTime = workflowCfg.getExpiry();
       // Check if this workflow has been finished past its expiry.
@@ -150,7 +149,10 @@ public class WorkflowDispatcher extends AbstractTaskDispatcher {
     // For workflows that have already reached final states, STOP should not take into effect.
     if (!TaskConstants.FINAL_STATES.contains(workflowCtx.getWorkflowState())
         && TargetState.STOP.equals(targetState)) {
-      LOG.info("Workflow {} is marked as stopped. Workflow state is {}", workflow,
+      if (workflowCtx.getWorkflowState() == TaskState.STOPPED) {
+        return;
+      }
+      LOG.debug("Workflow {} is marked as stopped. Workflow state is {}", workflow,
           workflowCtx.getWorkflowState());
       if (isWorkflowStopped(workflowCtx, workflowCfg)) {
         workflowCtx.setWorkflowState(TaskState.STOPPED);

--- a/helix-core/src/main/java/org/apache/helix/task/assigner/ThreadCountBasedTaskAssigner.java
+++ b/helix-core/src/main/java/org/apache/helix/task/assigner/ThreadCountBasedTaskAssigner.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.PriorityQueue;
 
+import java.util.Set;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.task.AssignableInstanceManager;
 import org.apache.helix.task.TaskConfig;
@@ -74,19 +75,16 @@ public class ThreadCountBasedTaskAssigner implements TaskAssigner {
   public Map<String, TaskAssignResult> assignTasks(
       AssignableInstanceManager assignableInstanceManager, Collection<String> instances,
       Iterable<TaskConfig> tasks, String quotaType) {
-    Iterable<AssignableInstance> assignableInstances = new HashSet<>();
+    Set<AssignableInstance> assignableInstances = new HashSet<>();
     // Only add the AssignableInstances that are also in instances
     for (String instance : instances) {
-      ((HashSet<AssignableInstance>) assignableInstances)
-          .add(assignableInstanceManager.getAssignableInstance(instance));
+      assignableInstances.add(assignableInstanceManager.getAssignableInstance(instance));
     }
 
     if (tasks == null || !tasks.iterator().hasNext()) {
-      logger.warn("No task to assign!");
       return Collections.emptyMap();
     }
-    if (assignableInstances == null || !assignableInstances.iterator().hasNext()) {
-      logger.warn("No instance to assign!");
+    if (assignableInstances.isEmpty()) {
       return buildNoInstanceAssignment(tasks, quotaType);
     }
     if (quotaType == null || quotaType.equals("") || quotaType.equals("null")) {
@@ -148,7 +146,7 @@ public class ThreadCountBasedTaskAssigner implements TaskAssigner {
     return result;
   }
 
-  private class AssignableInstanceComparator implements Comparator<AssignableInstance> {
+  private static class AssignableInstanceComparator implements Comparator<AssignableInstance> {
 
     /**
      * Resource type this comparator needs to compare


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fix https://github.com/apache/helix/issues/2080

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
We are seeing issue in certain product where controller is generating way too many logs that fill up disk space. 
In this PR, we reduce a few logger level from INFO to DEBUG and update the logic to avoid duplicated messages in `WorkflowDispatcher` (Step 5: handle workflow that should STOP)


### Tests

- [X] The following tests are written for this issue:

[info] ./zookeeper-api/target/surefire-reports/TestSuite.txt: Tests run: 54, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 123.232 s - in TestSuite
[info] ./recipes/rsync-replicated-file-system/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.585 s - in TestSuite
[info] ./recipes/task-execution/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.582 s - in TestSuite
[info] ./recipes/distributed-lock-manager/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.705 s - in TestSuite
[info] ./recipes/rabbitmq-consumer-group/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.78[9](https://github.com/apache/helix/runs/6494616692?check_suite_focus=true#step:6:10) s - in TestSuite
[info] ./recipes/service-discovery/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.415 s - in TestSuite
[info] ./metadata-store-directory-common/target/surefire-reports/TestSuite.txt: Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.745 s - in TestSuite
[info] ./helix-rest/target/surefire-reports/TestSuite.txt: Tests run: 205, Failures: 1, Errors: 0, Skipped: 35, Time elapsed: 138.881 s <<< FAILURE! - in TestSuite
Error:  Test failed: testGetClusters(org.apache.helix.rest.server.TestClusterAccessor)  Time elapsed: 0.513 s  <<< FAILURE!
[info] ./metrics-common/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.335 s - in TestSuite
[info] ./helix-view-aggregator/target/surefire-reports/TestSuite.txt: Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 58.735 s - in TestSuite
[info] ./helix-common/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.272 s - in TestSuite
[info] ./helix-core/target/surefire-reports/TestSuite.txt: Tests run: 1314, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,903.158 s - in TestSuite
[info] ./helix-lock/target/surefire-reports/TestSuite.txt: Tests run: [11](https://github.com/apache/helix/runs/6494616692?check_suite_focus=true#step:6:12), Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 53.896 s - in TestSuite

Known issue with `TestClusterAccessor`, verified passed locally.

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
