### PR TITLE
Rename and reformat metaclient test and util

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/exception/MetaClientException.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/exception/MetaClientException.java
@@ -35,4 +35,5 @@ public class MetaClientException extends RuntimeException {
   public MetaClientException(Throwable cause) {
     super(cause);
   }
+
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -44,7 +44,8 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static org.apache.helix.metaclient.impl.zk.util.ZkMetaClientUtil.convertZkEntryMode;
+
+import static org.apache.helix.metaclient.impl.zk.util.ZkMetaClientUtil.convertZkEntryModeToMetaClientEntryMode;
 import static org.apache.helix.metaclient.impl.zk.util.ZkMetaClientUtil.translateZkExceptionToMetaclientException;
 
 public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
@@ -122,7 +123,8 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
       if (zkStats == null) {
         return null;
       }
-      return new Stat(convertZkEntryMode(zkStats.getEphemeralOwner()), zkStats.getVersion());
+      return new Stat(convertZkEntryModeToMetaClientEntryMode(zkStats.getEphemeralOwner()),
+          zkStats.getVersion());
     } catch (ZkException e) {
       throw translateZkExceptionToMetaclientException(e);
     }
@@ -177,7 +179,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
   }
 
   @Override
-  public void asyncSet(String key, Object data, int version, AsyncCallback.VoidCallback cb) {
+  public void asyncSet(String key, T data, int version, AsyncCallback.VoidCallback cb) {
 
   }
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2237 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

1. Format class `ZkMetaClientUtil` to 80 chars.
2. Change 'convertZkEntryMode' to 'convertZkEntryModeToMetaClientEntryMode'
3. Remove 'multi' in var name and comments from test and use 'transactional operation instead.

- [X] The following tests are written for this issue:

NA

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
