### PR TITLE
Use JDK 11 for Helix Project

### DIFF
--- a/.github/workflows/Helix-CI.yml
+++ b/.github/workflows/Helix-CI.yml
@@ -17,9 +17,9 @@ jobs:
       with:
         java-version: 11
     - name: Build with Maven
-      run: mvn clean install -Dmaven.test.skip.exec=true
+      run: mvn clean install -Dmaven.test.skip.exec=true -DretryFailedDeploymentCount=5
     - name: Run All Tests
-      run: mvn -q -fae test
+      run: mvn -q -fae -Dsurefire.rerunFailingTestsCount=5 test
     - name: Upload to Codecov
       run: bash <(curl -s https://codecov.io/bash)
       if: ${{ github.repository == 'apache/helix' && github.event_name == 'push' && (success() || failure()) }}

--- a/.github/workflows/Helix-CI.yml
+++ b/.github/workflows/Helix-CI.yml
@@ -12,14 +12,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Maven
-      run: mvn clean install -Dmaven.test.skip.exec=true -DretryFailedDeploymentCount=5
+      run: mvn clean install -Dmaven.test.skip.exec=true
     - name: Run All Tests
-      run: mvn -q -fae -Dsurefire.rerunFailingTestsCount=5 test
+      run: mvn -q -fae test
     - name: Upload to Codecov
       run: bash <(curl -s https://codecov.io/bash)
       if: ${{ github.repository == 'apache/helix' && github.event_name == 'push' && (success() || failure()) }}

--- a/.github/workflows/Helix-PR-CI.yml
+++ b/.github/workflows/Helix-PR-CI.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Maven
-      run: mvn clean install -Dmaven.test.skip.exec=true -DretryFailedDeploymentCount=5
+      run: mvn clean install -Dmaven.test.skip.exec=true
     - name: Run All Tests
-      run: mvn -q -fae -Dsurefire.rerunFailingTestsCount=5 test
+      run: mvn -q -fae test
     - name: Print Tests Results
       run: .github/scripts/printTestResult.sh
       if: ${{ success() || failure() }}

--- a/.github/workflows/Helix-PR-CI.yml
+++ b/.github/workflows/Helix-PR-CI.yml
@@ -19,9 +19,9 @@ jobs:
       with:
         java-version: 11
     - name: Build with Maven
-      run: mvn clean install -Dmaven.test.skip.exec=true
+      run: mvn clean install -Dmaven.test.skip.exec=true -DretryFailedDeploymentCount=5
     - name: Run All Tests
-      run: mvn -q -fae test
+      run: mvn -q -fae -Dsurefire.rerunFailingTestsCount=5 test
     - name: Print Tests Results
       run: .github/scripts/printTestResult.sh
       if: ${{ success() || failure() }}

--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -91,27 +91,32 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.48.v20220622</version>
+      <version>10.0.13</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>2.15</version>
+      <version>2.35</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework</groupId>
       <artifactId>jersey-test-framework-core</artifactId>
-      <version>2.15</version>
+      <version>2.35</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
-      <version>2.15</version>
+      <version>2.35</version>
+    </dependency>
+    <dependency>
+        <groupId>org.glassfish.jersey.inject</groupId>
+        <artifactId>jersey-hk2</artifactId>
+        <version>2.35</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.48.v20220622</version>
+      <version>10.0.13</version>
     </dependency>
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
@@ -49,12 +49,12 @@ import org.apache.helix.rest.server.filters.CORSFilter;
 import org.apache.helix.rest.server.filters.ClusterAuthFilter;
 import org.apache.helix.rest.server.filters.NamespaceAuthFilter;
 import org.eclipse.jetty.http.HttpVersion;
-//import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
-//import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
-//import org.eclipse.jetty.server.ServerConnector;
-//import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -283,8 +283,8 @@ public class HelixRestServer {
     }
   }
 
