### PR TITLE
2212/ensure that create cluster button is visible [helix-front]

### DIFF
--- a/helix-front/src/app/cluster/cluster-detail/cluster-detail.component.html
+++ b/helix-front/src/app/cluster/cluster-detail/cluster-detail.component.html
@@ -39,7 +39,7 @@
         }}</a>
       </h6>
       <span fxFlex="1 1 auto"></span>
-      <button mat-mini-fab *ngIf="can" [matMenuTriggerFor]="menu">
+      <button mat-mini-fab [matMenuTriggerFor]="menu">
         <mat-icon>menu</mat-icon>
       </button>
       <mat-menu #menu="matMenu">

--- a/helix-front/src/app/cluster/cluster-detail/cluster-detail.component.html
+++ b/helix-front/src/app/cluster/cluster-detail/cluster-detail.component.html
@@ -39,7 +39,7 @@
         }}</a>
       </h6>
       <span fxFlex="1 1 auto"></span>
-      <button mat-mini-fab [matMenuTriggerFor]="menu">
+      <button mat-mini-fab *ngIf="can" [matMenuTriggerFor]="menu">
         <mat-icon>menu</mat-icon>
       </button>
       <mat-menu #menu="matMenu">

--- a/helix-front/src/app/cluster/cluster-list/cluster-list.component.html
+++ b/helix-front/src/app/cluster/cluster-list/cluster-list.component.html
@@ -26,7 +26,7 @@
       <button class="back-to-index-button" mat-button routerLink="/">
         <mat-icon>arrow_back</mat-icon> Back to Index
       </button>
-      <button mat-mini-fab (click)="createCluster()">
+      <button mat-mini-fab *ngIf="can" (click)="createCluster()">
         <mat-icon>add</mat-icon>
       </button>
     </div>
@@ -42,7 +42,7 @@
     </a>
     <div *ngIf="clusters.length == 0" class="empty">
       There's no cluster here.
-      <a mat-button (click)="createCluster()">Create one?</a>
+      <a mat-button *ngIf="can" (click)="createCluster()">Create one?</a>
     </div>
   </mat-nav-list>
   <section class="error-message" *ngIf="errorMessage">

--- a/helix-front/src/app/cluster/cluster-list/cluster-list.component.html
+++ b/helix-front/src/app/cluster/cluster-list/cluster-list.component.html
@@ -22,12 +22,14 @@
     <mat-spinner> Loading all clusters ... </mat-spinner>
   </section>
   <mat-nav-list *ngIf="!isLoading && !errorMessage">
-    <button mat-button routerLink="/">
-      <mat-icon>arrow_back</mat-icon> Back to Index
-    </button>
-    <button mat-mini-fab *ngIf="can" (click)="createCluster()">
-      <mat-icon>add</mat-icon>
-    </button>
+    <div class="cluster-list-button-group">
+      <button class="back-to-index-button" mat-button routerLink="/">
+        <mat-icon>arrow_back</mat-icon> Back to Index
+      </button>
+      <button mat-mini-fab (click)="createCluster()">
+        <mat-icon>add</mat-icon>
+      </button>
+    </div>
     <h3 mat-subheader>Clusters in {{ service }} ({{ clusters.length }})</h3>
     <a
       *ngFor="let cluster of clusters"
@@ -40,7 +42,7 @@
     </a>
     <div *ngIf="clusters.length == 0" class="empty">
       There's no cluster here.
-      <a mat-button *ngIf="can" (click)="createCluster()">Create one?</a>
+      <a mat-button (click)="createCluster()">Create one?</a>
     </div>
   </mat-nav-list>
   <section class="error-message" *ngIf="errorMessage">

--- a/helix-front/src/app/cluster/cluster-list/cluster-list.component.scss
+++ b/helix-front/src/app/cluster/cluster-list/cluster-list.component.scss
@@ -1,6 +1,25 @@
 @use '@angular/material' as mat;
 @import 'src/theme.scss';
 
+.mat-nav-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.cluster-list-button-group {
+  display: flex;
+  justify-content: space-between;
+  margin-right: 1rem;
+}
+
+.back-to-index-button {
+  align-self: flex-start;
+}
+
+.add-cluster-button {
+  align-self: flex-end;
+}
+
 .mat-spinner {
   margin: 20px;
 }
@@ -12,12 +31,6 @@
 
 .error-message {
   padding: 10px;
-}
-
-.mat-mini-fab {
-  position: fixed;
-  right: 16px;
-  top: 16px;
 }
 
 .empty {

--- a/helix-front/src/app/cluster/cluster-list/cluster-list.component.ts
+++ b/helix-front/src/app/cluster/cluster-list/cluster-list.component.ts
@@ -17,6 +17,8 @@ export class ClusterListComponent implements OnInit {
   clusters: Cluster[] = [];
   errorMessage = '';
   isLoading = true;
+  // is the currrent user logged in? If true, then yes.
+  can = false;
   service = '';
 
   constructor(
@@ -28,6 +30,8 @@ export class ClusterListComponent implements OnInit {
 
   ngOnInit() {
     this.loadClusters();
+    // check if the current user is logged in
+    this.clusterService.can().subscribe((data) => (this.can = data));
     this.service = this.router.url.split('/')[1];
   }
 
@@ -37,6 +41,8 @@ export class ClusterListComponent implements OnInit {
       /* error path */ (error) => this.showErrorMessage(error),
       /* onComplete */ () => (this.isLoading = false)
     );
+    // check if the current user is logged in again
+    this.clusterService.can().subscribe((data) => (this.can = data));
   }
 
   showErrorMessage(error: any) {

--- a/helix-front/src/app/cluster/cluster-list/cluster-list.component.ts
+++ b/helix-front/src/app/cluster/cluster-list/cluster-list.component.ts
@@ -17,7 +17,6 @@ export class ClusterListComponent implements OnInit {
   clusters: Cluster[] = [];
   errorMessage = '';
   isLoading = true;
-  can = false;
   service = '';
 
   constructor(
@@ -29,7 +28,6 @@ export class ClusterListComponent implements OnInit {
 
   ngOnInit() {
     this.loadClusters();
-    this.clusterService.can().subscribe((data) => (this.can = data));
     this.service = this.router.url.split('/')[1];
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fix #2212

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR ensures that the create cluster button is visible in the left sidebar in the cluster list view. This is done both by updating styles as well as by verifying that the current user is logged in after loading all clusters.

![Screen Shot 2022-09-14 at 11 17 33 AM](https://user-images.githubusercontent.com/2119400/190232046-6a16a6de-ccd1-4d99-b2c6-f04dfac0e555.png)

![Screen Shot 2022-09-14 at 11 19 22 AM](https://user-images.githubusercontent.com/2119400/190232105-4cf85a44-cb05-4c97-98cc-2f6b3a693cb8.png)


### Tests

- [x] The following tests are written for this issue:

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- 
### Code Quality

- My diff has been formatted using [Prettier](https://prettier.io)