### PR TITLE
Add metrics for rebalance throttled because of error partition

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -419,7 +419,8 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
     if (clusterStatusMonitor != null) {
       clusterStatusMonitor
           .updateRebalancerStats(resourceName, messagesForRecovery.size(), messagesForLoad.size(),
-              messagesThrottledForRecovery.size(), messagesThrottledForLoad.size(), onlyDownwardLoadBalance);
+              messagesThrottledForRecovery.size(), messagesThrottledForLoad.size(),
+              onlyDownwardLoadBalance);
     }
 
     if (logger.isDebugEnabled()) {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -28,7 +28,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -52,7 +51,6 @@ import org.apache.helix.model.Resource;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
 import org.apache.helix.monitoring.mbeans.ResourceMonitor;
-import org.apache.helix.participant.statemachine.StateModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -421,7 +419,7 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
     if (clusterStatusMonitor != null) {
       clusterStatusMonitor
           .updateRebalancerStats(resourceName, messagesForRecovery.size(), messagesForLoad.size(),
-              messagesThrottledForRecovery.size(), messagesThrottledForLoad.size());
+              messagesThrottledForRecovery.size(), messagesThrottledForLoad.size(), onlyDownwardLoadBalance);
     }
 
     if (logger.isDebugEnabled()) {

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -585,13 +585,13 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
 
   public void updateRebalancerStats(String resourceName, long numPendingRecoveryRebalancePartitions,
       long numPendingLoadRebalancePartitions, long numRecoveryRebalanceThrottledPartitions,
-      long numLoadRebalanceThrottledPartitions) {
+      long numLoadRebalanceThrottledPartitions, boolean rebalanceThrottledByErrorPartition) {
     ResourceMonitor resourceMonitor = getOrCreateResourceMonitor(resourceName);
 
     if (resourceMonitor != null) {
       resourceMonitor.updateRebalancerStats(numPendingRecoveryRebalancePartitions,
           numPendingLoadRebalancePartitions, numRecoveryRebalanceThrottledPartitions,
-          numLoadRebalanceThrottledPartitions);
+          numLoadRebalanceThrottledPartitions, rebalanceThrottledByErrorPartition);
     }
   }
 
@@ -1118,6 +1118,15 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     long total = 0;
     for (Map.Entry<String, ResourceMonitor> entry : _resourceMonitorMap.entrySet()) {
       total += entry.getValue().getNumPendingStateTransitionGauge();
+    }
+    return total;
+  }
+
+  @Override
+  public long getRebalanceThrottledByErrorPartition() {
+    long total = 0;
+    for (Map.Entry<String, ResourceMonitor> entry : _resourceMonitorMap.entrySet()) {
+      total += entry.getValue().getRebalanceThrottledByErrorPartition();
     }
     return total;
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -36,6 +36,7 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider;
@@ -937,7 +938,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     }
   }
 
-  // For test only
+  @VisibleForTesting
   protected ResourceMonitor getResourceMonitor(String resourceName) {
     return _resourceMonitorMap.get(resourceName);
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -1122,7 +1122,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   }
 
   @Override
