### PR TITLE
(WIP) ZkMetaClient data change listener and ZK implementation

### DIFF
--- a/.github/workflows/Helix-PR-CI.yml
+++ b/.github/workflows/Helix-PR-CI.yml
@@ -1,7 +1,7 @@
 name: Helix PR CI
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ master, metaclient ] # TODO: remove side branch
     paths-ignore:
       - '.github/**'
       - 'helix-front/**'

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
@@ -110,7 +110,7 @@ public class TestZkClientMonitor {
     long stateChangeCount = (long) _beanServer.getAttribute(name, "StateChangeEventCounter");
     Assert.assertEquals(stateChangeCount, 1);
 
-    monitor.increasExpiredSessionCounter();
+    monitor.increaseExpiredSessionCounter();
     long expiredSessionCount = (long) _beanServer.getAttribute(name, "ExpiredSessionCounter");
     Assert.assertEquals(expiredSessionCount, 1);
 

--- a/meta-client/pom.xml
+++ b/meta-client/pom.xml
@@ -60,6 +60,11 @@ under the License.
       <version>1.1.7</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/meta-client/pom.xml
+++ b/meta-client/pom.xml
@@ -43,6 +43,23 @@ under the License.
       <artifactId>zookeeper-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>1.1.7</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/common/ListenerContainer.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/common/ListenerContainer.java
@@ -1,0 +1,143 @@
+package org.apache.helix.metaclient.impl.common;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+/**
+ * A container wrapper class for Listeners registered to {@link org.apache.helix.metaclient.api.MetaClientInterface}
+ * @param <T> the type of listener
+ */
+public class ListenerContainer<T> {
+  private final ReentrantReadWriteLock _readWriteLock = new ReentrantReadWriteLock(true);
+  private final Map<String, Set<T>> _persistentListener = new HashMap<>();
+  private final Map<String, Set<T>> _onetimeListener = new HashMap<>();
+
+  public void addListener(String key, T listener, boolean persistListener) {
+    _readWriteLock.writeLock().lock();
+    try {
+      if (persistListener) {
+        Set<T> entryListeners = _persistentListener.computeIfAbsent(key, k -> new HashSet<>());
+        entryListeners.add(listener);
+        _persistentListener.put(key, entryListeners);
+      } else {
+        Set<T> entryListeners = _onetimeListener.computeIfAbsent(key, k -> new HashSet<>());
+        entryListeners.add(listener);
+        _onetimeListener.put(key, entryListeners);
+      }
+    } finally {
+      _readWriteLock.writeLock().unlock();
+    }
+  }
+
+  public void removeListener(String key, T listener) {
+    _readWriteLock.writeLock().lock();
+    try {
+      removeFromListenerMap(key, listener, _persistentListener);
+      removeFromListenerMap(key, listener, _onetimeListener);
+    } finally {
+      _readWriteLock.writeLock().unlock();
+    }
+  }
+
+  public void removeListener(String key, T listener, boolean persistListener) {
+    _readWriteLock.writeLock().lock();
+    try {
+      if (persistListener) {
+        removeFromListenerMap(key, listener, _persistentListener);
+      } else {
+        removeFromListenerMap(key, listener, _onetimeListener);
+      }
+    } finally {
+      _readWriteLock.writeLock().unlock();
+    }
+  }
+
+  public void removeListeners(String key, Set<T> listeners, boolean persistListener) {
+    _readWriteLock.writeLock().lock();
+    try {
+      if (persistListener) {
+        removeFromListenerMap(key, listeners, _persistentListener);
+      } else {
+        removeFromListenerMap(key, listeners, _onetimeListener);
+      }
+    } finally {
+      _readWriteLock.writeLock().unlock();
+    }
+  }
+
+  /**
+   * Consume the listeners registered to the given key. The given consumer is applied to all one-time and persistent
+   * listeners with the given key.
+   * The one-time listeners are removed after this operation.
+   * @param key the key of the listeners
+   * @param consumer the consuming action for the listeners
+   */
+  public void consumeListeners(String key, Consumer<? super T> consumer) {
+    Set<T> onetimeListeners;
+    Set<T> persistentListeners;
+    _readWriteLock.readLock().lock();
+    try {
+      persistentListeners = _persistentListener.getOrDefault(key, Collections.emptySet());
+      onetimeListeners = _onetimeListener.getOrDefault(key, Collections.emptySet());
+      if (persistentListeners.isEmpty() && onetimeListeners.isEmpty()) {
+        return;
+      }
+    } finally {
+      _readWriteLock.readLock().unlock();
+    }
+    Stream.concat(persistentListeners.stream(), onetimeListeners.stream()).forEach(consumer);
+    // remove one-time listeners
+    if (!onetimeListeners.isEmpty()) {
+      removeListeners(key, onetimeListeners, false);
+    }
+  }
+
+  private static <T> void removeFromListenerMap(String key, T listener, Map<String, Set<T>> listenerMap) {
+    Set<T> listeners = listenerMap.get(key);
+    if (listeners == null) {
+      return;
+    }
+    listeners.remove(listener);
+    if (listeners.isEmpty()) {
+      listenerMap.remove(key);
+    }
+  }
+
+  private static <T> void removeFromListenerMap(String key, Set<T> listeners, Map<String, Set<T>> listenerMap) {
+    if (listeners == null || listeners.isEmpty()) {
+      return;
+    }
+    Set<T> current = listenerMap.get(key);
+    if (current == null || current.isEmpty()) {
+      return;
+    }
+    current.removeAll(listeners);
+  }
+}

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -27,7 +27,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -246,7 +245,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, Watcher, Closeab
         entryListeners.add(listener);
         _oneTimeDataChangeListener.put(key, entryListeners);
       } else {
-        Set<DataChangeListener> entryListeners = _dataChangeListener.computeIfAbsent(key, k -> new CopyOnWriteArraySet<>());
+        Set<DataChangeListener> entryListeners = _dataChangeListener.computeIfAbsent(key, k -> new HashSet<>());
         entryListeners.add(listener);
         _dataChangeListener.put(key, entryListeners);
       }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -19,9 +19,17 @@ package org.apache.helix.metaclient.impl.zk;
  * under the License.
  */
 
