### PR TITLE
Prepare zkclient for meta-client DataChangeListener implementation

### DIFF
--- a/.github/workflows/Helix-PR-CI.yml
+++ b/.github/workflows/Helix-PR-CI.yml
@@ -1,7 +1,7 @@
 name: Helix PR CI
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ master, metaclient ] # TODO: remove side branch
     paths-ignore:
       - '.github/**'
       - 'helix-front/**'

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -283,5 +283,22 @@ public class ZkMetaClient implements MetaClientInterface {
     public void handleDataChange(String dataPath, Object data, Watcher.Event.EventType eventType) throws Exception {
       _listener.handleDataChange(dataPath, data, convertType(eventType));
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      DataListenerConverter that = (DataListenerConverter) o;
+      return _listener.equals(that._listener);
+    }
+
+    @Override
+    public int hashCode() {
+      return _listener.hashCode();
+    }
   }
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -33,7 +33,9 @@ import org.apache.helix.metaclient.api.MetaClientInterface;
 import org.apache.helix.metaclient.api.OpResult;
 import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.helix.zookeeper.zkclient.ZkConnection;
+import org.apache.zookeeper.Watcher;
 
 
 public class ZkMetaClient implements MetaClientInterface {
@@ -246,5 +248,40 @@ public class ZkMetaClient implements MetaClientInterface {
   @Override
   public List<OpResult> transactionOP(Iterable iterable) {
     return null;
+  }
+
+  /**
+   * A converter class to transform {@link DataChangeListener} to {@link IZkDataListener}
+   */
+  static class DataListenerConverter implements IZkDataListener {
+    private final DataChangeListener _listener;
+
+    DataListenerConverter(DataChangeListener listener) {
+      _listener = listener;
+    }
+
+    private DataChangeListener.ChangeType convertType(Watcher.Event.EventType eventType) {
+      switch (eventType) {
+        case NodeCreated: return DataChangeListener.ChangeType.ENTRY_CREATED;
+        case NodeDataChanged: return DataChangeListener.ChangeType.ENTRY_UPDATE;
+        case NodeDeleted: return DataChangeListener.ChangeType.ENTRY_DELETED;
+        default: throw new IllegalArgumentException("EventType " + eventType + " is not supported.");
+      }
+    }
+
+    @Override
+    public void handleDataChange(String dataPath, Object data) throws Exception {
+      throw new UnsupportedOperationException("handleDataChange(String dataPath, Object data) is not supported.");
+    }
+
+    @Override
+    public void handleDataDeleted(String dataPath) throws Exception {
+      handleDataChange(dataPath, null, Watcher.Event.EventType.NodeDeleted);
+    }
+
+    @Override
+    public void handleDataChange(String dataPath, Object data, Watcher.Event.EventType eventType) throws Exception {
+      _listener.handleDataChange(dataPath, data, convertType(eventType));
+    }
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/ZkClient.java
@@ -85,13 +85,23 @@ public class ZkClient extends org.apache.helix.zookeeper.zkclient.ZkClient imple
    *            The JMX bean name will be: HelixZkClient.monitorType.monitorKey.monitorInstanceName.
    * @param monitorRootPathOnly
    *            Should only stat of access to root path be reported to JMX bean or path-specific stat be reported too.
+   * @param connectOnInit true if connect to ZK during initialization, otherwise user will need to call connect
+   *                      explicitly before talking to ZK.
    */
   public ZkClient(IZkConnection zkConnection, int connectionTimeout, long operationRetryTimeout,
       PathBasedZkSerializer zkSerializer,
       String monitorType, String monitorKey, String monitorInstanceName,
-      boolean monitorRootPathOnly) {
+      boolean monitorRootPathOnly, boolean connectOnInit) {
     super(zkConnection, connectionTimeout, operationRetryTimeout, zkSerializer, monitorType,
-        monitorKey, monitorInstanceName, monitorRootPathOnly);
+        monitorKey, monitorInstanceName, monitorRootPathOnly, connectOnInit);
+  }
+
+  public ZkClient(IZkConnection zkConnection, int connectionTimeout, long operationRetryTimeout,
+      PathBasedZkSerializer zkSerializer,
+      String monitorType, String monitorKey, String monitorInstanceName,
+      boolean monitorRootPathOnly) {
+    this(zkConnection, connectionTimeout, operationRetryTimeout, zkSerializer, monitorType, monitorKey,
+        monitorInstanceName, monitorRootPathOnly, true);
   }
 
   public ZkClient(IZkConnection connection, int connectionTimeout,
@@ -187,6 +197,16 @@ public class ZkClient extends org.apache.helix.zookeeper.zkclient.ZkClient imple
     String _monitorKey;
     String _monitorInstanceName = null;
     boolean _monitorRootPathOnly = true;
+    boolean _connectOnInit = true;
+
+    /**
+     * If set true, the client will connect to ZK during initialization.
+     * Otherwise, user has to call connect() method explicitly before talking to ZK.
+     */
+    public Builder setConnectOnInit(boolean connectOnInit) {
+      _connectOnInit = connectOnInit;
+      return this;
+    }
 
     public Builder setConnection(IZkConnection connection) {
       this._connection = connection;
@@ -271,7 +291,7 @@ public class ZkClient extends org.apache.helix.zookeeper.zkclient.ZkClient imple
       }
 
       return new ZkClient(_connection, _connectionTimeout, _operationRetryTimeout, _zkSerializer,
-          _monitorType, _monitorKey, _monitorInstanceName, _monitorRootPathOnly);
+          _monitorType, _monitorKey, _monitorInstanceName, _monitorRootPathOnly, _connectOnInit);
     }
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkDataListener.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkDataListener.java
@@ -19,6 +19,9 @@ package org.apache.helix.zookeeper.zkclient;
  * under the License.
  */
 
+import org.apache.zookeeper.Watcher;
+
+
 /**
  * An {@link IZkDataListener} can be registered at a {@link ZkClient} for listening on zk data changes for a given path.
  *
@@ -31,4 +34,8 @@ public interface IZkDataListener {
     public void handleDataChange(String dataPath, Object data) throws Exception;
 
     public void handleDataDeleted(String dataPath) throws Exception;
+
+    default void handleDataChange(String dataPath, Object data, Watcher.Event.EventType eventType) throws Exception {
+        handleDataChange(dataPath, data);
+    }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1312,13 +1312,13 @@ public class ZkClient implements Watcher {
     }
   }
 
-  private void fireAllEvents() {
+  private void fireAllEvents(WatchedEvent event) {
     //TODO: During handling new session, if the path is deleted, watcher leakage could still happen
     for (Entry<String, Set<IZkChildListener>> entry : _childListener.entrySet()) {
       fireChildChangedEvents(entry.getKey(), entry.getValue(), true);
     }
     for (Entry<String, Set<IZkDataListenerEntry>> entry : _dataListener.entrySet()) {
-      fireDataChangedEvents(entry.getKey(), entry.getValue(), OptionalLong.empty(), true);
+      fireDataChangedEvents(entry.getKey(), entry.getValue(), OptionalLong.empty(), true, event.getType());
     }
   }
 
@@ -1518,7 +1518,7 @@ public class ZkClient implements Watcher {
          * reconnecting when the session expired. Because previous session expired, we also have to
          * notify all listeners that something might have changed.
          */
-        fireAllEvents();
+        fireAllEvents(event);
       }
     } else if (event.getState() == KeeperState.Expired) {
       _isNewSessionEventFired = false;
@@ -1766,13 +1766,13 @@ public class ZkClient implements Watcher {
       Set<IZkDataListenerEntry> listeners = _dataListener.get(path);
       if (listeners != null && !listeners.isEmpty()) {
         fireDataChangedEvents(event.getPath(), listeners, OptionalLong.of(notificationTime),
-            pathExists);
+            pathExists, event.getType());
       }
     }
   }
 
   private void fireDataChangedEvents(final String path, Set<IZkDataListenerEntry> listeners,
-      final OptionalLong notificationTime, boolean pathExists) {
+      final OptionalLong notificationTime, boolean pathExists, EventType eventType) {
     try {
       final ZkPathStatRecord pathStatRecord = new ZkPathStatRecord(path);
       // Trigger listener callbacks
@@ -1815,7 +1815,7 @@ public class ZkClient implements Watcher {
                   return;
                 }
               }
-              listener.getDataListener().handleDataChange(path, data);
+              listener.getDataListener().handleDataChange(path, data, eventType);
             }
           }
         });

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/metric/ZkClientMonitor.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/metric/ZkClientMonitor.java
@@ -55,6 +55,7 @@ public class ZkClientMonitor extends DynamicMBeanProvider {
   private String _monitorKey;
   private String _monitorInstanceName;
   private boolean _monitorRootOnly;
+  private volatile boolean _registered = false;
 
   private SimpleDynamicMetric<Long> _stateChangeEventCounter;
   private SimpleDynamicMetric<Long> _expiredSessionCounter;
@@ -123,6 +124,9 @@ public class ZkClientMonitor extends DynamicMBeanProvider {
 
   @Override
   public DynamicMBeanProvider register() throws JMException {
+    if (_registered) {
+      return this;
+    }
     List<DynamicMetric<?, ?>> attributeList = new ArrayList<>();
     attributeList.add(_dataChangeEventCounter);
     attributeList.add(_outstandingRequestGauge);
@@ -143,6 +147,7 @@ public class ZkClientMonitor extends DynamicMBeanProvider {
         }
       }
     });
