### PR TITLE
Refactor zookeeper-api module with more flexible watcher and connection setup

### DIFF
--- a/.github/workflows/Helix-PR-CI.yml
+++ b/.github/workflows/Helix-PR-CI.yml
@@ -1,7 +1,7 @@
 name: Helix PR CI
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ master, metaclient ] # TODO: remove side branch
     paths-ignore:
       - '.github/**'
       - 'helix-front/**'

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestZkClientMonitor.java
@@ -110,7 +110,7 @@ public class TestZkClientMonitor {
     long stateChangeCount = (long) _beanServer.getAttribute(name, "StateChangeEventCounter");
     Assert.assertEquals(stateChangeCount, 1);
 
-    monitor.increasExpiredSessionCounter();
+    monitor.increaseExpiredSessionCounter();
     long expiredSessionCount = (long) _beanServer.getAttribute(name, "ExpiredSessionCounter");
     Assert.assertEquals(expiredSessionCount, 1);
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/ZkClient.java
@@ -71,7 +71,7 @@ public class ZkClient extends org.apache.helix.zookeeper.zkclient.ZkClient imple
    * @param zkConnection
    *            The Zookeeper connection
    * @param watcher
-   *            The watcher to register to zookeeper
+   *            The watcher to register to zookeeper. If null is passed in, the native zkclient is used as default
    * @param connectionTimeout
    *            The connection timeout in milli seconds
    * @param zkSerializer
@@ -88,6 +88,8 @@ public class ZkClient extends org.apache.helix.zookeeper.zkclient.ZkClient imple
    *            The JMX bean name will be: HelixZkClient.monitorType.monitorKey.monitorInstanceName.
    * @param monitorRootPathOnly
    *            Should only stat of access to root path be reported to JMX bean or path-specific stat be reported too.
+   * @param connectOnInit true if connect to ZK during initialization, otherwise user will need to call connect
+   *                      explicitly before talking to ZK.
    */
   public ZkClient(IZkConnection zkConnection, Watcher watcher, int connectionTimeout, long operationRetryTimeout,
       PathBasedZkSerializer zkSerializer,
@@ -209,11 +211,20 @@ public class ZkClient extends org.apache.helix.zookeeper.zkclient.ZkClient imple
       return this;
     }
 
+    /**
+     * Set zookeeper watcher to register for notification.
+     * If left empty, a NULL is passed down to the native {@link org.apache.helix.zookeeper.zkclient.ZkClient},
+     * where the native zkclient will be used as watcher by default.
+     */
     public Builder setWatcher(Watcher watcher) {
       this._watcher = watcher;
       return this;
     }
 
+    /**
+     * If set true, the client will connect to ZK during initialization.
+     * Otherwise, user has to call connect() method explicitly before talking to ZK.
+     */
     public Builder setConnectOnInit(boolean connectOnInit) {
       _connectOnInit = connectOnInit;
       return this;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -250,6 +250,7 @@ public class ZkClient implements Watcher {
     } else {
       LOG.info("ZkClient monitor key or type is not provided. Skip monitoring.");
     }
+    // set the zookeeper watcher for notification, use "this" native zkclient instance by default if not explicitly set
     _watcher = watcher == null ? this : watcher;
   }
 
@@ -1568,7 +1569,7 @@ public class ZkClient implements Watcher {
     getEventLock().lock();
     try {
       ZkConnection connection = ((ZkConnection) getConnection());
-      connection.reconnect(_watcher == null ? this : _watcher);
+      connection.reconnect(_watcher);
     } catch (InterruptedException e) {
       throw new ZkInterruptedException(e);
     } finally {
@@ -2398,6 +2399,13 @@ public class ZkClient implements Watcher {
     watchForData(path, false, false);
   }
 
+  /**
+   * Register watcher for certain ZK path for notification.
+   * @param path the zk path
+   * @param skipWatchingNonExistNode whether skip watching non exist node
+   * @param persistListener if set true, a persistent ZK watcher is set to the given path
+   * @return true if set successfully
+   */
   public boolean watchForData(final String path, boolean skipWatchingNonExistNode, boolean persistListener) {
     try {
       if (persistListener) {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkEventThread.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkEventThread.java
@@ -81,7 +81,7 @@ public class ZkEventThread extends Thread {
     }
   }
 
-  ZkEventThread(String name) {
+  public ZkEventThread(String name) {
     setDaemon(true);
     setName("ZkClient-EventThread-" + getId() + "-" + name);
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/metric/ZkClientMonitor.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/metric/ZkClientMonitor.java
@@ -167,7 +167,7 @@ public class ZkClientMonitor extends DynamicMBeanProvider {
     }
   }
 
-  public void increasExpiredSessionCounter() {
+  public void increaseExpiredSessionCounter() {
     synchronized (_expiredSessionCounter) {
       _expiredSessionCounter.updateValue(_expiredSessionCounter.getValue() + 1);
     }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestBase.java
@@ -124,7 +124,7 @@ public class ZkTestBase {
    * @param zkAddress
    * @return
    */
-  protected ZkServer startZkServer(final String zkAddress) {
+  protected static ZkServer startZkServer(final String zkAddress) {
     String zkDir = zkAddress.replace(':', '_');
     final String logDir = "/tmp/" + zkDir + "/logs";
     final String dataDir = "/tmp/" + zkDir + "/dataDir";


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
N.A.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

See also https://github.com/apache/helix/pull/2306

Refactor the zookeeper-api module as preparation for DataChangeListener notification implementation in ZkMetaClient.
A new set of listeners need to be triggered on ZK events, and in order to support this, the watcher has to be registered from the new meta-client module. We CANNOT reuse ZkClient to implement the new listener interface because it's introducing circular dependency.

The change includes:
1. Accepts `watcher` as param in ZkClient construction, in order to override the watcher registration while maintain backward compatibility.
2. Introduce `boolean connectOnInit`, zkclient was default to connect right after class initialization, this is causing trouble in ZkMetaClient implementation because the instance might not be fully constructed and causing `NullPointerException`. In MetaClient API, `connect` is a standalone method and supposed to be invoked separately. 
3. Marking a few methods and class public to be reused in meta-client module
4. Fixing some typo and styling.

This PR also enables Helix PR CI for this feature branch to have better coverage during development.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

2022-12-19T19:50:35.7766335Z [info] ./helix-core/target/surefire-reports/TestSuite.txt: Tests run: 1319, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6,140.342 s - in TestSuite
2022-12-19T19:50:35.7773618Z [info] ./metadata-store-directory-common/target/surefire-reports/TestSuite.txt: Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.995 s - in TestSuite
2022-12-19T19:50:35.7774976Z [info] ./helix-rest/target/surefire-reports/TestSuite.txt: Tests run: 208, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 173.517 s - in TestSuite
2022-12-19T19:50:35.7780928Z [info] ./helix-common/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.275 s - in TestSuite
2022-12-19T19:50:35.7789686Z [info] ./zookeeper-api/target/surefire-reports/TestSuite.txt: Tests run: 67, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 183.284 s - in TestSuite
2022-12-19T19:50:35.7792624Z [info] ./helix-lock/target/surefire-reports/TestSuite.txt: Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 52.773 s - in TestSuite
2022-12-19T19:50:35.7798219Z [info] ./metrics-common/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.382 s - in TestSuite
2022-12-19T19:50:35.7799439Z [info] ./recipes/task-execution/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.462 s - in TestSuite
2022-12-19T19:50:35.7801005Z [info] ./recipes/rabbitmq-consumer-group/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.706 s - in TestSuite
2022-12-19T19:50:35.7802214Z [info] ./recipes/service-discovery/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.643 s - in TestSuite
2022-12-19T19:50:35.7804771Z [info] ./recipes/distributed-lock-manager/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.601 s - in TestSuite
2022-12-19T19:50:35.7805790Z [info] ./recipes/rsync-replicated-file-system/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.733 s - in TestSuite
2022-12-19T19:50:35.7807476Z [info] ./helix-view-aggregator/target/surefire-reports/TestSuite.txt: Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 80.888 s - in TestSuite

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