+import com.google.common.annotations.VisibleForTesting;
+import java.io.Closeable;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.helix.metaclient.api.AsyncCallback;
 import org.apache.helix.metaclient.api.ChildChangeListener;
 import org.apache.helix.metaclient.api.ConnectStateChangeListener;
@@ -34,28 +42,64 @@ import org.apache.helix.metaclient.api.OpResult;
 import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.helix.zookeeper.zkclient.ZkConnection;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.apache.helix.zookeeper.zkclient.IZkConnection;
+import org.apache.helix.zookeeper.zkclient.ZkEventThread;
+import org.apache.helix.zookeeper.zkclient.ZkLock;
+import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
+import org.apache.helix.zookeeper.zkclient.metric.ZkClientMonitor;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.helix.zookeeper.impl.client.ZkClient.*;
 
 
-public class ZkMetaClient implements MetaClientInterface {
-
+public class ZkMetaClient implements MetaClientInterface, Watcher, Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(ZkMetaClient.class);
+  private static final AtomicLong UID = new AtomicLong(0);
+  private final long _uid;
+  private final ConcurrentHashMap<String, Set<DataChangeListener>> _dataChangeListener = new ConcurrentHashMap<>();
   private final ZkClient _zkClient;
 
+  private ZkEventThread _eventThread;
+
+  private boolean _shutdownTriggered;
+
   public ZkMetaClient(ZkMetaClientConfig config) {
-    _zkClient =  new ZkClient(new ZkConnection(config.getConnectionAddress(),
-        (int) config.getSessionTimeoutInMillis()),
-        (int) config.getConnectionInitTimeoutInMillis(), -1 /*operationRetryTimeout*/,
-        config.getZkSerializer(), config.getMonitorType(), config.getMonitorKey(),
-        config.getMonitorInstanceName(), config.getMonitorRootPathOnly());
+    _uid = UID.getAndIncrement();
+    _zkClient = new ZkClient.Builder()
+        .setConnection(new ZkConnection(config.getConnectionAddress(),
+            (int) config.getSessionTimeoutInMillis()))
+        .setConnectionTimeout((int) config.getConnectionInitTimeoutInMillis())
+        .setOperationRetryTimeout(-1L)
+        .setZkSerializer(config.getZkSerializer())
+        .setMonitorType(config.getMonitorType())
+        .setMonitorKey(config.getMonitorKey())
+        .setMonitorInstanceName(config.getMonitorInstanceName())
+        .setMonitorRootPathOnly(config.getMonitorRootPathOnly())
+        .setWatcher(this)
+        .setConnectOnInit(false)
+        .build();
+    _eventThread = new ZkEventThread(_zkClient.getConnection().getServers());
+    // create _zkClient and set this class as watcher
   }
 
   @Override
   public void create(String key, Object data) {
-
+    _zkClient.create(key, data, CreateMode.PERSISTENT);
   }
 
   @Override
   public void create(String key, Object data, EntryMode mode) {
-
+    switch (mode) {
+      case PERSISTENT: _zkClient.create(key, data, CreateMode.PERSISTENT);
+      case EPHEMERAL: _zkClient.create(key, data, CreateMode.EPHEMERAL);
+      case CONTAINER: _zkClient.create(key, data, CreateMode.CONTAINER);
+      default: throw new IllegalArgumentException("EntryMode " + mode + " is not supported.");
+    }
   }
 
   @Override
@@ -155,12 +199,19 @@ public class ZkMetaClient implements MetaClientInterface {
 
   @Override
   public boolean connect() {
-    return false;
+    _zkClient.connect(DEFAULT_CONNECTION_TIMEOUT, this);
+    _eventThread = new ZkEventThread(_zkClient.getConnection().getServers());
+    return true;
   }
 
   @Override
   public void disconnect() {
+    close();
+  }
 
+  @Override
+  public void close() {
+    _zkClient.close();
   }
 
   @Override
@@ -171,7 +222,17 @@ public class ZkMetaClient implements MetaClientInterface {
   @Override
   public boolean subscribeDataChange(String key, DataChangeListener listener,
       boolean skipWatchingNonExistNode, boolean persistListener) {
-    return false;
+    Set<DataChangeListener> entryListeners = _dataChangeListener.computeIfAbsent(key, k -> new CopyOnWriteArraySet<>());
+    entryListeners.add(listener);
+    _dataChangeListener.put(key, entryListeners);
+    // prefetch?
+    boolean watchInstalled = _zkClient.watchForData(key, skipWatchingNonExistNode, persistListener);
+    if (!watchInstalled) {
+      unsubscribeDataChange(key, listener);
+      LOG.error("ZkMetaClient {} failed to subscribe data change on key {}", _uid, key);
+      return false;
+    }
+    return true;
   }
 
   @Override
@@ -195,7 +256,14 @@ public class ZkMetaClient implements MetaClientInterface {
 
   @Override
   public void unsubscribeDataChange(String key, DataChangeListener listener) {
-
+    Set<DataChangeListener> listeners = _dataChangeListener.get(key);
+    if (listeners == null) {
+      return;
+    }
+    listeners.remove(listener);
+    if (listeners.isEmpty()) {
+      _dataChangeListener.remove(key);
+    }
   }
 
   @Override
@@ -246,5 +314,193 @@ public class ZkMetaClient implements MetaClientInterface {
   @Override
   public List<OpResult> transactionOP(Iterable iterable) {
     return null;
+  }
+
+  @Override
+  public void process(WatchedEvent event) {
+    long notificationTime = System.currentTimeMillis();
+    LOG.debug("ZkMetaClient {} receives event: {} ", _uid, event);
+
+    // local _eventThread
+    if (_shutdownTriggered) {
+      LOG.debug("ZkMetaClient {} Ignoring event {} because shutdown has been triggered.", _uid, event);
+      return;
+    }
+    getZkEventLock().lock();
+    try {
+      handleStateChanged(event);
+      handleDataChanged(event, notificationTime);
+    } finally {
+      signalConditions(event);
+      getZkEventLock().unlock();
+    }
+
+  }
+
+  private void signalConditions(WatchedEvent event) {
+    boolean stateChanged = event.getType() == Event.EventType.None;
+    boolean znodeChanged = event.getPath() != null;
+    boolean dataChanged = event.getType() == Event.EventType.NodeDataChanged
+        || event.getType() == Event.EventType.NodeDeleted
+        || event.getType() == Event.EventType.NodeCreated
+        || event.getType() == Event.EventType.NodeChildrenChanged;
+    if (stateChanged) {
+      getZkEventLock().getStateChangedCondition().signalAll();
+      if (event.getState() == Event.KeeperState.Expired) {
+        getZkEventLock().getZNodeEventCondition().signalAll();
+        getZkEventLock().getDataChangedCondition().signalAll();
+      }
+    }
+    if (znodeChanged) {
+      getZkEventLock().getZNodeEventCondition().signalAll();
+    }
+    if (dataChanged) {
+      getZkEventLock().getDataChangedCondition().signalAll();
+    }
+  }
+
+  private void handleDataChanged(WatchedEvent event, long notificationTime) {
+    if (_zkClient.getMonitor() != null) {
+      _zkClient.getMonitor().increaseDataChangeEventCounter();
+    }
+    if (event.getType() == Event.EventType.NodeDataChanged
+        || event.getType() == Event.EventType.NodeDeleted
+        || event.getType() == Event.EventType.NodeCreated) {
+      System.out.println("handleDataChanged triggered by " + event);
+      Set<DataChangeListener> listeners = _dataChangeListener.getOrDefault(event.getPath(), Collections.emptySet());
+      if (listeners.isEmpty()) {
+        return;
+      }
+      try {
+        final ZkPathStatRecord pathStatRecord = new ZkPathStatRecord(event.getPath(), _zkClient.getMonitor());
+        listeners.forEach(listener ->
+            _eventThread.send(new DataChangedZkEvent(event, listener, pathStatRecord, notificationTime)));
+      } catch (Exception e) {
+        LOG.error("ZkMetaClient {} failed to process event {}.", _uid, event, e);
+      }
+    }
+
+    // TODO: impl handle data changed event
+  }
+
+  private void handleStateChanged(WatchedEvent event) {
+    if (event.getType() != Event.EventType.None) {
+      // not state change
+      return;
+    }
+    System.out.println("handleStateChanged triggered by " + event);
+    _zkClient.setCurrentState(event.getState());
+    if (_zkClient.getMonitor() != null) {
+      _zkClient.getMonitor().increaseStateChangeEventCounter();
+      if (event.getState() == Event.KeeperState.Expired) {
+        _zkClient.getMonitor().increaseExpiredSessionCounter();
+      }
+    }
+    // TODO: impl handle state changed event
+  }
+
+  protected ZkLock getZkEventLock() {
+    return _zkClient.getEventLock();
+  }
+
+  public void setShutdownTrigger(boolean triggerState) {
+    _shutdownTriggered = triggerState;
+  }
+
+  public boolean getShutdownTrigger() {
+    return _shutdownTriggered;
+  }
+
+  @VisibleForTesting
+  Map<String, Set<DataChangeListener>> getDataChangeListenerMap() {
+    return _dataChangeListener;
+  }
+
+  private static class ZkPathStatRecord {
+    private final String _path;
+    private final ZkClientMonitor _monitor;
+    private org.apache.zookeeper.data.Stat _stat = null;
+    private boolean _checked = false;
+
+    public ZkPathStatRecord(String path, ZkClientMonitor monitor) {
+      _path = path;
+      _monitor = monitor;
+    }
+
+    public boolean pathExists() {
+      return _stat != null;
+    }
+
+    public boolean pathChecked() {
+      return _checked;
+    }
+
+    /*
+     * Note this method is not thread safe.
+     */
+    public void recordPathStat(org.apache.zookeeper.data.Stat stat, long notificationTime) {
+      recordPathStat(stat);
+      if (_monitor != null && stat != null) {
+        long updateTime = Math.max(stat.getCtime(), stat.getMtime());
+        if (notificationTime > updateTime) {
+          _monitor.recordDataPropagationLatency(_path, notificationTime - updateTime);
+        } // else, the node was updated again after the notification. Propagation latency is
+        // unavailable.
+      }
+    }
+
+    public void recordPathStat(org.apache.zookeeper.data.Stat stat) {
+      _checked = true;
+      _stat = stat;
+    }
+  }
+
+  private class DataChangedZkEvent extends ZkEventThread.ZkEvent {
+
+    private final WatchedEvent _event;
+    private final DataChangeListener _listener;
+    private final ZkPathStatRecord _pathStatRecord;
+    private final long _notificationTime;
+
+    public DataChangedZkEvent(WatchedEvent event, DataChangeListener listener,
+        ZkPathStatRecord pathStatRecord, long notificationTime) {
+      super("Data of " + event.getPath() + " sent to " + listener);
+      _event = event;
+      _listener = listener;
+      _pathStatRecord = pathStatRecord;
+      _notificationTime = notificationTime;
+    }
+
+    @Override
+    public void run() throws Exception {
+      String path = _event.getPath();
+      if (!_pathStatRecord.pathChecked()) {
+        org.apache.zookeeper.data.Stat stat;
+        if (_event.getType() == Event.EventType.NodeDeleted) {
+          stat = _zkClient.getStat(path);
+        } else {
+          stat = _zkClient.installWatchOnlyPathExist(path);
+        }
+        _pathStatRecord.recordPathStat(stat, _notificationTime);
+      }
+      if (!_pathStatRecord.pathExists()) {
+        _listener.handleDataChange(path, null, DataChangeListener.ChangeType.ENTRY_DELETED);
+      } else {
+        Object data;
+        try {
+          // TODO: the data is redundantly read multiple times when multiple listeners exist
+          data = get(Collections.singletonList(path));
+        } catch (ZkNoNodeException e) {
+          LOG.error("ZkMetaClient {} failed to read data for path: {}.", _uid, path, e);
+          _listener.handleDataChange(path, null, DataChangeListener.ChangeType.ENTRY_DELETED);
+          return;
+        }
+        if (_event.getType() == Event.EventType.NodeCreated) {
+          _listener.handleDataChange(path, data, DataChangeListener.ChangeType.ENTRY_CREATED);
+        } else if (_event.getType() == Event.EventType.NodeDataChanged) {
+          _listener.handleDataChange(path, data, DataChangeListener.ChangeType.ENTRY_UPDATE);
+        }
+      }
+    }
   }
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/factory/ZkMetaClientConfig.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/factory/ZkMetaClientConfig.java
@@ -60,11 +60,11 @@ public class ZkMetaClientConfig extends MetaClientConfig {
   }
 
   protected ZkMetaClientConfig(String connectionAddress, long connectionInitTimeoutInMillis,
-      long sessionTimeoutInMillis, boolean enableAuth, StoreType storeType, String monitorType,
+      long sessionTimeoutInMillis, boolean enableAuth, String monitorType,
       String monitorKey, String monitorInstanceName, boolean monitorRootPathOnly,
       PathBasedZkSerializer zkSerializer) {
     super(connectionAddress, connectionInitTimeoutInMillis, sessionTimeoutInMillis, enableAuth,
-        storeType);
+        StoreType.ZOOKEEPER);
     _zkSerializer = zkSerializer;
     _monitorType = monitorType;
     _monitorKey = monitorKey;
@@ -128,12 +128,12 @@ public class ZkMetaClientConfig extends MetaClientConfig {
     }
 
     @Override
-    public MetaClientConfig build() {
+    public ZkMetaClientConfig build() {
       if (_zkSerializer == null) {
         _zkSerializer = new BasicZkSerializer(new SerializableSerializer());
       }
       return new ZkMetaClientConfig(_connectionAddress, _connectionInitTimeoutInMillis,
-          _sessionTimeoutInMillis, _enableAuth, MetaClientConfig.StoreType.ZOOKEEPER, _monitorType,
+          _sessionTimeoutInMillis, _enableAuth, _monitorType,
           _monitorKey, _monitorInstanceName, _monitorRootPathOnly, _zkSerializer);
     }
 

--- a/meta-client/src/test/conf/testng.xml
+++ b/meta-client/src/test/conf/testng.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Suite" parallel="false">
+  <test name="Test" preserve-order="true">
+    <packages>
+      <package name="org.apache.helix.metaclient.*"/>
+    </packages>
+  </test>
+</suite>

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/common/TestListenerContainer.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/common/TestListenerContainer.java
@@ -1,0 +1,57 @@
+package org.apache.helix.metaclient.impl.common;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestListenerContainer {
+
+  @Test
+  public void basicTest() {
+    ListenerContainer<String> container = new ListenerContainer<>();
+    String key1 = "key-1";
+    String key2 = "key-2";
+    container.addListener(key1, "test1", false);
+    container.addListener(key1, "test2", false);
+    container.addListener(key2, "test3", false);
+    container.addListener(key2, "test4", false);
+    container.addListener(key2, "test5", false);
+    container.addListener(key2, "test5", true);
+    container.addListener(key1, "test1", true);
+    container.addListener(key1, "test4", true);
+    container.addListener(key1, "test5", true);
+    Assert.assertEquals(container.getOnetimeListener().get(key1).size(), 2);
+    Assert.assertEquals(container.getPersistentListener().get(key1).size(), 3);
+    Assert.assertEquals(container.getOnetimeListener().get(key2).size(), 3);
+    container.removeListener(key2, "test4", false);
+    container.removeListener(key2, "test5");
+    Assert.assertEquals(container.getOnetimeListener().get(key2).size(), 1);
+    Assert.assertNull(container.getPersistentListener().get(key2));
+    AtomicInteger invocationCnt = new AtomicInteger(0);
+    container.consumeListeners(key1, s -> invocationCnt.incrementAndGet());
+    Assert.assertEquals(invocationCnt.get(), 4);
+    Assert.assertNull(container.getOnetimeListener().get(key1));
+    Assert.assertEquals(container.getPersistentListener().get(key1).size(), 3);
+    Assert.assertEquals(container.getOnetimeListener().get(key2).size(), 1);
+  }
+}

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -21,14 +21,15 @@ package org.apache.helix.metaclient.impl.zk;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.io.FileUtils;
-import org.apache.helix.metaclient.api.MetaClientInterface;
-import org.apache.helix.metaclient.factories.MetaClientConfig;
+import org.apache.helix.metaclient.api.DataChangeListener;
 import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.apache.helix.zookeeper.zkclient.IDefaultNameSpace;
 import org.apache.helix.zookeeper.zkclient.ZkServer;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -37,6 +38,7 @@ import org.testng.annotations.Test;
 public class TestZkMetaClient {
 
   private static final String ZK_ADDR = "localhost:2183";
+  private final Object _syncObject = new Object();
   private ZkServer _zkServer;
 
   @BeforeClass
@@ -47,14 +49,73 @@ public class TestZkMetaClient {
 
   @Test
   public void testConnect() {
+    try (ZkMetaClient zkMetaClient = createZkMetaClient()) {
+      boolean connected = zkMetaClient.connect();
+      Assert.assertTrue(connected);
+    }
+  }
+
+  @Test(dependsOnMethods = "testConnect")
+  public void testDataChangeListenerTrigger() throws Exception {
+    final String path = "/TestZkMetaClient/testDataChangeListener";
+    try (ZkMetaClient zkMetaClient = createZkMetaClient()) {
+      zkMetaClient.connect();
+      zkMetaClient.create(path, "test-node");
+      MockDataChangeListener listener = new MockDataChangeListener();
+      zkMetaClient.subscribeDataChange(path, listener, false, true);
+      Assert.assertEquals(zkMetaClient.getDataChangeListenerMap().size(), 1);
+      Assert.assertEquals(listener.getTriggeredCount(), 0);
+      synchronized (_syncObject) {
+        zkMetaClient.process(
+            new WatchedEvent(Watcher.Event.EventType.NodeDataChanged, Watcher.Event.KeeperState.SyncConnected, path));
+        while (listener.getTriggeredCount() == 0) {
+          _syncObject.wait(3000);
+        }
+        Assert.assertEquals(listener.getTriggeredCount(), 1);
+      }
+      // register another listener
+      MockDataChangeListener listener2 = new MockDataChangeListener();
+      zkMetaClient.subscribeDataChange(path, listener2, true, true);
+      synchronized (_syncObject) {
+        zkMetaClient.process(
+            new WatchedEvent(Watcher.Event.EventType.NodeDataChanged, Watcher.Event.KeeperState.SyncConnected, path));
+        while (listener.getTriggeredCount() == 1) {
+          _syncObject.wait(3000);
+        }
+        Assert.assertEquals(listener.getTriggeredCount(), 2);
+        Assert.assertEquals(listener2.getTriggeredCount(), 1);
+      }
+      // unregister the first listener, it shouldn't be triggered anymore
+      zkMetaClient.unsubscribeDataChange(path, listener);
+      synchronized (_syncObject) {
+        zkMetaClient.process(
+            new WatchedEvent(Watcher.Event.EventType.NodeDataChanged, Watcher.Event.KeeperState.SyncConnected, path));
+        while (listener2.getTriggeredCount() == 1) {
+          _syncObject.wait(3000);
+        }
+        Assert.assertEquals(listener.getTriggeredCount(), 2);
+        Assert.assertEquals(listener2.getTriggeredCount(), 2);
+      }
+      // TODO register the 3rd listener on a different path
+      // remove all listener and expect no more triggering
+      zkMetaClient.unsubscribeDataChange(path, listener2);
+      Assert.assertTrue(zkMetaClient.getDataChangeListenerMap().isEmpty());
+      synchronized (_syncObject) {
+        zkMetaClient.process(
+            new WatchedEvent(Watcher.Event.EventType.NodeDataChanged, Watcher.Event.KeeperState.SyncConnected, path));
+        _syncObject.wait(3000);
+        Assert.assertEquals(listener.getTriggeredCount(), 2);
+        Assert.assertEquals(listener2.getTriggeredCount(), 2);
+      }
+    }
+  }
+
+  private static ZkMetaClient createZkMetaClient() {
     ZkMetaClientConfig config = new ZkMetaClientConfig.ZkMetaClientConfigBuilder()
         .setZkSerializer(new ZNRecordSerializer())
         .setConnectionAddress(ZK_ADDR)
         .build();
-    try (ZkMetaClient zkMetaClient = new ZkMetaClient(config)) {
-      boolean connected = zkMetaClient.connect();
-      Assert.assertTrue(connected);
-    }
+    return new ZkMetaClient(config);
   }
 
   private static ZkServer startZkServer(final String zkAddress) {
@@ -78,5 +139,20 @@ public class TestZkMetaClient {
     System.out.println("Starting ZK server at " + zkAddress);
     zkServer.start();
     return zkServer;
+  }
+
+  private class MockDataChangeListener implements DataChangeListener {
+    private final AtomicInteger _triggeredCount = new AtomicInteger(0);
+    @Override
+    public void handleDataChange(String key, Object data, ChangeType changeType) {
+      _triggeredCount.getAndIncrement();
+      synchronized (_syncObject) {
+        _syncObject.notifyAll();
+      }
+    }
+
+    int getTriggeredCount() {
+      return _triggeredCount.get();
+    }
   }
 }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -1,0 +1,82 @@
+package org.apache.helix.metaclient.impl.zk;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.metaclient.api.MetaClientInterface;
+import org.apache.helix.metaclient.factories.MetaClientConfig;
+import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
+import org.apache.helix.zookeeper.zkclient.IDefaultNameSpace;
+import org.apache.helix.zookeeper.zkclient.ZkServer;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestZkMetaClient {
+
+  private static final String ZK_ADDR = "localhost:2183";
+  private ZkServer _zkServer;
+
+  @BeforeClass
+  public void prepare() {
+    // start local zookeeper server
+    _zkServer = startZkServer(ZK_ADDR);
+  }
+
+  @Test
+  public void testConnect() {
+    ZkMetaClientConfig config = new ZkMetaClientConfig.ZkMetaClientConfigBuilder()
+        .setZkSerializer(new ZNRecordSerializer())
+        .setConnectionAddress(ZK_ADDR)
+        .build();
+    try (ZkMetaClient zkMetaClient = new ZkMetaClient(config)) {
+      boolean connected = zkMetaClient.connect();
+      Assert.assertTrue(connected);
+    }
+  }
+
+  private static ZkServer startZkServer(final String zkAddress) {
+    String zkDir = zkAddress.replace(':', '_');
+    final String logDir = "/tmp/" + zkDir + "/logs";
+    final String dataDir = "/tmp/" + zkDir + "/dataDir";
+
+    // Clean up local directory
+    try {
+      FileUtils.deleteDirectory(new File(dataDir));
+      FileUtils.deleteDirectory(new File(logDir));
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    IDefaultNameSpace defaultNameSpace = zkClient -> {
+    };
+
+    int port = Integer.parseInt(zkAddress.substring(zkAddress.lastIndexOf(':') + 1));
+    ZkServer zkServer = new ZkServer(dataDir, logDir, defaultNameSpace, port);
+    System.out.println("Starting ZK server at " + zkAddress);
+    zkServer.start();
+    return zkServer;
+  }
+}

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/ZkClient.java
@@ -27,6 +27,7 @@ import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.SerializableSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
+import org.apache.zookeeper.Watcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,6 +87,17 @@ public class ZkClient extends org.apache.helix.zookeeper.zkclient.ZkClient imple
    * @param monitorRootPathOnly
    *            Should only stat of access to root path be reported to JMX bean or path-specific stat be reported too.
    */
+  public ZkClient(IZkConnection zkConnection, Watcher watcher, int connectionTimeout, long operationRetryTimeout,
+      PathBasedZkSerializer zkSerializer,
+      String monitorType, String monitorKey, String monitorInstanceName,
+      boolean monitorRootPathOnly, boolean connectOnInit) {
+    super(zkConnection, watcher, operationRetryTimeout, zkSerializer, monitorType, monitorKey, monitorInstanceName,
+        monitorRootPathOnly);
+    if (connectOnInit) {
+      connect(connectionTimeout, watcher);
+    }
+  }
+
   public ZkClient(IZkConnection zkConnection, int connectionTimeout, long operationRetryTimeout,
       PathBasedZkSerializer zkSerializer,
       String monitorType, String monitorKey, String monitorInstanceName,
@@ -175,6 +187,7 @@ public class ZkClient extends org.apache.helix.zookeeper.zkclient.ZkClient imple
 
   public static class Builder {
     IZkConnection _connection;
+    Watcher _watcher;
     String _zkServer;
 
     PathBasedZkSerializer _zkSerializer;
@@ -187,9 +200,20 @@ public class ZkClient extends org.apache.helix.zookeeper.zkclient.ZkClient imple
     String _monitorKey;
     String _monitorInstanceName = null;
     boolean _monitorRootPathOnly = true;
+    boolean _connectOnInit = true;
 
     public Builder setConnection(IZkConnection connection) {
       this._connection = connection;
+      return this;
+    }
+
+    public Builder setWatcher(Watcher watcher) {
+      this._watcher = watcher;
+      return this;
+    }
+
+    public Builder setConnectOnInit(boolean connectOnInit) {
+      _connectOnInit = connectOnInit;
       return this;
     }
 
@@ -270,8 +294,8 @@ public class ZkClient extends org.apache.helix.zookeeper.zkclient.ZkClient imple
         _zkSerializer = new BasicZkSerializer(new SerializableSerializer());
       }
 
-      return new ZkClient(_connection, _connectionTimeout, _operationRetryTimeout, _zkSerializer,
-          _monitorType, _monitorKey, _monitorInstanceName, _monitorRootPathOnly);
+      return new ZkClient(_connection, _watcher, _connectionTimeout, _operationRetryTimeout, _zkSerializer,
+          _monitorType, _monitorKey, _monitorInstanceName, _monitorRootPathOnly, _connectOnInit);
     }
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
 import javax.management.JMException;
 import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.constant.ZkSystemPropertyKeys;
@@ -58,6 +59,7 @@ import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.apache.helix.zookeeper.zkclient.util.ExponentialBackoffStrategy;
+import org.apache.zookeeper.AddWatchMode;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.ConnectionLossException;
@@ -107,6 +109,7 @@ public class ZkClient implements Watcher {
       Integer.getInteger(ZkSystemPropertyKeys.JUTE_MAXBUFFER, ZNRecord.SIZE_LIMIT);
 
   private final IZkConnection _connection;
+  private final Watcher _watcher;
   private final long _operationRetryTimeoutInMillis;
   private final Map<String, Set<IZkChildListener>> _childListener = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, Set<IZkDataListenerEntry>> _dataListener =
@@ -215,10 +218,18 @@ public class ZkClient implements Watcher {
   protected ZkClient(IZkConnection zkConnection, int connectionTimeout, long operationRetryTimeout,
       PathBasedZkSerializer zkSerializer, String monitorType, String monitorKey,
       String monitorInstanceName, boolean monitorRootPathOnly) {
+    this(zkConnection, null, operationRetryTimeout, zkSerializer, monitorType, monitorKey,
+        monitorInstanceName, monitorRootPathOnly);
+    connect(connectionTimeout, _watcher);
+  }
+
+  protected ZkClient(IZkConnection zkConnection, @Nullable Watcher watcher, long operationRetryTimeout,
+      PathBasedZkSerializer zkSerializer, String monitorType, String monitorKey,
+      String monitorInstanceName, boolean monitorRootPathOnly) {
     if (zkConnection == null) {
       throw new NullPointerException("Zookeeper connection is null!");
     }
-
+    _watcher = watcher == null ? this : watcher;
     _uid = UID.getAndIncrement();
     validateWriteSizeLimitConfig();
 
@@ -239,8 +250,6 @@ public class ZkClient implements Watcher {
     } else {
       LOG.info("ZkClient monitor key or type is not provided. Skip monitoring.");
     }
-
-    connect(connectionTimeout, this);
 
     try {
       if (_monitor != null) {
@@ -305,7 +314,7 @@ public class ZkClient implements Watcher {
       }
     }
 
-    boolean watchInstalled = watchForData(path, skipWatchingNonExistNode);
+    boolean watchInstalled = watchForData(path, skipWatchingNonExistNode, false);
     if (!watchInstalled) {
       // Now let us remove this handler.
       unsubscribeDataChanges(path, listener);
@@ -1455,7 +1464,7 @@ public class ZkClient implements Watcher {
   /*
    * This one installs watch only if path is there. Meant to avoid leaking watch in Zk server.
    */
-  private Stat installWatchOnlyPathExist(final String path) {
+  public Stat installWatchOnlyPathExist(final String path) {
     long startT = System.currentTimeMillis();
     final Stat stat;
     try {
@@ -1566,7 +1575,7 @@ public class ZkClient implements Watcher {
     getEventLock().lock();
     try {
       ZkConnection connection = ((ZkConnection) getConnection());
-      connection.reconnect(this);
+      connection.reconnect(_watcher);
     } catch (InterruptedException e) {
       throw new ZkInterruptedException(e);
     } finally {
@@ -2396,12 +2405,17 @@ public class ZkClient implements Watcher {
   }
 
   public void watchForData(final String path) {
-    watchForData(path, false);
+    watchForData(path, false, false);
   }
 
-  private boolean watchForData(final String path, boolean skipWatchingNonExistNode) {
+  public boolean watchForData(final String path, boolean skipWatchingNonExistNode, boolean persistListener) {
     try {
-      if (skipWatchingNonExistNode) {
+      if (persistListener) {
+        retryUntilConnected(() -> {
+          ((ZkConnection) getConnection()).getZookeeper().addWatch(path, AddWatchMode.PERSISTENT);
+          return true;
+        });
+      } else if (skipWatchingNonExistNode) {
         retryUntilConnected(() -> (((ZkConnection) getConnection()).getZookeeper().getData(path, true, new Stat())));
       } else {
         retryUntilConnected(() -> (((ZkConnection) getConnection()).getZookeeper().exists(path, true)));
@@ -2784,9 +2798,13 @@ public class ZkClient implements Watcher {
         _monitor.increaseDataChangeEventCounter();
       }
       if (sessionExpired) {
-        _monitor.increasExpiredSessionCounter();
+        _monitor.increaseExpiredSessionCounter();
       }
     }
+  }
+
+  public ZkClientMonitor getMonitor() {
+    return _monitor;
   }
 
   /**

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkEventThread.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkEventThread.java
@@ -81,7 +81,7 @@ public class ZkEventThread extends Thread {
     }
   }
 
-  ZkEventThread(String name) {
+  public ZkEventThread(String name) {
     setDaemon(true);
     setName("ZkClient-EventThread-" + getId() + "-" + name);
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/metric/ZkClientMonitor.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/metric/ZkClientMonitor.java
@@ -167,7 +167,7 @@ public class ZkClientMonitor extends DynamicMBeanProvider {
     }
   }
 
-  public void increasExpiredSessionCounter() {
+  public void increaseExpiredSessionCounter() {
     synchronized (_expiredSessionCounter) {
       _expiredSessionCounter.updateValue(_expiredSessionCounter.getValue() + 1);
     }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestBase.java
@@ -124,7 +124,7 @@ public class ZkTestBase {
    * @param zkAddress
    * @return
    */
-  protected ZkServer startZkServer(final String zkAddress) {
+  protected static ZkServer startZkServer(final String zkAddress) {
     String zkDir = zkAddress.replace(':', '_');
     final String logDir = "/tmp/" + zkDir + "/logs";
     final String dataDir = "/tmp/" + zkDir + "/dataDir";


### PR DESCRIPTION
NOT READY YET

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
N.A.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Implement the DataChangeListener notification layer of ZkMetaClient. Some key ideas of this change:
1. Reuse ZkClient and its connection as possible
2. Re-implement the watcher interface in ZkMetaClient, and register this class as watcher
3. Re-implement the event thread used in ZkMetaClient
4. Thread-safe ListenerContainer
5. refactoring in zookeeper-api module to allow watcher override

### Tests

- [X] The following tests are written for this issue:
TestZkMetaClient

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
