### PR TITLE
Optimize HelixTaskExecutor reset() in event of shutdown

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -137,7 +137,8 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
   private final ParticipantStatusMonitor _monitor;
   public static final String MAX_THREADS = "maxThreads";
 
-  private volatile boolean _isResetComplete = false;
+  // true if all partition state are "clean" as same after reset()
+  private volatile boolean _isCleanState = true;
   private MessageQueueMonitor _messageQueueMonitor;
   private GenericHelixController _controller;
   private Long _lastSessionSyncTime;
@@ -239,7 +240,6 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
     }
 
     _isShuttingDown = false;
-    _isResetComplete = false;
 
     MsgHandlerFactoryRegistryItem newItem = new MsgHandlerFactoryRegistryItem(factory, threadpoolSize, resetTimeoutMs);
     MsgHandlerFactoryRegistryItem prevItem = _hdlrFtyRegistry.putIfAbsent(type, newItem);
@@ -680,17 +680,10 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
     }
   }
 
-  synchronized void reset() {
-    if (_isResetComplete) {
-      LOG.info("HelixTaskExecutor.reset() has completed, no need to reset again");
-      return;
-    }
-    LOG.info("Reset HelixTaskExecutor");
-
-    if (_messageQueueMonitor != null) {
-      _messageQueueMonitor.reset();
-    }
-
+  /**
+   * Shutdown the registered thread pool executors. This method will be no-op if called repeatedly.
+   */
+  private void shutdownExecutors() {
     synchronized (_hdlrFtyRegistry) {
       for (String msgType : _hdlrFtyRegistry.keySet()) {
         // don't un-register factories, just shutdown all executors
@@ -702,8 +695,25 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
           shutdownAndAwaitTermination(pool, item);
         }
       }
+    }
+  }
+
+  synchronized void reset() {
+    if (_isCleanState) {
+      LOG.info("HelixTaskExecutor is in clean state, no need to reset again");
+      return;
+    }
+    LOG.info("Reset HelixTaskExecutor");
+
+    if (_messageQueueMonitor != null) {
+      _messageQueueMonitor.reset();
+    }
+
+    shutdownExecutors();
+
+    synchronized (_hdlrFtyRegistry) {
       _hdlrFtyRegistry.values()
-          .parallelStream()
+          .stream()
           .map(MsgHandlerFactoryRegistryItem::factory)
           .distinct()
           .filter(Objects::nonNull)
@@ -733,7 +743,7 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
     _knownMessageIds.clear();
 
     _lastSessionSyncTime = null;
-    _isResetComplete = true;
+    _isCleanState = true;
   }
 
   void init() {
@@ -744,7 +754,6 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
     }
 
     _isShuttingDown = false;
-    _isResetComplete = false;
 
     // Re-init all existing factories
     for (final String msgType : _hdlrFtyRegistry.keySet()) {
@@ -755,7 +764,7 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
         _monitor.createExecutorMonitor(type, newPool);
         return newPool;
       });
-      LOG.info("Setup the thread pool for type: %s, isShutdown: %s", msgType, pool.isShutdown());
+      LOG.info("Setup the thread pool for type: {}, isShutdown: {}", msgType, pool.isShutdown());
     }
   }
 
@@ -838,11 +847,7 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
     // and terminate all the thread pools
     // TODO: see if we should have a separate notification call for resetting
     if (changeContext.getType() == Type.FINALIZE) {
-      if (_isShuttingDown) {
-        LOG.info("Helix task executor is shutting down, skip reset() in FINALIZE");
-      } else {
-        reset();
-      }
+      reset();
       return;
     }
 
@@ -850,6 +855,7 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
       init();
       // continue to process messages
     }
+    _isCleanState = false;
 
     // if prefetch is disabled in MessageListenerCallback, we need to read all new messages from zk.
     if (messages == null || messages.isEmpty()) {
@@ -1457,7 +1463,7 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
       nopMsg.setTgtName(instanceName);
       accessor
           .setProperty(accessor.keyBuilder().message(nopMsg.getTgtName(), nopMsg.getId()), nopMsg);
-      LOG.info("Send NO_OP message to {}}, msgId: {}.", nopMsg.getTgtName(), nopMsg.getId());
+      LOG.info("Send NO_OP message to {}, msgId: {}.", nopMsg.getTgtName(), nopMsg.getId());
     } catch (Exception e) {
       LOG.error("Failed to send NO_OP message to {}.", instanceName, e);
     }
@@ -1469,6 +1475,7 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
     _isShuttingDown = true;
     _timer.cancel();
 
+    shutdownExecutors();
     reset();
     _monitor.shutDown();
     LOG.info("Shutdown HelixTaskExecutor finished");

--- a/helix-core/src/main/java/org/apache/helix/participant/HelixStateMachineEngine.java
+++ b/helix-core/src/main/java/org/apache/helix/participant/HelixStateMachineEngine.java
@@ -164,6 +164,7 @@ public class HelixStateMachineEngine implements StateMachineEngine {
   }
 
   private void loopStateModelFactories(Consumer<StateModel> consumer) {
+    // TODO: evaluate impact and consider parallelization
     for (Map<String, StateModelFactory<? extends StateModel>> ftyMap : _stateModelFactoryMap
         .values()) {
       for (StateModelFactory<? extends StateModel> stateModelFactory : ftyMap.values()) {

--- a/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java
@@ -816,11 +816,20 @@ public class TestHelixTaskExecutor {
   @Test
   public void testMsgHandlerRegistryAndShutdown() {
     HelixTaskExecutor executor = new HelixTaskExecutor();
-
+    HelixManager manager = new MockClusterManager();
     TestMessageHandlerFactory factory = new TestMessageHandlerFactory();
     TestMessageHandlerFactory3 factoryMulti = new TestMessageHandlerFactory3();
     executor.registerMessageHandlerFactory(factory, HelixTaskExecutor.DEFAULT_PARALLEL_TASKS, 200);
     executor.registerMessageHandlerFactory(factoryMulti, HelixTaskExecutor.DEFAULT_PARALLEL_TASKS, 200);
+
+    final Message msg = new Message(factory.getMessageTypes().get(0), UUID.randomUUID().toString());
+    msg.setTgtSessionId("*");
+    msg.setTgtName("Localhost_1123");
+    msg.setSrcName("127.101.1.23_2234");
+
+    NotificationContext changeContext = new NotificationContext(manager);
+    changeContext.setChangeType(HelixConstants.ChangeType.MESSAGE);
+    executor.onMessage("some", Collections.singletonList(msg), changeContext);
     Assert.assertEquals(executor._hdlrFtyRegistry.size(), 4);
     // Ensure TestMessageHandlerFactory3 instance is reset and reset exactly once
     executor.shutdown();


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

Resolve https://github.com/apache/helix/issues/2182 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

`HelixStateMachineEngine.reset()` is invoked 4 times during participant shutdown and that could take up to a few minutes. Two causes:

1. The above is triggered by `HelixTaskExecutor` twice because the same HelixStateMachineEngine is registered for two different message types.
2. There is also an additional thread doing similar cleanup, from `ZKHelixManager.cleanupCallbackHandlers`

This PR refactor the logic in HelixTaskExecutor to reduce unnecessary method call.

### Tests

- [X] The following tests are written for this issue:

New test case in helix-core/src/test/java/org/apache/helix/messaging/handling/TestHelixTaskExecutor.java

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
