### PR TITLE
Issue-2296 Fixed Possible Json Ordering Permutations Problem in Tests

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/json/cluster/TestClusterInfo.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/json/cluster/TestClusterInfo.java
@@ -39,7 +39,7 @@ public class TestClusterInfo {
     ObjectMapper mapper = new ObjectMapper();
     String result = mapper.writeValueAsString(clusterInfo);
 
-    Assert.assertEquals(result,
-        "{\"id\":\"cluster0\",\"controller\":\"controller\",\"paused\":true,\"maintenance\":true,\"resources\":[\"idealState0\"],\"instances\":[\"instance0\"],\"liveInstances\":[\"instance0\"]}");
+    Assert.assertEquals(mapper.readTree(result),
+    mapper.readTree("{\"id\":\"cluster0\",\"controller\":\"controller\",\"paused\":true,\"maintenance\":true,\"resources\":[\"idealState0\"],\"instances\":[\"instance0\"],\"liveInstances\":[\"instance0\"]}"));
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/json/cluster/TestClusterInfo.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/json/cluster/TestClusterInfo.java
@@ -40,6 +40,6 @@ public class TestClusterInfo {
     String result = mapper.writeValueAsString(clusterInfo);
 
     Assert.assertEquals(mapper.readTree(result),
-    mapper.readTree("{\"id\":\"cluster0\",\"controller\":\"controller\",\"paused\":true,\"maintenance\":true,\"resources\":[\"idealState0\"],\"instances\":[\"instance0\"],\"liveInstances\":[\"instance0\"]}"));
+                        mapper.readTree("{\"id\":\"cluster0\",\"controller\":\"controller\",\"paused\":true,\"maintenance\":true,\"resources\":[\"idealState0\"],\"instances\":[\"instance0\"],\"liveInstances\":[\"instance0\"]}"));
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/json/cluster/TestClusterTopology.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/json/cluster/TestClusterTopology.java
@@ -42,7 +42,7 @@ public class TestClusterTopology {
     ObjectMapper mapper = new ObjectMapper();
     String result = mapper.writeValueAsString(clusterTopology);
 
-    Assert.assertEquals(result,
-        "{\"id\":\"cluster0\",\"zones\":[{\"id\":\"zone\",\"instances\":[{\"id\":\"instance\"}]}],\"allInstances\":[]}");
+    Assert.assertEquals(mapper.readTree(result),
+                        mapper.readTree("{\"id\":\"cluster0\",\"zones\":[{\"id\":\"zone\",\"instances\":[{\"id\":\"instance\"}]}],\"allInstances\":[]}"));
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/json/instance/TestStoppableCheck.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/json/instance/TestStoppableCheck.java
@@ -36,7 +36,7 @@ public class TestStoppableCheck {
     ObjectMapper mapper = new ObjectMapper();
     String result = mapper.writeValueAsString(stoppableCheck);
 
-    Assert.assertEquals(result, "{\"stoppable\":false,\"failedChecks\":[\"HELIX:check\"]}");
+    Assert.assertEquals(mapper.readTree(result), mapper.readTree("{\"stoppable\":false,\"failedChecks\":[\"HELIX:check\"]}"));
   }
 
   @Test


### PR DESCRIPTION


### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

[Helix-2296](https://github.com/apache/helix/issues/2296)

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

The test flakiness is due to comparisons between Json Strings.
However, JsonObject does not guarantee entry orders, its object is an unordered set of name/value pairs, and internal permutations may occur in the output as JSON String.

Since JSON library `com.fasterxml.jackson.databind` is used in the current project, And in this test, `ObjectMapper`and used to read a json file.
Use `mapper.readTree(JSON String)` when comparing them, thus, the equals() method ignores the order and treats them as equal.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 206, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 172.33 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 206, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /home/boyuli4/helix2/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 91 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:02 min
[INFO] Finished at: 2022-11-29T01:00:53-06:00
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
