### PR TITLE
Add TTL and Container Modes to ZkClient and BaseDataAccessor APIs

### DIFF
--- a/helix-core/helix-core-1.0.5-SNAPSHOT.ivy
+++ b/helix-core/helix-core-1.0.5-SNAPSHOT.ivy
@@ -52,7 +52,7 @@ under the License.
     <dependency org="org.apache.logging.log4j" name="log4j-slf4j-impl" rev="2.17.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)">
         <artifact name="log4j-slf4j-impl" ext="jar"/>
     </dependency>
-    <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.4.13" conf="compile->compile(default);runtime->runtime(default);default->default"/>
+    <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.5.9" conf="compile->compile(default);runtime->runtime(default);default->default"/>
 		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.12.6.1" conf="compile->compile(default);runtime->runtime(default);default->default"/>
     <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.12.6" conf="compile->compile(default);runtime->runtime(default);default->default"/>
     <dependency org="commons-io" name="commons-io" rev="2.11.0" conf="compile->compile(default);runtime->runtime(default);default->default"/>

--- a/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
@@ -44,6 +44,18 @@ public interface BaseDataAccessor<T> {
   boolean create(String path, T record, int options);
 
   /**
+   * This will always attempt to create the znode, if it exists it will return false. Will
+   * create parents if they do not exist. For performance reasons, it may try to create
+   * child first and only if it fails it will try to create parents
+   * @param path path to the ZNode to create
+   * @param record the data to write to the ZNode
+   * @param options Set the type of ZNode see the valid values in {@link AccessOption}
+   * @param ttl TTL of the node in milliseconds, if options supports it
+   * @return true if creation succeeded, false otherwise (e.g. if the ZNode exists)
+   */
+  boolean create(String path, T record, int options, long ttl);
+
+  /**
    * This will always attempt to set the data on existing node. If the ZNode does not
    * exist it will create it and all its parents ZNodes if necessary
    * @param path path to the ZNode to set
@@ -94,6 +106,17 @@ public interface BaseDataAccessor<T> {
    * @return For each child: true if creation succeeded, false otherwise (e.g. if the child exists)
    */
   boolean[] createChildren(List<String> paths, List<T> records, int options);
+
+  /**
+   * Use it when creating children under a parent node. This will use async api for better
+   * performance. If the child already exists it will return false.
+   * @param paths the paths to the children ZNodes
+   * @param records List of data to write to each of the path
+   * @param options Set the type of ZNode see the valid values in {@link AccessOption}
+   * @param ttl TTL of the node in milliseconds, if options supports it
+   * @return For each child: true if creation succeeded, false otherwise (e.g. if the child exists)
+   */
+  boolean[] createChildren(List<String> paths, List<T> records, int options, long ttl);
 
   /**
    * can set multiple children under a parent node. This will use async api for better

--- a/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
@@ -68,6 +68,11 @@ public class MockBaseDataAccessor implements BaseDataAccessor<ZNRecord> {
   }
 
   @Override
+  public boolean create(String path, ZNRecord record, int options, long ttl) {
+    return set(path, record, options);
+  }
+
+  @Override
   public boolean set(String path, ZNRecord record, int options) {
     ZNode zNode = _recordMap.get(path);
     if (zNode == null) {
@@ -109,6 +114,12 @@ public class MockBaseDataAccessor implements BaseDataAccessor<ZNRecord> {
   @Override
   public boolean[] createChildren(List<String> paths, List<ZNRecord> records,
       int options) {
+    return setChildren(paths, records, options);
+  }
+
+  @Override
+  public boolean[] createChildren(List<String> paths, List<ZNRecord> records,
+      int options, long ttl) {
     return setChildren(paths, records, options);
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -175,9 +175,33 @@ public interface RealmAwareZkClient {
 
   void createPersistent(String path, Object data, List<ACL> acl);
 
+  void createPersistentWithTTL(String path, long ttl);
+
+  void createPersistentWithTTL(String path, boolean createParents, long ttl);
+
+  void createPersistentWithTTL(String path, boolean createParents, List<ACL> acl, long ttl);
+
+  void createPersistentWithTTL(String path, Object data, long ttl);
+
+  void createPersistentWithTTL(String path, Object data, List<ACL> acl, long ttl);
+
   String createPersistentSequential(String path, Object data);
 
   String createPersistentSequential(String path, Object data, List<ACL> acl);
+
+  String createPersistentSequentialWithTTL(String path, Object data, long ttl);
+
+  String createPersistentSequentialWithTTL(String path, Object data, List<ACL> acl, long ttl);
+
+  void createContainer(String path);
+
+  void createContainer(String path, boolean createParents);
+
+  void createContainer(String path, boolean createParents, List<ACL> acl);
+
+  void createContainer(String path, Object data);
+
+  void createContainer(String path, Object data, List<ACL> acl);
 
   void createEphemeral(final String path);
 
@@ -189,7 +213,12 @@ public interface RealmAwareZkClient {
 
   String create(final String path, Object data, final CreateMode mode);
 
+  String create(final String path, Object data, final CreateMode mode, long ttl);
+
   String create(final String path, Object datat, final List<ACL> acl, final CreateMode mode);
+
+  String create(final String path, Object datat, final List<ACL> acl, final CreateMode mode,
+      long ttl);
 
   void createEphemeral(final String path, final Object data);
 
@@ -244,6 +273,9 @@ public interface RealmAwareZkClient {
   Stat writeDataGetStat(final String path, Object datat, final int expectedVersion);
 
   void asyncCreate(final String path, Object datat, final CreateMode mode,
+      final ZkAsyncCallbacks.CreateCallbackHandler cb);
+
+  void asyncCreate(final String path, Object datat, final CreateMode mode, long ttl,
       final ZkAsyncCallbacks.CreateCallbackHandler cb);
 
   void asyncSetData(final String path, Object datat, final int version,

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -182,6 +182,32 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public void createPersistentWithTTL(String path, long ttl) {
+    createPersistentWithTTL(path, false, ttl);
+  }
+
+  @Override
+  public void createPersistentWithTTL(String path, boolean createParents, long ttl) {
+    createPersistentWithTTL(path, createParents, ZooDefs.Ids.OPEN_ACL_UNSAFE, ttl);
+  }
+
+  @Override
+  public void createPersistentWithTTL(String path, boolean createParents, List<ACL> acl, long ttl) {
+    checkIfPathContainsShardingKey(path);
+    _rawZkClient.createPersistentWithTTL(path, createParents, acl, ttl);
+  }
+
+  @Override
+  public void createPersistentWithTTL(String path, Object data, long ttl) {
+    create(path, data, CreateMode.PERSISTENT_WITH_TTL, ttl);
+  }
+
+  @Override
+  public void createPersistentWithTTL(String path, Object data, List<ACL> acl, long ttl) {
+    create(path, data, acl, CreateMode.PERSISTENT_WITH_TTL, ttl);
+  }
+
+  @Override
   public String createPersistentSequential(String path, Object data) {
     return create(path, data, CreateMode.PERSISTENT_SEQUENTIAL);
   }
@@ -189,6 +215,42 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   @Override
   public String createPersistentSequential(String path, Object data, List<ACL> acl) {
     return create(path, data, acl, CreateMode.PERSISTENT_SEQUENTIAL);
+  }
+
+  @Override
+  public String createPersistentSequentialWithTTL(String path, Object data, long ttl) {
+    return create(path, data, CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL, ttl);
+  }
+
+  @Override
+  public String createPersistentSequentialWithTTL(String path, Object data, List<ACL> acl, long ttl) {
+    return create(path, data, acl, CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL, ttl);
+  }
+
+  @Override
+  public void createContainer(String path) {
+    createContainer(path, false);
+  }
+
+  @Override
+  public void createContainer(String path, boolean createParents) {
+    createContainer(path, createParents, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+  }
+
+  @Override
+  public void createContainer(String path, boolean createParents, List<ACL> acl) {
+    checkIfPathContainsShardingKey(path);
+    _rawZkClient.createContainer(path, createParents, acl);
+  }
+
+  @Override
+  public void createContainer(String path, Object data) {
+    create(path, data, CreateMode.CONTAINER);
+  }
+
+  @Override
+  public void createContainer(String path, Object data, List<ACL> acl) {
+    create(path, data, acl, CreateMode.CONTAINER);
   }
 
   @Override
@@ -218,9 +280,20 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public String create(String path, Object data, CreateMode mode, long ttl) {
+    return create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, mode, ttl);
+  }
+
+  @Override
   public String create(String path, Object datat, List<ACL> acl, CreateMode mode) {
     checkIfPathContainsShardingKey(path);
     return _rawZkClient.create(path, datat, acl, mode);
+  }
+
+  @Override
+  public String create(String path, Object datat, List<ACL> acl, CreateMode mode, long ttl) {
+    checkIfPathContainsShardingKey(path);
+    return _rawZkClient.create(path, datat, acl, mode, ttl);
   }
 
   @Override
@@ -364,6 +437,13 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   @Override
   public Stat writeDataGetStat(String path, Object datat, int expectedVersion) {
     return writeDataReturnStat(path, datat, expectedVersion);
+  }
+
+  @Override
+  public void asyncCreate(String path, Object datat, CreateMode mode, long ttl,
+      ZkAsyncCallbacks.CreateCallbackHandler cb) {
+    checkIfPathContainsShardingKey(path);
+    _rawZkClient.asyncCreate(path, datat, mode, ttl, cb);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -192,6 +192,31 @@ public class FederatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public void createPersistentWithTTL(String path, long ttl) {
+    createPersistentWithTTL(path, false, ttl);
+  }
+
+  @Override
+  public void createPersistentWithTTL(String path, boolean createParents, long ttl) {
+    createPersistentWithTTL(path, createParents, ZooDefs.Ids.OPEN_ACL_UNSAFE, ttl);
+  }
+
+  @Override
+  public void createPersistentWithTTL(String path, boolean createParents, List<ACL> acl, long ttl) {
+    getZkClient(path).createPersistentWithTTL(path, createParents, acl, ttl);
+  }
+
+  @Override
+  public void createPersistentWithTTL(String path, Object data, long ttl) {
+    create(path, data, CreateMode.PERSISTENT_WITH_TTL, ttl);
+  }
+
+  @Override
+  public void createPersistentWithTTL(String path, Object data, List<ACL> acl, long ttl) {
+    create(path, data, acl, CreateMode.PERSISTENT_WITH_TTL, ttl);
+  }
+
+  @Override
   public String createPersistentSequential(String path, Object data) {
     return create(path, data, CreateMode.PERSISTENT_SEQUENTIAL);
   }
@@ -199,6 +224,41 @@ public class FederatedZkClient implements RealmAwareZkClient {
   @Override
   public String createPersistentSequential(String path, Object data, List<ACL> acl) {
     return create(path, data, acl, CreateMode.PERSISTENT_SEQUENTIAL);
+  }
+
+  @Override
+  public String createPersistentSequentialWithTTL(String path, Object data, long ttl) {
+    return create(path, data, CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL, ttl);
+  }
+
+  @Override
+  public String createPersistentSequentialWithTTL(String path, Object data, List<ACL> acl, long ttl) {
+    return create(path, data, acl, CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL, ttl);
+  }
+
+  @Override
+  public void createContainer(String path) {
+    createContainer(path, false);
+  }
+
+  @Override
+  public void createContainer(String path, boolean createParents) {
+    createContainer(path, createParents, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+  }
+
+  @Override
+  public void createContainer(String path, boolean createParents, List<ACL> acl) {
+    getZkClient(path).createContainer(path, createParents, acl);
+  }
+
+  @Override
+  public void createContainer(String path, Object data) {
+    create(path, data, CreateMode.CONTAINER);
+  }
+
+  @Override
+  public void createContainer(String path, Object data, List<ACL> acl) {
+    create(path, data, acl, CreateMode.CONTAINER);
   }
 
   @Override
@@ -227,8 +287,18 @@ public class FederatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public String create(String path, Object data, CreateMode mode, long ttl) {
+    return create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, mode, ttl);
+  }
+
+  @Override
   public String create(String path, Object data, List<ACL> acl, CreateMode mode) {
     return create(path, data, acl, mode, null);
+  }
+
+  @Override
+  public String create(String path, Object data, List<ACL> acl, CreateMode mode, long ttl) {
+    return create(path, data, acl, mode, ttl, null);
   }
 
   @Override
@@ -357,6 +427,12 @@ public class FederatedZkClient implements RealmAwareZkClient {
   @Override
   public Stat writeDataGetStat(String path, Object data, int expectedVersion) {
     return writeDataReturnStat(path, data, expectedVersion);
+  }
+
+  @Override
+  public void asyncCreate(String path, Object data, CreateMode mode, long ttl,
+      ZkAsyncCallbacks.CreateCallbackHandler cb) {
+    getZkClient(path).asyncCreate(path, data, mode, ttl, cb);
   }
 
   @Override
@@ -501,13 +577,18 @@ public class FederatedZkClient implements RealmAwareZkClient {
 
   private String create(final String path, final Object dataObject, final List<ACL> acl,
       final CreateMode mode, final String expectedSessionId) {
+    return create(path, dataObject, acl, mode, ZkClient.TTL_NOT_SET, expectedSessionId);
+  }
+
+  private String create(final String path, final Object dataObject, final List<ACL> acl,
+      final CreateMode mode, final long ttl, final String expectedSessionId) {
     if (mode.isEphemeral()) {
       throwUnsupportedOperationException();
     }
 
     // Create mode is not session-aware, so the node does not have to be created
     // by the expectedSessionId.
-    return getZkClient(path).create(path, dataObject, acl, mode);
+    return getZkClient(path).create(path, dataObject, acl, mode, ttl);
   }
 
   private ZkClient getZkClient(String path) {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -39,6 +39,7 @@ import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Op;
 import org.apache.zookeeper.OpResult;
+import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
@@ -190,6 +191,33 @@ public class SharedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public void createPersistentWithTTL(String path, long ttl) {
+    createPersistentWithTTL(path, false, ttl);
+  }
+
+  @Override
+  public void createPersistentWithTTL(String path, boolean createParents, long ttl) {
+    createPersistentWithTTL(path, createParents, ZooDefs.Ids.OPEN_ACL_UNSAFE, ttl);
+  }
+
+  @Override
+  public void createPersistentWithTTL(String path, boolean createParents, List<ACL> acl, long ttl) {
+    checkIfPathContainsShardingKey(path);
+    _innerSharedZkClient.createPersistentWithTTL(path, createParents, acl, ttl);
+  }
+
+  @Override
+  public void createPersistentWithTTL(String path, Object data, long ttl) {
+    createPersistentWithTTL(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, ttl);
+  }
+
+  @Override
+  public void createPersistentWithTTL(String path, Object data, List<ACL> acl, long ttl) {
+    checkIfPathContainsShardingKey(path);
+    _innerSharedZkClient.createPersistentWithTTL(path, data, acl, ttl);
+  }
+
+  @Override
   public String createPersistentSequential(String path, Object data) {
     checkIfPathContainsShardingKey(path);
     return _innerSharedZkClient.createPersistentSequential(path, data);
@@ -199,6 +227,44 @@ public class SharedZkClient implements RealmAwareZkClient {
   public String createPersistentSequential(String path, Object data, List<ACL> acl) {
     checkIfPathContainsShardingKey(path);
     return _innerSharedZkClient.createPersistentSequential(path, data, acl);
+  }
+
+  @Override
+  public String createPersistentSequentialWithTTL(String path, Object data, long ttl) {
+    return createPersistentSequentialWithTTL(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, ttl);
+  }
+
+  @Override
+  public String createPersistentSequentialWithTTL(String path, Object data, List<ACL> acl, long ttl) {
+    checkIfPathContainsShardingKey(path);
+    return _innerSharedZkClient.createPersistentSequentialWithTTL(path, data, acl, ttl);
+  }
+
+  @Override
+  public void createContainer(String path) {
+    createContainer(path, false);
+  }
+
+  @Override
+  public void createContainer(String path, boolean createParents) {
+    createContainer(path, createParents, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+  }
+
+  @Override
+  public void createContainer(String path, boolean createParents, List<ACL> acl) {
+    checkIfPathContainsShardingKey(path);
+    _innerSharedZkClient.createContainer(path, createParents, acl);
+  }
+
+  @Override
+  public void createContainer(String path, Object data) {
+    createContainer(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+  }
+
+  @Override
+  public void createContainer(String path, Object data, List<ACL> acl) {
+    checkIfPathContainsShardingKey(path);
+    _innerSharedZkClient.createContainer(path, data, acl);
   }
 
   @Override
@@ -231,16 +297,26 @@ public class SharedZkClient implements RealmAwareZkClient {
 
   @Override
   public String create(String path, Object data, CreateMode mode) {
+    return create(path, data, mode, ZkClient.TTL_NOT_SET);
+  }
+
+  @Override
+  public String create(String path, Object data, CreateMode mode, long ttl) {
     checkIfPathContainsShardingKey(path);
     // delegate to _innerSharedZkClient is fine as _innerSharedZkClient would not allow creating ephemeral node.
     // this still keeps the same behavior.
-    return _innerSharedZkClient.create(path, data, mode);
+    return _innerSharedZkClient.create(path, data, mode, ttl);
   }
 
   @Override
   public String create(String path, Object datat, List<ACL> acl, CreateMode mode) {
+    return create(path, datat, acl, mode, ZkClient.TTL_NOT_SET);
+  }
+
+  @Override
+  public String create(String path, Object datat, List<ACL> acl, CreateMode mode, long ttl) {
     checkIfPathContainsShardingKey(path);
-    return _innerSharedZkClient.create(path, datat, acl, mode);
+    return _innerSharedZkClient.create(path, datat, acl, mode, ttl);
   }
 
   @Override
@@ -403,10 +479,16 @@ public class SharedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public void asyncCreate(String path, Object datat, CreateMode mode,
+  public void asyncCreate(String path, Object datat, CreateMode mode, long ttl,
       ZkAsyncCallbacks.CreateCallbackHandler cb) {
     checkIfPathContainsShardingKey(path);
-    _innerSharedZkClient.asyncCreate(path, datat, mode, cb);
+    _innerSharedZkClient.asyncCreate(path, datat, mode, ttl, cb);
+  }
+
+  @Override
+  public void asyncCreate(String path, Object datat, CreateMode mode,
+      ZkAsyncCallbacks.CreateCallbackHandler cb) {
+    asyncCreate(path, datat, mode, ZkClient.TTL_NOT_SET, cb);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/SharedZkClientFactory.java
@@ -194,12 +194,17 @@ public class SharedZkClientFactory extends HelixZkClientFactory {
     @Override
     public String create(final String path, Object datat, final List<ACL> acl,
         final CreateMode mode) {
+      return create(path, datat, acl, mode, TTL_NOT_SET);
+    }
+    @Override
+    public String create(final String path, Object datat, final List<ACL> acl,
+        final CreateMode mode, long ttl) {
       if (mode.isEphemeral()) {
         throw new UnsupportedOperationException(
             "Create ephemeral nodes using " + SharedZkClient.class.getSimpleName()
                 + " is not supported.");
       }
-      return super.create(path, datat, acl, mode);
+      return super.create(path, datat, acl, mode, ttl);
     }
 
     @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkConnection.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkConnection.java
@@ -40,6 +40,8 @@ public interface IZkConnection {
 
     public String create(String path, byte[] data, List<ACL> acl, CreateMode mode) throws KeeperException, InterruptedException;
 
+    public String create(String path, byte[] data, List<ACL> acl, CreateMode mode, long ttl) throws KeeperException, InterruptedException;
+
     public void delete(String path) throws InterruptedException, KeeperException;
 
     boolean exists(final String path, final boolean watch) throws KeeperException, InterruptedException;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -439,6 +439,41 @@ public class ZkClient implements Watcher {
   }
 
   /**
+   * Create a persistent node with TTL.
+   * @param path the path where you want the node to be created
+   * @param ttl TTL of the node in milliseconds
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public void createPersistentWithTTL(String path, long ttl)
+      throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
+    createPersistentWithTTL(path, false, ttl);
+  }
+
+  /**
+   * Create a container node.
+   * @param path the path where you want the node to be created
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public void createContainer(String path)
+      throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
+    createContainer(path, false);
+  }
+
+  /**
    * Create a persistent node and set its ACLs.
    * @param path
    * @param createParents
@@ -457,6 +492,45 @@ public class ZkClient implements Watcher {
   public void createPersistent(String path, boolean createParents)
       throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
     createPersistent(path, createParents, ZooDefs.Ids.OPEN_ACL_UNSAFE);
+  }
+
+  /**
+   * Create a persistent node with TTL and set its ACLs.
+   * @param path the path where you want the node to be created
+   * @param createParents if true all parent dirs are created as well and no
+   *                      {@link ZkNodeExistsException} is thrown in case the path already exists
+   * @param ttl TTL of the node in milliseconds
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public void createPersistentWithTTL(String path, boolean createParents, long ttl)
+      throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
+    createPersistentWithTTL(path, createParents, ZooDefs.Ids.OPEN_ACL_UNSAFE, ttl);
+  }
+
+  /**
+   * Create a container node and set its ACLs.
+   * @param path the path where you want the node to be created
+   * @param createParents if true all parent dirs are created as well and no
+   *                      {@link ZkNodeExistsException} is thrown in case the path already exists
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public void createContainer(String path, boolean createParents)
+      throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
+    createContainer(path, createParents, ZooDefs.Ids.OPEN_ACL_UNSAFE);
   }
 
   /**
@@ -496,6 +570,73 @@ public class ZkClient implements Watcher {
   }
 
   /**
+   * Create a persistent node with TTL and set its ACLs.
+   * @param path the path where you want the node to be created
+   * @param createParents if true all parent dirs are created as well and no
+   *                      {@link ZkNodeExistsException} is thrown in case the path already exists
+   * @param acl List of ACL permissions to assign to the node
+   * @param ttl TTL of the node in milliseconds
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public void createPersistentWithTTL(String path, boolean createParents, List<ACL> acl, long ttl)
+      throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
+    try {
+      create(path, null, acl, CreateMode.PERSISTENT_WITH_TTL, ttl);
+    } catch (ZkNodeExistsException e) {
+      if (!createParents) {
+        throw e;
+      }
+    } catch (ZkNoNodeException e) {
+      if (!createParents) {
+        throw e;
+      }
+      String parentDir = path.substring(0, path.lastIndexOf('/'));
+      createPersistentWithTTL(parentDir, createParents, acl, ttl);
+      createPersistentWithTTL(path, createParents, acl, ttl);
+    }
+  }
+
+  /**
+   * Create a container node and set its ACLs.
+   * @param path the path where you want the node to be created
+   * @param createParents if true all parent dirs are created as well and no
+   *                      {@link ZkNodeExistsException} is thrown in case the path already exists
+   * @param acl List of ACL permissions to assign to the node
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public void createContainer(String path, boolean createParents, List<ACL> acl)
+      throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
+    try {
+      create(path, null, acl, CreateMode.CONTAINER);
+    } catch (ZkNodeExistsException e) {
+      if (!createParents) {
+        throw e;
+      }
+    } catch (ZkNoNodeException e) {
+      if (!createParents) {
+        throw e;
+      }
+      String parentDir = path.substring(0, path.lastIndexOf('/'));
+      createContainer(parentDir, createParents, acl);
+      createContainer(path, createParents, acl);
+    }
+  }
+
+  /**
    * Create a persistent node.
    * @param path
    * @param data
@@ -514,6 +655,43 @@ public class ZkClient implements Watcher {
   }
 
   /**
+   * Create a persistent node with TTL.
+   * @param path the path where you want the node to be created
+   * @param data data of the node
+   * @param ttl TTL of the node in milliseconds
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public void createPersistentWithTTL(String path, Object data, long ttl)
+      throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
+    create(path, data, CreateMode.PERSISTENT_WITH_TTL, ttl);
+  }
+
+  /**
+   * Create a container node.
+   * @param path the path where you want the node to be created
+   * @param data data of the node
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public void createContainer(String path, Object data)
+      throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
+    create(path, data, CreateMode.CONTAINER);
+  }
+
+  /**
    * Create a persistent node.
    * @param path
    * @param data
@@ -529,6 +707,43 @@ public class ZkClient implements Watcher {
    */
   public void createPersistent(String path, Object data, List<ACL> acl) {
     create(path, data, acl, CreateMode.PERSISTENT);
+  }
+
+  /**
+   * Create a persistent node with TTL.
+   * @param path the path where you want the node to be created
+   * @param data data of the node
+   * @param acl list of ACL for the node
+   * @param ttl TTL of the node in milliseconds
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public void createPersistentWithTTL(String path, Object data, List<ACL> acl, long ttl) {
+    create(path, data, acl, CreateMode.PERSISTENT_WITH_TTL, ttl);
+  }
+
+  /**
+   * Create a container node.
+   * @param path the path where you want the node to be created
+   * @param data data of the node
+   * @param acl list of ACL for the node
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public void createContainer(String path, Object data, List<ACL> acl) {
+    create(path, data, acl, CreateMode.CONTAINER);
   }
 
   /**
@@ -551,6 +766,26 @@ public class ZkClient implements Watcher {
   }
 
   /**
+   * Create a persistent, sequential node.
+   * @param path the path where you want the node to be created
+   * @param data data of the node
+   * @param ttl TTL of the node in milliseconds
+   * @return create node's path
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public String createPersistentSequentialWithTTL(String path, Object data, long ttl)
+      throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
+    return create(path, data, CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL, ttl);
+  }
+
+  /**
    * Create a persistent, sequential node and set its ACL.
    * @param path
    * @param acl
@@ -568,6 +803,27 @@ public class ZkClient implements Watcher {
   public String createPersistentSequential(String path, Object data, List<ACL> acl)
       throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
     return create(path, data, acl, CreateMode.PERSISTENT_SEQUENTIAL);
+  }
+
+  /**
+   * Create a persistent, sequential node and set its ACL.
+   * @param path the path where you want the node to be created
+   * @param acl list of ACL for the node
+   * @param data data of the node
+   * @param ttl TTL of the node in milliseconds
+   * @return create node's path
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public String createPersistentSequentialWithTTL(String path, Object data, List<ACL> acl, long ttl)
+      throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
+    return create(path, data, acl, CreateMode.PERSISTENT_SEQUENTIAL_WITH_TTL, ttl);
   }
 
   /**
@@ -648,7 +904,7 @@ public class ZkClient implements Watcher {
    */
   public void createEphemeral(final String path, final List<ACL> acl, final String sessionId)
       throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
-    create(path, null, acl, CreateMode.EPHEMERAL, sessionId);
+    create(path, null, acl, CreateMode.EPHEMERAL, TTL_NOT_SET, sessionId);
   }
 
   /**
@@ -672,6 +928,28 @@ public class ZkClient implements Watcher {
   }
 
   /**
+   * Create a node.
+   * @param path the path where you want the node to be created
+   * @param data data of the node
+   * @param mode {@link CreateMode} of the node
+   * @param ttl TTL of the node in milliseconds, if mode is {@link CreateMode#PERSISTENT_WITH_TTL}
+   *            or {@link CreateMode#PERSISTENT_SEQUENTIAL_WITH_TTL}
+   * @return create node's path
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public String create(final String path, Object data, final CreateMode mode, long ttl)
+      throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
+    return create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, mode, ttl);
+  }
+
+  /**
    * Create a node with ACL.
    * @param path
    * @param datat
@@ -689,7 +967,30 @@ public class ZkClient implements Watcher {
    */
   public String create(final String path, Object datat, final List<ACL> acl, final CreateMode mode)
       throws IllegalArgumentException, ZkException {
-    return create(path, datat, acl, mode, null);
+    return create(path, datat, acl, mode, TTL_NOT_SET, null);
+  }
+
+  /**
+   * Create a node with ACL.
+   * @param path the path where you want the node to be created
+   * @param datat data of the node
+   * @param acl list of ACL for the node
+   * @param mode {@link CreateMode} of the node
+   * @param ttl TTL of the node in milliseconds, if mode is {@link CreateMode#PERSISTENT_WITH_TTL}
+   *            or {@link CreateMode#PERSISTENT_SEQUENTIAL_WITH_TTL}
+   * @return create node's path
+   * @throws ZkInterruptedException
+   *           if operation was interrupted, or a required reconnection got interrupted
+   * @throws IllegalArgumentException
+   *           if called from anything except the ZooKeeper event thread
+   * @throws ZkException
+   *           if any ZooKeeper exception occurred
+   * @throws RuntimeException
+   *           if any other exception occurs
+   */
+  public String create(final String path, Object datat, final List<ACL> acl, final CreateMode mode,
+      long ttl) throws IllegalArgumentException, ZkException {
+    return create(path, datat, acl, mode, ttl, null);
   }
 
   /**
@@ -705,6 +1006,8 @@ public class ZkClient implements Watcher {
    * @param dataObject data of the node
    * @param acl list of ACL for the node
    * @param mode {@link CreateMode} of the node
+   * @param ttl TTL of the node in milliseconds, if mode is {@link CreateMode#PERSISTENT_WITH_TTL}
+   *            or {@link CreateMode#PERSISTENT_SEQUENTIAL_WITH_TTL}
    * @param expectedSessionId the expected session ID of the ZK connection. It is not necessarily the
    *                  session ID of current ZK Connection. If the expected session ID is NOT null,
    *                  the node is guaranteed to be created in the expected session, or creation is
@@ -715,7 +1018,7 @@ public class ZkClient implements Watcher {
    * @throws ZkException if any zookeeper exception occurs
    */
   private String create(final String path, final Object dataObject, final List<ACL> acl,
-      final CreateMode mode, final String expectedSessionId)
+      final CreateMode mode, long ttl, final String expectedSessionId)
       throws IllegalArgumentException, ZkException {
     if (path == null) {
       throw new NullPointerException("Path must not be null.");
@@ -728,8 +1031,14 @@ public class ZkClient implements Watcher {
       final byte[] dataBytes = dataObject == null ? null : serialize(dataObject, path);
       checkDataSizeLimit(path, dataBytes);
 
-      final String actualPath = retryUntilConnected(
-          () -> getExpectedZookeeper(expectedSessionId).create(path, dataBytes, acl, mode));
+      final String actualPath;
+      if (mode.isTTL()) {
+        actualPath = retryUntilConnected(() -> getExpectedZookeeper(expectedSessionId)
+            .create(path, dataBytes, acl, mode, null, ttl));
+      } else {
+        actualPath = retryUntilConnected(() -> getExpectedZookeeper(expectedSessionId)
+            .create(path, dataBytes, acl, mode));
+      }
 
       record(path, dataBytes, startT, ZkClientMonitor.AccessType.WRITE);
       return actualPath;
@@ -786,7 +1095,7 @@ public class ZkClient implements Watcher {
    */
   public void createEphemeral(final String path, final Object data, final String sessionId)
       throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
-    create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL, sessionId);
+    create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL, TTL_NOT_SET, sessionId);
   }
 
   /**
@@ -836,7 +1145,7 @@ public class ZkClient implements Watcher {
   public void createEphemeral(final String path, final Object data, final List<ACL> acl,
       final String sessionId)
       throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
-    create(path, data, acl, CreateMode.EPHEMERAL, sessionId);
+    create(path, data, acl, CreateMode.EPHEMERAL, TTL_NOT_SET, sessionId);
   }
 
   /**
@@ -882,7 +1191,7 @@ public class ZkClient implements Watcher {
   public String createEphemeralSequential(final String path, final Object data, final List<ACL> acl,
       final String sessionId)
       throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
-    return create(path, data, acl, CreateMode.EPHEMERAL_SEQUENTIAL, sessionId);
+    return create(path, data, acl, CreateMode.EPHEMERAL_SEQUENTIAL, TTL_NOT_SET, sessionId);
   }
 
   /**
@@ -914,7 +1223,7 @@ public class ZkClient implements Watcher {
       final String sessionId)
       throws ZkInterruptedException, IllegalArgumentException, ZkException, RuntimeException {
     return create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL,
-        sessionId);
+        TTL_NOT_SET, sessionId);
   }
 
   /**

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkConnection.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkConnection.java
@@ -134,6 +134,12 @@ public class ZkConnection implements IZkConnection {
   }
 
   @Override
+  public String create(String path, byte[] data, List<ACL> acl, CreateMode mode, long ttl)
+      throws KeeperException, InterruptedException {
+    return _zk.create(path, data, acl, mode, null, ttl);
+  }
+
+  @Override
   public void delete(String path) throws InterruptedException, KeeperException {
     _zk.delete(path, -1);
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.helix.zookeeper.zkclient.metric.ZkClientMonitor;
 import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.AsyncCallback.Create2Callback;
 import org.apache.zookeeper.AsyncCallback.DataCallback;
 import org.apache.zookeeper.AsyncCallback.StatCallback;
 import org.apache.zookeeper.AsyncCallback.StringCallback;
@@ -111,9 +112,14 @@ public class ZkAsyncCallbacks {
     }
   }
 
-  public static class CreateCallbackHandler extends DefaultCallback implements StringCallback {
+  public static class CreateCallbackHandler extends DefaultCallback implements StringCallback, Create2Callback {
     @Override
     public void processResult(int rc, String path, Object ctx, String name) {
+      callback(rc, path, ctx);
+    }
+
+    @Override
+    public void processResult(int rc, String path, Object ctx, String name, Stat stat) {
       callback(rc, path, ctx);
     }
 

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientFactoryTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/RealmAwareZkClientFactoryTestBase.java
@@ -134,6 +134,7 @@ public abstract class RealmAwareZkClientFactoryTestBase extends RealmAwareZkClie
 
     // Clean up
     _realmAwareZkClient.deleteRecursively(TEST_VALID_PATH);
+    System.clearProperty("zookeeper.extendedTypesEnabled");
   }
 
   /**
@@ -141,6 +142,7 @@ public abstract class RealmAwareZkClientFactoryTestBase extends RealmAwareZkClie
    */
   @Test(dependsOnMethods = "testRealmAwareZkClientCreateContainer")
   public void testRealmAwareZkClientCreateSequentialWithTTL() {
+    System.setProperty("zookeeper.extendedTypesEnabled", "true");
     // Test writing and reading data
     _realmAwareZkClient.createPersistent(TEST_VALID_PATH, true);
     long ttl = 1L;
@@ -152,6 +154,7 @@ public abstract class RealmAwareZkClientFactoryTestBase extends RealmAwareZkClie
 
     // Clean up
     _realmAwareZkClient.deleteRecursively(TEST_VALID_PATH);
+    System.clearProperty("zookeeper.extendedTypesEnabled");
   }
 
   /**
@@ -159,6 +162,7 @@ public abstract class RealmAwareZkClientFactoryTestBase extends RealmAwareZkClie
    */
   @Test(dependsOnMethods = "testRealmAwareZkClientCreateSequentialWithTTL")
   public void testRealmAwareZkClientCreateWithTTL() {
+    System.setProperty("zookeeper.extendedTypesEnabled", "true");
     // Test with createParents = true
     long ttl = 1L;
     _realmAwareZkClient.createPersistentWithTTL(TEST_VALID_PATH, true, ttl);

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
@@ -167,15 +167,88 @@ public class TestFederatedZkClient extends RealmAwareZkClientTestBase {
     }
   }
 
+  /**
+   * Test creating a container node.
+   */
+  @Test(dependsOnMethods = "testUnsupportedOperations")
+  public void testRealmAwareZkClientCreateContainer() {
+    System.setProperty("zookeeper.extendedTypesEnabled", "true");
+    _realmAwareZkClient.setZkSerializer(new ZNRecordSerializer());
+
+    // Create a dummy ZNRecord
+    ZNRecord znRecord = new ZNRecord("DummyRecord");
+    znRecord.setSimpleField("Dummy", "Value");
+
+    // Test with createParents = true
+    _realmAwareZkClient.createContainer(TEST_VALID_PATH, true);
+    Assert.assertTrue(_realmAwareZkClient.exists(TEST_VALID_PATH));
+
+    // Test writing and reading data
+    String childPath = TEST_VALID_PATH + "/child";
+    _realmAwareZkClient.createContainer(childPath, znRecord);
+    ZNRecord retrievedRecord = _realmAwareZkClient.readData(childPath);
+    Assert.assertEquals(znRecord.getSimpleField("Dummy"),
+        retrievedRecord.getSimpleField("Dummy"));
+
+    // Clean up
+    _realmAwareZkClient.deleteRecursively(TEST_VALID_PATH);
+  }
+
+  /**
+   * Test creating a sequential TTL node.
+   */
+  @Test(dependsOnMethods = "testRealmAwareZkClientCreateContainer")
+  public void testRealmAwareZkClientCreateSequentialWithTTL() {
+    // Create a dummy ZNRecord
+    ZNRecord znRecord = new ZNRecord("DummyRecord");
+    znRecord.setSimpleField("Dummy", "Value");
+
+    // Test writing and reading data
+    _realmAwareZkClient.createPersistent(TEST_VALID_PATH, true);
+    long ttl = 1L;
+    String childPath = TEST_VALID_PATH + "/child";
+    _realmAwareZkClient.createPersistentSequentialWithTTL(childPath, znRecord, ttl);
+    ZNRecord retrievedRecord = _realmAwareZkClient.readData(childPath + "0000000000");
+    Assert.assertEquals(znRecord.getSimpleField("Dummy"),
+        retrievedRecord.getSimpleField("Dummy"));
+
+    // Clean up
+    _realmAwareZkClient.deleteRecursively(TEST_VALID_PATH);
+  }
+
+  /**
+   * Test creating a TTL node.
+   */
+  @Test(dependsOnMethods = "testRealmAwareZkClientCreateSequentialWithTTL")
+  public void testRealmAwareZkClientCreateWithTTL() {
+    // Create a dummy ZNRecord
+    ZNRecord znRecord = new ZNRecord("DummyRecord");
+    znRecord.setSimpleField("Dummy", "Value");
+
+    // Test with createParents = true
+    long ttl = 1L;
+    _realmAwareZkClient.createPersistentWithTTL(TEST_VALID_PATH, true, ttl);
+    Assert.assertTrue(_realmAwareZkClient.exists(TEST_VALID_PATH));
+
+    // Test writing and reading data
+    String childPath = TEST_VALID_PATH + "/child";
+    _realmAwareZkClient.createPersistentWithTTL(childPath, znRecord, ttl);
+    ZNRecord retrievedRecord = _realmAwareZkClient.readData(childPath);
+    Assert.assertEquals(znRecord.getSimpleField("Dummy"),
+        retrievedRecord.getSimpleField("Dummy"));
+
+    // Clean up
+    _realmAwareZkClient.deleteRecursively(TEST_VALID_PATH);
+    System.clearProperty("zookeeper.extendedTypesEnabled");
+  }
+
   /*
    * Tests the persistent create() call against a valid path and an invalid path.
    * Valid path is one that belongs to the realm designated by the sharding key.
    * Invalid path is one that does not belong to the realm designated by the sharding key.
    */
-  @Test(dependsOnMethods = "testUnsupportedOperations")
+  @Test(dependsOnMethods = "testRealmAwareZkClientCreateWithTTL")
   public void testCreatePersistent() {
-    _realmAwareZkClient.setZkSerializer(new ZNRecordSerializer());
-
     // Create a dummy ZNRecord
     ZNRecord znRecord = new ZNRecord("DummyRecord");
     znRecord.setSimpleField("Dummy", "Value");

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
@@ -192,6 +192,7 @@ public class TestFederatedZkClient extends RealmAwareZkClientTestBase {
 
     // Clean up
     _realmAwareZkClient.deleteRecursively(TEST_VALID_PATH);
+    System.clearProperty("zookeeper.extendedTypesEnabled");
   }
 
   /**
@@ -199,6 +200,7 @@ public class TestFederatedZkClient extends RealmAwareZkClientTestBase {
    */
   @Test(dependsOnMethods = "testRealmAwareZkClientCreateContainer")
   public void testRealmAwareZkClientCreateSequentialWithTTL() {
+    System.setProperty("zookeeper.extendedTypesEnabled", "true");
     // Create a dummy ZNRecord
     ZNRecord znRecord = new ZNRecord("DummyRecord");
     znRecord.setSimpleField("Dummy", "Value");
@@ -214,6 +216,7 @@ public class TestFederatedZkClient extends RealmAwareZkClientTestBase {
 
     // Clean up
     _realmAwareZkClient.deleteRecursively(TEST_VALID_PATH);
+    System.clearProperty("zookeeper.extendedTypesEnabled");
   }
 
   /**
@@ -221,6 +224,7 @@ public class TestFederatedZkClient extends RealmAwareZkClientTestBase {
    */
   @Test(dependsOnMethods = "testRealmAwareZkClientCreateSequentialWithTTL")
   public void testRealmAwareZkClientCreateWithTTL() {
+    System.setProperty("zookeeper.extendedTypesEnabled", "true");
     // Create a dummy ZNRecord
     ZNRecord znRecord = new ZNRecord("DummyRecord");
     znRecord.setSimpleField("Dummy", "Value");

--- a/zookeeper-api/zookeeper-api-1.0.5-SNAPSHOT.ivy
+++ b/zookeeper-api/zookeeper-api-1.0.5-SNAPSHOT.ivy
@@ -43,7 +43,7 @@ under the License.
     <dependency org="org.apache.logging.log4j" name="log4j-slf4j-impl" rev="2.17.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)">
         <artifact name="log4j-slf4j-impl" ext="jar"/>
     </dependency>
-    <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.4.13" conf="compile->compile(default);runtime->runtime(default);default->default"/>
+    <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.5.9" conf="compile->compile(default);runtime->runtime(default);default->default"/>
 		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.12.6.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.12.6" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #2081 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds methods that support creating container nodes and persistent nodes with TTL to several classes, including ZkConnection, ZkClient and its descendants in zookeeper-api, and BaseDataAccessors in helix-core.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
