### PR TITLE
Implement zk Meta client async crud

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/AsyncCallback.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/AsyncCallback.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
  */
 // TODO: define return code. failure code should map to MetaClient exceptions.
 public interface AsyncCallback {
+
   //This callback is used when stat object is returned from the operation.
   interface StatCallback extends AsyncCallback {
     /**

--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/AsyncCallback.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/AsyncCallback.java
@@ -28,7 +28,6 @@ import javax.annotation.Nullable;
  * The corresponding callback is registered when async CRUD API is invoked. Implementation processes
  * the result of each CRUD call. It should check return code and perform accordingly.
  */
-// TODO: define return code. failure code should map to MetaClient exceptions.
 public interface AsyncCallback {
 
   //This callback is used when stat object is returned from the operation.

--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -515,9 +515,23 @@ public interface MetaClientInterface<T> {
    */
   boolean waitUntilExists(String key, TimeUnit timeUnit, long timeOut);
 
-  public byte[] serialize(T data, String path);
+  /**
+   * Serialize the data in type T to a byte array. This function can be used in API that returns or
+   * has input value in byte array format.
+   * @param data to be serialized.
+   * @param path timeout unit
+   * @return
+   */
+   byte[] serialize(T data, String path);
 
-  public T deserialize(byte[] bytes, String path);
+  /**
+   * Serialize a byte array to data in type T. This function can be used in API that returns or
+   * has input value in byte array format.
+   * @param bytes to be deserialized.
+   * @param path timeout unit
+   * @return
+   */
+   T deserialize(byte[] bytes, String path);
 
   // TODO: Secure CRUD APIs
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -515,5 +515,9 @@ public interface MetaClientInterface<T> {
    */
   boolean waitUntilExists(String key, TimeUnit timeUnit, long timeOut);
 
+  public byte[] serialize(T data, String path);
+
+  public T deserialize(byte[] bytes, String path);
+
   // TODO: Secure CRUD APIs
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/ZkMetaClientSetCallbackHandler.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/ZkMetaClientSetCallbackHandler.java
@@ -1,0 +1,42 @@
+package org.apache.helix.metaclient.impl.zk.adapter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.metaclient.api.AsyncCallback;
+import org.apache.helix.metaclient.api.MetaClientInterface;
+import org.apache.helix.metaclient.impl.zk.util.ZkMetaClientUtil;
+import org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks;
+
+
+public class ZkMetaClientSetCallbackHandler extends ZkAsyncCallbacks.SetDataCallbackHandler {
+  AsyncCallback.StatCallback userCallback;
+
+  public ZkMetaClientSetCallbackHandler(AsyncCallback.StatCallback cb) {
+    userCallback = cb;
+  }
+
+  @Override
+  public void handle() {
+    userCallback.processResult(getRc(), getPath(), getStat() == null ? null
+        : new MetaClientInterface.Stat(
+            ZkMetaClientUtil.convertZkEntryModeToMetaClientEntryMode(getStat().getEphemeralOwner()),
+            getStat().getVersion()));
+  }
+}

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -27,6 +27,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.helix.metaclient.api.DataUpdater;
+import org.apache.helix.metaclient.api.MetaClientInterface;
+import org.apache.helix.metaclient.exception.MetaClientException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.metaclient.api.DataUpdater;
 import org.apache.helix.metaclient.api.DirectChildChangeListener;
@@ -55,7 +62,7 @@ import static org.apache.helix.metaclient.api.MetaClientInterface.EntryMode.CONT
 import static org.apache.helix.metaclient.api.MetaClientInterface.EntryMode.PERSISTENT;
 
 
-public class TestZkMetaClient {
+public class TestZkMetaClient extends ZkMetaClientTestBase{
 
   private static final String ZK_ADDR = "localhost:2183";
   private static final int DEFAULT_TIMEOUT_MS = 1000;
@@ -115,7 +122,7 @@ public class TestZkMetaClient {
       Assert.assertNotNull(zkMetaClient.exists(key));
     }
   }
-  
+
   @Test
   public void testGet() {
     final String key = "/TestZkMetaClient_testGet";
@@ -350,37 +357,6 @@ public class TestZkMetaClient {
       zkMetaClient.create(basePath + "/child_3", "test-data");
       Assert.assertTrue(countDownLatch.await(5000, TimeUnit.MILLISECONDS));
     }
-  }
-
-  // TODO: Create a ZkMetadata test base class and move these helper to base class when more tests
-  // are added.
-  private static ZkMetaClient<String> createZkMetaClient() {
-    ZkMetaClientConfig config =
-        new ZkMetaClientConfig.ZkMetaClientConfigBuilder().setConnectionAddress(ZK_ADDR).build();
-    return new ZkMetaClient<>(config);
-  }
-
-  private static ZkServer startZkServer(final String zkAddress) {
-    String zkDir = zkAddress.replace(':', '_');
-    final String logDir = "/tmp/" + zkDir + "/logs";
-    final String dataDir = "/tmp/" + zkDir + "/dataDir";
-
-    // Clean up local directory
-    try {
-      FileUtils.deleteDirectory(new File(dataDir));
-      FileUtils.deleteDirectory(new File(logDir));
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-
-    IDefaultNameSpace defaultNameSpace = zkClient -> {
-    };
-
-    int port = Integer.parseInt(zkAddress.substring(zkAddress.lastIndexOf(':') + 1));
-    System.out.println("Starting ZK server at " + zkAddress);
-    ZkServer zkServer = new ZkServer(dataDir, logDir, defaultNameSpace, port);
-    zkServer.start();
-    return zkServer;
   }
 
   /**

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -72,31 +72,6 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
 
   private final Object _syncObject = new Object();
 
-
-  private ZkServer _zkServer;
-
-  /**
-   * Creates local Zk Server
-   * Note: Cannot test container / TTL node end to end behavior as
-   * the zk server setup doesn't allow for that. To enable this, zk server
-   * setup must invoke ContainerManager.java. However, the actual
-   * behavior has been verified to work on native ZK Client.
-   * TODO: Modify zk server setup to include ContainerManager.
-   * This can be done through ZooKeeperServerMain.java or
-   * LeaderZooKeeperServer.java.
-   */
-  @BeforeClass
-  public void prepare() {
-    System.setProperty("zookeeper.extendedTypesEnabled", "true");
-    // start local zookeeper server
-    _zkServer = startZkServer(ZK_ADDR);
-  }
-
-  @AfterClass
-  public void cleanUp() {
-    _zkServer.shutdown();
-  }
-
   @Test
   public void testCreate() {
     final String key = "/TestZkMetaClient_testCreate";

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClientAsyncOperations.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClientAsyncOperations.java
@@ -1,0 +1,231 @@
+package org.apache.helix.metaclient.impl.zk;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.annotation.Nullable;
+
+import org.apache.helix.metaclient.api.AsyncCallback;
+import org.apache.helix.metaclient.api.MetaClientInterface;
+import org.apache.zookeeper.KeeperException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestZkMetaClientAsyncOperations extends ZkMetaClientTestBase {
+
+  static TestAsyncContext[] asyncContext = new TestAsyncContext[1];
+  static final String entryKey = "/TestAsyncEntryKey";
+  static final String nonExistsEntry = "/a/b/c";
+
+  static class TestAsyncContext {
+    int _asyncCallSize;
+    CountDownLatch _countDownLatch;
+    int[] _returnCode;
+    MetaClientInterface.Stat[] _stats;
+    String[] _data;
+
+    TestAsyncContext(int callSize) {
+      _asyncCallSize = callSize;
+      _countDownLatch = new CountDownLatch(callSize);
+      _returnCode = new int[callSize];
+      _stats = new MetaClientInterface.Stat[callSize];
+      _data = new String[callSize];
+    }
+
+    public CountDownLatch getCountDownLatch() {
+      return _countDownLatch;
+    }
+
+    public void countDown() {
+      _countDownLatch.countDown();
+    }
+
+    public int getReturnCode(int idx) {
+      return _returnCode[idx];
+    }
+
+    public MetaClientInterface.Stat getStats(int idx) {
+      return _stats[idx];
+    }
+
+    public String getData(int idx) {
+      return _data[idx];
+    }
+
+    public void setReturnCodeWhenFinished(int idx, int returnCode) {
+      _returnCode[idx] = returnCode;
+    }
+
+    public void setStatWhenFinished(int idx, MetaClientInterface.Stat stat) {
+      _stats[idx] = stat;
+    }
+
+    public void setDataWhenFinished(int idx, String data) {
+      _data[idx] = data;
+    }
+  }
+
+  @Test
+  public void testAsyncCreateSetAndGet() {
+    asyncContext[0] = new TestAsyncContext(2);
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      zkMetaClient.connect();
+
+      zkMetaClient
+          .asyncCreate(entryKey, "async_create-data", MetaClientInterface.EntryMode.PERSISTENT,
+              new AsyncCallback.VoidCallback() {
+                @Override
+                public void processResult(int returnCode, String key) {
+                  asyncContext[0].setReturnCodeWhenFinished(0, returnCode);
+                  asyncContext[0].countDown();
+                }
+              });
+
+      zkMetaClient.asyncCreate(nonExistsEntry, "async_create-data-invalid",
+          MetaClientInterface.EntryMode.PERSISTENT, new AsyncCallback.VoidCallback() {
+            @Override
+            public void processResult(int returnCode, String key) {
+              asyncContext[0].setReturnCodeWhenFinished(1, returnCode);
+              asyncContext[0].countDown();
+            }
+          });
+
+      asyncContext[0].getCountDownLatch().await();
+
+      Assert.assertEquals(asyncContext[0].getReturnCode(0), KeeperException.Code.OK.intValue());
+      Assert.assertEquals(asyncContext[0].getReturnCode(1), KeeperException.Code.NONODE.intValue());
+
+      // create the entry again and expect a duplicated error code
+      asyncContext[0] = new TestAsyncContext(1);
+      zkMetaClient
+          .asyncCreate(entryKey, "async_create-data", MetaClientInterface.EntryMode.PERSISTENT,
+              new AsyncCallback.VoidCallback() {
+                @Override
+                public void processResult(int returnCode, String key) {
+                  asyncContext[0].setReturnCodeWhenFinished(0, returnCode);
+                  asyncContext[0].countDown();
+                }
+              });
+      asyncContext[0].getCountDownLatch().await();
+      Assert.assertEquals(asyncContext[0].getReturnCode(0),
+          KeeperException.Code.NODEEXISTS.intValue());
+
+
+      // test set
+      asyncContext[0] = new TestAsyncContext(1);
+      zkMetaClient
+          .asyncSet(entryKey, "async_create-data-new", 0,
+              new AsyncCallback.StatCallback() {
+                @Override
+                public void processResult(int returnCode, String key,
+                    @Nullable MetaClientInterface.Stat stat) {
+                  asyncContext[0].setReturnCodeWhenFinished(0, returnCode);
+                  asyncContext[0].setStatWhenFinished(0, stat);
+                  asyncContext[0].countDown();
+                }
+              });
+      asyncContext[0].getCountDownLatch().await();
+      Assert.assertEquals(asyncContext[0].getReturnCode(0),
+          KeeperException.Code.OK.intValue());
+      Assert.assertEquals(asyncContext[0].getStats(0).getEntryType(),
+          MetaClientInterface.EntryMode.PERSISTENT);
+      Assert.assertEquals(asyncContext[0].getStats(0).getVersion(), 1);
+
+      // test get
+      asyncContext[0] = new TestAsyncContext(1);
+      zkMetaClient.asyncGet(entryKey, new AsyncCallback.DataCallback() {
+        @Override
+        public void processResult(int returnCode, String key, byte[] data,
+            MetaClientInterface.Stat stat) {
+          asyncContext[0].setReturnCodeWhenFinished(0, returnCode);
+          asyncContext[0].setStatWhenFinished(0, stat);
+          asyncContext[0].setDataWhenFinished(0, zkMetaClient.deserialize(data, key));
+          asyncContext[0].countDown();
+        }
+      });
+
+      asyncContext[0].getCountDownLatch().await();
+
+      Assert.assertEquals(asyncContext[0].getReturnCode(0), KeeperException.Code.OK.intValue());
+      Assert.assertEquals(asyncContext[0].getStats(0).getEntryType(),
+          MetaClientInterface.EntryMode.PERSISTENT);
+      Assert.assertEquals(asyncContext[0].getStats(0).getVersion(), 1);
+      Assert.assertEquals(asyncContext[0].getData(0), "async_create-data-new");
+    } catch (Exception ex) {
+      Assert.fail("Test testAsyncCreate failed because of:", ex);
+    }
+  }
+
+  @Test(dependsOnMethods = "testAsyncCreateSetAndGet")
+  public void testAsyncExistsAndDelete() {
+    asyncContext[0] = new TestAsyncContext(2);
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      zkMetaClient.connect();
+
+      zkMetaClient.asyncExist(entryKey, new AsyncCallback.StatCallback() {
+        @Override
+        public void processResult(int returnCode, String key, MetaClientInterface.Stat stat) {
+          asyncContext[0].setReturnCodeWhenFinished(0, returnCode);
+          asyncContext[0].setStatWhenFinished(0, stat);
+          asyncContext[0].countDown();
+        }
+      });
+
+      zkMetaClient.asyncExist(nonExistsEntry, new AsyncCallback.StatCallback() {
+        @Override
+        public void processResult(int returnCode, String key, MetaClientInterface.Stat stat) {
+          asyncContext[0].setReturnCodeWhenFinished(1, returnCode);
+          asyncContext[0].setStatWhenFinished(1, stat);
+          asyncContext[0].countDown();
+        }
+      });
+
+      asyncContext[0].getCountDownLatch().await();
+
+      Assert.assertEquals(asyncContext[0].getReturnCode(0), KeeperException.Code.OK.intValue());
+      Assert.assertEquals(asyncContext[0].getStats(0).getEntryType(),
+          MetaClientInterface.EntryMode.PERSISTENT);
+      Assert.assertEquals(asyncContext[0].getStats(0).getVersion(), 1);
+      Assert.assertEquals(asyncContext[0].getReturnCode(1), KeeperException.Code.NONODE.intValue());
+      Assert.assertNull(asyncContext[0].getStats(1));
+
+      // test delete
+      asyncContext[0] = new TestAsyncContext(1);
+      zkMetaClient.asyncDelete(entryKey, new AsyncCallback.VoidCallback() {
+        @Override
+        public void processResult(int returnCode, String key) {
+          asyncContext[0].setReturnCodeWhenFinished(0, returnCode);
+          asyncContext[0].countDown();
+        }
+      });
+
+      asyncContext[0].getCountDownLatch().await();
+
+      Assert.assertEquals(asyncContext[0].getReturnCode(0), KeeperException.Code.OK.intValue());
+
+      // node should not be there
+      Assert.assertNull(zkMetaClient.get(entryKey));
+    } catch (InterruptedException ex) {
+      Assert.fail("Test testAsyncCreate failed because of:", ex);
+    }
+  }
+}

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClientAsyncOperations.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClientAsyncOperations.java
@@ -20,6 +20,7 @@ package org.apache.helix.metaclient.impl.zk;
  */
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
@@ -35,6 +36,7 @@ public class TestZkMetaClientAsyncOperations extends ZkMetaClientTestBase {
   static TestAsyncContext[] asyncContext = new TestAsyncContext[1];
   static final String entryKey = "/TestAsyncEntryKey";
   static final String nonExistsEntry = "/a/b/c";
+  static final long LATCH_WAIT_TIMEOUT_IN_S = 3 * 60;
 
   static class TestAsyncContext {
     int _asyncCallSize;
@@ -109,7 +111,7 @@ public class TestZkMetaClientAsyncOperations extends ZkMetaClientTestBase {
             }
           });
 
-      asyncContext[0].getCountDownLatch().await();
+      asyncContext[0].getCountDownLatch().await(LATCH_WAIT_TIMEOUT_IN_S, TimeUnit.SECONDS);
 
       Assert.assertEquals(asyncContext[0].getReturnCode(0), KeeperException.Code.OK.intValue());
       Assert.assertEquals(asyncContext[0].getReturnCode(1), KeeperException.Code.NONODE.intValue());
@@ -125,7 +127,7 @@ public class TestZkMetaClientAsyncOperations extends ZkMetaClientTestBase {
                   asyncContext[0].countDown();
                 }
               });
-      asyncContext[0].getCountDownLatch().await();
+      asyncContext[0].getCountDownLatch().await(LATCH_WAIT_TIMEOUT_IN_S, TimeUnit.SECONDS);
       Assert.assertEquals(asyncContext[0].getReturnCode(0),
           KeeperException.Code.NODEEXISTS.intValue());
 
@@ -143,7 +145,7 @@ public class TestZkMetaClientAsyncOperations extends ZkMetaClientTestBase {
                   asyncContext[0].countDown();
                 }
               });
-      asyncContext[0].getCountDownLatch().await();
+      asyncContext[0].getCountDownLatch().await(LATCH_WAIT_TIMEOUT_IN_S, TimeUnit.SECONDS);
       Assert.assertEquals(asyncContext[0].getReturnCode(0),
           KeeperException.Code.OK.intValue());
       Assert.assertEquals(asyncContext[0].getStats(0).getEntryType(),
@@ -163,7 +165,7 @@ public class TestZkMetaClientAsyncOperations extends ZkMetaClientTestBase {
         }
       });
 
-      asyncContext[0].getCountDownLatch().await();
+      asyncContext[0].getCountDownLatch().await(LATCH_WAIT_TIMEOUT_IN_S, TimeUnit.SECONDS);
 
       Assert.assertEquals(asyncContext[0].getReturnCode(0), KeeperException.Code.OK.intValue());
       Assert.assertEquals(asyncContext[0].getStats(0).getEntryType(),
@@ -199,7 +201,7 @@ public class TestZkMetaClientAsyncOperations extends ZkMetaClientTestBase {
         }
       });
 
