### PR TITLE
WAGED pipeline change

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
@@ -111,6 +111,10 @@ public class AssignmentMetadataStore {
     }
   }
 
+  /**
+   * Persist a new baseline assignment to metadata store first, then to memory
+   * @param globalBaseline
+   */
   public synchronized void persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
     // write to metadata store
     persistAssignmentToMetadataStore(globalBaseline, _baselinePath, BASELINE_KEY);
@@ -119,8 +123,12 @@ public class AssignmentMetadataStore {
     getBaseline().putAll(globalBaseline);
   }
 
-  public synchronized void persistBestPossibleAssignment(
-      Map<String, ResourceAssignment> bestPossibleAssignment) {
+  /**
+   * Persist a new best possible assignment to metadata store first, then to memory.
+   * Increment best possible version by 1 - this is a high priority in-memory write.
+   * @param bestPossibleAssignment
+   */
+  public synchronized void persistBestPossibleAssignment(Map<String, ResourceAssignment> bestPossibleAssignment) {
     // write to metadata store
     persistAssignmentToMetadataStore(bestPossibleAssignment, _bestPossiblePath, BEST_POSSIBLE_KEY);
     // write to memory
@@ -131,6 +139,7 @@ public class AssignmentMetadataStore {
 
   /**
    * Attempts to persist Best Possible Assignment in memory from an asynchronous thread.
+   * Persist only happens when the provided version is not stale - this is a low priority in-memory write.
    * @param bestPossibleAssignment - new assignment to be persisted
    * @param newVersion - attempted new version to write. This version is obtained earlier from getBestPossibleVersion()
    * @return true if the attempt succeeded, false otherwise.

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
@@ -50,7 +50,7 @@ public class AssignmentMetadataStore {
   private String _bestPossiblePath;
   protected Map<String, ResourceAssignment> _globalBaseline;
   protected Map<String, ResourceAssignment> _bestPossibleAssignment;
-  private int _bestPossibleVersion = 0;
+  protected int _bestPossibleVersion = 0;
 
   AssignmentMetadataStore(String metadataStoreAddrs, String clusterName) {
     this(new ZkBucketDataAccessor(metadataStoreAddrs), clusterName);
@@ -98,8 +98,8 @@ public class AssignmentMetadataStore {
    * @param key  the key of the assignment in the record
    * @throws HelixException if the method failed to persist the baseline.
    */
-  private void persistAssignmentToMetadataStore(Map<String, ResourceAssignment> newAssignment, String path,
-      String key) {
+  private void persistAssignmentToMetadataStore(Map<String, ResourceAssignment> newAssignment, String path, String key)
+      throws HelixException {
     // TODO: Make the write async?
     // Persist to ZK
     HelixProperty combinedAssignments = combineAssignments(key, newAssignment);
@@ -107,8 +107,7 @@ public class AssignmentMetadataStore {
       _dataAccessor.compressedBucketWrite(path, combinedAssignments);
     } catch (IOException e) {
       // TODO: Improve failure handling
-      throw new HelixException(
-          String.format("Failed to persist %s assignment to path %s", key, path), e);
+      throw new HelixException(String.format("Failed to persist %s assignment to path %s", key, path), e);
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
@@ -233,11 +233,11 @@ public class AssignmentMetadataStore {
     return oldAssignment != null && oldAssignment.equals(newAssignment);
   }
 
-  protected boolean compareBaseline(Map<String, ResourceAssignment> newBaseline) {
+  protected boolean isBaselineChanged(Map<String, ResourceAssignment> newBaseline) {
     return compareAssignments(getBaseline(), newBaseline);
   }
 
-  protected boolean compareBestPossibleAssignment(Map<String, ResourceAssignment> newBaseline) {
+  protected boolean isBestPossibleChanged(Map<String, ResourceAssignment> newBaseline) {
     return compareAssignments(getBestPossibleAssignment(), newBaseline);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
@@ -106,7 +106,6 @@ public class AssignmentMetadataStore {
     try {
       _dataAccessor.compressedBucketWrite(path, combinedAssignments);
     } catch (IOException e) {
-      // TODO: Improve failure handling
       throw new HelixException(String.format("Failed to persist %s assignment to path %s", key, path), e);
     }
   }
@@ -144,7 +143,7 @@ public class AssignmentMetadataStore {
    * @param newVersion - attempted new version to write. This version is obtained earlier from getBestPossibleVersion()
    * @return true if the attempt succeeded, false otherwise.
    */
-  public synchronized boolean asyncPersistBestPossibleAssignmentInMemory(
+  public synchronized boolean asyncUpdateBestPossibleAssignmentCache(
       Map<String, ResourceAssignment> bestPossibleAssignment, int newVersion) {
     // Check if the version is stale by this point
     if (newVersion > _bestPossibleVersion) {
@@ -220,24 +219,11 @@ public class AssignmentMetadataStore {
     return assignmentMap;
   }
 
-  /**
-   * Returns whether two assignments are same.
-   * @param oldAssignment
-   * @param newAssignment
-   * @return true if they are the same. False otherwise or oldAssignment is null
-   */
-  private boolean compareAssignments(Map<String, ResourceAssignment> oldAssignment,
-      Map<String, ResourceAssignment> newAssignment) {
-    // If oldAssignment is null, that means that we haven't read from/written to
-    // the metadata store yet. In that case, we return false so that we write to metadata store.
-    return oldAssignment != null && oldAssignment.equals(newAssignment);
-  }
-
   protected boolean isBaselineChanged(Map<String, ResourceAssignment> newBaseline) {
-    return compareAssignments(getBaseline(), newBaseline);
+    return !getBaseline().equals(newBaseline);
   }
 
-  protected boolean isBestPossibleChanged(Map<String, ResourceAssignment> newBaseline) {
-    return compareAssignments(getBestPossibleAssignment(), newBaseline);
+  protected boolean isBestPossibleChanged(Map<String, ResourceAssignment> newBestPossible) {
+    return !getBestPossibleAssignment().equals(newBestPossible);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
@@ -67,26 +67,16 @@ public class ReadOnlyWagedRebalancer extends WagedRebalancer {
     }
 
     @Override
-    public boolean persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
-      // If baseline hasn't changed, skip updating the metadata store
-      if (compareAssignments(_globalBaseline, globalBaseline)) {
-        return false;
-      }
+    public void persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
       // Update the in-memory reference only
       _globalBaseline = globalBaseline;
-      return true;
     }
 
     @Override
-    public boolean persistBestPossibleAssignment(
+    public void persistBestPossibleAssignment(
         Map<String, ResourceAssignment> bestPossibleAssignment) {
-      // If bestPossibleAssignment hasn't changed, skip updating the metadata store
-      if (compareAssignments(_bestPossibleAssignment, bestPossibleAssignment)) {
-        return false;
-      }
       // Update the in-memory reference only
       _bestPossibleAssignment = bestPossibleAssignment;
-      return true;
     }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
@@ -80,7 +80,7 @@ public class ReadOnlyWagedRebalancer extends WagedRebalancer {
       _bestPossibleVersion++;
     }
     @Override
-    public synchronized boolean asyncPersistBestPossibleAssignmentInMemory(
+    public synchronized boolean asyncUpdateBestPossibleAssignmentCache(
         Map<String, ResourceAssignment> bestPossibleAssignment, int newVersion) {
       // Check if the version is stale by this point
       if (newVersion > _bestPossibleVersion) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/ReadOnlyWagedRebalancer.java
@@ -77,6 +77,19 @@ public class ReadOnlyWagedRebalancer extends WagedRebalancer {
         Map<String, ResourceAssignment> bestPossibleAssignment) {
       // Update the in-memory reference only
       _bestPossibleAssignment = bestPossibleAssignment;
+      _bestPossibleVersion++;
+    }
+    @Override
+    public synchronized boolean asyncPersistBestPossibleAssignmentInMemory(
+        Map<String, ResourceAssignment> bestPossibleAssignment, int newVersion) {
+      // Check if the version is stale by this point
+      if (newVersion > _bestPossibleVersion) {
+        _bestPossibleAssignment = bestPossibleAssignment;
+        _bestPossibleVersion = newVersion;
+        return true;
+      }
+
+      return false;
     }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -495,7 +495,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
 
     Map<String, ResourceAssignment> newBaseline = calculateAssignment(clusterModel, algorithm);
     boolean isBaselineChanged =
-        _assignmentMetadataStore != null && !_assignmentMetadataStore.compareBaseline(newBaseline);
+        _assignmentMetadataStore != null && !_assignmentMetadataStore.isBaselineChanged(newBaseline);
     // Write the new baseline to metadata store
     if (isBaselineChanged) {
       try {
@@ -602,7 +602,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
         currentBaseline, newAssignmentCopy);
 
     boolean bestPossibleUpdateSuccessful = false;
-    if (_assignmentMetadataStore != null && !_assignmentMetadataStore.compareBestPossibleAssignment(newAssignment)) {
+    if (_assignmentMetadataStore != null && !_assignmentMetadataStore.isBestPossibleChanged(newAssignment)) {
       bestPossibleUpdateSuccessful = _assignmentMetadataStore.asyncPersistBestPossibleAssignmentInMemory(newAssignment,
           newBestPossibleAssignmentVersion);
     } else {
@@ -793,7 +793,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
 
   private void persistBestPossibleAssignment(Map<String, ResourceAssignment> bestPossibleAssignment)
       throws HelixRebalanceException {
-    if (_assignmentMetadataStore != null && !_assignmentMetadataStore.compareBestPossibleAssignment(bestPossibleAssignment)) {
+    if (_assignmentMetadataStore != null && !_assignmentMetadataStore.isBestPossibleChanged(bestPossibleAssignment)) {
       try {
         _writeLatency.startMeasuringLatency();
         _assignmentMetadataStore.persistBestPossibleAssignment(bestPossibleAssignment);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -523,6 +523,13 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
       Set<String> activeNodes, final CurrentStateOutput currentStateOutput,
       RebalanceAlgorithm algorithm)
       throws HelixRebalanceException {
+    // If partial rebalance is async and the previous result is not completed yet,
+    // do not start another partial rebalance.
+    if (_asyncPartialRebalanceEnabled && _asyncPartialRebalanceResult != null
+        && !_asyncPartialRebalanceResult.isDone()) {
+      return;
+    }
+
     _asyncPartialRebalanceResult = _bestPossibleCalculateExecutor.submit(() -> {
       try {
         doPartialRebalance(clusterData, resourceMap, activeNodes, algorithm,

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -495,7 +495,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
 
     Map<String, ResourceAssignment> newBaseline = calculateAssignment(clusterModel, algorithm);
     boolean isBaselineChanged =
-        _assignmentMetadataStore != null && !_assignmentMetadataStore.isBaselineChanged(newBaseline);
+        _assignmentMetadataStore != null && _assignmentMetadataStore.isBaselineChanged(newBaseline);
     // Write the new baseline to metadata store
     if (isBaselineChanged) {
       try {
@@ -602,8 +602,8 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
         currentBaseline, newAssignmentCopy);
 
     boolean bestPossibleUpdateSuccessful = false;
-    if (_assignmentMetadataStore != null && !_assignmentMetadataStore.isBestPossibleChanged(newAssignment)) {
-      bestPossibleUpdateSuccessful = _assignmentMetadataStore.asyncPersistBestPossibleAssignmentInMemory(newAssignment,
+    if (_assignmentMetadataStore != null && _assignmentMetadataStore.isBestPossibleChanged(newAssignment)) {
+      bestPossibleUpdateSuccessful = _assignmentMetadataStore.asyncUpdateBestPossibleAssignmentCache(newAssignment,
           newBestPossibleAssignmentVersion);
     } else {
       LOG.debug("Assignment Metadata Store is null. Skip persisting the baseline assignment.");
@@ -793,7 +793,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
 
   private void persistBestPossibleAssignment(Map<String, ResourceAssignment> bestPossibleAssignment)
       throws HelixRebalanceException {
-    if (_assignmentMetadataStore != null && !_assignmentMetadataStore.isBestPossibleChanged(bestPossibleAssignment)) {
+    if (_assignmentMetadataStore != null && _assignmentMetadataStore.isBestPossibleChanged(bestPossibleAssignment)) {
       try {
         _writeLatency.startMeasuringLatency();
         _assignmentMetadataStore.persistBestPossibleAssignment(bestPossibleAssignment);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -231,6 +231,11 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     _asyncGlobalRebalanceEnabled = isAsyncGlobalRebalanceEnabled;
   }
 
+  // Update the partial rebalance mode to be asynchronous or synchronous
+  public void setPartialRebalanceAsyncMode(boolean isAsyncPartialRebalanceEnabled) {
+    _asyncPartialRebalanceEnabled = isAsyncPartialRebalanceEnabled;
+  }
+
   // Update the rebalancer preference if the new options are different from the current preference.
   public synchronized void updateRebalancePreference(
       Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> newPreference) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -571,7 +571,6 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     Map<String, ResourceAssignment> currentBestPossibleAssignment =
         getBestPossibleAssignment(_assignmentMetadataStore, currentStateOutput,
             resourceMap.keySet());
-
     ClusterModel clusterModel;
     try {
       clusterModel = ClusterModelProvider
@@ -581,8 +580,8 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
       throw new HelixRebalanceException("Failed to generate cluster model for partial rebalance.",
           HelixRebalanceException.Type.INVALID_CLUSTER_STATUS, ex);
     }
-
     Map<String, ResourceAssignment> newAssignment = calculateAssignment(clusterModel, algorithm);
+
     // Asynchronously report baseline divergence metric before persisting to metadata store,
     // just in case if persisting fails, we still have the metric.
     // To avoid changes of the new assignment and make it safe when being used to measure baseline

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -422,9 +422,8 @@ public class ClusterModelProvider {
         Set<String> currentAllocations =
             currentPartitionStateMap.getOrDefault(partitionName, Collections.emptyMap())
                 .getOrDefault(replicaState, Collections.emptySet());
-        List<String> currentAllocationsList = new ArrayList<>(currentAllocations);
         if (!currentAllocations.isEmpty()) {
-          currentAllocations.remove(currentAllocationsList.get(0));
+          currentAllocations.iterator().remove();
         } else {
           toBeAssignedReplicas.add(replica);
         }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -176,10 +176,6 @@ public class ClusterModelProvider {
       case EMERGENCY:
         toBeAssignedReplicas = findToBeAssignedReplicasIllegalPlacements(replicaMap, activeInstances,
             currentAssignment, allocatedReplicas);
-        if (toBeAssignedReplicas.isEmpty()) {
-          // Immediately return if there's nothing to assign. TODO: make this flow better
-          return null;
-        }
         break;
       default:
         throw new HelixException("Unknown rebalance scope type: " + scopeType);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -52,6 +52,7 @@ public class ClusterModelProvider {
     // Set the rebalance scope to cover all replicas that need relocation based on the cluster
     // changes.
     GLOBAL_BASELINE,
+    // Set the rebalance scope to cover only replicas that are assigned to downed instances.
     EMERGENCY
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -424,7 +424,9 @@ public class ClusterModelProvider {
             currentPartitionStateMap.getOrDefault(partitionName, Collections.emptyMap())
                 .getOrDefault(replicaState, Collections.emptySet());
         if (!currentAllocations.isEmpty()) {
-          currentAllocations.remove(currentAllocations.iterator().next());
+          String allocatedInstance = currentAllocations.iterator().next();
+          allocatedReplicas.computeIfAbsent(allocatedInstance, key -> new HashSet<>()).add(replica);
+          currentAllocations.remove(allocatedInstance);
         } else {
           toBeAssignedReplicas.add(replica);
         }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -180,6 +180,7 @@ public class ClusterModelProvider {
           // Immediately return if there's nothing to assign. TODO: make this flow better
           return null;
         }
+        break;
       default:
         throw new HelixException("Unknown rebalance scope type: " + scopeType);
     }
@@ -423,7 +424,7 @@ public class ClusterModelProvider {
             currentPartitionStateMap.getOrDefault(partitionName, Collections.emptyMap())
                 .getOrDefault(replicaState, Collections.emptySet());
         if (!currentAllocations.isEmpty()) {
-          currentAllocations.iterator().remove();
+          currentAllocations.remove(currentAllocations.iterator().next());
         } else {
           toBeAssignedReplicas.add(replica);
         }

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -184,6 +184,7 @@ public class ClusterConfig extends HelixProperty {
   private final static int MAX_REBALANCE_PREFERENCE = 1000;
   private final static int MIN_REBALANCE_PREFERENCE = 0;
   public final static boolean DEFAULT_GLOBAL_REBALANCE_ASYNC_MODE_ENABLED = true;
+  public final static boolean DEFAULT_PARTIAL_REBALANCE_ASYNC_MODE_ENABLED = true;
   private static final int GLOBAL_TARGET_TASK_THREAD_POOL_SIZE_NOT_SET = -1;
   private static final int OFFLINE_NODE_TIME_OUT_FOR_MAINTENANCE_MODE_NOT_SET = -1;
   private final static int DEFAULT_VIEW_CLUSTER_REFRESH_PERIOD = 30;

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/MockAssignmentMetadataStore.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/MockAssignmentMetadataStore.java
@@ -50,6 +50,19 @@ public class MockAssignmentMetadataStore extends AssignmentMetadataStore {
   public void persistBestPossibleAssignment(
       Map<String, ResourceAssignment> bestPossibleAssignment) {
     _bestPossibleAssignment = bestPossibleAssignment;
+    _bestPossibleVersion++;
+  }
+
+  public synchronized boolean asyncPersistBestPossibleAssignmentInMemory(
+      Map<String, ResourceAssignment> bestPossibleAssignment, int newVersion) {
+    // Check if the version is stale by this point
+    if (newVersion > _bestPossibleVersion) {
+      _bestPossibleAssignment = bestPossibleAssignment;
+      _bestPossibleVersion = newVersion;
+      return true;
+    }
+
+    return false;
   }
 
   public void close() {

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/MockAssignmentMetadataStore.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/MockAssignmentMetadataStore.java
@@ -53,7 +53,7 @@ public class MockAssignmentMetadataStore extends AssignmentMetadataStore {
     _bestPossibleVersion++;
   }
 
-  public synchronized boolean asyncPersistBestPossibleAssignmentInMemory(
+  public synchronized boolean asyncUpdateBestPossibleAssignmentCache(
       Map<String, ResourceAssignment> bestPossibleAssignment, int newVersion) {
     // Check if the version is stale by this point
     if (newVersion > _bestPossibleVersion) {

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/MockAssignmentMetadataStore.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/MockAssignmentMetadataStore.java
@@ -39,19 +39,17 @@ public class MockAssignmentMetadataStore extends AssignmentMetadataStore {
     return _globalBaseline == null ? Collections.emptyMap() : _globalBaseline;
   }
 
-  public boolean persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
+  public void persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
     _globalBaseline = globalBaseline;
-    return true;
   }
 
   public Map<String, ResourceAssignment> getBestPossibleAssignment() {
     return _bestPossibleAssignment == null ? Collections.emptyMap() : _bestPossibleAssignment;
   }
 
-  public boolean persistBestPossibleAssignment(
+  public void persistBestPossibleAssignment(
       Map<String, ResourceAssignment> bestPossibleAssignment) {
     _bestPossibleAssignment = bestPossibleAssignment;
-    return true;
   }
 
   public void close() {

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestAssignmentMetadataStore.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestAssignmentMetadataStore.java
@@ -96,31 +96,7 @@ public class TestAssignmentMetadataStore extends ZkTestBase {
     Assert.assertTrue(_store.getBestPossibleAssignment().isEmpty());
   }
 
-  /**
-   * Test that if the old assignment and new assignment are the same,
-   */
   @Test(dependsOnMethods = "testReadEmptyBaseline")
-  public void testAvoidingRedundantWrite() {
-    Map<String, ResourceAssignment> dummyAssignment = getDummyAssignment();
-
-    // Call persist functions
-    _store.persistBaseline(dummyAssignment);
-    _store.persistBestPossibleAssignment(dummyAssignment);
-
-    // Check that only one version exists
-    Assert.assertEquals(getExistingVersionNumbers(BASELINE_KEY).size(), 1);
-    Assert.assertEquals(getExistingVersionNumbers(BEST_POSSIBLE_KEY).size(), 1);
-
-    // Call persist functions again
-    _store.persistBaseline(dummyAssignment);
-    _store.persistBestPossibleAssignment(dummyAssignment);
-
-    // Check that only one version exists still
-    Assert.assertEquals(getExistingVersionNumbers(BASELINE_KEY).size(), 1);
-    Assert.assertEquals(getExistingVersionNumbers(BEST_POSSIBLE_KEY).size(), 1);
-  }
-
-  @Test(dependsOnMethods = "testAvoidingRedundantWrite")
   public void testAssignmentCache() {
     Map<String, ResourceAssignment> dummyAssignment = getDummyAssignment();
     // Call persist functions

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -255,8 +255,8 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     Map<String, ResourceAssignment> testResourceAssignmentMap = new HashMap<>();
     ZNRecord mappingNode = new ZNRecord(_resourceNames.get(0));
     HashMap<String, String> mapping = new HashMap<>();
-    mapping.put(_partitionNames.get(0), "MASTER");
-    mappingNode.setMapField(_testInstanceId, mapping);
+    mapping.put(_testInstanceId, "MASTER");
+    mappingNode.setMapField(_partitionNames.get(0), mapping);
     testResourceAssignmentMap.put(_resourceNames.get(0), new ResourceAssignment(mappingNode));
 
     _metadataStore.reset();
@@ -373,9 +373,9 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
           clusterData.getEnabledLiveInstances(), new CurrentStateOutput(), _algorithm);
       Assert.fail("Rebalance shall fail.");
     } catch (HelixRebalanceException ex) {
-      Assert.assertEquals(ex.getFailureType(), HelixRebalanceException.Type.INVALID_CLUSTER_STATUS);
+      Assert.assertEquals(ex.getFailureType(), HelixRebalanceException.Type.FAILED_TO_CALCULATE);
       Assert.assertEquals(ex.getMessage(),
-          "Failed to generate cluster model for emergency rebalance. Failure Type: INVALID_CLUSTER_STATUS");
+          "Failed to calculate for the new best possible. Failure Type: FAILED_TO_CALCULATE");
     }
 
     // The rebalance will be done with empty mapping result since there is no previously calculated

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -389,7 +389,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
   public void testInvalidRebalancerStatus() throws IOException {
     // Mock a metadata store that will fail on all the calls.
     AssignmentMetadataStore metadataStore = Mockito.mock(AssignmentMetadataStore.class);
-    when(metadataStore.getBaseline())
+    when(metadataStore.getBestPossibleAssignment())
         .thenThrow(new RuntimeException("Mock Error. Metadata store fails."));
     WagedRebalancer rebalancer = new WagedRebalancer(metadataStore, _algorithm, Optional.empty());
 
@@ -404,7 +404,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
       Assert.assertEquals(ex.getFailureType(),
           HelixRebalanceException.Type.INVALID_REBALANCER_STATUS);
       Assert.assertEquals(ex.getMessage(),
-          "Failed to get the current baseline assignment because of unexpected error. Failure Type: INVALID_REBALANCER_STATUS");
+          "Failed to get the current best possible assignment because of unexpected error. Failure Type: INVALID_REBALANCER_STATUS");
     }
   }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -375,7 +375,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     } catch (HelixRebalanceException ex) {
       Assert.assertEquals(ex.getFailureType(), HelixRebalanceException.Type.INVALID_CLUSTER_STATUS);
       Assert.assertEquals(ex.getMessage(),
-          "Failed to generate cluster model for partial rebalance. Failure Type: INVALID_CLUSTER_STATUS");
+          "Failed to generate cluster model for emergency rebalance. Failure Type: INVALID_CLUSTER_STATUS");
     }
 
     // The rebalance will be done with empty mapping result since there is no previously calculated
@@ -439,7 +439,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
       Assert.fail("Rebalance shall fail.");
     } catch (HelixRebalanceException ex) {
       Assert.assertEquals(ex.getFailureType(), HelixRebalanceException.Type.FAILED_TO_CALCULATE);
-      Assert.assertEquals(ex.getMessage(), "Algorithm fails. Failure Type: FAILED_TO_CALCULATE");
+      Assert.assertEquals(ex.getMessage(), "Failed to calculate for the new best possible. Failure Type: FAILED_TO_CALCULATE");
     }
     // But if call with the public method computeNewIdealStates(), the rebalance will return with
     // the previous rebalance result.


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
https://github.com/apache/helix/issues/2287

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

NOTE: no test or metrics are included in this PR due to PR size. Once reviewed, I will merge this PR into a feature branch instead of master branch, and a subsequent PR will be created for tests and metrics. The test changes here are for test passing only. 

This PR includes a couple feature changes:
1. Introducing the emergency rebalance process. 
2. Move partial rebalance to asynchronous. 
3. Add conditions to skip rebalance overwrite. 
4. Move cluster model generation to asynchronous global rebalance thread. 
5. Changes some API to AssignmentMetadata for operation purposes. For example, the persistX functions no longer include the "check for same assignment" logic for early termination. This allows us to a) accurately track write latency and b) tie boolean return values to actual persist failures. 

### Tests

- [x] The following tests are written for this issue:
No test or metrics are included in this PR due to PR size. A subsequent PR will be submitted later. 

- The following is the result of the "mvn test" command on the appropriate module:

```
[ERROR] Tests run: 1318, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 15,419.043 s <<< FAILURE! - in TestSuite
[ERROR] testP2PStateTransitionEnabled(org.apache.helix.integration.messaging.TestP2PNoDuplicatedMessage)  Time elapsed: 31.816 s  <<< FAILURE!
java.lang.AssertionError: There are duplicated transition messages sent at same time! expected:<0> but was:<3>
	at org.apache.helix.integration.messaging.TestP2PNoDuplicatedMessage.testP2PStateTransitionEnabled(TestP2PNoDuplicatedMessage.java:183)

[ERROR] testAggregateMetrics(org.apache.helix.monitoring.mbeans.TestClusterAggregateMetrics)  Time elapsed: 1.626 s  <<< FAILURE!
java.lang.AssertionError: expected:<true> but was:<false>
	at org.apache.helix.monitoring.mbeans.TestClusterAggregateMetrics.testAggregateMetrics(TestClusterAggregateMetrics.java:186)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestP2PNoDuplicatedMessage.testP2PStateTransitionEnabled:183 There are duplicated transition messages sent at same time! expected:<0> but was:<3>
[ERROR]   TestClusterAggregateMetrics.testAggregateMetrics:186 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1318, Failures: 2, Errors: 0, Skipped: 0
```

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 208.345 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
