### PR TITLE
Adding a manual workflow which allows triggering CI on any PR

### DIFF
--- a/.github/workflows/Helix-Manual-CI.yml
+++ b/.github/workflows/Helix-Manual-CI.yml
@@ -7,11 +7,11 @@ on:
         required: true
         default: refs/pull/1234/merge
       mvnOpts:
-        description: Maven options
+        description: Can provide custom Maven options in addition to existing one.
         required: true
         default: --fail-at-end
       goals:
-        description: Maven goals
+        description: Can provide custom Maven goals in addition to existing one.
         required: true
         default: -fae test
 

--- a/.github/workflows/Helix-Manual-CI.yml
+++ b/.github/workflows/Helix-Manual-CI.yml
@@ -1,0 +1,37 @@
+name: Helix Manual CI
+on:
+  workflow_dispatch:
+    inputs:
+      buildRef:
+        description: Ref to build (commit, branch, or refs/pull/1234/head or refs/pull/1234/merge)
+        required: true
+        default: refs/pull/1234/merge
+      mvnOpts:
+        description: Maven options
+        required: true
+        default: --fail-at-end
+      goals:
+        description: Maven goals
+        required: true
+        default: -fae test
+
+jobs:
+  MANUAL_CI:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        - with:
+            ref: ${{ github.event.inputs.buildRef }}
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn clean install -Dmaven.test.skip.exec=true
+      - name: Run All Tests
+        run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ github.event.inputs.mvnOpts }} ${{ github.event.inputs.goals }}
+      - name: Print Tests Results
+        run: .github/scripts/printTestResult.sh
+        if: ${{ success() || failure() }}


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Fixes #2369. 

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Currently, there are two main workflows for CI pipeline - Helix-CI and Helix-merge-CI. Both these pipelines gets triggered whenever any new PR is created and /or merged. But if anyone wants to run tests with few different maven options (maybe like rat, verify etc) or trigger builds after adding any workflow then there is not workflow for it.
Ask here is add a workflow which allows to manually trigger a CI pipeline on-demand an any PR with customized maven options.

Proposed solution :
A new workflow can be added which implements "workflow_dispatch" and allow input fields for user to accept maven build options and PR path.

### Tests

- [ ] The following tests are written for this issue:

Tried this options locally and it works but workflow itself can not be tested until it's added to repo.

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
NA
(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits
