### PR TITLE
Create adapter package for data and child change listener and prepare zkclient

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/ChildListenerAdapter.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/ChildListenerAdapter.java
@@ -1,0 +1,75 @@
+package org.apache.helix.metaclient.impl.zk.adapter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+import org.apache.helix.metaclient.api.ChildChangeListener;
+import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+import org.apache.zookeeper.Watcher;
+
+
+/**
+ * A adapter class to transform {@link ChildChangeListener} to {@link IZkChildListener}.
+ */
+public class ChildListenerAdapter implements IZkChildListener {
+  private final ChildChangeListener _listener;
+
+  public ChildListenerAdapter(ChildChangeListener listener) {
+    _listener = listener;
+  }
+
+  @Override
+  public void handleChildChange(String parentPath, List<String> currentChilds) throws Exception {
+    throw new UnsupportedOperationException("handleChildChange(String parentPath, List<String> currentChilds) "
+        + "is not supported");
+  }
+
+  @Override
+  public void handleChildChange(String parentPath, List<String> currentChilds, Watcher.Event.EventType eventType)
+      throws Exception {
+    _listener.handleChildChange(parentPath, convertType(eventType));
+  }
+
+  private static ChildChangeListener.ChangeType convertType(Watcher.Event.EventType eventType) {
+    switch (eventType) {
+      case NodeCreated: return ChildChangeListener.ChangeType.ENTRY_CREATED;
+      case NodeChildrenChanged: return ChildChangeListener.ChangeType.ENTRY_DATA_CHANGE;
+      case NodeDeleted: return ChildChangeListener.ChangeType.ENTRY_DELETED;
+      default: throw new IllegalArgumentException("EventType " + eventType + " is not supported.");
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ChildListenerAdapter that = (ChildListenerAdapter) o;
+    return _listener.equals(that._listener);
+  }
+
+  @Override
+  public int hashCode() {
+    return _listener.hashCode();
+  }
+}

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/DataListenerAdapter.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/DataListenerAdapter.java
@@ -1,0 +1,77 @@
+package org.apache.helix.metaclient.impl.zk.adapter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.metaclient.api.DataChangeListener;
+import org.apache.helix.zookeeper.zkclient.IZkDataListener;
+import org.apache.zookeeper.Watcher;
+
+
+/**
+ * A Adapter class to transform {@link DataChangeListener} to {@link IZkDataListener}
+ */
+public class DataListenerAdapter implements IZkDataListener {
+  private final DataChangeListener _listener;
+
+  public DataListenerAdapter(DataChangeListener listener) {
+    _listener = listener;
+  }
+
+  @Override
+  public void handleDataChange(String dataPath, Object data) throws Exception {
+    throw new UnsupportedOperationException("handleDataChange(String dataPath, Object data) is not supported.");
+  }
+
+  @Override
+  public void handleDataDeleted(String dataPath) throws Exception {
+    handleDataChange(dataPath, null, Watcher.Event.EventType.NodeDeleted);
+  }
+
+  @Override
+  public void handleDataChange(String dataPath, Object data, Watcher.Event.EventType eventType) throws Exception {
+    _listener.handleDataChange(dataPath, data, convertType(eventType));
+  }
+
+  private static DataChangeListener.ChangeType convertType(Watcher.Event.EventType eventType) {
+    switch (eventType) {
+      case NodeCreated: return DataChangeListener.ChangeType.ENTRY_CREATED;
+      case NodeDataChanged: return DataChangeListener.ChangeType.ENTRY_UPDATE;
+      case NodeDeleted: return DataChangeListener.ChangeType.ENTRY_DELETED;
+      default: throw new IllegalArgumentException("EventType " + eventType + " is not supported.");
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DataListenerAdapter that = (DataListenerAdapter) o;
+    return _listener.equals(that._listener);
+  }
+
+  @Override
+  public int hashCode() {
+    return _listener.hashCode();
+  }
+}

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkChildListener.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkChildListener.java
@@ -20,6 +20,8 @@ package org.apache.helix.zookeeper.zkclient;
  */
 
 import java.util.List;
+import org.apache.zookeeper.Watcher;
+
 
 /**
  * An {@link IZkChildListener} can be registered at a {@link ZkClient} for listening on zk child changes for a given
@@ -42,4 +44,9 @@ public interface IZkChildListener {
      * @throws Exception
      */
     public void handleChildChange(String parentPath, List<String> currentChilds) throws Exception;
+
+    default void handleChildChange(String parentPath, List<String> currentChilds, Watcher.Event.EventType eventType)
+        throws Exception {
+        handleChildChange(parentPath, currentChilds);
+    }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkChildListener.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkChildListener.java
@@ -45,6 +45,14 @@ public interface IZkChildListener {
      */
     public void handleChildChange(String parentPath, List<String> currentChilds) throws Exception;
 
+    /**
+     * Called when the children of the given path changed.
+     *
+     * @param parentPath The parent path
+     * @param currentChilds The children or null if the root node (parent path) was deleted.
+     * @param eventType The zookeeper event type
+     * @throws Exception
+     */
     default void handleChildChange(String parentPath, List<String> currentChilds, Watcher.Event.EventType eventType)
         throws Exception {
         handleChildChange(parentPath, currentChilds);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1316,7 +1316,7 @@ public class ZkClient implements Watcher {
   private void fireAllEvents(WatchedEvent event) {
     //TODO: During handling new session, if the path is deleted, watcher leakage could still happen
     for (Entry<String, Set<IZkChildListener>> entry : _childListener.entrySet()) {
-      fireChildChangedEvents(entry.getKey(), entry.getValue(), true);
+      fireChildChangedEvents(entry.getKey(), entry.getValue(), true, event.getType());
     }
     for (Entry<String, Set<IZkDataListenerEntry>> entry : _dataListener.entrySet()) {
       fireDataChangedEvents(entry.getKey(), entry.getValue(), OptionalLong.empty(), true, event.getType());
@@ -1758,7 +1758,7 @@ public class ZkClient implements Watcher {
       if (childListeners != null && !childListeners.isEmpty()) {
         // TODO recording child changed event propagation latency as well. Note this change will
         // introduce additional ZK access.
-        fireChildChangedEvents(path, childListeners, pathExists);
+        fireChildChangedEvents(path, childListeners, pathExists, event.getType());
       }
     }
 
@@ -1826,7 +1826,8 @@ public class ZkClient implements Watcher {
     }
   }
 
-  private void fireChildChangedEvents(final String path, Set<IZkChildListener> childListeners, boolean pathExists) {
+  private void fireChildChangedEvents(final String path, Set<IZkChildListener> childListeners, boolean pathExists,
+      EventType eventType) {
     try {
       final ZkPathStatRecord pathStatRecord = new ZkPathStatRecord(path);
       for (final IZkChildListener listener : childListeners) {
@@ -1853,7 +1854,7 @@ public class ZkClient implements Watcher {
                 // Continue trigger the change handler
               }
             }
-            listener.handleChildChange(path, children);
+            listener.handleChildChange(path, children, eventType);
           }
         });
       }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Prepare zkclient and implement new adapter for child change listener.
**The real implementation of child change listener in meta-client is left for future PR.**

Similar as https://github.com/apache/helix/pull/2333, this PR adds a new default method in `IZkChildListener` to make it applicable to be used in meta-client. Implement a adapter class that bridges the old and new listener interface.
Move previous inner converter class to separate module. 

### Tests

- [X] The following tests are written for this issue:

Change in zookeeper-api and meta-client are both backward compatible, covered by existing tests.


- The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 67, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1,044.795 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 67, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ zookeeper-api ---
[INFO] Loading execution data file /Users/qqu/workspace/qqu-helix/zookeeper-api/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: ZooKeeper API' with 116 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  17:40 min
[INFO] Finished at: 2023-01-20T11:36:57-05:00
[INFO] ------------------------------------------------------------------------

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
