### PR TITLE
Upgrade to zookeeper 3.6.3

### DIFF
--- a/helix-core/helix-core-1.0.5-SNAPSHOT.ivy
+++ b/helix-core/helix-core-1.0.5-SNAPSHOT.ivy
@@ -52,7 +52,7 @@ under the License.
     <dependency org="org.apache.logging.log4j" name="log4j-slf4j-impl" rev="2.17.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)">
         <artifact name="log4j-slf4j-impl" ext="jar"/>
     </dependency>
-    <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.5.9" conf="compile->compile(default);runtime->runtime(default);default->default"/>
+    <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.6.3" conf="compile->compile(default);runtime->runtime(default);default->default"/>
 		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.12.6.1" conf="compile->compile(default);runtime->runtime(default);default->default"/>
     <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.12.6" conf="compile->compile(default);runtime->runtime(default);default->default"/>
     <dependency org="commons-io" name="commons-io" rev="2.11.0" conf="compile->compile(default);runtime->runtime(default);default->default"/>
@@ -63,6 +63,7 @@ under the License.
     <dependency org="org.yaml" name="snakeyaml" rev="1.30" conf="compile->compile(default);runtime->runtime(default);default->default"/>
     <dependency org="commons-logging" name="commons-logging-api" rev="1.1" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
     <dependency org="io.dropwizard.metrics" name="metrics-core" rev="4.1.14" conf="compile->compile(default);runtime->runtime(default);default->default"/>
+    <dependency org="org.xerial.snappy" name="snappy-java" rev="1.1.7" conf="compile->compile(default);runtime->runtime(default);default->default"/>
 	</dependencies>
 </ivy-module>
 

--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -146,6 +146,12 @@
       <artifactId>jaxb-api</artifactId>
       <version>2.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>1.1.7</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/helix-core/src/main/java/org/apache/helix/tools/commandtools/ZKLogFormatter.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/commandtools/ZKLogFormatter.java
@@ -44,6 +44,7 @@ import org.apache.zookeeper.ZooDefs.OpCode;
 import org.apache.zookeeper.data.Stat;
 import org.apache.zookeeper.server.DataNode;
 import org.apache.zookeeper.server.DataTree;
+import org.apache.zookeeper.server.TxnLogEntry;
 import org.apache.zookeeper.server.persistence.FileHeader;
 import org.apache.zookeeper.server.persistence.FileSnap;
 import org.apache.zookeeper.server.persistence.FileTxnLog;
