### PR TITLE
Add TTL and Container modes to BaseDataAccessor and its implementations

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
@@ -44,6 +44,18 @@ public interface BaseDataAccessor<T> {
   boolean create(String path, T record, int options);
 
   /**
+   * This will always attempt to create the znode, if it exists it will return false. Will
+   * create parents if they do not exist. For performance reasons, it may try to create
+   * child first and only if it fails it will try to create parents
+   * @param path path to the ZNode to create
+   * @param record the data to write to the ZNode
+   * @param options Set the type of ZNode see the valid values in {@link AccessOption}
+   * @param ttl TTL of the node in milliseconds, if options supports it
+   * @return true if creation succeeded, false otherwise (e.g. if the ZNode exists)
+   */
+  boolean create(String path, T record, int options, long ttl);
+
+  /**
    * This will always attempt to set the data on existing node. If the ZNode does not
    * exist it will create it and all its parents ZNodes if necessary
    * @param path path to the ZNode to set
@@ -94,6 +106,17 @@ public interface BaseDataAccessor<T> {
    * @return For each child: true if creation succeeded, false otherwise (e.g. if the child exists)
    */
   boolean[] createChildren(List<String> paths, List<T> records, int options);
+
+  /**
+   * Use it when creating children under a parent node. This will use async api for better
+   * performance. If the child already exists it will return false.
+   * @param paths the paths to the children ZNodes
+   * @param records List of data to write to each of the path
+   * @param options Set the type of ZNode see the valid values in {@link AccessOption}
+   * @param ttl TTL of the node in milliseconds, if options supports it
+   * @return For each child: true if creation succeeded, false otherwise (e.g. if the child exists)
+   */
+  boolean[] createChildren(List<String> paths, List<T> records, int options, long ttl);
 
   /**
    * can set multiple children under a parent node. This will use async api for better

--- a/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
@@ -68,6 +68,11 @@ public class MockBaseDataAccessor implements BaseDataAccessor<ZNRecord> {
   }
 
   @Override
+  public boolean create(String path, ZNRecord record, int options, long ttl) {
+    return set(path, record, options);
+  }
+
+  @Override
   public boolean set(String path, ZNRecord record, int options) {
     ZNode zNode = _recordMap.get(path);
     if (zNode == null) {
@@ -109,6 +114,12 @@ public class MockBaseDataAccessor implements BaseDataAccessor<ZNRecord> {
   @Override
   public boolean[] createChildren(List<String> paths, List<ZNRecord> records,
       int options) {
+    return setChildren(paths, records, options);
+  }
+
+  @Override
+  public boolean[] createChildren(List<String> paths, List<ZNRecord> records,
+      int options, long ttl) {
     return setChildren(paths, records, options);
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #2081 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds support for TTL and Container modes to BaseDataAccessor and its implementations by taking advantage of relevant API from ZkClient and its descendent classes.

### Tests

- [x] The following tests are written for this issue:

Two tests (`testSyncCreateWithTTL()` and `testSyncCreateContainer()`) were added to `TestZkBaseDataAccessor`. In addition, `testAsyncZkBaseDataAccessor()` in the same class was modified to test the newly added API.

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
