### PR TITLE
Adding a new metric to report number of partitions with missing top state beyond threshold

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MissingTopStateRecord.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MissingTopStateRecord.java
@@ -49,6 +49,7 @@ public class MissingTopStateRecord {
   }
 
   /* package */ void setFailed() {
+    // Mark missingTopStateRecord as failed if partition has missing top state beyond threshold value.
     failed = true;
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
@@ -206,7 +206,9 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
 
     if (missingTopStateMap.containsKey(resourceName) && missingTopStateMap.get(resourceName)
         .containsKey(partition.getPartitionName())) {
-      // We previously recorded a top state missing, and it's not coming back
+      // We previously recorded a top state missing, and it's coming back.
+      // Note : Decrement missingTopStatePartitionsBeyondGuage in this code path because this guage will be incremented
+      //        only if we were able to record it in the first place.
       reportTopStateComesBack(cache, currentStateOutput.getCurrentStateMap(resourceName, partition),
           resourceName, partition, clusterStatusMonitor, durationThreshold,
           stateModelDef.getTopState());
@@ -304,7 +306,8 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
 
   /**
    * Check if the given partition of the given resource has a missing top state duration larger
-   * than the threshold, if so, report a top state transition failure
+   * than the threshold, if so, report a top state transition failure as well increment a guage which reports number
+   * of partitions with missing top state.
    *
    * @param cache cluster data cache
    * @param resourceName resource name
@@ -471,6 +474,7 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
       }
     }
 
+    // TODO: why are we checking if handoff happened within threshold here? it should be reported either way.
     if (handOffStartTime > 0 && handOffEndTime - handOffStartTime <= threshold) {
       long duration = handOffEndTime - handOffStartTime;
       long helixLatency = duration - fromTopStateUserLatency - toTopStateUserLatency;

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
@@ -474,7 +474,6 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
       }
     }
 
-    // TODO: why are we checking if handoff happened within threshold here? it should be reported either way.
     if (handOffStartTime > 0 && handOffEndTime - handOffStartTime <= threshold) {
       long duration = handOffEndTime - handOffStartTime;
       long helixLatency = duration - fromTopStateUserLatency - toTopStateUserLatency;

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -71,11 +71,16 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   // Counters
   private SimpleDynamicMetric<Long> _successfulTopStateHandoffDurationCounter;
   private SimpleDynamicMetric<Long> _successTopStateHandoffCounter;
-  // A new Gauage for reporting number of partitions with missing top state has been added. The main reason of deprecating
-  // this counter because it doesn't give clear picture on how many partitions are missing with top state at any point
-  // of time. New gauage will help with that. Please find more info at https://github.com/apache/helix/pull/2381
+
+  // A new Gauage _missingTopStatePartitionsBeyondThresholdGauge for reporting number of partitions with missing top
+  // state has been added. Reason of deprecating this two metrics is because they are similar and doesn't tell about
+  // how many partitions are missing beyond threshold. The average duration of different partitions hands-off would not
+  // be helpful and can be used to find that out. Please find more info at https://github.com/apache/helix/pull/2381
   @Deprecated
   private SimpleDynamicMetric<Long> _failedTopStateHandoffCounter;
+  @Deprecated
+  private HistogramDynamicMetric _partitionTopStateNonGracefulHandoffDurationGauge;
+
   private SimpleDynamicMetric<Long> _maxSinglePartitionTopStateHandoffDuration;
   @Deprecated
   private SimpleDynamicMetric<Long> _totalMessageReceived; // This should be counter since the value behavior is ever-increasing
@@ -83,14 +88,6 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   // Histograms
   private HistogramDynamicMetric _partitionTopStateHandoffDurationGauge;
   private HistogramDynamicMetric _partitionTopStateHandoffHelixLatencyGauge;
-  // A new Gauage for reporting number of partitions with missing top state has been added. The main reason of deprecating
-  // this gauge because it's similar to other failedTopStateCounter and averaging out duration of all those handsoff
-  // won't really help in debugging the issue. Hence please use new gauage _missingTopStatePartitionsBeyondThresholdGauge
-  // to find number of partitions with missing top state beyond threshold and to find duration use
-  // _maxSinglePartitionTopStateHandoffDuration. New gauage will help with that. Please find more info at
-  // https://github.com/apache/helix/pull/2381
-  @Deprecated
-  private HistogramDynamicMetric _partitionTopStateNonGracefulHandoffDurationGauge;
 
   private SimpleDynamicMetric<String> _rebalanceState;
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -372,8 +372,8 @@ public class ResourceMonitor extends DynamicMBeanProvider {
           _partitionTopStateHandoffDurationGauge.updateValue(totalDuration);
           _partitionTopStateHandoffHelixLatencyGauge.updateValue(helixLatency);
         } else {
-          // TODO: Should be deprecated and not to be used. Instead of this counter a MissingTopStateBeyondThresholdGuage
-          // should be used to find out number of partitions with missing top state.
+          // TODO: Deprecated. use MissingTopStateBeyondThresholdGuage to find out number of partitions with missing top
+          //  state.
           _partitionTopStateNonGracefulHandoffDurationGauge.updateValue(totalDuration);
         }
         if (totalDuration > _maxSinglePartitionTopStateHandoffDuration.getValue()) {
@@ -381,8 +381,8 @@ public class ResourceMonitor extends DynamicMBeanProvider {
           _lastResetTime = System.currentTimeMillis();
         }
       } else {
-        // TODO: Should be deprecated and not to be used. Instead of this counter a MissingTopStateBeyondThresholdGuage
-        // should be used to find out number of partitions with missing top state.
+        // TODO: Deprecated. use MissingTopStateBeyondThresholdGuage to find out number of partitions with missing top
+        //  state.
         _failedTopStateHandoffCounter.updateValue(_failedTopStateHandoffCounter.getValue() + 1);
         _missingTopStatePartitionsBeyondThresholdGauge
             .updateValue(_missingTopStatePartitionsBeyondThresholdGauge.getValue() + 1);

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -54,7 +54,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
 
   // Gauges
   private SimpleDynamicMetric<Long> _numOfPartitions;
-  private SimpleDynamicMetric<Long> _missingTopStatePartitionsBeyondThresholdGuage;
+  private SimpleDynamicMetric<Long> _missingTopStatePartitionsBeyondThresholdGauge;
   private SimpleDynamicMetric<Long> _numOfPartitionsInExternalView;
   private SimpleDynamicMetric<Long> _numOfErrorPartitions;
   private SimpleDynamicMetric<Long> _numNonTopStatePartitions;
@@ -128,7 +128,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     _numLessMinActiveReplicaPartitions =
         new SimpleDynamicMetric("MissingMinActiveReplicaPartitionGauge", 0L);
     _numNonTopStatePartitions = new SimpleDynamicMetric("MissingTopStatePartitionGauge", 0L);
-    _missingTopStatePartitionsBeyondThresholdGuage = new SimpleDynamicMetric("MissingTopStatePartitionsBeyondThresholdGauge", 0L);
+    _missingTopStatePartitionsBeyondThresholdGauge = new SimpleDynamicMetric("MissingTopStatePartitionsBeyondThresholdGauge", 0L);
     _numOfErrorPartitions = new SimpleDynamicMetric("ErrorPartitionGauge", 0L);
     _numOfPartitionsInExternalView = new SimpleDynamicMetric("ExternalViewPartitionGauge", 0L);
     _numOfPartitions = new SimpleDynamicMetric("PartitionGauge", 0L);
@@ -178,7 +178,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   }
 
   public long getMissingTopStatePartitionsBeyondThresholdGuage() {
-    return _missingTopStatePartitionsBeyondThresholdGuage.getValue();
+    return _missingTopStatePartitionsBeyondThresholdGauge.getValue();
   }
 
   public long getDifferenceWithIdealStateGauge() {
@@ -378,8 +378,8 @@ public class ResourceMonitor extends DynamicMBeanProvider {
         // TODO: Should be deprecated and not to be used. Instead of this counter a MissingTopStateBeyondThresholdGuage
         // should be used to find out number of partitions with missing top state.
         _failedTopStateHandoffCounter.updateValue(_failedTopStateHandoffCounter.getValue() + 1);
-        _missingTopStatePartitionsBeyondThresholdGuage
-            .updateValue(_missingTopStatePartitionsBeyondThresholdGuage.getValue() + 1);
+        _missingTopStatePartitionsBeyondThresholdGauge
+            .updateValue(_missingTopStatePartitionsBeyondThresholdGauge.getValue() + 1);
         _lastResetTime = System.currentTimeMillis();
       }
       break;
@@ -476,7 +476,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   public void resetMaxTopStateHandoffGauge() {
     if (_lastResetTime + DEFAULT_RESET_INTERVAL_MS <= System.currentTimeMillis()) {
       _maxSinglePartitionTopStateHandoffDuration.updateValue(0L);
-      _missingTopStatePartitionsBeyondThresholdGuage.updateValue(0L);
+      _missingTopStatePartitionsBeyondThresholdGauge.updateValue(0L);
       _lastResetTime = System.currentTimeMillis();
     }
   }
@@ -487,7 +487,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
         _numOfPartitionsInExternalView,
         _numOfErrorPartitions,
         _numNonTopStatePartitions,
-        _missingTopStatePartitionsBeyondThresholdGuage,
+        _missingTopStatePartitionsBeyondThresholdGauge,
         _numLessMinActiveReplicaPartitions,
         _numLessReplicaPartitions,
         _numPendingRecoveryRebalanceReplicas,

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -71,6 +71,9 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   // Counters
   private SimpleDynamicMetric<Long> _successfulTopStateHandoffDurationCounter;
   private SimpleDynamicMetric<Long> _successTopStateHandoffCounter;
+  // A new Gauage for reporting number of partitions with missing top state has been added. The main reason of deprecating
+  // this counter because it doesn't give clear picture on how many partitions are missing with top state at any point
+  // of time. New gauage will help with that. Please find more info at https://github.com/apache/helix/pull/2381
   @Deprecated
   private SimpleDynamicMetric<Long> _failedTopStateHandoffCounter;
   private SimpleDynamicMetric<Long> _maxSinglePartitionTopStateHandoffDuration;
@@ -80,6 +83,12 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   // Histograms
   private HistogramDynamicMetric _partitionTopStateHandoffDurationGauge;
   private HistogramDynamicMetric _partitionTopStateHandoffHelixLatencyGauge;
+  // A new Gauage for reporting number of partitions with missing top state has been added. The main reason of deprecating
+  // this gauge because it's similar to other failedTopStateCounter and averaging out duration of all those handsoff
+  // won't really help in debugging the issue. Hence please use new gauage _missingTopStatePartitionsBeyondThresholdGauge
+  // to find number of partitions with missing top state beyond threshold and to find duration use
+  // _maxSinglePartitionTopStateHandoffDuration. New gauage will help with that. Please find more info at
+  // https://github.com/apache/helix/pull/2381
   @Deprecated
   private HistogramDynamicMetric _partitionTopStateNonGracefulHandoffDurationGauge;
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixes #2345 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR emits a new metric which will report number of partitions with missing top state beyond threshold value. It will update this value as soon as top state goes missing for a partition. This metric will be reset only after default reset time i.e., 1 min. 
Existing two metrics - FailedTopStateHandoffCounter and PartitionTopStateNonGracefulHandoffGauge are very much similar and they both try to say that top state is missing beyond certain threshold. So we would deprecate both this metrics and encourage to use this new guage.

### Tests

- [X] The following tests are written for this issue:
Current test testTopStateFailedHandoff takes care of all scenarios. Updated this test with detailed scenario.
```
mvn test -Dtest=TestTopStateHandoffMetrics
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.308 s - in org.apache.helix.monitoring.mbeans.TestTopStateHandoffMetrics
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
```
### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

None

### Documentation (Optional)

NA

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
