### PR TITLE
Removed confusing test variable naming

### DIFF
--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -57,7 +57,7 @@ public class TestZkMetaClient {
   private static final String ZK_ADDR = "localhost:2183";
   private static final int DEFAULT_TIMEOUT_MS = 1000;
   private static final String ENTRY_STRING_VALUE = "test-value";
-  private static String PARENT_PATH = "/transactionOpTestPath";
+  private static String TRANSACTION_TEST_PARENT_PATH = "/transactionOpTestPath";
   private static final String TEST_INVALID_PATH = "_invalid/a/b/c";
 
   private final Object _syncObject = new Object();
@@ -346,11 +346,11 @@ public class TestZkMetaClient {
 
       //Create Nodes
       List<Op> ops = Arrays.asList(
-          Op.create(PARENT_PATH, new byte[0], MetaClientInterface.EntryMode.PERSISTENT),
-          Op.create(PARENT_PATH + test_name, new byte[0], MetaClientInterface.EntryMode.PERSISTENT),
-          Op.delete(PARENT_PATH + test_name, -1),
-          Op.create(PARENT_PATH + test_name, new byte[0], MetaClientInterface.EntryMode.PERSISTENT),
-          Op.set(PARENT_PATH + test_name, new byte[0], -1));
+          Op.create(TRANSACTION_TEST_PARENT_PATH, new byte[0], MetaClientInterface.EntryMode.PERSISTENT),
+          Op.create(TRANSACTION_TEST_PARENT_PATH + test_name, new byte[0], MetaClientInterface.EntryMode.PERSISTENT),
+          Op.delete(TRANSACTION_TEST_PARENT_PATH + test_name, -1),
+          Op.create(TRANSACTION_TEST_PARENT_PATH + test_name, new byte[0], MetaClientInterface.EntryMode.PERSISTENT),
+          Op.set(TRANSACTION_TEST_PARENT_PATH + test_name, new byte[0], -1));
 
       //Execute transactional support on operations
       List<OpResult> opResults = zkMetaClient.transactionOP(ops);
@@ -362,12 +362,12 @@ public class TestZkMetaClient {
       Assert.assertTrue(opResults.get(4) instanceof OpResult.SetDataResult);
 
       //Verify paths have been created
-      MetaClientInterface.Stat entryStat = zkMetaClient.exists(PARENT_PATH + test_name);
+      MetaClientInterface.Stat entryStat = zkMetaClient.exists(TRANSACTION_TEST_PARENT_PATH + test_name);
       Assert.assertNotNull(entryStat, "Path should have been created.");
 
       //Cleanup
-      zkMetaClient.recursiveDelete(PARENT_PATH);
-      if (zkMetaClient.exists(PARENT_PATH) != null) {
+      zkMetaClient.recursiveDelete(TRANSACTION_TEST_PARENT_PATH);
+      if (zkMetaClient.exists(TRANSACTION_TEST_PARENT_PATH) != null) {
         Assert.fail("Parent Path should have been removed.");
       }
     }
@@ -386,8 +386,8 @@ public class TestZkMetaClient {
       zkMetaClient.connect();
       //Create Nodes
       List<Op> ops = Arrays.asList(
-          Op.create(PARENT_PATH, new byte[0], MetaClientInterface.EntryMode.PERSISTENT),
-          Op.create(PARENT_PATH + test_name, new byte[0], MetaClientInterface.EntryMode.PERSISTENT),
+          Op.create(TRANSACTION_TEST_PARENT_PATH, new byte[0], MetaClientInterface.EntryMode.PERSISTENT),
+          Op.create(TRANSACTION_TEST_PARENT_PATH + test_name, new byte[0], MetaClientInterface.EntryMode.PERSISTENT),
           Op.create(TEST_INVALID_PATH, new byte[0], MetaClientInterface.EntryMode.PERSISTENT));
 
       try {
@@ -395,7 +395,7 @@ public class TestZkMetaClient {
         Assert.fail(
             "Should have thrown an exception. Cannot run transactional create OP on incorrect path.");
       } catch (Exception e) {
-        MetaClientInterface.Stat entryStat = zkMetaClient.exists(PARENT_PATH);
+        MetaClientInterface.Stat entryStat = zkMetaClient.exists(TRANSACTION_TEST_PARENT_PATH);
         Assert.assertNull(entryStat);
       }
     }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -57,9 +57,8 @@ public class TestZkMetaClient {
   private static final String ZK_ADDR = "localhost:2183";
   private static final int DEFAULT_TIMEOUT_MS = 1000;
   private static final String ENTRY_STRING_VALUE = "test-value";
-  protected static final String TRANSACTION_TEST_KEY_PREFIX = "/sharding-key-0";
-  protected static String PARENT_PATH = TRANSACTION_TEST_KEY_PREFIX + "/RealmAwareZkClient";
-  protected static final String TEST_INVALID_PATH = TRANSACTION_TEST_KEY_PREFIX + "_invalid" + "/a/b/c";
+  protected static String PARENT_PATH = "/ZkClient";
+  protected static final String TEST_INVALID_PATH = "_invalid" + "/a/b/c";
 
   private final Object _syncObject = new Object();
 
@@ -342,7 +341,6 @@ public class TestZkMetaClient {
 
     try(ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
       zkMetaClient.connect();
-      zkMetaClient.create(TRANSACTION_TEST_KEY_PREFIX, ENTRY_STRING_VALUE);
 
       //Create Nodes
       List<Op> ops = Arrays.asList(

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -58,7 +58,7 @@ public class TestZkMetaClient {
   private static final int DEFAULT_TIMEOUT_MS = 1000;
   private static final String ENTRY_STRING_VALUE = "test-value";
   protected static String PARENT_PATH = "/transactionOpTestPath";
-  protected static final String TEST_INVALID_PATH = "_invalid" + "/a/b/c";
+  protected static final String TEST_INVALID_PATH = "_invalid/a/b/c";
 
   private final Object _syncObject = new Object();
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -57,7 +57,7 @@ public class TestZkMetaClient {
   private static final String ZK_ADDR = "localhost:2183";
   private static final int DEFAULT_TIMEOUT_MS = 1000;
   private static final String ENTRY_STRING_VALUE = "test-value";
-  protected static String PARENT_PATH = "/ZkClient";
+  protected static String PARENT_PATH = "/transactionOpTestPath";
   protected static final String TEST_INVALID_PATH = "_invalid" + "/a/b/c";
 
   private final Object _syncObject = new Object();
@@ -332,8 +332,10 @@ public class TestZkMetaClient {
   }
 
   /**
-   * Test that zk transactional operation works for zkmetaclient operations create,
-   * delete, and set.
+   * Transactional op calls zk.multi() with a set of ops (operations)
+   * and the return values are converted into metaclient opResults.
+   * This test checks whether each op was run by verifying its opResult and
+   * the created/deleted/set path in zk.
    */
   @Test
   public void testTransactionOps() {
@@ -372,7 +374,9 @@ public class TestZkMetaClient {
   }
 
   /**
-   * Tests that attempts to call transactional operation on an invalid path. Should fail.
+   * This test calls transactionOp on an invalid path.
+   * It checks that the invalid path has not been created to verify the
+   * "all or nothing" behavior of transactionOp.
    * @throws KeeperException
    */
   @Test(dependsOnMethods = "testTransactionOps")

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -57,8 +57,8 @@ public class TestZkMetaClient {
   private static final String ZK_ADDR = "localhost:2183";
   private static final int DEFAULT_TIMEOUT_MS = 1000;
   private static final String ENTRY_STRING_VALUE = "test-value";
-  protected static String PARENT_PATH = "/transactionOpTestPath";
-  protected static final String TEST_INVALID_PATH = "_invalid/a/b/c";
+  private static String PARENT_PATH = "/transactionOpTestPath";
+  private static final String TEST_INVALID_PATH = "_invalid/a/b/c";
 
   private final Object _syncObject = new Object();
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

N/A

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Removed unnecessary and confusing variables. Sharding key is a concept for federatedzkclient which isn't being used in Cunina. Removing as it doesn't provide any value and can be confusing.

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
