### PR TITLE
Fix static instance bug in DistViewAggregatorStateModel

### DIFF
--- a/helix-view-aggregator/src/main/java/org/apache/helix/view/statemodel/DistViewAggregatorStateModel.java
+++ b/helix-view-aggregator/src/main/java/org/apache/helix/view/statemodel/DistViewAggregatorStateModel.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class DistViewAggregatorStateModel extends AbstractHelixLeaderStandbyStateModel {
   private final static Logger logger = LoggerFactory.getLogger(DistViewAggregatorStateModel.class);
   private final static Object stateTransitionLock = new Object();
-  private static HelixViewAggregator _aggregator;
+  private HelixViewAggregator _aggregator;
 
   public DistViewAggregatorStateModel(String zkAddr) {
     super(zkAddr);

--- a/helix-view-aggregator/src/test/java/org/apache/helix/view/integration/TestHelixViewAggregator.java
+++ b/helix-view-aggregator/src/test/java/org/apache/helix/view/integration/TestHelixViewAggregator.java
@@ -56,6 +56,7 @@ public class TestHelixViewAggregator extends ViewAggregatorIntegrationTestBase {
   private HelixAdmin _helixAdmin;
   private MockViewClusterSpectator _monitor;
   private Set<String> _allResources = new HashSet<>();
+  // TODO: add test coverage on multiple statemodel instances for different view clusters
   private DistViewAggregatorStateModel _viewAggregatorStateModel;
 
   @BeforeClass


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixes https://github.com/apache/helix/issues/2123

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

A one line bug fix for DistViewAggregatorStateModel. It shouldn't hold mutable static instance which is resource specific. This is causing issue when multiple resources are assigned to the same participant.

### Tests

- [X] The following tests are written for this issue:

Verified in internal testing environment. Aggregator works when multiple resources are assigned.

- The following is the result of the "mvn test" command on the appropriate module:
- 
[INFO] Apache Helix ....................................... SUCCESS [  1.100 s]
[INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  3.830 s]
[INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [ 14.378 s]
[INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [02:31 min]
[INFO] Apache Helix :: Helix Common ....................... SUCCESS [  2.138 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [  01:49 h]
[INFO] Apache Helix :: Admin Webapp ....................... SUCCESS [  0.985 s]
[INFO] Apache Helix :: Restful Interface .................. SUCCESS [02:55 min]
[INFO] Apache Helix :: Distributed Lock ................... SUCCESS [ 55.106 s]
[INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  0.390 s]
[INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.013 s]
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  1.979 s]
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  2.295 s]
[INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  1.937 s]
[INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  1.755 s]
[INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  1.978 s]
[INFO] Apache Helix :: View Aggregator .................... SUCCESS [01:02 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:57 h
[INFO] Finished at: 2022-05-26T17:42:12-07:00
[INFO] ------------------------------------------------------------------------

Known issue with `TestClusterAccessor`, verified passed locally. 

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
