### PR TITLE
Fix ZkClient retry logic for customized callback and test

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
@@ -54,6 +54,14 @@ public class ZkAsyncCallbacks {
       callback(rc, path, ctx);
     }
 
+    public Stat getStat() {
+      return _stat;
+    }
+
+    public byte[] getData() {
+      return _data;
+    }
+
     @Override
     public void handle() {
       // TODO Auto-generated method stub
@@ -61,7 +69,7 @@ public class ZkAsyncCallbacks {
 
     @Override
     protected void recordFailure(int rc, String path, ZkAsyncCallMonitorContext monitor) {
-      if(rc != Code.NONODE.intValue()) {
+      if (rc != Code.NONODE.intValue()) {
         monitor.recordFailure(path);
       }
     }
@@ -99,6 +107,10 @@ public class ZkAsyncCallbacks {
       callback(rc, path, ctx);
     }
 
+    public Stat getStat() {
+      return _stat;
+    }
+
     @Override
     public void handle() {
       // TODO Auto-generated method stub
@@ -106,7 +118,7 @@ public class ZkAsyncCallbacks {
 
     @Override
     protected void recordFailure(int rc, String path, ZkAsyncCallMonitorContext monitor) {
-      if(rc != Code.NONODE.intValue()) {
+      if (rc != Code.NONODE.intValue()) {
         monitor.recordFailure(path);
       }
     }
@@ -182,6 +194,7 @@ public class ZkAsyncCallbacks {
   public static abstract class DefaultCallback implements CancellableZkAsyncCallback {
     AtomicBoolean _isOperationDone = new AtomicBoolean(false);
     int _rc = KeeperException.Code.APIERROR.intValue();
+    String _path;
 
     public void callback(int rc, String path, Object ctx) {
       if (rc != 0 && LOG.isDebugEnabled()) {
@@ -198,12 +211,14 @@ public class ZkAsyncCallbacks {
       }
 
       _rc = rc;
+      _path = path;
 
       // If retry is requested by passing the retry callback context, do retry if necessary.
       if (needRetry(rc)) {
         if (ctx != null && ctx instanceof ZkAsyncRetryCallContext) {
           try {
             if (((ZkAsyncRetryCallContext) ctx).requestRetry()) {
+              LOG.info("Received {} for async request on path {}, requested retry.", rc, path);
               // The retry operation will be done asynchronously. Once it is done, the same callback
               // handler object shall be triggered to ensure the result is notified to the right
               // caller(s).
@@ -225,6 +240,8 @@ public class ZkAsyncCallbacks {
       // If operation is done successfully or no retry needed, notify the caller(s).
       try {
         handle();
+      } catch (Exception ex) {
+        LOG.error("Exception while handling user callback for path {}.", _path, ex);
       } finally {
         markOperationDone();
       }
@@ -259,10 +276,15 @@ public class ZkAsyncCallbacks {
       return _rc;
     }
 
+    public String getPath() {
+      return _path;
+    }
+
     @Override
     public void notifyCallers() {
       LOG.warn("The callback {} has been cancelled.", this);
       markOperationDone();
+      handle();
     }
 
     /**

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/callback/ZkAsyncCallbacks.java
@@ -283,8 +283,8 @@ public class ZkAsyncCallbacks {
     @Override
     public void notifyCallers() {
       LOG.warn("The callback {} has been cancelled.", this);
-      markOperationDone();
       handle();
+      markOperationDone();
     }
 
     /**


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2363 
When async retry is canceled in ZkClient, user injected callback that implements handle() in ZkAsyncCallback.DefaultCallback() will never be executed.
If there is no retry is needed, user logic in handle() is executed in either operation failed or succeeded cases.
These 2 behavior does not align.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

To solve the previous issue, this change add execution of handle() when retry is canceled.

### Tests

- [X] The following tests are written for this issue:

testAsyncRetryCustomizedCallback


- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
