### PR TITLE
MetaClient Container Node Implementation

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -75,20 +75,9 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
   public void create(String key, Object data, MetaClientInterface.EntryMode mode) {
 
     try{
-      _zkClient.create(key, data, metaClientModeToZkMode(mode));
+      _zkClient.create(key, data, ZkMetaClientUtil.convertMetaClientMode(mode));
     } catch (ZkException | KeeperException e) {
       throw new MetaClientException(e);
-    }
-  }
-
-  private static CreateMode metaClientModeToZkMode(EntryMode mode) throws KeeperException {
-    switch (mode) {
-      case PERSISTENT:
-        return CreateMode.PERSISTENT;
-      case EPHEMERAL:
-        return CreateMode.EPHEMERAL;
-      default:
-        return CreateMode.PERSISTENT;
     }
   }
 

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
@@ -110,7 +110,7 @@ public class ZkMetaClientUtil {
     return OpMapHolder.OPMAP;
   }
 
-  private static CreateMode convertMetaClientMode(MetaClientInterface.EntryMode entryMode) throws KeeperException {
+  public static CreateMode convertMetaClientMode(MetaClientInterface.EntryMode entryMode) throws KeeperException {
     switch (entryMode) {
       case PERSISTENT:
         return CreateMode.PERSISTENT;

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -57,9 +57,8 @@ public class TestZkMetaClient {
   private static final String ZK_ADDR = "localhost:2183";
   private static final int DEFAULT_TIMEOUT_MS = 1000;
   private static final String ENTRY_STRING_VALUE = "test-value";
-  protected static final String TRANSACTION_TEST_KEY_PREFIX = "/sharding-key-0";
-  protected static String PARENT_PATH = TRANSACTION_TEST_KEY_PREFIX + "/RealmAwareZkClient";
-  protected static final String TEST_INVALID_PATH = TRANSACTION_TEST_KEY_PREFIX + "_invalid" + "/a/b/c";
+  protected static String PARENT_PATH = "/ZkClient";
+  protected static final String TEST_INVALID_PATH = "_invalid" + "/a/b/c";
 
   private final Object _syncObject = new Object();
 
@@ -342,7 +341,6 @@ public class TestZkMetaClient {
 
     try(ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
       zkMetaClient.connect();
-      zkMetaClient.create(TRANSACTION_TEST_KEY_PREFIX, ENTRY_STRING_VALUE);
 
       //Create Nodes
       List<Op> ops = Arrays.asList(

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -71,9 +71,10 @@ public class TestZkMetaClient {
   /**
    * Creates local Zk Server
    * Note: Cannot test container / TTL node end to end behavior as
-   * the zk server setup doesn't allow for that. However, the actual
+   * the zk server setup doesn't allow for that. To enable this, zk server
+   * setup must invoke ContainerManager.java. However, the actual
    * behavior has been verified to work on native ZK Client.
-   * TODO: Change zk server setup to test TTL and Container Node behavior
+   * TODO: Modify zk server setup to include ContainerManager.
    */
   @BeforeClass
   public void prepare() {

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -49,6 +49,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.apache.helix.metaclient.api.MetaClientInterface.EntryMode.CONTAINER;
 import static org.apache.helix.metaclient.api.MetaClientInterface.EntryMode.PERSISTENT;
 
 
@@ -65,8 +66,16 @@ public class TestZkMetaClient {
 
   private ZkServer _zkServer;
 
+  /**
+   * Creates local Zk Server
+   * Note: Cannot test container / TTL node end to end behavior as
+   * the zk server setup doesn't allow for that. However, the actual
+   * behavior has been verified to work on native ZK Client.
+   * TODO: Change zk server setup to test TTL and Container Node behavior
+   */
   @BeforeClass
   public void prepare() {
+    System.setProperty("zookeeper.extendedTypesEnabled", "true");
     // start local zookeeper server
     _zkServer = startZkServer(ZK_ADDR);
   }
@@ -92,6 +101,16 @@ public class TestZkMetaClient {
     }
   }
 
+  @Test
+  public void testCreateContainer() {
+    final String key = "/TestZkMetaClient_testCreateContainer";
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      zkMetaClient.connect();
+      zkMetaClient.create(key, ENTRY_STRING_VALUE, CONTAINER);
+      Assert.assertNotNull(zkMetaClient.exists(key));
+    }
+  }
+  
   @Test
   public void testGet() {
     final String key = "/TestZkMetaClient_testGet";

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -75,6 +75,8 @@ public class TestZkMetaClient {
    * setup must invoke ContainerManager.java. However, the actual
    * behavior has been verified to work on native ZK Client.
    * TODO: Modify zk server setup to include ContainerManager.
+   * This can be done through ZooKeeperServerMain.java or
+   * LeaderZooKeeperServer.java.
    */
   @BeforeClass
   public void prepare() {


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

https://github.com/apache/helix/issues/2237

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Implementation of Container Node in ZkMetaClient.

### Tests

- [x] The following tests are written for this issue:

Unit test `createContainer()`.
Note: Cannot test end to end behavior (i.e. that the container node disappears after it's children are deleted) as the current setup of the zk server doesn't permit it. This is also a issue in HelixZkClient testbase. However, it has been tested and confirmed that the actual behavior does work (in native zkclient) and is merely a unit testing bug. Will track and fix this effort in the future but current implementation will use existing test base framework.

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
