### PR TITLE
Added new metric to report real time missing top state for partition

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
@@ -322,8 +322,7 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
     String partitionName = partition.getPartitionName();
     MissingTopStateRecord record = missingTopStateMap.get(resourceName).get(partitionName);
     long startTime = record.getStartTimeStamp();
-    if (startTime > 0 && !record
-        .isFailed()) {
+    if (startTime > 0 && !record.isFailed()) {
       if (clusterStatusMonitor != null) {
         clusterStatusMonitor.updateMissingTopStateResourceMap(resourceName, partitionName, true, startTime);
       }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -744,8 +744,8 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       _continuousResourceRebalanceFailureCount.set(0L);
       _continuousTaskRebalanceFailureCount.set(0L);
       // No need to wait until this async thread finishes because interrupting it means stop reporting metric.
-      _asyncMissingTopStateMonitor.interrupt();
       _asyncMissingTopStateMonitor.reset();
+      _asyncMissingTopStateMonitor.interrupt();
     } catch (Exception e) {
       LOG.error("Fail to reset ClusterStatusMonitor, cluster: " + _clusterName, e);
     }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -99,7 +99,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
           }
         }
       } catch (InterruptedException e) {
-        LOG.error("AsyncMissingTopStateMonitor has been interrupted {}", e);
+        LOG.error("AsyncMissingTopStateMonitor has been interrupted.", e);
       }
     }
   };
@@ -739,6 +739,8 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       _rebalanceFailureCount.set(0L);
       _continuousResourceRebalanceFailureCount.set(0L);
       _continuousTaskRebalanceFailureCount.set(0L);
+      _asyncMissingTopStateMonitor.interrupt();
+      _missingTopStateResourceMap.clear();
     } catch (Exception e) {
       LOG.error("Fail to reset ClusterStatusMonitor, cluster: " + _clusterName, e);
     }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -94,6 +94,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
 
               }
             }
+            sleep(50); // Instead of providing stream of durtion values to histogram thread can sleep in between to save some CPU cycles.
           }
         }
       } catch (InterruptedException e) {

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -213,6 +213,10 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     return _totalMessageReceived.getValue();
   }
 
+  public long getSlidingWindowResetIntervalInMs() {
+    return getResetIntervalInMs();
+  }
+
   public HistogramDynamicMetric getMissingTopStateDurationGauge() {
     return _missingTopStateDurationGuage;
   }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestTopStateHandoffMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestTopStateHandoffMetrics.java
