### PR TITLE
Meta client - implement CRUD for zkMetaClient

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -22,6 +22,9 @@ package org.apache.helix.metaclient.api;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.helix.metaclient.constants.MetaClientInterruptException;
+import org.apache.helix.metaclient.constants.MetaClientTimeoutException;
+
 
 public interface MetaClientInterface<T> {
 
@@ -349,7 +352,12 @@ public interface MetaClientInterface<T> {
   /**
    * Maintains a connection with underlying metadata service based on config params. Connection
    * created by this method will be used to perform CRUD operations on metadata service.
-   * @Throws MetaClientException when failed to connect.
+   * @throws MetaClientInterruptException
+   *          if the connection timed out due to thread interruption
+   * @throws MetaClientTimeoutException
+   *          if the connection timed out
+   * @throws IllegalStateException
+   *         if already connected or the connection is already closed explicitly
    */
   void connect();
 

--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -36,7 +36,11 @@ public interface MetaClientInterface<T> {
 
     // The node will not be automatically deleted when the last sub-entry of the node is deleted.
     // The node is an ephemeral node.
-    CONTAINER
+    CONTAINER,
+
+    // If the entry is not modified within the TTL and has no children it will become a candidate
+    // to be deleted by the server at some point in the future.
+    TTL
   }
 
   enum ConnectState {

--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -71,6 +71,11 @@ public interface MetaClientInterface<T> {
     public int getVersion() {
       return _version;
     }
+
+    public Stat (EntryMode mode, int version) {
+      _version = version;
+      _entryMode = mode;
+    }
   }
 
   //synced CRUD API
@@ -143,7 +148,7 @@ public interface MetaClientInterface<T> {
    * @eturn Return a list of children keys. Return direct child name only for hierarchical key
    *        space, return the whole sub key for non-hierarchical key space.
    */
-  List<String> getDirestChildrenKeys(final String key);
+  List<String> getDirectChildrenKeys(final String key);
 
   /**
    * Return the number of children for the given keys.
@@ -152,7 +157,7 @@ public interface MetaClientInterface<T> {
    *            For metadata storage that has non-hierarchical key space (e.g. etcd), the key would
    *            be a prefix key.
    */
-  int countDirestChildren(final String key);
+  int countDirectChildren(final String key);
 
   /**
    * Remove the entry associated with the given key.

--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -34,12 +34,20 @@ public interface MetaClientInterface<T> {
     // An ephemeral node cannot have sub entry.
     PERSISTENT,
 
-    // The node will not be automatically deleted when the last sub-entry of the node is deleted.
+    // For metadata storage that has hierarchical key space (e.g. ZK), the node will be
+    // automatically deleted at some point in the future if the last child of the node is deleted.
+    // For metadata storage that has non-hierarchical key space (e.g. etcd), the node will be
+    // automatically deleted at some point in the future if the last entry that has the prefix
+    // is deleted.
     // The node is an ephemeral node.
     CONTAINER,
 
-    // If the entry is not modified within the TTL and has no children it will become a candidate
-    // to be deleted by the server at some point in the future.
+    // For metadata storage that has hierarchical key space (e.g. ZK) If the entry is not modified
+    // within the TTL and has no children it will become a candidate to be deleted by the server
+    // at some point in the future.
+    // For metadata storage that has non-hierarchical key space (e.g. etcd) If the entry is not modified
+    // within the TTL, it will become a candidate to be deleted by the server at some point in the
+    // future.
     TTL
   }
 
@@ -341,9 +349,9 @@ public interface MetaClientInterface<T> {
   /**
    * Maintains a connection with underlying metadata service based on config params. Connection
    * created by this method will be used to perform CRUD operations on metadata service.
-   * @return True if connection is successfully established.
+   * @Throws MetaClientException when failed to connect.
    */
-  boolean connect();
+  void connect();
 
   /**
    * Disconnect from server explicitly.

--- a/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientBadVersionException.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientBadVersionException.java
@@ -1,0 +1,20 @@
+package org.apache.helix.metaclient.constants;
+
+public class MetaClientBadVersionException extends MetaClientException {
+  public MetaClientBadVersionException() {
+    super();
+  }
+
+  public MetaClientBadVersionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public MetaClientBadVersionException(String message) {
+    super(message);
+  }
+
+  public MetaClientBadVersionException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientBadVersionException.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientBadVersionException.java
@@ -1,6 +1,6 @@
 package org.apache.helix.metaclient.constants;
 
-public class MetaClientBadVersionException extends MetaClientException {
+public final class MetaClientBadVersionException extends MetaClientException {
   public MetaClientBadVersionException() {
     super();
   }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientException.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientException.java
@@ -19,5 +19,20 @@ package org.apache.helix.metaclient.constants;
  * under the License.
  */
 
-public final class MetaClientException {
+public class MetaClientException extends RuntimeException{
+  public MetaClientException() {
+    super();
+  }
+
+  public MetaClientException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public MetaClientException(String message) {
+    super(message);
+  }
+
+  public MetaClientException(Throwable cause) {
+    super(cause);
+  }
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientException.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientException.java
@@ -19,7 +19,7 @@ package org.apache.helix.metaclient.constants;
  * under the License.
  */
 
-public class MetaClientException extends RuntimeException{
+public class MetaClientException extends RuntimeException {
   public MetaClientException() {
     super();
   }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientInterruptException.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientInterruptException.java
@@ -1,0 +1,19 @@
+package org.apache.helix.metaclient.constants;
+
+public final class MetaClientInterruptException extends MetaClientException {
+  public MetaClientInterruptException() {
+    super();
+  }
+
+  public MetaClientInterruptException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public MetaClientInterruptException(String message) {
+    super(message);
+  }
+
+  public MetaClientInterruptException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientInterruptException.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientInterruptException.java
@@ -1,5 +1,24 @@
 package org.apache.helix.metaclient.constants;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 public final class MetaClientInterruptException extends MetaClientException {
   public MetaClientInterruptException() {
     super();

--- a/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientNoNodeException.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientNoNodeException.java
@@ -1,0 +1,20 @@
+package org.apache.helix.metaclient.constants;
+
+public final class MetaClientNoNodeException extends MetaClientException {
+  public MetaClientNoNodeException() {
+    super();
+  }
+
+  public MetaClientNoNodeException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public MetaClientNoNodeException(String message) {
+    super(message);
+  }
+
+  public MetaClientNoNodeException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientNoNodeException.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientNoNodeException.java
@@ -1,5 +1,24 @@
 package org.apache.helix.metaclient.constants;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 public final class MetaClientNoNodeException extends MetaClientException {
   public MetaClientNoNodeException() {
     super();

--- a/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientTimeoutException.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientTimeoutException.java
@@ -1,0 +1,20 @@
+package org.apache.helix.metaclient.constants;
+
+public final class MetaClientTimeoutException extends MetaClientException {
+  public MetaClientTimeoutException() {
+    super();
+  }
+
+  public MetaClientTimeoutException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public MetaClientTimeoutException(String message) {
+    super(message);
+  }
+
+  public MetaClientTimeoutException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientTimeoutException.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientTimeoutException.java
@@ -1,5 +1,24 @@
 package org.apache.helix.metaclient.constants;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 public final class MetaClientTimeoutException extends MetaClientException {
   public MetaClientTimeoutException() {
     super();

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -214,6 +214,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
 
   @Override
   public void connect() {
+    // TODO: throws IllegalStateException when already connected
     try {
       _zkClient.connect(_connectionTimeout, _zkClient);
     } catch (ZkException e) {
@@ -363,7 +364,8 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
       return _listener.hashCode();
     }
   }
-  private MetaClientException translateZkExceptionToMetaclientException(ZkException e) {
+
+  private static MetaClientException translateZkExceptionToMetaclientException(ZkException e) {
     if (e instanceof ZkNodeExistsException) {
       return new MetaClientNoNodeException(e);
     } else if (e instanceof ZkBadVersionException) {
@@ -377,7 +379,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
     }
   }
 
-  private EntryMode convertZkEntryMode(long ephemeralOwner) {
+  private static EntryMode convertZkEntryMode(long ephemeralOwner) {
     EphemeralType zkEphemeralType = EphemeralType.get(ephemeralOwner);
     switch (zkEphemeralType) {
       case VOID:

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -19,8 +19,6 @@ package org.apache.helix.metaclient.impl.zk;
  * under the License.
  */
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -54,7 +52,7 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.server.EphemeralType;
 
 
-public class ZkMetaClient<T> implements MetaClientInterface<T> , Closeable {
+public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
 
   private final ZkClient _zkClient;
   private final int _connectionTimeout;
@@ -215,10 +213,9 @@ public class ZkMetaClient<T> implements MetaClientInterface<T> , Closeable {
   }
 
   @Override
-  public boolean connect() {
+  public void connect() {
     try {
       _zkClient.connect(_connectionTimeout, _zkClient);
-      return true;
     } catch (ZkException e) {
       throw translateZkExceptionToMetaclientException(e);
     }
@@ -226,7 +223,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T> , Closeable {
 
   @Override
   public void disconnect() {
-    // TODO: This is a temp impl for test only. no proper event handling and error handling.
+    // TODO: This is a temp impl for test only. no proper interrupt handling and error handling.
     _zkClient.close();
   }
 
@@ -311,8 +308,8 @@ public class ZkMetaClient<T> implements MetaClientInterface<T> , Closeable {
   }
 
   @Override
-  public void close() throws IOException {
-
+  public void close() {
+    disconnect();
   }
 
   /**

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -110,8 +110,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T> , Closeable {
       if (zkStats == null) {
         return null;
       }
-      return new Stat(EphemeralType.get(zkStats.getEphemeralOwner()) == EphemeralType.VOID
-          ? EntryMode.PERSISTENT : EntryMode.EPHEMERAL, zkStats.getVersion());
+      return new Stat(convertZkEntryMode(zkStats.getEphemeralOwner()), zkStats.getVersion());
     } catch (ZkException e) {
       throw translateZkExceptionToMetaclientException(e);
     }
@@ -381,4 +380,20 @@ public class ZkMetaClient<T> implements MetaClientInterface<T> , Closeable {
     }
   }
 
+  private EntryMode convertZkEntryMode(long ephemeralOwner) {
+    EphemeralType zkEphemeralType = EphemeralType.get(ephemeralOwner);
+    switch (zkEphemeralType) {
+      case VOID:
+        return EntryMode.PERSISTENT;
+      case CONTAINER:
+        return EntryMode.CONTAINER;
+      case NORMAL:
+        return EntryMode.EPHEMERAL;
+      // TODO: TTL is not supported now.
+      //case TTL:
+      //  return EntryMode.TTL;
+      default:
+        throw new IllegalArgumentException(zkEphemeralType + " is not supported.");
+    }
+  }
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -211,14 +211,14 @@ public class ZkMetaClient<T> implements MetaClientInterface<T> , Closeable {
 
   @Override
   public boolean connect() {
-    // TODO: This is a tempp impl for test only. no proper event handling and error handling.
-    _zkClient.connect(Integer.MAX_VALUE, _zkClient);
+    // TODO: Currently zkclient is connected to ZK when initiated in constructor. This is temp behavior
+    // for test only. Change later.
     return true;
   }
 
   @Override
   public void disconnect() {
-    // TODO: This is a tempp impl for test only. no proper event handling and error handling.
+    // TODO: This is a temp impl for test only. no proper event handling and error handling.
     _zkClient.close();
   }
 

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -126,7 +126,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T> , Closeable {
     try {
       return _zkClient.getChildren(key);
     } catch (ZkException e) {
-      throw new MetaClientException(e);
+      throw translateZkExceptionToMetaclientException(e);
     }
   }
 
@@ -140,7 +140,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T> , Closeable {
     try {
       return _zkClient.delete(key);
     } catch (ZkException e) {
-      throw new MetaClientException(e);
+      throw translateZkExceptionToMetaclientException(e);
     }
   }
 

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/factory/ZkMetaClientConfig.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/factory/ZkMetaClientConfig.java
@@ -128,7 +128,7 @@ public class ZkMetaClientConfig extends MetaClientConfig {
     }
 
     @Override
-    public MetaClientConfig build() {
+    public ZkMetaClientConfig build() {
       if (_zkSerializer == null) {
         _zkSerializer = new BasicZkSerializer(new SerializableSerializer());
       }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -21,19 +21,30 @@ package org.apache.helix.metaclient.impl.zk;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.helix.metaclient.api.DataUpdater;
+import org.apache.helix.metaclient.api.MetaClientInterface;
+import org.apache.helix.metaclient.constants.MetaClientException;
 import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
 import org.apache.helix.zookeeper.zkclient.IDefaultNameSpace;
 import org.apache.helix.zookeeper.zkclient.ZkServer;
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.apache.helix.metaclient.api.MetaClientInterface.EntryMode.PERSISTENT;
 
 
 public class TestZkMetaClient {
 
   private static final String ZK_ADDR = "localhost:2183";
   private ZkServer _zkServer;
+  private static final String ENTRY_STRING_VALUE = "test-value";
 
   @BeforeClass
   public void prepare() {
@@ -41,78 +52,118 @@ public class TestZkMetaClient {
     _zkServer = startZkServer(ZK_ADDR);
   }
 
-  /*@Test
-  public void testConnect() {
-    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
-      zkMetaClient.connect();
-    } catch (IOException e) {
-
-    }
-  }*/
-
   @Test
   public void testGet() {
-    final String path = "/TestZkMetaClient";
-    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
-      //zkMetaClient.connect();
-      zkMetaClient.create(path, "test-node");
-      zkMetaClient.set(path, "test-node-changed", -1);
-      zkMetaClient.delete(path);
-    } catch (IOException e) {
+    final String key = "/TestZkMetaClient_testGet";
+    ZkMetaClient<String> zkMetaClient = createZkMetaClient();
+    String value;
+    zkMetaClient.create(key, ENTRY_STRING_VALUE);
+    String dataValue = zkMetaClient.get(key);
+    Assert.assertEquals(dataValue, ENTRY_STRING_VALUE);
 
+    value = zkMetaClient.get(key + "/a/b/c");
+    Assert.assertNull(value);
+
+    zkMetaClient.delete(key);
+
+    value = zkMetaClient.get(key);
+    Assert.assertNull(value);
+  }
+
+  @Test
+  public void testSet() {
+    final String key = "/TestZkMetaClient_testSet";
+    ZkMetaClient<String> zkMetaClient = createZkMetaClient();
+    zkMetaClient.create(key, ENTRY_STRING_VALUE);
+    String testValueV1 = ENTRY_STRING_VALUE + "-v1";
+    String testValueV2 = ENTRY_STRING_VALUE + "-v2";
+
+    // test set() with no expected version and validate result.
+    zkMetaClient.set(key, testValueV1, -1);
+    Assert.assertEquals(zkMetaClient.get(key), testValueV1);
+    MetaClientInterface.Stat entryStat = zkMetaClient.exists(key);
+    Assert.assertEquals(entryStat.getVersion(), 1);
+    Assert.assertEquals(entryStat.getEntryType().name(), PERSISTENT.name());
+
+    // test set() with expected version and validate result and new version number
+    zkMetaClient.set(key, testValueV2, 1);
+    entryStat = zkMetaClient.exists(key);
+    Assert.assertEquals(zkMetaClient.get(key), testValueV2);
+    Assert.assertEquals(entryStat.getVersion(), 2);
+
+    // test set() with a wrong version
+    try {
+      zkMetaClient.set(key, "test-node-changed", 10);
+      Assert.fail("No reach.");
+    } catch (MetaClientException ex) {
+      Assert.assertEquals(ex.getClass().getName(),
+          "org.apache.helix.metaclient.constants.MetaClientBadVersionException");
     }
+    zkMetaClient.delete(key);
   }
 
   @Test
   public void testUpdate() {
-    final String path = "/TestZkMetaClient";
-    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
-      //zkMetaClient.connect();
-      zkMetaClient.create(path, "test-node");
-      zkMetaClient.set(path, "test-node-changed", -1);
-      zkMetaClient.delete(path);
-    } catch (IOException e) {
+    final String key = "/TestZkMetaClient_testUpdate";
+    ZkMetaClientConfig config =
+        new ZkMetaClientConfig.ZkMetaClientConfigBuilder().setConnectionAddress(ZK_ADDR).build();
+    ZkMetaClient<Integer> zkMetaClient = new ZkMetaClient<>(config);
+    int initValue = 3;
+    zkMetaClient.create(key, initValue);
+    MetaClientInterface.Stat entryStat = zkMetaClient.exists(key);
+    Assert.assertEquals(entryStat.getVersion(), 0);
 
-    }
+    // test update() and validate entry value and version
+    Integer newData = zkMetaClient.update(key, new DataUpdater<Integer>() {
+      @Override
+      public Integer update(Integer currentData) {
+        return currentData + 1;
+      }
+    });
+    Assert.assertEquals((int) newData, (int) initValue+1);
+
+    entryStat = zkMetaClient.exists(key);
+    Assert.assertEquals(entryStat.getVersion(), 1);
+
+    newData = zkMetaClient.update(key, new DataUpdater<Integer>() {
+
+      @Override
+      public Integer update(Integer currentData) {
+        return currentData + 1;
+      }
+    });
+
+    entryStat = zkMetaClient.exists(key);
+    Assert.assertEquals(entryStat.getVersion(), 2);
+    Assert.assertEquals((int) newData, (int) initValue+2);
+    zkMetaClient.delete(key);
   }
 
   @Test
-  public void testExists() {
-    final String path = "/TestZkMetaClient";
-    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
-      //zkMetaClient.connect();
-      zkMetaClient.create(path, "test-node");
-      zkMetaClient.set(path, "test-node-changed", -1);
-      zkMetaClient.delete(path);
-    } catch (IOException e) {
+  public void testGetAndCountChildrenAndRecursiveDelete() {
+    final String key = "/TestZkMetaClient_testGetAndCountChildren";
+    List<String> childrenNames = Arrays.asList("/c1", "/c2", "/c3");
 
+    // create child nodes and validate retrieved children count and names
+    ZkMetaClient<String> zkMetaClient = createZkMetaClient();
+    zkMetaClient.create(key, ENTRY_STRING_VALUE);
+    Assert.assertEquals(zkMetaClient.countDirectChildren(key), 0);
+    for (String str : childrenNames) {
+      zkMetaClient.create(key + str, ENTRY_STRING_VALUE);
     }
-  }
 
-  @Test
-  public void testGetCountChildren() {
-    final String path = "/TestZkMetaClient";
-    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
-      //zkMetaClient.connect();
-      zkMetaClient.create(path, "test-node");
-      zkMetaClient.set(path, "test-node-changed", -1);
-      zkMetaClient.delete(path);
-    } catch (IOException e) {
-
+    List<String> retrievedChildrenNames = zkMetaClient.getDirectChildrenKeys(key);
+    Assert.assertEquals(retrievedChildrenNames.size(), childrenNames.size());
+    Set<String> childrenNameSet = new HashSet<>(childrenNames);
+    for (String str : retrievedChildrenNames) {
+      Assert.assertTrue(childrenNameSet.contains("/"+str));
     }
-  }
 
-  @Test
-  public void testRecursiveDelete() {
-    final String path = "/TestZkMetaClient";
-    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
-      //zkMetaClient.connect();
-      zkMetaClient.create(path, "test-node");
-      zkMetaClient.set(path, "test-node-changed", -1);
-      zkMetaClient.delete(path);
-    } catch (IOException e) {
-
-    }
+    // recursive delete and validate
+    Assert.assertEquals(zkMetaClient.countDirectChildren(key), childrenNames.size());
+    Assert.assertNotNull(zkMetaClient.exists(key));
+    zkMetaClient.recursiveDelete(key);
+    Assert.assertNull(zkMetaClient.exists(key));
   }
 
 
@@ -141,7 +192,6 @@ public class TestZkMetaClient {
 
     int port = Integer.parseInt(zkAddress.substring(zkAddress.lastIndexOf(':') + 1));
     ZkServer zkServer = new ZkServer(dataDir, logDir, defaultNameSpace, port);
-    System.out.println("Starting ZK server at " + zkAddress);
     zkServer.start();
     return zkServer;
   }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -62,6 +62,7 @@ public class TestZkMetaClient {
   public void testGet() {
     final String key = "/TestZkMetaClient_testGet";
     ZkMetaClient<String> zkMetaClient = createZkMetaClient();
+    zkMetaClient.connect();
     String value;
     zkMetaClient.create(key, ENTRY_STRING_VALUE);
     String dataValue = zkMetaClient.get(key);
@@ -81,6 +82,7 @@ public class TestZkMetaClient {
   public void testSet() {
     final String key = "/TestZkMetaClient_testSet";
     ZkMetaClient<String> zkMetaClient = createZkMetaClient();
+    zkMetaClient.connect();
     zkMetaClient.create(key, ENTRY_STRING_VALUE);
     String testValueV1 = ENTRY_STRING_VALUE + "-v1";
     String testValueV2 = ENTRY_STRING_VALUE + "-v2";
@@ -116,6 +118,7 @@ public class TestZkMetaClient {
     ZkMetaClientConfig config =
         new ZkMetaClientConfig.ZkMetaClientConfigBuilder().setConnectionAddress(ZK_ADDR).build();
     ZkMetaClient<Integer> zkMetaClient = new ZkMetaClient<>(config);
+    zkMetaClient.connect();
     int initValue = 3;
     zkMetaClient.create(key, initValue);
     MetaClientInterface.Stat entryStat = zkMetaClient.exists(key);
@@ -155,6 +158,7 @@ public class TestZkMetaClient {
 
     // create child nodes and validate retrieved children count and names
     ZkMetaClient<String> zkMetaClient = createZkMetaClient();
+    zkMetaClient.connect();
     zkMetaClient.create(key, ENTRY_STRING_VALUE);
     Assert.assertEquals(zkMetaClient.countDirectChildren(key), 0);
     for (String str : childrenNames) {

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -21,10 +21,11 @@ package org.apache.helix.metaclient.impl.zk;
 
 import java.io.File;
 import java.io.IOException;
+
 import org.apache.commons.io.FileUtils;
+import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
 import org.apache.helix.zookeeper.zkclient.IDefaultNameSpace;
 import org.apache.helix.zookeeper.zkclient.ZkServer;
-import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -40,9 +41,86 @@ public class TestZkMetaClient {
     _zkServer = startZkServer(ZK_ADDR);
   }
 
+  /*@Test
+  public void testConnect() {
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      zkMetaClient.connect();
+    } catch (IOException e) {
+
+    }
+  }*/
+
   @Test
-  public void dummyTest() {
-    Assert.assertEquals(1+1, 2);
+  public void testGet() {
+    final String path = "/TestZkMetaClient";
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      //zkMetaClient.connect();
+      zkMetaClient.create(path, "test-node");
+      zkMetaClient.set(path, "test-node-changed", -1);
+      zkMetaClient.delete(path);
+    } catch (IOException e) {
+
+    }
+  }
+
+  @Test
+  public void testUpdate() {
+    final String path = "/TestZkMetaClient";
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      //zkMetaClient.connect();
+      zkMetaClient.create(path, "test-node");
+      zkMetaClient.set(path, "test-node-changed", -1);
+      zkMetaClient.delete(path);
+    } catch (IOException e) {
+
+    }
+  }
+
+  @Test
+  public void testExists() {
+    final String path = "/TestZkMetaClient";
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      //zkMetaClient.connect();
+      zkMetaClient.create(path, "test-node");
+      zkMetaClient.set(path, "test-node-changed", -1);
+      zkMetaClient.delete(path);
+    } catch (IOException e) {
+
+    }
+  }
+
+  @Test
+  public void testGetCountChildren() {
+    final String path = "/TestZkMetaClient";
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      //zkMetaClient.connect();
+      zkMetaClient.create(path, "test-node");
+      zkMetaClient.set(path, "test-node-changed", -1);
+      zkMetaClient.delete(path);
+    } catch (IOException e) {
+
+    }
+  }
+
+  @Test
+  public void testRecursiveDelete() {
+    final String path = "/TestZkMetaClient";
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      //zkMetaClient.connect();
+      zkMetaClient.create(path, "test-node");
+      zkMetaClient.set(path, "test-node-changed", -1);
+      zkMetaClient.delete(path);
+    } catch (IOException e) {
+
+    }
+  }
+
+
+
+  private static ZkMetaClient<String> createZkMetaClient() {
+    ZkMetaClientConfig config =
+        new ZkMetaClientConfig.ZkMetaClientConfigBuilder().setConnectionAddress(ZK_ADDR).build();
+    return new ZkMetaClient<>(config);
   }
 
   private static ZkServer startZkServer(final String zkAddress) {

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -191,6 +191,7 @@ public class TestZkMetaClient {
     };
 
     int port = Integer.parseInt(zkAddress.substring(zkAddress.lastIndexOf(':') + 1));
+    System.out.println("Starting ZK server at " + zkAddress);
     ZkServer zkServer = new ZkServer(dataDir, logDir, defaultNameSpace, port);
     zkServer.start();
     return zkServer;

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -34,6 +34,7 @@ import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
 import org.apache.helix.zookeeper.zkclient.IDefaultNameSpace;
 import org.apache.helix.zookeeper.zkclient.ZkServer;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -52,6 +53,11 @@ public class TestZkMetaClient {
     _zkServer = startZkServer(ZK_ADDR);
   }
 
+  @AfterClass
+  public void cleanUp() {
+    _zkServer.shutdown();
+  }
+
   @Test
   public void testGet() {
     final String key = "/TestZkMetaClient_testGet";
@@ -68,6 +74,7 @@ public class TestZkMetaClient {
 
     value = zkMetaClient.get(key);
     Assert.assertNull(value);
+    zkMetaClient.disconnect();
   }
 
   @Test
@@ -100,6 +107,7 @@ public class TestZkMetaClient {
           "org.apache.helix.metaclient.constants.MetaClientBadVersionException");
     }
     zkMetaClient.delete(key);
+    zkMetaClient.disconnect();
   }
 
   @Test
@@ -137,6 +145,7 @@ public class TestZkMetaClient {
     Assert.assertEquals(entryStat.getVersion(), 2);
     Assert.assertEquals((int) newData, (int) initValue+2);
     zkMetaClient.delete(key);
+    zkMetaClient.disconnect();
   }
 
   @Test
@@ -164,6 +173,7 @@ public class TestZkMetaClient {
     Assert.assertNotNull(zkMetaClient.exists(key));
     zkMetaClient.recursiveDelete(key);
     Assert.assertNull(zkMetaClient.exists(key));
+    zkMetaClient.disconnect();
   }
 
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2237 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change adds basic CRUD operation implementation for ZkMetaClient (excluding create)

### Tests

- [X] The following tests are written for this issue:

TestZkMetaClient

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
