### PR TITLE
Wire in the logic for TaskExecutor reset timeout parameter

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
@@ -62,6 +62,22 @@ public final class HelixManagerFactory {
   }
 
   /**
+   * Construct a zk-based cluster manager that enforces all types (PARTICIPANT, CONTROLLER, and
+   * SPECTATOR) to have a name
+   * @param clusterName
+   * @param instanceName
+   * @param type
+   * @param zkAddr
+   * @param stateListener
+   * @param helixManagerProperty
+   * @return a HelixManager backed by Zookeeper
+   */
+  public static HelixManager getZKHelixManager(String clusterName, String instanceName,
+      InstanceType type, String zkAddr, HelixManagerStateListener stateListener, HelixManagerProperty helixManagerProperty) {
+    return new ZKHelixManager(clusterName, instanceName, type, zkAddr, stateListener, helixManagerProperty);
+  }
+
+  /**
    * Construct a ZkHelixManager using the HelixManagerProperty instance given.
    * HelixManagerProperty given must contain a valid ZkConnectionConfig.
    * @param clusterName

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerFactory.java
@@ -62,30 +62,16 @@ public final class HelixManagerFactory {
   }
 
   /**
-   * Construct a zk-based cluster manager that enforces all types (PARTICIPANT, CONTROLLER, and
-   * SPECTATOR) to have a name
-   * @param clusterName
-   * @param instanceName
-   * @param type
-   * @param zkAddr
-   * @param stateListener
-   * @param helixManagerProperty
-   * @return a HelixManager backed by Zookeeper
-   */
-  public static HelixManager getZKHelixManager(String clusterName, String instanceName,
-      InstanceType type, String zkAddr, HelixManagerStateListener stateListener, HelixManagerProperty helixManagerProperty) {
-    return new ZKHelixManager(clusterName, instanceName, type, zkAddr, stateListener, helixManagerProperty);
-  }
-
-  /**
    * Construct a ZkHelixManager using the HelixManagerProperty instance given.
-   * HelixManagerProperty given must contain a valid ZkConnectionConfig.
+   * HelixManagerProperty given must contain a valid ZkConnectionConfig or zkAddress, but not both.
    * @param clusterName
    * @param instanceName
    * @param type
    * @param stateListener
-   * @param helixManagerProperty must contain a valid ZkConnectionConfig
-   * @return
+   * @param helixManagerProperty must contain one and only one of the following, not both:
+   *                             1. a valid ZkConnectionConfig
+   *                             2. a valid zkAddress
+   * @return a HelixManager backed by Zookeeper
    */
   public static HelixManager getZKHelixManager(String clusterName, String instanceName,
       InstanceType type, HelixManagerStateListener stateListener,

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
@@ -21,6 +21,7 @@ package org.apache.helix;
 
 import java.util.Properties;
 
+import org.apache.helix.messaging.handling.TaskExecutor;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.slf4j.Logger;
@@ -34,6 +35,7 @@ public class HelixManagerProperty {
   private static final Logger LOG = LoggerFactory.getLogger(HelixManagerProperty.class.getName());
   private String _version;
   private long _healthReportLatency;
+  private int _msgHandlerResetTimeout = TaskExecutor.DEFAULT_MSG_HANDLER_RESET_TIMEOUT_MS;
   private HelixCloudProperty _helixCloudProperty;
   private RealmAwareZkClient.RealmAwareZkConnectionConfig _zkConnectionConfig;
   private RealmAwareZkClient.RealmAwareZkClientConfig _zkClientConfig;
@@ -54,12 +56,13 @@ public class HelixManagerProperty {
         helixManagerProperties.getProperty(SystemPropertyKeys.PARTICIPANT_HEALTH_REPORT_LATENCY));
   }
 
-  private HelixManagerProperty(String version, long healthReportLatency,
+  private HelixManagerProperty(String version, long healthReportLatency, int msgHandlerResetTimeout,
       HelixCloudProperty helixCloudProperty,
       RealmAwareZkClient.RealmAwareZkConnectionConfig zkConnectionConfig,
       RealmAwareZkClient.RealmAwareZkClientConfig zkClientConfig) {
     _version = version;
     _healthReportLatency = healthReportLatency;
+    _msgHandlerResetTimeout = msgHandlerResetTimeout;
     _helixCloudProperty = helixCloudProperty;
     _zkConnectionConfig = zkConnectionConfig;
     _zkClientConfig = zkClientConfig;
@@ -80,6 +83,10 @@ public class HelixManagerProperty {
     return _healthReportLatency;
   }
 
+  public int getMsgHandlerResetTimeout() {
+    return _msgHandlerResetTimeout;
+  }
+
   public RealmAwareZkClient.RealmAwareZkConnectionConfig getZkConnectionConfig() {
     return _zkConnectionConfig;
   }
@@ -94,12 +101,13 @@ public class HelixManagerProperty {
     private HelixCloudProperty _helixCloudProperty;
     private RealmAwareZkClient.RealmAwareZkConnectionConfig _zkConnectionConfig;
     private RealmAwareZkClient.RealmAwareZkClientConfig _zkClientConfig;
+    private int _msgHandlerResetTimeout;
 
     public Builder() {
     }
 
     public HelixManagerProperty build() {
-      return new HelixManagerProperty(_version, _healthReportLatency, _helixCloudProperty,
+      return new HelixManagerProperty(_version, _healthReportLatency, _msgHandlerResetTimeout, _helixCloudProperty,
           _zkConnectionConfig, _zkClientConfig);
     }
 
@@ -127,6 +135,11 @@ public class HelixManagerProperty {
     public Builder setRealmAwareZkClientConfig(
         RealmAwareZkClient.RealmAwareZkClientConfig zkClientConfig) {
       _zkClientConfig = zkClientConfig;
+      return this;
+    }
+
+    public Builder setMsgHandlerResetTimeout(int msgHandlerResetTimeout) {
+      _msgHandlerResetTimeout = msgHandlerResetTimeout;
       return this;
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixPropertyFactory.java
@@ -65,9 +65,15 @@ public final class HelixPropertyFactory {
           HELIX_PARTICIPANT_PROPERTY_FILE);
       throw new IllegalArgumentException(errMsg, e);
     }
-    LOG.info("HelixPropertyFactory successfully loaded helix participant properties: {}",
-        properties);
-    return new HelixManagerProperty(properties, cloudConfig);
+    LOG.info("HelixPropertyFactory successfully loaded helix participant properties: {}", properties);
+    return new HelixManagerProperty.Builder()
+        .setVersion(properties.getProperty(SystemPropertyKeys.HELIX_MANAGER_VERSION))
+        .setHelixCloudProperty(new HelixCloudProperty(cloudConfig))
+        .setHealthReportLatency(
+            Long.parseLong(
+                properties.getProperty(SystemPropertyKeys.PARTICIPANT_HEALTH_REPORT_LATENCY)))
+        .setZkAddr(zkAddress)
+        .build();
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -31,9 +31,11 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
 import javax.management.JMException;
 
 import com.google.common.collect.Sets;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ClusterMessagingService;
 import org.apache.helix.ConfigAccessor;
@@ -233,12 +235,25 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
         HelixPropertyFactory.getInstance().getHelixManagerProperty(zkAddress, clusterName));
   }
 
+  /**
+   * The base constructor for {@link ZKHelixManager}.
+   * Only one of zkAddress or {@link HelixManagerProperty#_zkConnectionConfig} shall be provided, not both.
+   * {@link HelixManagerProperty#_zkAddr} takes higher precedence over zkAddress param, the latter is used if the first
+   * one is null.
+   * Users should use {@link org.apache.helix.HelixManagerFactory} to instantiate instead of using this constructor.
+   * @param clusterName
+   * @param instanceName
+   * @param instanceType
+   * @param zkAddress
+   * @param stateListener
+   * @param helixManagerProperty #_zkConnectionConfig cannot be set if non-null zkAddress is passed in
+   */
   public ZKHelixManager(String clusterName, String instanceName, InstanceType instanceType,
-      String zkAddress, HelixManagerStateListener stateListener,
+      @Nullable String zkAddress, HelixManagerStateListener stateListener,
       HelixManagerProperty helixManagerProperty) {
     validateZkConnectionSettings(zkAddress, helixManagerProperty);
 
-    _zkAddress = zkAddress;
+    _zkAddress = StringUtils.isEmpty(helixManagerProperty.getZkAddr()) ? zkAddress : helixManagerProperty.getZkAddr();
     _clusterName = clusterName;
     _instanceType = instanceType;
     LOG.info("Create a zk-based cluster manager. ZK connection: " + getZkConnectionInfo()

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -265,7 +265,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     _version = _properties.getVersion();
 
     _keyBuilder = new Builder(clusterName);
-    _messagingService = new DefaultMessagingService(this);
+    _messagingService = new DefaultMessagingService(this, helixManagerProperty.getMsgHandlerResetTimeout());
     try {
       _callbackMonitors = new HashMap<>();
       for (ChangeType changeType : ChangeType.values()) {

--- a/helix-core/src/main/java/org/apache/helix/messaging/DefaultMessagingService.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/DefaultMessagingService.java
@@ -19,6 +19,7 @@ package org.apache.helix.messaging;
  * under the License.
  */
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -50,7 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DefaultMessagingService implements ClusterMessagingService {
-  private final int _resetTimeoutMs;
+  private final int _taskResetTimeoutMs;
   private final HelixManager _manager;
   private final CriteriaEvaluator _evaluator;
   private final HelixTaskExecutor _taskExecutor;
@@ -65,7 +66,7 @@ public class DefaultMessagingService implements ClusterMessagingService {
     this(manager, TaskExecutor.DEFAULT_MSG_HANDLER_RESET_TIMEOUT_MS);
   }
 
-  public DefaultMessagingService(HelixManager manager, int resetTimeoutMs) {
+  public DefaultMessagingService(HelixManager manager, int taskResetTimeoutMs) {
     _manager = manager;
     _evaluator = new CriteriaEvaluator();
 
@@ -78,8 +79,8 @@ public class DefaultMessagingService implements ClusterMessagingService {
         new ParticipantStatusMonitor(isParticipant, manager.getInstanceName()),
         new MessageQueueMonitor(manager.getClusterName(), manager.getInstanceName()));
     _asyncCallbackService = new AsyncCallbackService();
-    _taskExecutor.registerMessageHandlerFactory(_asyncCallbackService, TaskExecutor.DEFAULT_PARALLEL_TASKS, resetTimeoutMs);
-    _resetTimeoutMs = resetTimeoutMs;
+    _taskExecutor.registerMessageHandlerFactory(_asyncCallbackService, TaskExecutor.DEFAULT_PARALLEL_TASKS, taskResetTimeoutMs);
+    _taskResetTimeoutMs = taskResetTimeoutMs;
   }
 
   @Override
@@ -370,7 +371,8 @@ public class DefaultMessagingService implements ClusterMessagingService {
     return sendAndWait(recipientCriteria, message, asyncCallback, timeOut, 0);
   }
 
-  public int getMsgResetTimeout() {
-    return _resetTimeoutMs;
+  @VisibleForTesting
+  public int getTaskResetTimeout() {
+    return _taskResetTimeoutMs;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -144,8 +144,6 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
   private static final int SESSION_SYNC_INTERVAL = 2000; // 2 seconds
   private static final String SESSION_SYNC = "SESSION-SYNC";
 
-  private static final int DEFAULT_MSG_HANDLER_RESET_TIMEOUT_MS = 200; // 200 ms
-
   /**
    * Map of MsgType->MsgHandlerFactoryRegistryItem
    */

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/TaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/TaskExecutor.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 public interface TaskExecutor {
   int DEFAULT_PARALLEL_TASKS = 40;
+  int DEFAULT_MSG_HANDLER_RESET_TIMEOUT_MS = 200;
 
   /**
    * Register MultiType message handler factory that the executor can handle.

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
@@ -106,10 +106,11 @@ public class TestParticipantManager extends ZkTestBase {
     int resetTimeout = 300;
     HelixManagerProperty helixManagerProperty = new HelixManagerProperty.Builder()
         .setMsgHandlerResetTimeout(resetTimeout)
+        .setZkAddr(ZK_ADDR)
         .build();
     HelixManager participant = HelixManagerFactory.getZKHelixManager(
-        _clusterName, instanceName, InstanceType.PARTICIPANT, ZK_ADDR, null, helixManagerProperty);
-    Assert.assertEquals(((DefaultMessagingService) participant.getMessagingService()).getMsgResetTimeout(), resetTimeout);
+        _clusterName, instanceName, InstanceType.PARTICIPANT, null, helixManagerProperty);
+    Assert.assertEquals(((DefaultMessagingService) participant.getMessagingService()).getTaskResetTimeout(), resetTimeout);
     participant.getStateMachineEngine().registerStateModelFactory("MasterSlave",
         new MockMSModelFactory());
     participant.connect();

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
@@ -37,14 +37,16 @@ import javax.management.ObjectName;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.HelixManagerProperty;
 import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.TestHelper;
+import org.apache.helix.messaging.DefaultMessagingService;
 import org.apache.helix.model.ClusterConfig;
-import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.ParticipantHistory;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.ZkTestHelper;
@@ -101,8 +103,13 @@ public class TestParticipantManager extends ZkTestBase {
         "MasterSlave", true); // do rebalance
 
     String instanceName = "localhost_12918";
-    HelixManager participant =
-        new ZKHelixManager(_clusterName, instanceName, InstanceType.PARTICIPANT, ZK_ADDR);
+    int resetTimeout = 300;
+    HelixManagerProperty helixManagerProperty = new HelixManagerProperty.Builder()
+        .setMsgHandlerResetTimeout(resetTimeout)
+        .build();
+    HelixManager participant = HelixManagerFactory.getZKHelixManager(
+        _clusterName, instanceName, InstanceType.PARTICIPANT, ZK_ADDR, null, helixManagerProperty);
+    Assert.assertEquals(((DefaultMessagingService) participant.getMessagingService()).getMsgResetTimeout(), resetTimeout);
     participant.getStateMachineEngine().registerStateModelFactory("MasterSlave",
         new MockMSModelFactory());
     participant.connect();

--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkConectionConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkConectionConfig.java
@@ -426,6 +426,18 @@ public class TestMultiZkConectionConfig {
     } catch (HelixException e) {
       // Expected
     }
+    try {
+      // zkAddr and zkConnectionConfig cannot coexist
+      HelixManagerProperty property = new HelixManagerProperty.Builder()
+          .setZkAddr("test-zk")
+          .setRealmAWareZkConnectionConfig(validZkConnectionConfig)
+          .build();
+      HelixManager invalidManager = HelixManagerFactory
+          .getZKHelixManager(clusterName, participantName, InstanceType.PARTICIPANT, null, property);
+      Assert.fail("Should see a IllegalArgumentException here because zkAddr and zkConnectionConfig cannot coexist");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
 
     // Connect as a participant
     HelixManager managerParticipant = HelixManagerFactory


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fix https://github.com/apache/helix/issues/2175

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
The timeout logic introduced in https://github.com/apache/helix/pull/1920, failed to provide a client side entry point. As a followup, this PR address the issue by passing down the parameter from HelixManagerFactory down to HelixTaskExecutor so that helix users can specify.
The parameter is encapsulated in HelixManagerProperty to enable client to specify value and pass down from HelixManagerFactory

Update:

We add zkAddr to HelixManagerProperty and parameter validation to resolve param conflicts. Rollback the new constructor in HelixManagerFactory.
Validations in two places:
1. HelixManagerProperty construction, at most one of {zkAddr and ZkConnectionConfig} shall be set. They can both be empty though, a warning is logged but won't block.
2. (Existing logic) ZKHelixManager:validateZkConnectionSettings, if ZkConnectionConfig is set, zkAddress from ZKHelixManager constructor must be null, otherwise early stop.

With above two checks, we can ensure: if ZkConnectionConfig is set => the zkAddress must be null, either from HelixManagerProperty or from ZKHelixManager.
We set higher precedence for zkAddr from HelixManagerProperty, if this is empty, zkAddress passed from constructor is used.

### Tests

- [X] The following tests are written for this issue:
Modified existing test case in [TestParticipantManager.java](https://github.com/apache/helix/compare/master...qqu0127:reset-timeout?expand=1#diff-41a02eec6acda934146e47c98a53813c4af8fd82091db2aadd9f80165af04d17)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