@@ -248,13 +249,12 @@ public class ZKLogFormatter {
       if (crcValue != crc.getValue()) {
         throw new IOException("CRC doesn't match " + crcValue + " vs " + crc.getValue());
       }
-      TxnHeader hdr = new TxnHeader();
-      Record txn = SerializeUtils.deserializeTxn(bytes, hdr);
+      TxnLogEntry txnLogEntry =  SerializeUtils.deserializeTxn(bytes);
       if (bw != null) {
-        bw.write(formatTransaction(hdr, txn));
+        bw.write(formatTransaction(txnLogEntry.getHeader(), txnLogEntry.getTxn()));
         bw.newLine();
       } else {
-        System.out.println(formatTransaction(hdr, txn));
+        System.out.println(formatTransaction(txnLogEntry.getHeader(), txnLogEntry.getTxn()));
       }
 
       if (logStream.readByte("EOR") != 'B') {

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <osgi.import>
       org.slf4j*;version="[1.7,2)",
-      org.apache.zookeeper*;version="[3.5,9)",
+      org.apache.zookeeper*;version="[3.6,3)",
       *
     </osgi.import>
     <osgi.export>org.apache.helix.zookeeper*;version="${project.version};-noimport:=true</osgi.export>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.5.9</version>
+      <version>3.6.3</version>
       <exclusions>
         <exclusion>
           <groupId>junit</groupId>

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkServer.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkServer.java
@@ -168,7 +168,7 @@ public class ZkServer {
             _nioFactory = null;
         }
         if (_zk != null) {
-            _zk.shutdown();
+            _zk.shutdown(true);
             _zk = null;
         }
         LOG.info("Shutting down ZkServer...done");

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -1067,19 +1067,23 @@ public class TestRawZkClient extends ZkTestBase {
   public void testGetChildrenOnLargeNumChildren() throws Exception {
     final String methodName = TestHelper.getTestMethodName();
     System.out.println("Start test: " + methodName);
-    String[] nodePaths = new String[110001];
     // Create 110K children to make packet length of children exceed 4 MB
     // and cause connection loss for getChildren() operation
     String path = "/" + methodName;
-    nodePaths[110000] = path;
+    int numOps = 110;
+    int numOpInOps = 1000;
+    // All the paths that are going to be created as children nodes, plus one parent node
+    // Record paths so can be deleted at the end of the test
+    String[] nodePaths = new String[numOps * numOpInOps + 1];
+    nodePaths[numOps * numOpInOps] = path;
 
     _zkClient.createPersistent(path);
 
-    for (int i = 0; i < 110; i++) {
-      List<Op> ops = new ArrayList<>(1000);
-      for (int j = 0; j < 1000; j++) {
+    for (int i = 0; i < numOps; i++) {
+      List<Op> ops = new ArrayList<>(numOpInOps);
+      for (int j = 0; j < numOpInOps; j++) {
         String childPath = path + "/" + UUID.randomUUID().toString();
-        nodePaths[1000 * i + j] = childPath;
+        nodePaths[numOpInOps * i + j] = childPath;
         ops.add(
             Op.create(childPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT));
       }

--- a/zookeeper-api/zookeeper-api-1.0.5-SNAPSHOT.ivy
+++ b/zookeeper-api/zookeeper-api-1.0.5-SNAPSHOT.ivy
@@ -43,7 +43,7 @@ under the License.
     <dependency org="org.apache.logging.log4j" name="log4j-slf4j-impl" rev="2.17.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)">
         <artifact name="log4j-slf4j-impl" ext="jar"/>
     </dependency>
-    <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.5.9" conf="compile->compile(default);runtime->runtime(default);default->default"/>
+    <dependency org="org.apache.zookeeper" name="zookeeper" rev="3.6.3" conf="compile->compile(default);runtime->runtime(default);default->default"/>
 		<dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.12.6.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.12.6" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="commons-cli" name="commons-cli" rev="1.2" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Resolves #2220.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This commit includes several efforts in order to bump up zookeeper version:
1. Upgrade zookeeper version to 3.6.3 in pom.xml and ivy file
2. Add snappy-java dependency to helix-core
3. Some code change in ZKLogFormatter to fix the differences in SerializeUtils class between zk version 3.5.9 and 3.6.3
4. Due to the change of zookeeper server shutdown mode ([link](https://github.com/apache/zookeeper/commit/722ba9409a44a35d287aac803813f508cff2420a)) in zookeeper version 3.6.0+, one test `testGetChildrenOnLargeNumChildren` failed after upgrade. The detailed reason is that zookeeper server shutdown failed because of a too large transaction log entry with the large number of ephemeral children nodes created in the test. This commit changes the children nodes created from ephemeral mode to persistent mode, so it won't cause large transaction log entry, and deletes those children nodes at the end of the test.
5. Change the shutdown() in ZkServer to align the shutdown new behavior with old one.

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:
[ERROR] Failures:
[ERROR]   TestZkConnectionLost.testLostZkConnection:176 » Helix Workflow testLostZkConne...
[ERROR]   TestP2PNoDuplicatedMessage.testP2PStateTransitionEnabled:180 expected:<true> but was:<false>
[INFO]
[ERROR] Tests run: 1318, Failures: 2, Errors: 0, Skipped: 0
[INFO]
Both are flaky tests, passed after re-run.

CI tests:
All failed tests are known flaky tests, will fix separately
Error:  Test failed: testZKHelixManager(org.apache.helix.integration.multizk.TestMultiZkConectionConfig)  Time elapsed: 900.02 s  <<< FAILURE! [https://github.com/apache/helix/issues/2192](url)
Error:  Test failed: afterClass(org.apache.helix.integration.multizk.TestMultiZkConectionConfig)  Time elapsed: 965.409 s  <<< FAILURE! [https://github.com/apache/helix/issues/2193](url)
Error:  Test failed: testZkClientCreationMultiZk(org.apache.helix.task.TestTaskStateModelFactory)  Time elapsed: 0.028 s  <<< FAILURE! [https://github.com/apache/helix/issues/2194](url)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
