### PR TITLE
Add TASK_THREADPOOL_RESET_TIMEOUT as system property

### DIFF
--- a/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
+++ b/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
@@ -34,6 +34,9 @@ public class SystemPropertyKeys {
   // Task Driver
   public static final String TASK_CONFIG_LIMITATION = "helixTask.configsLimitation";
 
+  // Task executor threadpool reset timeout in ms
+  public static final String TASK_THREADPOOL_RESET_TIMEOUT = "helixTask.threadpool.reset.timeout";
+
   // ZKHelixManager
   public static final String CLUSTER_MANAGER_VERSION = "cluster-manager-version.properties";
 

--- a/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
+++ b/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
@@ -35,7 +35,7 @@ public class SystemPropertyKeys {
   public static final String TASK_CONFIG_LIMITATION = "helixTask.configsLimitation";
 
   // Task executor threadpool reset timeout in ms
-  public static final String TASK_THREADPOOL_RESET_TIMEOUT = "helixTask.threadpool.reset.timeout";
+  public static final String TASK_THREADPOOL_RESET_TIMEOUT = "helixTask.threadpool.resetTimeout";
 
   // ZKHelixManager
   public static final String CLUSTER_MANAGER_VERSION = "cluster-manager-version.properties";

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -144,8 +144,6 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
   private static final int SESSION_SYNC_INTERVAL = 2000; // 2 seconds
   private static final String SESSION_SYNC = "SESSION-SYNC";
 
-  private static final int DEFAULT_MSG_HANDLER_RESET_TIMEOUT_MS = 200; // 200 ms
-
   /**
    * Map of MsgType->MsgHandlerFactoryRegistryItem
    */

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/TaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/TaskExecutor.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 public interface TaskExecutor {
   int DEFAULT_PARALLEL_TASKS = 40;
+  int DEFAULT_MSG_HANDLER_RESET_TIMEOUT_MS = 200;
 
   /**
    * Register MultiType message handler factory that the executor can handle.

--- a/helix-core/src/test/java/org/apache/helix/messaging/TestDefaultMessagingService.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/TestDefaultMessagingService.java
@@ -34,10 +34,12 @@ import org.apache.helix.MockAccessor;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyType;
+import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.messaging.handling.HelixTaskResult;
 import org.apache.helix.messaging.handling.MessageHandler;
 import org.apache.helix.messaging.handling.MessageHandlerFactory;
 import org.apache.helix.messaging.handling.MultiTypeMessageHandlerFactory;
+import org.apache.helix.messaging.handling.TaskExecutor;
 import org.apache.helix.mock.MockManager;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.LiveInstance.LiveInstanceProperty;
@@ -290,5 +292,16 @@ public class TestDefaultMessagingService {
         .containsKey(Message.MessageType.STATE_TRANSITION_CANCELLATION.name()));
     Assert.assertTrue(
         svc.getMessageHandlerFactoryMap().containsKey(Message.MessageType.CONTROLLER_MSG.name()));
+  }
+
+  @Test
+  public void testTaskThreadpoolResetTimeoutProperty() {
+    HelixManager manager = new MockManager();
+    System.setProperty(SystemPropertyKeys.TASK_THREADPOOL_RESET_TIMEOUT, "300");
+    MockDefaultMessagingService svc = new MockDefaultMessagingService(manager);
+    Assert.assertEquals(svc.getTaskThreadpoolResetTimeout(), 300);
+    System.clearProperty(SystemPropertyKeys.TASK_THREADPOOL_RESET_TIMEOUT);
+    svc = new MockDefaultMessagingService(new MockManager());
+    Assert.assertEquals(svc.getTaskThreadpoolResetTimeout(), TaskExecutor.DEFAULT_MSG_HANDLER_RESET_TIMEOUT_MS);
   }
 }


### PR DESCRIPTION
Allow users to specify reset timeout with system property.

### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fix https://github.com/apache/helix/issues/2175

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Add a new system property `TASK_THREADPOOL_RESET_TIMEOUT` so that users can set to specify the timeout limit for reseting the task threadpool.
The timeout was introduced in https://github.com/apache/helix/pull/1920, but users wouldn't be able to set it unless they have access to `DefaultMessagingService`.

### Tests

- [X] The following tests are written for this issue:
TestDefaultMessagingService.testTaskThreadpoolResetTimeoutProperty

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