+    _registered = true;
     return this;
   }
 
@@ -154,6 +159,7 @@ public class ZkClientMonitor extends DynamicMBeanProvider {
     for (ZkClientPathMonitor zkClientPathMonitor : _zkClientPathMonitorMap.values()) {
       zkClientPathMonitor.unregister();
     }
+    _registered = false;
   }
 
   @Override


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
N.A.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Some new features and improve in zookeeper-api to prepare meta-client implementation.

1. Add a new method in `IZkDataListener` and a converter class in `ZkMetaClient` so that it's easier to reuse existing zkclient.
2. Implement `connectOnInit` flag (backward compatible) to control whether zkclient should connect during initialization. (Meta-client API will require a separate connect() method to be called explicitly to connect.)
3. Minor change in the code flow, constructor and ZkClientMonitor.

### Tests

- [X] The following tests are written for this issue:

- The following is the result of the "mvn test" command on the appropriate module:
[INFO] Reactor Summary for Apache Helix 1.0.5-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  3.743 s]
[INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  4.606 s]
[INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [  3.312 s]
[INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [  6.523 s]
[INFO] Apache Helix :: Helix Common ....................... SUCCESS [  2.037 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [ 18.894 s]
[INFO] Apache Helix :: Admin Webapp ....................... SUCCESS [  2.963 s]
[INFO] Apache Helix :: Restful Interface .................. SUCCESS [  6.143 s]
[INFO] Apache Helix :: Distributed Lock ................... SUCCESS [  1.735 s]
[INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  2.277 s]
[INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.043 s]
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  2.419 s]
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  2.026 s]
[INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  2.317 s]
[INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  2.331 s]
[INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  2.548 s]
[INFO] Apache Helix :: View Aggregator .................... SUCCESS [  1.638 s]
[INFO] Apache Helix :: Meta Client ........................ SUCCESS [  1.241 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:08 min
[INFO] Finished at: 2023-01-05T13:18:08-05:00
[INFO] ------------------------------------------------------------------------

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
