### PR TITLE
2221/config update 500

### DIFF
--- a/helix-front/server/controllers/helix.ts
+++ b/helix-front/server/controllers/helix.ts
@@ -47,10 +47,7 @@ export class HelixCtrl {
       console.log('');
       console.log('request body');
       console.log(req.body);
-      console.log('');
-      console.log('req');
-      console.log(req);
-      console.log(JSON.stringify(req, null, 2));
+
       const options = {
         url: realUrl,
         json: req.body,

--- a/helix-front/server/controllers/helix.ts
+++ b/helix-front/server/controllers/helix.ts
@@ -15,6 +15,7 @@ export class HelixCtrl {
 
   protected proxy(req: HelixUserRequest, res: Response) {
     const url = req.originalUrl.replace(HelixCtrl.ROUTE_PREFIX, '');
+
     const helixKey = url.split('/')[1];
 
     const segments = helixKey.split('.');
@@ -41,6 +42,11 @@ export class HelixCtrl {
 
     if (apiPrefix) {
       const realUrl = apiPrefix + url.replace(`/${helixKey}`, '');
+      console.log('realUrl from helix api proxy');
+      console.log(realUrl);
+      console.log('');
+      console.log('request body');
+      console.log(req.body);
       const options = {
         url: realUrl,
         json: req.body,

--- a/helix-front/server/controllers/helix.ts
+++ b/helix-front/server/controllers/helix.ts
@@ -47,6 +47,10 @@ export class HelixCtrl {
       console.log('');
       console.log('request body');
       console.log(req.body);
+      console.log('');
+      console.log('req');
+      console.log(req);
+      console.log(JSON.stringify(req, null, 2));
       const options = {
         url: realUrl,
         json: req.body,
@@ -56,9 +60,9 @@ export class HelixCtrl {
       };
       request[method](options, (error, response, body) => {
         if (error) {
-          res.status(500).send(error);
+          res.status(response.statusCode || 500).send(error);
         } else if (body?.error) {
-          res.status(500).send(body?.error);
+          res.status(response.statusCode || 500).send(body?.error);
         } else {
           res.status(response.statusCode).send(body);
         }

--- a/helix-front/server/controllers/helix.ts
+++ b/helix-front/server/controllers/helix.ts
@@ -41,11 +41,7 @@ export class HelixCtrl {
 
     if (apiPrefix) {
       const realUrl = apiPrefix + url.replace(`/${helixKey}`, '');
-      console.log('realUrl from helix api proxy');
-      console.log(realUrl);
-      console.log('');
-      console.log('request body');
-      console.log(req.body);
+      console.log(`helix-rest request url ${realUrl}`);
 
       const options = {
         url: realUrl,

--- a/helix-front/server/controllers/helix.ts
+++ b/helix-front/server/controllers/helix.ts
@@ -56,11 +56,11 @@ export class HelixCtrl {
       };
       request[method](options, (error, response, body) => {
         if (error) {
-          res.status(response.statusCode || 500).send(error);
+          res.status(response?.statusCode || 500).send(error);
         } else if (body?.error) {
-          res.status(response.statusCode || 500).send(body?.error);
+          res.status(response?.statusCode || 500).send(body?.error);
         } else {
-          res.status(response.statusCode).send(body);
+          res.status(response?.statusCode).send(body);
         }
       });
     } else {

--- a/helix-front/server/controllers/helix.ts
+++ b/helix-front/server/controllers/helix.ts
@@ -15,7 +15,6 @@ export class HelixCtrl {
 
   protected proxy(req: HelixUserRequest, res: Response) {
     const url = req.originalUrl.replace(HelixCtrl.ROUTE_PREFIX, '');
-
     const helixKey = url.split('/')[1];
 
     const segments = helixKey.split('.');

--- a/helix-front/src/app/cluster/shared/cluster.service.ts
+++ b/helix-front/src/app/cluster/shared/cluster.service.ts
@@ -42,12 +42,9 @@ export class ClusterService extends HelixService {
   }
 
   public enableMaintenanceMode(name: string, reason: string) {
-    return this.post(
-      `/clusters/${name}?command=enableMaintenanceMode`,
-      JSON.stringify({
-        reason,
-      })
-    );
+    return this.post(`/clusters/${name}?command=enableMaintenanceMode`, {
+      reason,
+    });
   }
 
   public disableMaintenanceMode(name: string) {

--- a/helix-front/src/app/configuration/config-detail/config-detail.component.ts
+++ b/helix-front/src/app/configuration/config-detail/config-detail.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute } from '@angular/router';
 
 import { ConfigurationService } from '../shared/configuration.service';
 import { HelperService } from '../../shared/helper.service';
-
 @Component({
   selector: 'hi-config-detail',
   templateUrl: './config-detail.component.html',
@@ -88,6 +87,7 @@ export class ConfigDetailComponent implements OnInit {
         value
       );
     } else {
+      console.log('value from updateConfig', value);
       observer = this.service.setClusterConfig(this.clusterName, value);
     }
 

--- a/helix-front/src/app/configuration/config-detail/config-detail.component.ts
+++ b/helix-front/src/app/configuration/config-detail/config-detail.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 
 import { ConfigurationService } from '../shared/configuration.service';
 import { HelperService } from '../../shared/helper.service';
+
 @Component({
   selector: 'hi-config-detail',
   templateUrl: './config-detail.component.html',
@@ -87,7 +88,6 @@ export class ConfigDetailComponent implements OnInit {
         value
       );
     } else {
-      console.log('value from updateConfig', value);
       observer = this.service.setClusterConfig(this.clusterName, value);
     }
 

--- a/helix-front/src/app/configuration/shared/configuration.service.ts
+++ b/helix-front/src/app/configuration/shared/configuration.service.ts
@@ -10,6 +10,7 @@ export class ConfigurationService extends HelixService {
   }
 
   public setClusterConfig(name: string, config: Node) {
+    console.log('payload from setClusterConfig', config.json(name));
     return this.post(
       `/clusters/${name}/configs?command=update`,
       JSON.parse(config.json(name))

--- a/helix-front/src/app/configuration/shared/configuration.service.ts
+++ b/helix-front/src/app/configuration/shared/configuration.service.ts
@@ -10,6 +10,7 @@ export class ConfigurationService extends HelixService {
   }
 
   public setClusterConfig(name: string, config: Node) {
+    console.log('payload from setClusterConfig', config.json(name));
     return this.post(
       `/clusters/${name}/configs?command=update`,
       config.json(name)

--- a/helix-front/src/app/configuration/shared/configuration.service.ts
+++ b/helix-front/src/app/configuration/shared/configuration.service.ts
@@ -13,14 +13,14 @@ export class ConfigurationService extends HelixService {
     console.log('payload from setClusterConfig', config.json(name));
     return this.post(
       `/clusters/${name}/configs?command=update`,
-      config.json(name)
+      JSON.parse(config.json(name))
     );
   }
 
   public deleteClusterConfig(name: string, config: Node) {
     return this.post(
       `/clusters/${name}/configs?command=delete`,
-      config.json(name)
+      JSON.parse(config.json(name))
     );
   }
 
@@ -37,7 +37,7 @@ export class ConfigurationService extends HelixService {
   ) {
     return this.post(
       `/clusters/${clusterName}/instances/${instanceName}/configs?command=update`,
-      config.json(instanceName)
+      JSON.parse(config.json(instanceName))
     );
   }
 
@@ -48,7 +48,7 @@ export class ConfigurationService extends HelixService {
   ) {
     return this.post(
       `/clusters/${clusterName}/instances/${instanceName}/configs?command=delete`,
-      config.json(instanceName)
+      JSON.parse(config.json(instanceName))
     );
   }
 
@@ -65,7 +65,7 @@ export class ConfigurationService extends HelixService {
   ) {
     return this.post(
       `/clusters/${clusterName}/resources/${resourceName}/configs?command=update`,
-      config.json(resourceName)
+      JSON.parse(config.json(resourceName))
     );
   }
 
@@ -76,7 +76,7 @@ export class ConfigurationService extends HelixService {
   ) {
     return this.post(
       `/clusters/${clusterName}/resources/${resourceName}/configs?command=delete`,
-      config.json(resourceName)
+      JSON.parse(config.json(resourceName))
     );
   }
 }

--- a/helix-front/src/app/configuration/shared/configuration.service.ts
+++ b/helix-front/src/app/configuration/shared/configuration.service.ts
@@ -10,7 +10,6 @@ export class ConfigurationService extends HelixService {
   }
 
   public setClusterConfig(name: string, config: Node) {
-    console.log('payload from setClusterConfig', config.json(name));
     return this.post(
       `/clusters/${name}/configs?command=update`,
       JSON.parse(config.json(name))

--- a/helix-front/src/app/instance/shared/instance.service.ts
+++ b/helix-front/src/app/instance/shared/instance.service.ts
@@ -71,7 +71,7 @@ export class InstanceService extends HelixService {
 
     return this.put(
       `/clusters/${clusterName}/instances/${name}`,
-      node.json(name)
+      JSON.parse(node.json(name))
     );
   }
 

--- a/helix-front/src/app/shared/models/node.model.ts
+++ b/helix-front/src/app/shared/models/node.model.ts
@@ -15,6 +15,13 @@ interface MapFieldObject {
   value: SimpleFieldObject[];
 }
 
+interface Payload {
+  id: string;
+  simpleFields?: any;
+  listFields?: any;
+  mapFields?: any;
+}
+
 // This is a typical Helix Node definition
 export class Node {
   id: string;
@@ -77,30 +84,36 @@ export class Node {
   }
 
   public json(id: string): string {
-    const obj = {
+    const obj: Payload = {
       id,
-      simpleFields: {},
-      listFields: {},
-      mapFields: {},
     };
 
-    _.forEach(this.simpleFields, (item: SimpleFieldObject) => {
-      obj.simpleFields[item.name] = item.value;
-    });
-
-    _.forEach(this.listFields, (item: ListFieldObject) => {
-      obj.listFields[item.name] = [];
-      _.forEach(item.value, (subItem: SimpleFieldObject) => {
-        obj.listFields[item.name].push(subItem.value);
+    if (this?.simpleFields.length > 0) {
+      obj.simpleFields = {};
+      _.forEach(this.simpleFields, (item: SimpleFieldObject) => {
+        obj.simpleFields[item.name] = item.value;
       });
-    });
+    }
 
-    _.forEach(this.mapFields, (item: MapFieldObject) => {
-      obj.mapFields[item.name] = item.value ? {} : null;
-      _.forEach(item.value, (subItem: SimpleFieldObject) => {
-        obj.mapFields[item.name][subItem.name] = subItem.value;
+    if (this?.listFields.length > 0) {
+      obj.listFields = {};
+      _.forEach(this.listFields, (item: ListFieldObject) => {
+        obj.listFields[item.name] = [];
+        _.forEach(item.value, (subItem: SimpleFieldObject) => {
+          obj.listFields[item.name].push(subItem.value);
+        });
       });
-    });
+    }
+
+    if (this?.mapFields.length > 0) {
+      obj.mapFields = {};
+      _.forEach(this.mapFields, (item: MapFieldObject) => {
+        obj.mapFields[item.name] = item.value ? {} : null;
+        _.forEach(item.value, (subItem: SimpleFieldObject) => {
+          obj.mapFields[item.name][subItem.name] = subItem.value;
+        });
+      });
+    }
 
     return JSON.stringify(obj);
   }

--- a/helix-front/src/app/shared/models/node.model.ts
+++ b/helix-front/src/app/shared/models/node.model.ts
@@ -110,8 +110,6 @@ export class Node {
       _.forEach(this.mapFields, (item: MapFieldObject) => {
         obj.mapFields[item.name] = item.value ? {} : null;
         _.forEach(item.value, (subItem: SimpleFieldObject) => {
-          console.log('subItem from node model json method', subItem);
-
           // if the value is a string that contains all digits, parse it to a number
           let parsedValue: string | number = subItem.value;
           if (
@@ -121,7 +119,6 @@ export class Node {
             parsedValue = Number(subItem.value);
           }
 
-          console.log('parsedValue from node model json method', parsedValue);
           obj.mapFields[item.name][subItem.name] = parsedValue;
         });
       });

--- a/helix-front/src/app/shared/models/node.model.ts
+++ b/helix-front/src/app/shared/models/node.model.ts
@@ -110,7 +110,19 @@ export class Node {
       _.forEach(this.mapFields, (item: MapFieldObject) => {
         obj.mapFields[item.name] = item.value ? {} : null;
         _.forEach(item.value, (subItem: SimpleFieldObject) => {
-          obj.mapFields[item.name][subItem.name] = subItem.value;
+          console.log('subItem from node model json method', subItem);
+
+          // if the value is a string that contains all digits, parse it to a number
+          let parsedValue: string | number = subItem.value;
+          if (
+            typeof subItem.value === 'string' &&
+            /^\d+$/.test(subItem.value)
+          ) {
+            parsedValue = Number(subItem.value);
+          }
+
+          console.log('parsedValue from node model json method', parsedValue);
+          obj.mapFields[item.name][subItem.name] = parsedValue;
         });
       });
     }


### PR DESCRIPTION
### Description

<!-- Write a concise description: "what?, why?, how?" and then add some details about this PR, including screenshots of any UI changes -->

<!-- This PR fixes this Helix issue & includes the Helix issue in the PR description. Link your issue number here: You can write `Fix #123`.  See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue -->

This PR fixes a bug that occurs because the request body is now [ignored silently by the Angular http library if it is passed as stringified JSON](https://stackoverflow.com/a/35874339/1732222).  Now, all request bodies are passed as objects, which the Angular http library then stringifies itself.

This PR also passes the http response status code from the **helix-front** web server to the UI, so that response codes from the **helix-rest** like `400 Bad Request` are shown in the UI.  This helps the user better understand what is going wrong.

This PR also ensures that the response sent from **helix-front** to **helix-rest**  is identical to the working curl request. 

Here is the desired payload format, modeled after the working curl request:

```json
{
  "id": "my-test-cluster",
  "mapFields": { "TEST_FIELD": { "test_sub_field": 18 } }
}
```

Here is the bug format seen before, which differed slightly from the curl request:

```json
{
  "id": "my-test-cluster",
  "mapFields": { "TEST_FIELD": { "test_sub_field": "18" } },
  "listFields": {},
  "simpleFields": {}
}
```

Notice the following differences:

1. properties with empty object values are included 
2. the number value of `"test_sub_field"` is a string, not a number. 

Fix #2221

### Tests

<!-- List the names of new unit or integration tests -->

TODO: add a test for this case.

### Code Style

<!-- Ensure the PR diff has been formatted using [Prettier](https://prettier.io) -->

Formatted using [Prettier](https://prettier.io)

<!-- ### Changes that Break Backward Compatibility (Optional)

- [ ] My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include: -->

<!-- Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method or API behavior. -->

<!-- ### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page: -->

<!-- Link the GitHub wiki you added -->
