### PR TITLE
Reuse zkclient in BestPossibleExternalViewVerifier and fix resource leak

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
@@ -88,10 +88,5 @@ public class ReadOnlyWagedRebalancer extends WagedRebalancer {
       _bestPossibleAssignment = bestPossibleAssignment;
       return true;
     }
-
-    @Override
-    // BucketDataAccessor will be reused, won't be closed here.
-    public void close() {
-    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -453,8 +453,8 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
   // TODO: to clean up, finalize is deprecated in Java 9
   @Override
   public void finalize() {
-    super.finalize();
     close();
+    super.finalize();
   }
 
   private static class DryrunWagedRebalancer extends ReadOnlyWagedRebalancer implements AutoCloseable {
@@ -470,11 +470,6 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
         RebalanceAlgorithm algorithm) throws HelixRebalanceException {
       return getBestPossibleAssignment(getAssignmentMetadataStore(), currentStateOutput,
           resourceMap.keySet());
-    }
-
-    @Override
-    public void close() {
-      super.close();
     }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
@@ -44,7 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class ZkHelixClusterVerifier
-    implements IZkChildListener, IZkDataListener, HelixClusterVerifier {
+    implements IZkChildListener, IZkDataListener, HelixClusterVerifier, AutoCloseable {
   private static Logger LOG = LoggerFactory.getLogger(ZkHelixClusterVerifier.class);
   protected static int DEFAULT_TIMEOUT = 300 * 1000;
   protected static int DEFAULT_PERIOD = 500;
@@ -229,6 +229,7 @@ public abstract class ZkHelixClusterVerifier
     return verifyByPolling(DEFAULT_TIMEOUT, DEFAULT_PERIOD);
   }
 
+  @Override
   public void close() {
     if (_zkClient != null && !_usesExternalZkClient) {
       _zkClient.close();

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/ZkHelixClusterVerifier.java
@@ -229,6 +229,10 @@ public abstract class ZkHelixClusterVerifier
     return verifyByPolling(DEFAULT_TIMEOUT, DEFAULT_PERIOD);
   }
 
+  /**
+   * Implement close() for {@link AutoCloseable} and {@link HelixClusterVerifier}.
+   * Non-external resources should be closed in this method to prevent resource leak.
+   */
   @Override
   public void close() {
     if (_zkClient != null && !_usesExternalZkClient) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
@@ -285,7 +285,7 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
     if (_zkBucketDataAccessor == null) {
       synchronized (this) {
         if (_zkBucketDataAccessor == null) {
-          _zkBucketDataAccessor = new ZkBucketDataAccessor(_zkAddr);
+          _zkBucketDataAccessor = new ZkBucketDataAccessor(getByteArrayRealmAwareZkClient());
         }
       }
     }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Fix https://github.com/apache/helix/issues/2178 and https://github.com/apache/helix/issues/2179

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

A few changes for resource leak fix:
1. Reuse zkclient in verifier
2. Allow passing in zkclient in `ZkBucketDataAccessor`
3. Improve resource closure logic in a few classes with AutoCloseable
4. Change to use external ZkClient in `ServerContext` to fix unit test failure, this also prevents unnecessary zkclient creation

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

Central CI passed https://github.com/apache/helix/runs/7604254487?check_suite_focus=true 

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
