### PR TITLE
Add default method for TTL support

### DIFF
--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -150,7 +150,6 @@
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
       <version>1.1.7</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
@@ -53,7 +53,9 @@ public interface BaseDataAccessor<T> {
    * @param ttl TTL of the node in milliseconds, if options supports it
    * @return true if creation succeeded, false otherwise (e.g. if the ZNode exists)
    */
-  boolean create(String path, T record, int options, long ttl);
+  default boolean create(String path, T record, int options, long ttl) {
+    throw new UnsupportedOperationException("create with TTL support is not implemented.");
+  }
 
   /**
    * This will always attempt to set the data on existing node. If the ZNode does not
@@ -116,7 +118,9 @@ public interface BaseDataAccessor<T> {
    * @param ttl TTL of the node in milliseconds, if options supports it
    * @return For each child: true if creation succeeded, false otherwise (e.g. if the child exists)
    */
-  boolean[] createChildren(List<String> paths, List<T> records, int options, long ttl);
+  default boolean[] createChildren(List<String> paths, List<T> records, int options, long ttl) {
+    throw new UnsupportedOperationException("createChildren with TTL support is not implemented.");
+  }
 
   /**
    * can set multiple children under a parent node. This will use async api for better


### PR DESCRIPTION
Implement default methods for two TTL related methods in BaseDataAccessor to maintain compatibility. 
Also fix the snappy java dependency issue by removing the "test" scope.