-  /*
-  public void setupSslServer(int port, SslContextFactory sslContextFactory) {
+
+  public void setupSslServer(int port, SslContextFactory.Server sslContextFactory) {
     if (_server != null && port > 0) {
       try {
         HttpConfiguration https = new HttpConfiguration();
@@ -303,7 +303,7 @@ public class HelixRestServer {
       }
     }
   }
-  */
+
 
   /**
    * Register a SSLContext so that it could be used to create HTTPS clients.

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/HelixRestServer.java
@@ -49,12 +49,12 @@ import org.apache.helix.rest.server.filters.CORSFilter;
 import org.apache.helix.rest.server.filters.ClusterAuthFilter;
 import org.apache.helix.rest.server.filters.NamespaceAuthFilter;
 import org.eclipse.jetty.http.HttpVersion;
-import org.eclipse.jetty.server.HttpConfiguration;
+//import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
-import org.eclipse.jetty.server.SecureRequestCustomizer;
+//import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.SslConnectionFactory;
+//import org.eclipse.jetty.server.ServerConnector;
+//import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -283,6 +283,7 @@ public class HelixRestServer {
     }
   }
 
+  /*
   public void setupSslServer(int port, SslContextFactory sslContextFactory) {
     if (_server != null && port > 0) {
       try {
@@ -302,6 +303,7 @@ public class HelixRestServer {
       }
     }
   }
+  */
 
   /**
    * Register a SSLContext so that it could be used to create HTTPS clients.

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -117,11 +117,12 @@ public class AbstractResource {
   }
 
   protected Response notFound() {
-    return Response.status(Response.Status.NOT_FOUND).build();
+    return Response.status(Response.Status.NOT_FOUND).type(MediaType.TEXT_PLAIN).build();
   }
 
   protected Response notFound(String errorMsg) {
-    return Response.status(Response.Status.NOT_FOUND).entity(errorMsgToJson(errorMsg)).build();
+    return Response.status(Response.Status.NOT_FOUND).type(MediaType.TEXT_PLAIN)
+      .entity(errorMsgToJson(errorMsg)).build();
   }
 
   protected Response OK(Object entity) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PropertyStoreAccessor.java
@@ -28,6 +28,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.codahale.metrics.annotation.ResponseMetered;
@@ -77,6 +78,7 @@ public class PropertyStoreAccessor extends AbstractHelixResource {
     BaseDataAccessor<byte[]> propertyStoreDataAccessor = getByteArrayDataAccessor();
     if (!propertyStoreDataAccessor.exists(recordPath, AccessOption.PERSISTENT)) {
       throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
+          .type(MediaType.TEXT_PLAIN)
           .entity(String.format("The property store path %s doesn't exist", recordPath))
           .build());
     }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/zookeeper/ZooKeeperAccessor.java
@@ -27,6 +27,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.codahale.metrics.annotation.ResponseMetered;
@@ -180,7 +181,8 @@ public class ZooKeeperAccessor extends AbstractResource {
       return zkBaseDataAccessor.get(path, stat, AccessOption.PERSISTENT);
     } else {
       throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
-          .entity(String.format("The ZNode at path %s does not exist!", path)).build());
+          .entity(String.format("The ZNode at path %s does not exist!", path))
+          .type(MediaType.TEXT_PLAIN).build());
     }
   }
 
@@ -197,6 +199,7 @@ public class ZooKeeperAccessor extends AbstractResource {
       return JSONRepresentation(result);
     } else {
       throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
+          .type(MediaType.TEXT_PLAIN)
           .entity(String.format("The ZNode at path %s does not exist", path)).build());
     }
   }
@@ -211,6 +214,7 @@ public class ZooKeeperAccessor extends AbstractResource {
     Stat stat = zkBaseDataAccessor.getStat(path, AccessOption.PERSISTENT);
     if (stat == null) {
       throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
+          .type(MediaType.TEXT_PLAIN)
           .entity(String.format("The ZNode at path %s does not exist!", path)).build());
     }
     Map<String, String> result = ZKUtil.fromStatToMap(stat);

--- a/pom.xml
+++ b/pom.xml
@@ -542,10 +542,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.5.1</version>
+          <version>3.10.1</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <release>11</release>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:


### Description
Helix has been using JDK 1.8. We want to move to latest JDK but prior to that, we can use JDK11 as intermediate step. This will help us remain current and use all the language optimizations for performance improvements.

We were using Jetty - 9.4.48.v20220622 and Jersey version 2.15.
Both these versions were not compatible with JDK11.
If you go with the latest version of Jetty and latest of Jersey, the REST Server never starts.
So we need to do 2 levels of compatibility:
- with JDK 11 compatibility
- compatibility amongst both of them. 

It took me while to figure out Jetty/Jersey compatibility. In addition some APIs had changed.

### Tests
- The following is the result of the "mvn test" command on the appropriate module:
[ERROR] Failures:
[ERROR]   TestNoThrottleDisabledPartitions.testDisablingTopStateReplicaByDisablingInstance:98 expected:<false> but was:<true>
[ERROR]   TestNoThrottleDisabledPartitions.testNoThrottleOnDisabledInstance:231->setupEnvironment:317->setupCluster:436 » ZkClient
[ERROR]   TestP2PNoDuplicatedMessage.testP2PStateTransitionEnabled:180 expected:<true> but was:<false>
[ERROR]   TestMultiZkConnectionConfig>MultiZkTestBase.afterClass:137 expected:<true> but was:<false>
[ERROR]   TestMultiZkConnectionConfig.testZKHelixManager:295->Object.wait:328->Object.wait:-2 » ThreadTimeout
[ERROR]   TestWagedRebalanceFaultZone.testAddZone:270->validate:318->validateZoneAndTagIsolation:342 expected:<3> but was:<2>
[ERROR]   TestTaskStateModelFactory.testZkClientCreationMultiZk:80 » Bind Address alread...
[INFO]
[ERROR] Tests run: 1325, Failures: 7, Errors: 0, Skipped: 6

I ran all the 7 failures as independent test-runs. Some tests passed on running while some failed. I took a fresh code branch with no changes and ran the same failed tests against it and they failed there as well. So between re-run and clean branch, there are NO NEW failures.


PR-CI run is completely GREEN (including all other components)
https://github.com/apache/helix/actions/runs/4289361614

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
