### PR TITLE
Implement direct child change listener in ZkMetaClient

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/DirectChildListenerAdapter.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/DirectChildListenerAdapter.java
@@ -32,7 +32,7 @@ public class DirectChildListenerAdapter implements IZkChildListener {
   }
 
   @Override
-  public void handleChildChange(String parentPath, List<String> currentChilds) throws Exception {
+  public void handleChildChange(String parentPath, List<String> currentChildren) throws Exception {
     _listener.handleDirectChildChange(parentPath);
   }
 

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/DirectChildListenerAdapter.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/DirectChildListenerAdapter.java
@@ -1,0 +1,55 @@
+package org.apache.helix.metaclient.impl.zk.adapter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+import org.apache.helix.metaclient.api.DirectChildChangeListener;
+import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+
+
+public class DirectChildListenerAdapter implements IZkChildListener {
+  private final DirectChildChangeListener _listener;
+
+  public DirectChildListenerAdapter(DirectChildChangeListener listener) {
+    _listener = listener;
+  }
+
+  @Override
+  public void handleChildChange(String parentPath, List<String> currentChilds) throws Exception {
+    _listener.handleDirectChildChange(parentPath);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DirectChildListenerAdapter that = (DirectChildListenerAdapter) o;
+    return _listener.equals(that._listener);
+  }
+
+  @Override
+  public int hashCode() {
+    return _listener.hashCode();
+  }
+}


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
N.A.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR implements the direct child change listener in ZkMetaClient using the native ZkClient.

There is a known issue with the native zkclient in use where it's not providing real persistent listener functionalities, and event might be lost. This will be tracked and fixed in separate PRs.

### Tests

- [X] The following tests are written for this issue:

New test in `TestZkMetaClient`

- The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 117.143 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ meta-client ---
[INFO] Loading execution data file /Users/qqu/workspace/qqu-helix/meta-client/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Meta Client' with 40 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:08 min
[INFO] Finished at: 2023-01-27T10:53:44-05:00
[INFO] ------------------------------------------------------------------------

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
