### PR TITLE
Removed Error Log to Avoid Spam Logging

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -726,7 +726,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
       // case, we try to delete recursively
       _zkClient.delete(path);
     } catch (ZkException e) {
-      LOG.debug("Failed to delete {} with opts {}, err: {}. Try recursive delete", path, options,
+      LOG.info("Failed to delete {} with opts {}, err: {}. Try recursive delete", path, options,
           e.getMessage());
       try {
         _zkClient.deleteRecursively(path);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -726,7 +726,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
       // case, we try to delete recursively
       _zkClient.delete(path);
     } catch (ZkException e) {
-      LOG.info("Failed to delete {} with opts {}, err: {}. Try recursive delete", path, options,
+      LOG.debug("Failed to delete {} with opts {}, err: {}. Try recursive delete", path, options,
           e.getMessage());
       try {
         _zkClient.deleteRecursively(path);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -434,6 +434,29 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
   }
 
   @Test
+  public void testDeleteLogging() {
+    String root = _rootPath;
+    _gZkClient.deleteRecursively("/" + root);
+
+    ZkBaseDataAccessor<ZNRecord> accessor = new ZkBaseDataAccessor<>(_gZkClient);
+
+    // CreateChildren
+    List<ZNRecord> records = new ArrayList<>();
+    List<String> paths = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      String msgId = "msg_" + i;
+      paths.add(PropertyPathBuilder.instanceMessage(root, "host_1", msgId));
+      records.add(new ZNRecord(msgId));
+    }
+    boolean[] success = accessor.createChildren(paths, records, AccessOption.PERSISTENT);
+
+    // Attempt to remove parent. Shouldn't throw an error or warning log.
+    // Should return True if recursive deletion succeeds.
+    Assert.assertTrue(accessor.remove(PropertyPathBuilder.instanceMessage(root, "host_1"), 0),
+            "Should return True despite log errors.");
+  }
+
+  @Test
   public void testSyncGet() {
     String className = TestHelper.getTestClassName();
     String methodName = TestHelper.getTestMethodName();

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -454,6 +454,14 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     // Should return True if recursive deletion succeeds.
     Assert.assertTrue(accessor.remove(PropertyPathBuilder.instanceMessage(root, "host_1"), 0),
             "Should return True despite log errors.");
+
+    // Assert child message nodes were removed when calling remove on parent
+    for (int i = 0; i < 10; i++) {
+      String msgId = "msg_" + i;
+      String path = PropertyPathBuilder.instanceMessage(root, "host_1", msgId);
+      boolean pathExists = _gZkClient.exists(path);
+      Assert.assertFalse(pathExists, "Message znode should have been removed by accessor msgId=" + msgId);
+    }
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -434,7 +434,7 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
   }
 
   @Test
-  public void testDeleteLogging() {
+  public void testDeleteNodeWithChildren() {
     String root = _rootPath;
 
     ZkBaseDataAccessor<ZNRecord> accessor = new ZkBaseDataAccessor<>(_gZkClient);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -436,7 +436,6 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
   @Test
   public void testDeleteLogging() {
     String root = _rootPath;
-    _gZkClient.deleteRecursively("/" + root);
 
     ZkBaseDataAccessor<ZNRecord> accessor = new ZkBaseDataAccessor<>(_gZkClient);
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -2073,7 +2073,7 @@ public class ZkClient implements Watcher {
       record(path, null, startT, ZkClientMonitor.AccessType.WRITE);
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.WRITE);
-      LOG.warn("zkclient {}, Failed to delete path {}! ", _uid, path, e);
+      LOG.info("zkclient {}, Failed to delete path {}! ", _uid, path, e);
       throw e;
     } finally {
       long endT = System.currentTimeMillis();

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -2066,14 +2066,11 @@ public class ZkClient implements Watcher {
         success = true;
       } catch (ZkNoNodeException e) {
         success = false;
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("zkclient {}, Failed to delete path {}, znode does not exist!", _uid, path);
-        }
+        LOG.debug("zkclient {}, Failed to delete path {}, znode does not exist!", _uid, path);
       }
       record(path, null, startT, ZkClientMonitor.AccessType.WRITE);
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.WRITE);
-      LOG.debug("zkclient {}, Failed to delete path {}! ", _uid, path, e);
       throw e;
     } finally {
       long endT = System.currentTimeMillis();

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -2073,7 +2073,7 @@ public class ZkClient implements Watcher {
       record(path, null, startT, ZkClientMonitor.AccessType.WRITE);
     } catch (Exception e) {
       recordFailure(path, ZkClientMonitor.AccessType.WRITE);
-      LOG.info("zkclient {}, Failed to delete path {}! ", _uid, path, e);
+      LOG.debug("zkclient {}, Failed to delete path {}! ", _uid, path, e);
       throw e;
     } finally {
       long endT = System.currentTimeMillis();


### PR DESCRIPTION
Deleted logging error in `ZkClient` delete method to eliminate log noise.

### Issues

https://github.com/apache/helix/issues/2202#issue-1357887240
References an issue where despite a successful retry, failure to remove a node still throws an error log.

### Description

https://github.com/apache/helix/issues/2202#issue-1357887240

Removed a failed remove log in `ZkClient.delete()`. This log error shows when there is an attempt to delete a parent ZNode with non-empty children. However, it automatically calls another function that recursively deletes the children of the node and in the case this operation is successful, having a stack-trace error from before can confuse users of a problem that is in fact trivial. By deleting the log shown when the above error occurs, we eliminate these misleading logs and avoid log flooding. We can do this as the exception is already being thrown so it is not necessary to log it. 

### Tests

Added `testDeleteNodeWithChildren()` in `TestZkBaseDataAccessor.java`

The test creates a 10 instance message records. It proceeds to call remove on the parent of those children. The test checks whether remove returns true, which it does. However, the purpose of it is to simulate the initial error that brought upon this change. Going through the debugger, we see that it does go through the right path and effectively does not throw any logs (as it has been removed).

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 57.175 s - in org.apache.helix.manager.zk.TestZkBaseDataAccessor
[INFO] Results:
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```



Local test result for failed CI tests:
For `testZKHelixManager` and `afterClass`

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 208.496 s - in org.apache.helix.integration.multizk.TestMultiZkConectionConfig
[INFO] Results:
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

For `testZkClientCreationMultiZk`

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 79.998 s - in org.apache.helix.task.TestTaskStateModelFactory
[INFO] Results:
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```