### PR TITLE
yarn add -D yargs-parser@21

### DIFF
--- a/helix-front/package.json
+++ b/helix-front/package.json
@@ -123,6 +123,7 @@
     "nodemon": "^2.0.16",
     "prettier": "2.7.0",
     "ts-node": "~2.0.0",
-    "typescript": "4.6.4"
+    "typescript": "4.6.4",
+    "yargs-parser": "21"
   }
 }

--- a/helix-front/yarn.lock
+++ b/helix-front/yarn.lock
@@ -11359,7 +11359,7 @@ yargs-parser@20.x, yargs-parser@^20.x:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-parser@21.0.1, yargs-parser@^21.0.0:
+yargs-parser@21, yargs-parser@21.0.1, yargs-parser@^21.0.0:
   version "21.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

fix #2163

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR should resolve this security vulnerability by upgrading the affected package:

```
yargs-parser@20.0.0: Vulnerability found:  
vulnerability: yargs-parser is vulnerable to 
Regular Expression Denial of Service (ReDoS). 
The `isUnknownOption` function in `yargs-parser.ts` does not 
properly replace `-` characters from parse, allowing a malicious 
user to slow down or hang the application when unknown-options-as-args 
is set to true.
```

The latest yargs-parser major version is 21.  The breaking change is dropping support for node 10.  This does not affect helix-front, which currently uses node 14.

https://github.com/yargs/yargs-parser/releases/tag/yargs-parser-v21.0.0

This means we should be able to resolve this security vulnerability by manually installing the latest yargs-parser as a direct  dev dependency:

```py
yarn add -D yargs-parser@21
```

which resolves to `yargs-parser@21.0.1` in helix-front's yarn.lock file.

### Tests

- [x] The following tests are written for this issue:

- The following is the result of the "mvn test" command on the appropriate module:

N/A No Java Changes

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":


### Code Quality

-[x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)

N/A No Java Changes