### PR TITLE
Add new interface IZkChildEventListener to allow pass in WatchedEvent

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/TestZkBasis.java
+++ b/helix-core/src/test/java/org/apache/helix/TestZkBasis.java
@@ -30,8 +30,10 @@ import java.util.concurrent.TimeUnit;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
+import org.apache.helix.zookeeper.zkclient.IZkChildEventListener;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
+import org.apache.zookeeper.WatchedEvent;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -39,7 +41,7 @@ import org.testng.annotations.Test;
  * test zookeeper basis
  */
 public class TestZkBasis extends ZkUnitTestBase {
-  class ZkListener implements IZkDataListener, IZkChildListener {
+  class ZkListener implements IZkDataListener, IZkChildEventListener {
     String _parentPath = null;
     String _dataDeletePath = null;
     List<String> _currentChilds = Collections.emptyList(); // make sure it's set to null in
@@ -49,7 +51,7 @@ public class TestZkBasis extends ZkUnitTestBase {
     CountDownLatch _dataDeleteCountDown = new CountDownLatch(1);
 
     @Override
-    public void handleChildChange(String parentPath, List<String> currentChilds) {
+    public void handleChildChange(String parentPath, List<String> currentChilds, WatchedEvent event) {
       _parentPath = parentPath;
       _currentChilds = currentChilds;
       _childChangeCountDown.countDown();

--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestBatchMessage.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestBatchMessage.java
@@ -40,16 +40,17 @@ import org.apache.helix.model.LiveInstance;
 import org.apache.helix.tools.ClusterSetup;
 import org.apache.helix.tools.ClusterStateVerifier;
 import org.apache.helix.tools.ClusterStateVerifier.BestPossAndExtViewZkVerifier;
-import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+import org.apache.helix.zookeeper.zkclient.IZkChildEventListener;
+import org.apache.zookeeper.WatchedEvent;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class TestBatchMessage extends ZkTestBase {
-  class TestZkChildListener implements IZkChildListener {
+  static class TestZkChildListener implements IZkChildEventListener {
     int _maxNumberOfChildren = 0;
 
     @Override
-    public void handleChildChange(String parentPath, List<String> currentChildren) {
+    public void handleChildChange(String parentPath, List<String> currentChildren, WatchedEvent event) {
       if (currentChildren == null) {
         return;
       }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -28,7 +28,7 @@ import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.constant.RoutingDataReaderType;
 import org.apache.helix.zookeeper.routing.RoutingDataManager;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
-import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+import org.apache.helix.zookeeper.zkclient.IZkChildEventListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.helix.zookeeper.zkclient.IZkStateListener;
 import org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks;
@@ -79,7 +79,7 @@ public interface RealmAwareZkClient {
    * under the path. The list can be empty if there is no children.
    */
   @Deprecated
-  List<String> subscribeChildChanges(String path, IZkChildListener listener);
+  List<String> subscribeChildChanges(String path, IZkChildEventListener listener);
 
   /**
    * Subscribe the path and the listener will handle child events of the path
@@ -90,10 +90,10 @@ public interface RealmAwareZkClient {
    * @return ChildrentSubsribeResult. If the path does not exists, the isInstalled field
    * is false. Otherwise, it is true and list of children are returned.
    */
-  ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener,
+  ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildEventListener listener,
       boolean skipWatchingNonExistNode);
 
-  void unsubscribeChildChanges(String path, IZkChildListener listener);
+  void unsubscribeChildChanges(String path, IZkChildEventListener listener);
 
   /**
    * Subscribe the path and the listener will handle data events of the path
@@ -667,7 +667,7 @@ public interface RealmAwareZkClient {
    * @param childListener
    * @param dataListener
    */
-  default void subscribeRoutingDataChanges(IZkChildListener childListener,
+  default void subscribeRoutingDataChanges(IZkChildEventListener childListener,
       IZkDataListener dataListener) {
     subscribeChildChanges(MetadataStoreRoutingConstants.ROUTING_DATA_PATH, childListener);
     for (String child : getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH)) {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -28,7 +28,7 @@ import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
-import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+import org.apache.helix.zookeeper.zkclient.IZkChildEventListener;
 import org.apache.helix.zookeeper.zkclient.IZkConnection;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.helix.zookeeper.zkclient.ZkConnection;
@@ -105,19 +105,19 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public List<String> subscribeChildChanges(String path, IZkChildListener listener) {
+  public List<String> subscribeChildChanges(String path, IZkChildEventListener listener) {
     checkIfPathContainsShardingKey(path);
     return _rawZkClient.subscribeChildChanges(path, listener);
   }
 
   @Override
-  public ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener,
+  public ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildEventListener listener,
       boolean skipWatchingNodeNotExist) {
     return _rawZkClient.subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override
-  public void unsubscribeChildChanges(String path, IZkChildListener listener) {
+  public void unsubscribeChildChanges(String path, IZkChildEventListener listener) {
     checkIfPathContainsShardingKey(path);
     _rawZkClient.unsubscribeChildChanges(path, listener);
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -36,7 +36,7 @@ import org.apache.helix.zookeeper.exception.MultiZkException;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
 import org.apache.helix.zookeeper.routing.RoutingDataManager;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
-import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+import org.apache.helix.zookeeper.zkclient.IZkChildEventListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.helix.zookeeper.zkclient.IZkStateListener;
 import org.apache.helix.zookeeper.zkclient.ZkConnection;
@@ -108,18 +108,18 @@ public class FederatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public List<String> subscribeChildChanges(String path, IZkChildListener listener) {
+  public List<String> subscribeChildChanges(String path, IZkChildEventListener listener) {
     return getZkClient(path).subscribeChildChanges(path, listener);
   }
 
   @Override
-  public ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener,
+  public ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildEventListener listener,
       boolean skipWatchingNodeNotExist) {
     return getZkClient(path).subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override
-  public void unsubscribeChildChanges(String path, IZkChildListener listener) {
+  public void unsubscribeChildChanges(String path, IZkChildEventListener listener) {
     getZkClient(path).unsubscribeChildChanges(path, listener);
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -30,7 +30,7 @@ import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
-import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+import org.apache.helix.zookeeper.zkclient.IZkChildEventListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks;
 import org.apache.helix.zookeeper.zkclient.deprecated.IZkStateListener;
@@ -110,19 +110,19 @@ public class SharedZkClient implements RealmAwareZkClient {
   }
 
   @Override
-  public List<String> subscribeChildChanges(String path, IZkChildListener listener) {
+  public List<String> subscribeChildChanges(String path, IZkChildEventListener listener) {
     checkIfPathContainsShardingKey(path);
     return _innerSharedZkClient.subscribeChildChanges(path, listener);
   }
 
   @Override
-  public ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildListener listener,
+  public ChildrenSubscribeResult subscribeChildChanges(String path, IZkChildEventListener listener,
       boolean skipWatchingNodeNotExist) {
     return _innerSharedZkClient.subscribeChildChanges(path, listener, skipWatchingNodeNotExist);
   }
 
   @Override
-  public void unsubscribeChildChanges(String path, IZkChildListener listener) {
+  public void unsubscribeChildChanges(String path, IZkChildEventListener listener) {
     checkIfPathContainsShardingKey(path);
     _innerSharedZkClient.unsubscribeChildChanges(path, listener);
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkChildEventListener.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkChildEventListener.java
@@ -1,0 +1,43 @@
+package org.apache.helix.zookeeper.zkclient;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+import org.apache.zookeeper.WatchedEvent;
+
+
+/**
+ * An {@link IZkChildEventListener} can be registered at a {@link ZkClient} for listening on zk child changes for a given
+ * path.
+ * Node: Also this listener re-subscribes it watch for the path on each zk event (zk watches are one-timers) is not
+ * guaranteed that events on the path are missing (see http://zookeeper.wiki.sourceforge.net/ZooKeeperWatches). An
+ * implementation of this class should take that into account.
+ */
+public interface IZkChildEventListener {
+
+  /**
+   * Called when the children of the given path changed.
+   *
+   * @param parentPath The parent path
+   * @param currentChildren The children or null if the root node (parent path) was deleted.
+   * @param event The watched event
+   */
+  void handleChildChange(String parentPath, List<String> currentChildren, WatchedEvent event) throws Exception;
+}

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkChildListener.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkChildListener.java
@@ -20,6 +20,8 @@ package org.apache.helix.zookeeper.zkclient;
  */
 
 import java.util.List;
+import org.apache.zookeeper.WatchedEvent;
+
 
 /**
  * An {@link IZkChildListener} can be registered at a {@link ZkClient} for listening on zk child changes for a given
@@ -29,17 +31,31 @@ import java.util.List;
  * guaranteed that events on the path are missing (see http://zookeeper.wiki.sourceforge.net/ZooKeeperWatches). An
  * implementation of this class should take that into account.
  *
+ * Deprecated: This interface is kept to maintain backward compatibility, please use {@link IZkChildEventListener}.
  */
-public interface IZkChildListener {
+@Deprecated
+public interface IZkChildListener extends IZkChildEventListener {
 
     /**
      * Called when the children of the given path changed.
      *
      * @param parentPath
      *            The parent path
-     * @param currentChilds
+     * @param currentChildren
      *            The children or null if the root node (parent path) was deleted.
      * @throws Exception
      */
-    public void handleChildChange(String parentPath, List<String> currentChilds) throws Exception;
+    void handleChildChange(String parentPath, List<String> currentChildren) throws Exception;
+
+    /**
+     * Called when the children of the given path changed.
+     *
+     * @param parentPath The parent path
+     * @param currentChildren The children or null if the root node (parent path) was deleted.
+     * @param event The watched event
+     */
+    default void handleChildChange(String parentPath, List<String> currentChildren, WatchedEvent event)
+        throws Exception {
+        handleChildChange(parentPath, currentChildren);
+    }
 }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Add a new interface for zk child listener and refactor to maintain backward compatibility.
The previous https://github.com/apache/helix/blob/ee61ff434ee37d4ab8456c739b2229f99d9e0e72/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkChildListener.java doesn't pass in `WatchedEvent` to the method, as a result implementation can't depend on different event types.

This PR introduce a new interface with the ideal API signature. The old interface is refactored to depend on the new one, AND use a default method for backward compatibility. New use cases should be changed to use `IZkChildEventListener` while there is no breaking change for existing users.
A few other places are changed to allow passing in the event and method signature change.

### Tests

- [X] The following tests are written for this issue:

Updated `TestZkBasis` and `TestBatchMessage`

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