@@ -56,6 +56,7 @@ public class TestTopStateHandoffMetrics extends BaseStageTest {
   private static final String NON_GRACEFUL_HANDOFF_DURATION = "PartitionTopStateNonGracefulHandoffGauge.Max";
   private static final String GRACEFUL_HANDOFF_DURATION = "PartitionTopStateHandoffDurationGauge.Max";
   private static final String HANDOFF_HELIX_LATENCY = "PartitionTopStateHandoffHelixLatencyGauge.Max";
+  private static final String MISSING_TOP_STATE_DURATION = "MissingTopStateDurationGauge.Max";
   private static final Range<Long> DURATION_ZERO = Range.closed(0L, 0L);
   private TestConfig config;
 
@@ -454,7 +455,7 @@ public class TestTopStateHandoffMetrics extends BaseStageTest {
       MissingStatesDataCacheInject inject,
       int successCnt,
       int failCnt,
-      int oneOrManyPartitionsMissingTopStateCnt,
+      long missingTopStateDuration,
       Range<Long> expectedDuration,
       Range<Long> expectedNonGracefulDuration,
       Range<Long> expectedMaxDuration,
@@ -470,7 +471,9 @@ public class TestTopStateHandoffMetrics extends BaseStageTest {
     Assert.assertEquals(monitor.getSucceededTopStateHandoffCounter(), successCnt);
     Assert.assertEquals(monitor.getFailedTopStateHandoffCounter(), failCnt);
 
-    Assert.assertTrue(monitor.getOneOrManyPartitionsMissingTopStateRealTimeGuage() >= oneOrManyPartitionsMissingTopStateCnt);
+    long duration = monitor.getMissingTopStateDurationGauge()
+        .getAttributeValue(MISSING_TOP_STATE_DURATION).longValue();
+    Assert.assertTrue(duration >= missingTopStateDuration);
 
     long graceful = monitor.getPartitionTopStateHandoffDurationGauge()
         .getAttributeValue(GRACEFUL_HANDOFF_DURATION).longValue();


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixes #2345 : Adds a new metric to report real time missing top state for any partition for each resource in a cluster.

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description
Issue :
Currently, if waged rebalancer is used then there could be a situation where multiple leader replicas are residing on same node. If that node goes down for maintainence or for any other reason then there is no current metric which reports about missing top state until any rebalancer event is triggered. 

Ask :
Ask here is to add a metric which satisfies following conditions :
1. The metric should be at resource level and should be reported irrespective of top state replica is recovered or not for any partition of that resource.
2. This metric should be started as soon as "any" partition for a resource has top state missing and it should be "reset" only when that resource has no partition with missing top state.

Solution :
The solution proposed in this PR starts a async thread as soon as first partition of any resource has top state missing and it continuously reports missing top state duration (atleast once in sliding window interval) for partitions at resource level as long as that resource has "at least one" partition with missing top state. If there are no resources with any partitions with missing top state then this async thread will sleep.
The guage reported by this thread is histogram which won't give exact values but will approximate about duration increasing and will be reset when all top state replicas for that resource are recovered. 


- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

### Tests

- [X ] The following tests are written for this issue:

CI pipeline and added new tests for verifying metrics.

```
mvn test -Dtest=TestTopStateHandoffMetrics
[WARNING] Tests run: 12, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 18.723 s - in org.apache.helix.monitoring.mbeans.TestTopStateHandoffMetrics
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 12, Failures: 0, Errors: 0, Skipped: 1

```

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

CI is failing with helix-rest tests. Verified locally that tests are running
Failing test results : 
```
2023-01-19T10:12:27.2107893Z [info] ./metadata-store-directory-common/target/surefire-reports/TestSuite.txt: Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.633 s - in TestSuite
2023-01-19T10:12:27.2108983Z [info] ./helix-core/target/surefire-reports/TestSuite.txt: Tests run: 1322, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 5,906.49 s - in TestSuite
2023-01-19T10:12:27.2110115Z [info] ./helix-view-aggregator/target/surefire-reports/TestSuite.txt: Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 100.176 s - in TestSuite
2023-01-19T10:12:27.2110941Z [info] ./recipes/distributed-lock-manager/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.492 s - in TestSuite
2023-01-19T10:12:27.2111791Z [info] ./recipes/rabbitmq-consumer-group/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.692 s - in TestSuite
2023-01-19T10:12:27.2112591Z [info] ./recipes/task-execution/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.534 s - in TestSuite
2023-01-19T10:12:27.2113368Z [info] ./recipes/service-discovery/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.63 s - in TestSuite
2023-01-19T10:12:27.2114188Z [info] ./recipes/rsync-replicated-file-system/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.582 s - in TestSuite
2023-01-19T10:12:27.2114980Z [info] ./helix-lock/target/surefire-reports/TestSuite.txt: Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 55.692 s - in TestSuite
2023-01-19T10:12:27.2115716Z [info] ./metrics-common/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.372 s - in TestSuite
2023-01-19T10:12:27.2116463Z [info] ./zookeeper-api/target/surefire-reports/TestSuite.txt: Tests run: 82, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 152.431 s - in TestSuite
2023-01-19T10:12:27.2117226Z [info] ./helix-rest/target/surefire-reports/TestSuite.txt: Tests run: 209, Failures: 1, Errors: 0, Skipped: 18, Time elapsed: 151.752 s <<< FAILURE! - in TestSuite
2023-01-19T10:12:27.2144940Z ##[error] Test failed: testActivateSuperCluster(org.apache.helix.rest.server.TestClusterAccessor)  Time elapsed: 8.741 s  <<< FAILURE!
2023-01-19T10:12:27.2146629Z [info] ./helix-common/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.264 s - in TestSuite

```

Verified locally :
```
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 208.189 s - in org.apache.helix.rest.server.TestClusterAccessor
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0
[INFO]
```
### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