-  public long getRebalanceThrottledByErrorPartitionGauge() {
+  public long getNumOfResourcesRebalanceThrottledGauge() {
     long total = 0;
     for (Map.Entry<String, ResourceMonitor> entry : _resourceMonitorMap.entrySet()) {
       total += entry.getValue().getRebalanceThrottledByErrorPartitionGauge();

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -585,13 +585,13 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
 
   public void updateRebalancerStats(String resourceName, long numPendingRecoveryRebalancePartitions,
       long numPendingLoadRebalancePartitions, long numRecoveryRebalanceThrottledPartitions,
-      long numLoadRebalanceThrottledPartitions, boolean rebalanceThrottledByErrorPartition) {
+      long numLoadRebalanceThrottledPartitions, boolean rebalanceThrottledByErrorPartitions) {
     ResourceMonitor resourceMonitor = getOrCreateResourceMonitor(resourceName);
 
     if (resourceMonitor != null) {
       resourceMonitor.updateRebalancerStats(numPendingRecoveryRebalancePartitions,
           numPendingLoadRebalancePartitions, numRecoveryRebalanceThrottledPartitions,
-          numLoadRebalanceThrottledPartitions, rebalanceThrottledByErrorPartition);
+          numLoadRebalanceThrottledPartitions, rebalanceThrottledByErrorPartitions);
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -36,7 +36,6 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider;
@@ -938,8 +937,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     }
   }
 
-  @VisibleForTesting
-  protected ResourceMonitor getResourceMonitor(String resourceName) {
+  public ResourceMonitor getResourceMonitor(String resourceName) {
     return _resourceMonitorMap.get(resourceName);
   }
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -1122,10 +1122,10 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   }
 
   @Override
-  public long getRebalanceThrottledByErrorPartition() {
+  public long getRebalanceThrottledByErrorPartitionGauge() {
     long total = 0;
     for (Map.Entry<String, ResourceMonitor> entry : _resourceMonitorMap.entrySet()) {
-      total += entry.getValue().getRebalanceThrottledByErrorPartition();
+      total += entry.getValue().getRebalanceThrottledByErrorPartitionGauge();
     }
     return total;
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -146,5 +146,5 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
    * @return number of resources will only do downward state transition because the number of ERROR
    * state partition is larger than configured threshold (default is 1).
    */
-  long getRebalanceThrottledByErrorPartitionGauge();
+  long getNumOfResourcesRebalanceThrottledGauge();
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -141,4 +141,10 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
    * @return number of pending state transitions in this cluster
    */
   long getPendingStateTransitionGuage();
+
+  /**
+   * @return number of resources will only do downward state transition because the number of ERROR
+   * state partition is larger than configured threshold (default is 1).
+   */
+  long getRebalanceThrottledByErrorPartition();
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -146,5 +146,5 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
    * @return number of resources will only do downward state transition because the number of ERROR
    * state partition is larger than configured threshold (default is 1).
    */
-  long getRebalanceThrottledByErrorPartition();
+  long getRebalanceThrottledByErrorPartitionGauge();
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -65,7 +65,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   private SimpleDynamicMetric<Long> _numRecoveryRebalanceThrottledReplicas;
   private SimpleDynamicMetric<Long> _numLoadRebalanceThrottledReplicas;
   private SimpleDynamicMetric<Long> _numPendingStateTransitions;
-  private SimpleDynamicMetric<Long> _rebalanceThrottledByErrorPartition;
+  private SimpleDynamicMetric<Long> _rebalanceThrottledByErrorPartitionGauge;
 
   // Counters
   private SimpleDynamicMetric<Long> _successfulTopStateHandoffDurationCounter;
@@ -129,7 +129,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     _numOfPartitionsInExternalView = new SimpleDynamicMetric("ExternalViewPartitionGauge", 0L);
     _numOfPartitions = new SimpleDynamicMetric("PartitionGauge", 0L);
     _numPendingStateTransitions = new SimpleDynamicMetric("PendingStateTransitionGauge", 0L);
-    _rebalanceThrottledByErrorPartition =
+    _rebalanceThrottledByErrorPartitionGauge =
         new SimpleDynamicMetric("RebalanceThrottledByErrorPartitionGauge", 0L);
 
     _partitionTopStateHandoffDurationGauge =
@@ -379,7 +379,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     _numPendingLoadRebalanceReplicas.updateValue(numPendingLoadRebalancePartitions);
     _numRecoveryRebalanceThrottledReplicas.updateValue(numRecoveryRebalanceThrottledPartitions);
     _numLoadRebalanceThrottledReplicas.updateValue(numLoadRebalanceThrottledPartitions);
-    _rebalanceThrottledByErrorPartition.updateValue(rebalanceThrottledByErrorPartitio? 1L : 0L);
+    _rebalanceThrottledByErrorPartitionGauge.updateValue(rebalanceThrottledByErrorPartitio? 1L : 0L);
   }
 
   /**
@@ -452,8 +452,8 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     return _rebalanceState.getValue();
   }
 
-  public long getRebalanceThrottledByErrorPartition() {
-    return _rebalanceThrottledByErrorPartition.getValue();
+  public long getRebalanceThrottledByErrorPartitionGauge() {
+    return _rebalanceThrottledByErrorPartitionGauge.getValue();
   }
 
   public void resetMaxTopStateHandoffGauge() {
@@ -475,13 +475,19 @@ public class ResourceMonitor extends DynamicMBeanProvider {
         _numPendingLoadRebalanceReplicas,
         _numRecoveryRebalanceThrottledReplicas,
         _numLoadRebalanceThrottledReplicas,
-        _externalViewIdealStateDiff, _successfulTopStateHandoffDurationCounter,
-        _successTopStateHandoffCounter, _failedTopStateHandoffCounter,
-        _maxSinglePartitionTopStateHandoffDuration, _partitionTopStateHandoffDurationGauge,
+        _externalViewIdealStateDiff,
+        _successfulTopStateHandoffDurationCounter,
+        _successTopStateHandoffCounter,
+        _failedTopStateHandoffCounter,
+        _maxSinglePartitionTopStateHandoffDuration,
+        _partitionTopStateHandoffDurationGauge,
         _partitionTopStateHandoffHelixLatencyGauge,
-        _partitionTopStateNonGracefulHandoffDurationGauge, _totalMessageReceived,
-        _totalMessageReceivedCounter, _numPendingStateTransitions, _rebalanceState,
-        _rebalanceThrottledByErrorPartition);
+        _partitionTopStateNonGracefulHandoffDurationGauge,
+        _totalMessageReceived,
+        _totalMessageReceivedCounter,
+        _numPendingStateTransitions,
+        _rebalanceState,
+        _rebalanceThrottledByErrorPartitionGauge);
 
     attributeList.addAll(_dynamicCapacityMetricsMap.values());
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -374,12 +374,12 @@ public class ResourceMonitor extends DynamicMBeanProvider {
 
   public void updateRebalancerStats(long numPendingRecoveryRebalancePartitions,
       long numPendingLoadRebalancePartitions, long numRecoveryRebalanceThrottledPartitions,
-      long numLoadRebalanceThrottledPartitions, boolean rebalanceThrottledByErrorPartitio) {
+      long numLoadRebalanceThrottledPartitions, boolean rebalanceThrottledByErrorPartitions) {
     _numPendingRecoveryRebalanceReplicas.updateValue(numPendingRecoveryRebalancePartitions);
     _numPendingLoadRebalanceReplicas.updateValue(numPendingLoadRebalancePartitions);
     _numRecoveryRebalanceThrottledReplicas.updateValue(numRecoveryRebalanceThrottledPartitions);
     _numLoadRebalanceThrottledReplicas.updateValue(numLoadRebalanceThrottledPartitions);
-    _rebalanceThrottledByErrorPartitionGauge.updateValue(rebalanceThrottledByErrorPartitio? 1L : 0L);
+    _rebalanceThrottledByErrorPartitionGauge.updateValue(rebalanceThrottledByErrorPartitions? 1L : 0L);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
@@ -269,10 +269,10 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
     IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
 
 
-    // Validate that there are 2 resourced load balance been throttled
+    // Validate that there are 0 resourced load balance been throttled
     ClusterStatusMonitor clusterStatusMonitor =
         event.getAttribute(AttributeName.clusterStatusMonitor.name());
-    Assert.assertEquals(clusterStatusMonitor.getRebalanceThrottledByErrorPartitionGauge(), 0);
+    Assert.assertEquals(clusterStatusMonitor.getNumOfResourcesRebalanceThrottledGauge(), 0);
     Assert.assertEquals(clusterStatusMonitor.getResourceMonitor("resource_0")
         .getRebalanceThrottledByErrorPartitionGauge(), 0);
 
@@ -390,7 +390,7 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
     // Validate that there are 2 resourced load balance been throttled
     ClusterStatusMonitor clusterStatusMonitor =
         event.getAttribute(AttributeName.clusterStatusMonitor.name());
-    Assert.assertEquals(clusterStatusMonitor.getRebalanceThrottledByErrorPartitionGauge(), 2);
+    Assert.assertEquals(clusterStatusMonitor.getNumOfResourcesRebalanceThrottledGauge(), 2);
     Assert.assertEquals(clusterStatusMonitor.getResourceMonitor("resource_0")
         .getRebalanceThrottledByErrorPartitionGauge(), 1);
     Assert.assertEquals(clusterStatusMonitor.getResourceMonitor("resource_1")

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
@@ -31,6 +31,7 @@ import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Partition;
+import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -263,6 +264,121 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
     runStage(event, new IntermediateStateCalcStage());
 
     IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+
+    for (String resource : resources) {
+      // Note Assert.assertEquals won't work. If "actual" is an empty map, it won't compare
+      // anything.
+      Assert.assertEquals(output.getPartitionStateMap(resource).getStateMap(),
+          expectedResult.getPartitionStateMap(resource).getStateMap());
+    }
+  }
+
+  @Test
+  public void testThrottleByErrorPartition() {
+    String resourcePrefix = "resource";
+    int nResource = 3;
+    int nPartition = 3;
+    int nReplica = 3;
+
+    String[] resources = new String[nResource];
+    for (int i = 0; i < nResource; i++) {
+      resources[i] = resourcePrefix + "_" + i;
+    }
+
+    preSetup(resources, nReplica, nReplica);
+    event.addAttribute(AttributeName.RESOURCES.name(),
+        getResourceMap(resources, nPartition, "OnlineOffline"));
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(),
+        getResourceMap(resources, nPartition, "OnlineOffline"));
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor(_clusterName);
+    monitor.active();
+    event.addAttribute(AttributeName.clusterStatusMonitor.name(), monitor);
+
+    // Initialize best possible state and current state
+    BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
+    MessageOutput messageSelectOutput = new MessageOutput();
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    IntermediateStateOutput expectedResult = new IntermediateStateOutput();
+
+    _clusterConfig.setErrorOrRecoveryPartitionThresholdForLoadBalance(0);
+    setClusterConfig(_clusterConfig);
+
+    for (String resource : resources) {
+      IdealState is = accessor.getProperty(accessor.keyBuilder().idealStates(resource));
+      setSingleIdealState(is);
+
+      Map<String, List<String>> partitionMap = new HashMap<>();
+      for (int p = 0; p < nPartition; p++) {
+        Partition partition = new Partition(resource + "_" + p);
+        for (int r = 0; r < nReplica; r++) {
+          String instanceName = HOSTNAME_PREFIX + r;
+          partitionMap.put(partition.getPartitionName(), Collections.singletonList(instanceName));
+          // a resource with 2 replicas in error state and one need recovery in offline->online. error state
+          // throttle won't block recovery rebalance
+          if (resource.endsWith("0")) {
+            if (p <= 1) {
+              currentStateOutput.setCurrentState(resource, partition, instanceName, "ERROR");
+              bestPossibleStateOutput.setState(resource, partition, instanceName, "ERROR");
+              expectedResult.setState(resource, partition, instanceName, "ERROR");
+            } else {
+              currentStateOutput.setCurrentState(resource, partition, instanceName, "OFFLINE");
+              bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
+              expectedResult.setState(resource, partition, instanceName, "OFFLINE");
+              if (r == 0) {
+                messageSelectOutput.addMessage(resource, partition,
+                    generateMessage("OFFLINE", "ONLINE", instanceName));
+                expectedResult.setState(resource, partition, instanceName, "ONLINE");
+              }
+            }
+          } else if (resource.endsWith("1")) {
+            // a resource with 1 replicas in error state and one need load balance in offline->online. error state
+            // throttle will block load rebalance
+            if (p <= 0) {
+              currentStateOutput.setCurrentState(resource, partition, instanceName, "ERROR");
+              bestPossibleStateOutput.setState(resource, partition, instanceName, "ERROR");
+              expectedResult.setState(resource, partition, instanceName, "ERROR");
+            } else {
+              if (r == 0) {
+                currentStateOutput.setCurrentState(resource, partition, instanceName, "ONLINE");
+                bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
+                expectedResult.setState(resource, partition, instanceName, "ONLINE");
+              } else {
+                // even though there is ST msg, it should be throttled
+                currentStateOutput.setCurrentState(resource, partition, instanceName, "OFFLINE");
+                bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
+                messageSelectOutput.addMessage(resource, partition,
+                    generateMessage("OFFLINE", "ONLINE", instanceName));
+                expectedResult.setState(resource, partition, instanceName, "OFFLINE");
+              }
+            }
+          } else {
+            // Regular load balance
+            currentStateOutput.setCurrentState(resource, partition, instanceName, "ONLINE");
+            currentStateOutput.setCurrentState(resource, partition, instanceName + "-1", "OFFLINE");
+            bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
+            messageSelectOutput.addMessage(resource, partition,
+                generateMessage("OFFLINE", "DROPPED", instanceName + "-1"));
+            // should be recovered:
+            expectedResult.setState(resource, partition, instanceName, "ONLINE");
+          }
+        }
+      }
+      bestPossibleStateOutput.setPreferenceLists(resource, partitionMap);
+    }
+
+    event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.MESSAGES_SELECTED.name(), messageSelectOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new IntermediateStateCalcStage());
+
+    IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+
+    ClusterStatusMonitor clusterStatusMonitor =
+        event.getAttribute(AttributeName.clusterStatusMonitor.name());
+    Assert.assertEquals(clusterStatusMonitor.getRebalanceThrottledByErrorPartition(), 2);
 
     for (String resource : resources) {
       // Note Assert.assertEquals won't work. If "actual" is an empty map, it won't compare

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
@@ -313,7 +313,7 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
         for (int r = 0; r < nReplica; r++) {
           String instanceName = HOSTNAME_PREFIX + r;
           partitionMap.put(partition.getPartitionName(), Collections.singletonList(instanceName));
-          // a resource with 2 replicas in error state and one need recovery in offline->online. error state
+          // A resource with 2 replicas in error state and one need recovery in offline->online. error state
           // throttle won't block recovery rebalance
           if (resource.endsWith("0")) {
             if (p <= 1) {
@@ -331,7 +331,7 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
               }
             }
           } else if (resource.endsWith("1")) {
-            // a resource with 1 replicas in error state and one need load balance in offline->online. error state
+            // A resource with 1 replicas in error state and one need load balance in offline->online. error state
             // throttle will block load rebalance
             if (p <= 0) {
               currentStateOutput.setCurrentState(resource, partition, instanceName, "ERROR");
@@ -352,7 +352,7 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
               }
             }
           } else {
-            // Regular load balance
+            // A resource need regular load balance
             currentStateOutput.setCurrentState(resource, partition, instanceName, "ONLINE");
             currentStateOutput.setCurrentState(resource, partition, instanceName + "-1", "OFFLINE");
             bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
@@ -376,9 +376,16 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
 
     IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
 
+    // Validate that there are 2 resourced load balance been throttled
     ClusterStatusMonitor clusterStatusMonitor =
         event.getAttribute(AttributeName.clusterStatusMonitor.name());
     Assert.assertEquals(clusterStatusMonitor.getRebalanceThrottledByErrorPartition(), 2);
+    Assert.assertEquals(clusterStatusMonitor.getResourceMonitor("resource_0")
+        .getRebalanceThrottledByErrorPartition(), 1);
+    Assert.assertEquals(clusterStatusMonitor.getResourceMonitor("resource_1")
+        .getRebalanceThrottledByErrorPartition(), 1);
+    Assert.assertEquals(clusterStatusMonitor.getResourceMonitor("resource_2")
+        .getRebalanceThrottledByErrorPartition(), 0);
 
     for (String resource : resources) {
       // Note Assert.assertEquals won't work. If "actual" is an empty map, it won't compare

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
@@ -379,13 +379,13 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
     // Validate that there are 2 resourced load balance been throttled
     ClusterStatusMonitor clusterStatusMonitor =
         event.getAttribute(AttributeName.clusterStatusMonitor.name());
-    Assert.assertEquals(clusterStatusMonitor.getRebalanceThrottledByErrorPartition(), 2);
+    Assert.assertEquals(clusterStatusMonitor.getRebalanceThrottledByErrorPartitionGauge(), 2);
     Assert.assertEquals(clusterStatusMonitor.getResourceMonitor("resource_0")
-        .getRebalanceThrottledByErrorPartition(), 1);
+        .getRebalanceThrottledByErrorPartitionGauge(), 1);
     Assert.assertEquals(clusterStatusMonitor.getResourceMonitor("resource_1")
-        .getRebalanceThrottledByErrorPartition(), 1);
+        .getRebalanceThrottledByErrorPartitionGauge(), 1);
     Assert.assertEquals(clusterStatusMonitor.getResourceMonitor("resource_2")
-        .getRebalanceThrottledByErrorPartition(), 0);
+        .getRebalanceThrottledByErrorPartitionGauge(), 0);
 
     for (String resource : resources) {
       // Note Assert.assertEquals won't work. If "actual" is an empty map, it won't compare


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2341

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change adds metrics for rebalance throttled because of error partition. Including aggregated metrics for the whole cluster and per resource metrics. 

### Tests

- [X] The following tests are written for this issue:
TestIntermediateStateCalcStage.testThrottleByErrorPartition

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
