### PR TITLE
Remove cloud config check in VirtualTopologyGroupService

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/VirtualTopologyGroupService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/VirtualTopologyGroupService.java
@@ -89,11 +89,6 @@ public class VirtualTopologyGroupService {
    */
   public void addVirtualTopologyGroup(String clusterName, Map<String, String> customFields) {
     // validation
-    CloudConfig cloudConfig = _configAccessor.getCloudConfig(clusterName);
-    if (cloudConfig == null || !cloudConfig.isCloudEnabled()) {
-      throw new HelixException(
-          "Cloud is not enabled, addVirtualTopologyGroup is not allowed to run in non-cloud environment.");
-    }
     ClusterConfig clusterConfig = _configAccessor.getClusterConfig(clusterName);
     Preconditions.checkState(clusterConfig.isTopologyAwareEnabled(),
         "Topology-aware rebalance is not enabled in cluster " + clusterName);

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestVirtualTopologyGroupService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestVirtualTopologyGroupService.java
@@ -83,13 +83,6 @@ public class TestVirtualTopologyGroupService {
     clusterConfig.setTopologyAwareEnabled(true);
     when(_configAccessor.getClusterConfig(TEST_CLUSTER0)).thenReturn(clusterConfig);
 
-    CloudConfig.Builder cloudConfigBuilder = new CloudConfig.Builder();
-    cloudConfigBuilder.setCloudEnabled(true);
-    cloudConfigBuilder.setCloudProvider(CloudProvider.AZURE);
-    cloudConfigBuilder.setCloudID("TestID");
-    CloudConfig cloudConfig = cloudConfigBuilder.build();
-    when(_configAccessor.getCloudConfig(TEST_CLUSTER0)).thenReturn(cloudConfig);
-
     _helixAdmin = mock(HelixAdmin.class);
     when(_helixAdmin.isInMaintenanceMode(anyString())).thenReturn(true);
 
@@ -101,10 +94,10 @@ public class TestVirtualTopologyGroupService {
     _service = new VirtualTopologyGroupService(_helixAdmin, clusterService, _configAccessor, _dataAccessor);
   }
 
-  @Test(expectedExceptions = HelixException.class, expectedExceptionsMessageRegExp = "Cloud is not enabled.*")
-  public void testClusterCloudConfigSetup() {
-    ClusterConfig clusterConfig1 = new ClusterConfig(TEST_CLUSTER1);
-    when(_configAccessor.getClusterConfig(TEST_CLUSTER1)).thenReturn(clusterConfig1);
+  @Test(expectedExceptions = IllegalStateException.class,
+      expectedExceptionsMessageRegExp = "Topology-aware rebalance is not enabled.*")
+  public void testTopologyAwareEnabledSetup() {
+    when(_configAccessor.getClusterConfig(TEST_CLUSTER1)).thenReturn(new ClusterConfig(TEST_CLUSTER1));
     _service.addVirtualTopologyGroup(TEST_CLUSTER1, ImmutableMap.of(GROUP_NAME, "test-group", GROUP_NUMBER, "2"));
   }
 


### PR DESCRIPTION
Remove the dependency on CloudConfig for setting virtual topology group.

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR removes the cloud config check in `VirtualTopologyGroupService` since we want to generalize this feature to all environments, both cloud and on-prem. 

Now the validation includes:
1. Request param validation
2. Cluster has topology aware enabled
3. Number of virtual zones should be less than the number of instances
4. In maintenance mode if configured

### Tests

- [X] The following tests are written for this issue:

Modified `TestVirtualTopologyGroupService` 

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
