### PR TITLE
Add backward compatibility support for constructing ZKHelixManager

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
@@ -21,6 +21,7 @@ package org.apache.helix;
 
 import java.util.Properties;
 
+import org.apache.helix.manager.zk.client.HelixZkClient;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.slf4j.Logger;
@@ -35,8 +36,11 @@ public class HelixManagerProperty {
   private String _version;
   private long _healthReportLatency;
   private HelixCloudProperty _helixCloudProperty;
-  private RealmAwareZkClient.RealmAwareZkConnectionConfig _zkConnectionConfig;
+  private RealmAwareZkClient.RealmAwareZkConnectionConfig _realmAwareZkConnectionConfig;
   private RealmAwareZkClient.RealmAwareZkClientConfig _zkClientConfig;
+  // This field is added for backward compatibility, when this field is set,
+  // _realmAwareZkConnectionConfig should not be set
+  private HelixZkClient.ZkConnectionConfig _zkConnectionConfig;
 
   /**
    * ** Deprecated - HelixManagerProperty should be a general property/config object used for
@@ -56,13 +60,15 @@ public class HelixManagerProperty {
 
   private HelixManagerProperty(String version, long healthReportLatency,
       HelixCloudProperty helixCloudProperty,
-      RealmAwareZkClient.RealmAwareZkConnectionConfig zkConnectionConfig,
-      RealmAwareZkClient.RealmAwareZkClientConfig zkClientConfig) {
+      RealmAwareZkClient.RealmAwareZkConnectionConfig realmAwareZkConnectionConfig,
+      RealmAwareZkClient.RealmAwareZkClientConfig zkClientConfig,
+      HelixZkClient.ZkConnectionConfig zkConnectionConfig) {
     _version = version;
     _healthReportLatency = healthReportLatency;
     _helixCloudProperty = helixCloudProperty;
-    _zkConnectionConfig = zkConnectionConfig;
+    _realmAwareZkConnectionConfig = realmAwareZkConnectionConfig;
     _zkClientConfig = zkClientConfig;
+    _zkConnectionConfig = zkConnectionConfig;
   }
 
   public HelixCloudProperty getHelixCloudProperty() {
@@ -80,27 +86,32 @@ public class HelixManagerProperty {
     return _healthReportLatency;
   }
 
-  public RealmAwareZkClient.RealmAwareZkConnectionConfig getZkConnectionConfig() {
-    return _zkConnectionConfig;
+  public RealmAwareZkClient.RealmAwareZkConnectionConfig getRealmAwareZkConnectionConfig() {
+    return _realmAwareZkConnectionConfig;
   }
 
   public RealmAwareZkClient.RealmAwareZkClientConfig getZkClientConfig() {
     return _zkClientConfig;
   }
 
+  public HelixZkClient.ZkConnectionConfig getZkConnectionConfig() {
+    return _zkConnectionConfig;
+  }
+
   public static class Builder {
     private String _version;
     private long _healthReportLatency;
     private HelixCloudProperty _helixCloudProperty;
-    private RealmAwareZkClient.RealmAwareZkConnectionConfig _zkConnectionConfig;
+    private RealmAwareZkClient.RealmAwareZkConnectionConfig _realmAwareZkConnectionConfig;
     private RealmAwareZkClient.RealmAwareZkClientConfig _zkClientConfig;
+    private HelixZkClient.ZkConnectionConfig _zkConnectionConfig;
 
     public Builder() {
     }
 
     public HelixManagerProperty build() {
       return new HelixManagerProperty(_version, _healthReportLatency, _helixCloudProperty,
-          _zkConnectionConfig, _zkClientConfig);
+          _realmAwareZkConnectionConfig, _zkClientConfig, _zkConnectionConfig);
     }
 
     public Builder setVersion(String version) {
@@ -120,13 +131,18 @@ public class HelixManagerProperty {
 
     public Builder setRealmAWareZkConnectionConfig(
         RealmAwareZkClient.RealmAwareZkConnectionConfig zkConnectionConfig) {
-      _zkConnectionConfig = zkConnectionConfig;
+      _realmAwareZkConnectionConfig = zkConnectionConfig;
       return this;
     }
 
     public Builder setRealmAwareZkClientConfig(
         RealmAwareZkClient.RealmAwareZkClientConfig zkClientConfig) {
       _zkClientConfig = zkClientConfig;
+      return this;
+    }
+
+    public Builder setZkConnectionConfig(HelixZkClient.ZkConnectionConfig zkConnectionConfig) {
+      _zkConnectionConfig = zkConnectionConfig;
       return this;
     }
   }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestHelixManagerFactory.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestHelixManagerFactory.java
@@ -1,10 +1,70 @@
 package org.apache.helix.manager.zk;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.HelixManagerProperty;
+import org.apache.helix.InstanceType;
+import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
-public class TestHelixManagerFactory {
+/**
+ * Test {@link org.apache.helix.HelixManagerFactory}. MSDS usages are tested in
+ * {@link org.apache.helix.integration.multizk.TestMultiZkHelixJavaApis}
+ */
+public class TestHelixManagerFactory extends ZkStandAloneCMTestBase {
   private static Logger LOG = LoggerFactory.getLogger(TestHelixManagerFactory.class);
+  private static final String PARTICIPANT_NAME_PREFIX = "testInstance_";
+  private HelixAdmin _helixAdmin;
 
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    super.beforeClass();
+    _helixAdmin = new ZKHelixAdmin.Builder().setZkAddress(ZK_ADDR).build();
+  }
 
+  @Test
+  public void testZKConnectionConfigForNonMsdsConnection() throws Exception {
+    // Create participant
+    String participantName = PARTICIPANT_NAME_PREFIX + "testZKConnectionConfigForNonMsdsConnection";
+    _helixAdmin.addInstance(CLUSTER_NAME, new InstanceConfig(participantName));
+
+    // Create zk helix manager using HelixManagerFactory API
+    HelixManager managerParticipant = HelixManagerFactory
+        .getZKHelixManager(CLUSTER_NAME, participantName, InstanceType.PARTICIPANT, null,
+            new HelixManagerProperty.Builder()
+                .setZkConnectionConfig(new HelixZkClient.ZkConnectionConfig(ZK_ADDR)).build());
+    managerParticipant.connect();
+
+    // Verify manager
+    InstanceConfig instanceConfigRead =
+        _helixAdmin.getInstanceConfig(CLUSTER_NAME, participantName);
+    Assert.assertNotNull(instanceConfigRead);
+    Assert.assertEquals(instanceConfigRead.getInstanceName(), participantName);
+  }
 }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestHelixManagerFactory.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestHelixManagerFactory.java
@@ -1,0 +1,10 @@
+package org.apache.helix.manager.zk;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestHelixManagerFactory {
+  private static Logger LOG = LoggerFactory.getLogger(TestHelixManagerFactory.class);
+
+
+}


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Resolves #2160 

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

This commit uses a deprecated class `HelixZkClient.ZkConnectionConfig` to convey the information for non-ZooScalability users in HelixManagerProperty, while ZooScalability users use `RealmAwareZkClient.RealmAwareZkConnectionConfig`. This commit adds some validation around there should be at least one, and only one of `HelixZkClient.ZkConnectionConfig`, `RealmAwareZkClient.RealmAwareZkConnectionConfig`, and zk address exists, and this one field will be used as the source of information to establish connection with ZK server.

### Tests

- [ ] The following tests are written for this issue:

Added TestHelixManagerFactory.
Also ran TestMultiZkHelixJavaApis.java to make sure this commit doesn't break current logic for ZooScalability cases.

- The following is the result of the "mvn test" command on the appropriate module:

Running

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
