### PR TITLE
Minor: Print exception as part of error log

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -904,8 +904,8 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
         pipeline.finish();
       } catch (Exception e) {
         logger.error(
-            "Exception while executing {} pipeline for cluster {}. Will not continue to next pipeline",
-            dataProvider.getPipelineName(), _clusterName, e);
+            "Exception while executing " + dataProvider.getPipelineName() + " pipeline for cluster "
+                + _clusterName + ". Will not continue to next pipeline. Exception: " + e);
         if (e instanceof HelixMetaDataAccessException) {
           helixMetaDataAccessRebalanceFail = true;
           // If pipeline failed due to read/write fails to zookeeper, retry the pipeline.


### PR DESCRIPTION
While debugging a pipeline failure, realized that only error message
without exception was getting printed.

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:


### Description

Error message printed in the log doesn't actually include the exception and hence difficult to debug sometime.
2022/05/31 15:35:09.767 ERROR [GenericHelixController] [HelixController-pipeline-default-xxx_-(bc8254a5_DEFAULT)] [helix] [] Exception while executing DEFAULT pipeline for cluster xxx. Will not continue to next pipeline


### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