-      asyncContext[0].getCountDownLatch().await();
+      asyncContext[0].getCountDownLatch().await(LATCH_WAIT_TIMEOUT_IN_S, TimeUnit.SECONDS);
 
       Assert.assertEquals(asyncContext[0].getReturnCode(0), KeeperException.Code.OK.intValue());
       Assert.assertEquals(asyncContext[0].getStats(0).getEntryType(),
@@ -218,7 +220,7 @@ public class TestZkMetaClientAsyncOperations extends ZkMetaClientTestBase {
         }
       });
 
-      asyncContext[0].getCountDownLatch().await();
+      asyncContext[0].getCountDownLatch().await(LATCH_WAIT_TIMEOUT_IN_S, TimeUnit.SECONDS);
 
       Assert.assertEquals(asyncContext[0].getReturnCode(0), KeeperException.Code.OK.intValue());
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/ZkMetaClientTestBase.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/ZkMetaClientTestBase.java
@@ -1,0 +1,104 @@
+package org.apache.helix.metaclient.impl.zk;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
+import org.apache.helix.zookeeper.zkclient.IDefaultNameSpace;
+import org.apache.helix.zookeeper.zkclient.ZkServer;
+import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
+import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+
+public abstract class ZkMetaClientTestBase {
+
+  // A Serializer for test. transfer byte <-> String
+  public static class TestStringSerializer implements PathBasedZkSerializer {
+
+    @Override
+    public byte[] serialize(Object data, String path) throws ZkMarshallingError {
+      return ((String) data).getBytes();
+    }
+
+    @Override
+    public Object deserialize(byte[] bytes, String path) throws ZkMarshallingError {
+      return new String(bytes, StandardCharsets.UTF_8);
+    }
+  }
+
+  protected static final String ZK_ADDR = "localhost:2183";
+  protected static final int DEFAULT_TIMEOUT_MS = 1000;
+  protected static final String ENTRY_STRING_VALUE = "test-value";
+
+  private final Object _syncObject = new Object();
+
+  private ZkServer _zkServer;
+
+  @BeforeClass
+  public void prepare() {
+    // start local zookeeper server
+    _zkServer = startZkServer(ZK_ADDR);
+  }
+
+  @AfterClass
+  public void cleanUp() {
+    _zkServer.shutdown();
+  }
+
+  protected static ZkMetaClient<String> createZkMetaClient() {
+    ZkMetaClientConfig config =
+        new ZkMetaClientConfig.ZkMetaClientConfigBuilder().setConnectionAddress(ZK_ADDR)
+            //.setZkSerializer(new TestStringSerializer())
+            .build();
+    return new ZkMetaClient<>(config);
+  }
+
+  protected static ZkServer startZkServer(final String zkAddress) {
+    String zkDir = zkAddress.replace(':', '_');
+    final String logDir = "/tmp/" + zkDir + "/logs";
+    final String dataDir = "/tmp/" + zkDir + "/dataDir";
+
+    // Clean up local directory
+    try {
+      FileUtils.deleteDirectory(new File(dataDir));
+      FileUtils.deleteDirectory(new File(logDir));
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    IDefaultNameSpace defaultNameSpace = zkClient -> {
+    };
+
+    int port = Integer.parseInt(zkAddress.substring(zkAddress.lastIndexOf(':') + 1));
+    System.out.println("Starting ZK server at " + zkAddress);
+    ZkServer zkServer = new ZkServer(dataDir, logDir, defaultNameSpace, port);
+    zkServer.start();
+    return zkServer;
+  }
+
+
+
+}

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/ZkMetaClientTestBase.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/ZkMetaClientTestBase.java
@@ -21,33 +21,16 @@ package org.apache.helix.metaclient.impl.zk;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
 import org.apache.helix.zookeeper.zkclient.IDefaultNameSpace;
 import org.apache.helix.zookeeper.zkclient.ZkServer;
-import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
-import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
 
 
 public abstract class ZkMetaClientTestBase {
-
-  // A Serializer for test. transfer byte <-> String
-  public static class TestStringSerializer implements PathBasedZkSerializer {
-
-    @Override
-    public byte[] serialize(Object data, String path) throws ZkMarshallingError {
-      return ((String) data).getBytes();
-    }
-
-    @Override
-    public Object deserialize(byte[] bytes, String path) throws ZkMarshallingError {
-      return new String(bytes, StandardCharsets.UTF_8);
-    }
-  }
 
   protected static final String ZK_ADDR = "localhost:2183";
   protected static final int DEFAULT_TIMEOUT_MS = 1000;
@@ -57,13 +40,24 @@ public abstract class ZkMetaClientTestBase {
 
   private ZkServer _zkServer;
 
-  @BeforeClass
+
+  /**
+   * Creates local Zk Server
+   * Note: Cannot test container / TTL node end to end behavior as
+   * the zk server setup doesn't allow for that. To enable this, zk server
+   * setup must invoke ContainerManager.java. However, the actual
+   * behavior has been verified to work on native ZK Client.
+   * TODO: Modify zk server setup to include ContainerManager.
+   * This can be done through ZooKeeperServerMain.java or
+   * LeaderZooKeeperServer.java.
+   */
+  @BeforeSuite
   public void prepare() {
     // start local zookeeper server
     _zkServer = startZkServer(ZK_ADDR);
   }
 
-  @AfterClass
+  @AfterSuite
   public void cleanUp() {
     _zkServer.shutdown();
   }
@@ -98,7 +92,4 @@ public abstract class ZkMetaClientTestBase {
     zkServer.start();
     return zkServer;
   }
-
-
-
 }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/ZkMetaClientTestBase.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/ZkMetaClientTestBase.java
@@ -35,11 +35,7 @@ public abstract class ZkMetaClientTestBase {
   protected static final String ZK_ADDR = "localhost:2183";
   protected static final int DEFAULT_TIMEOUT_MS = 1000;
   protected static final String ENTRY_STRING_VALUE = "test-value";
-
-  private final Object _syncObject = new Object();
-
-  private ZkServer _zkServer;
-
+  private static ZkServer _zkServer;
 
   /**
    * Creates local Zk Server

--- a/pom.xml
+++ b/pom.xml
@@ -742,7 +742,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.6</version>
+        <version>0.8.8</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -742,7 +742,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.8</version>
+        <version>0.8.6</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2237

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
This PR adds implementation to async CRUD operation in ZkMetaClient.
Refactor test code - add a test base class for set up and tear down to be used in all ZkMetaClients test classes.

### Tests

- [X] The following tests are written for this issue:
TestZkMetaClientAsyncOperations.testAsyncCreateSetAndGet
TestZkMetaClientAsyncOperations.testAsyncExistsAndDelete

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
