### PR TITLE
add support for state change

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -56,6 +56,9 @@ public interface MetaClientInterface<T> {
   }
 
   enum ConnectState {
+    // Client is not connected to server. Before initiating connection or after close.
+    NOT_CONNECTED,
+
     // Client is connected to server
     CONNECTED,
 
@@ -65,11 +68,15 @@ public interface MetaClientInterface<T> {
     // Server has expired this connection.
     EXPIRED,
 
-    // When client failed to connect server.
-    INIT_FAILED,
-
     // When client explicitly call disconnect.
-    CLOSED_BY_CLIENT
+    CLOSED_BY_CLIENT,
+
+    // Connection between client and server is lost.
+    DISCONNECTED,
+
+    // Client is authenticated. They can perform operation with authorized permissions.
+    // This state is not in use as of now.
+    AUTHENTICATED
   }
 
   /**

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -36,6 +36,7 @@ import org.apache.helix.metaclient.api.OpResult;
 import org.apache.helix.metaclient.exception.MetaClientException;
 import org.apache.helix.metaclient.impl.zk.adapter.DataListenerAdapter;
 import org.apache.helix.metaclient.impl.zk.adapter.DirectChildListenerAdapter;
+import org.apache.helix.metaclient.impl.zk.adapter.StateChangeAdapter;
 import org.apache.helix.metaclient.impl.zk.adapter.ZkMetaClientCreateCallbackHandler;
 import org.apache.helix.metaclient.impl.zk.adapter.ZkMetaClientDeleteCallbackHandler;
 import org.apache.helix.metaclient.impl.zk.adapter.ZkMetaClientExistCallbackHandler;
@@ -275,7 +276,8 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
 
   @Override
   public boolean subscribeStateChanges(ConnectStateChangeListener listener) {
-    return false;
+    _zkClient.subscribeStateChanges(new StateChangeAdapter(listener));
+    return true;
   }
 
   @Override
@@ -300,7 +302,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
 
   @Override
   public void unsubscribeConnectStateChanges(ConnectStateChangeListener listener) {
-
+    _zkClient.subscribeStateChanges(new StateChangeAdapter(listener));
   }
 
   @Override

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -36,7 +36,7 @@ import org.apache.helix.metaclient.api.OpResult;
 import org.apache.helix.metaclient.exception.MetaClientException;
 import org.apache.helix.metaclient.impl.zk.adapter.DataListenerAdapter;
 import org.apache.helix.metaclient.impl.zk.adapter.DirectChildListenerAdapter;
-import org.apache.helix.metaclient.impl.zk.adapter.StateChangeAdapter;
+import org.apache.helix.metaclient.impl.zk.adapter.StateChangeListenerAdapter;
 import org.apache.helix.metaclient.impl.zk.adapter.ZkMetaClientCreateCallbackHandler;
 import org.apache.helix.metaclient.impl.zk.adapter.ZkMetaClientDeleteCallbackHandler;
 import org.apache.helix.metaclient.impl.zk.adapter.ZkMetaClientExistCallbackHandler;
@@ -276,7 +276,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
 
   @Override
   public boolean subscribeStateChanges(ConnectStateChangeListener listener) {
-    _zkClient.subscribeStateChanges(new StateChangeAdapter(listener));
+    _zkClient.subscribeStateChanges(new StateChangeListenerAdapter(listener));
     return true;
   }
 
@@ -302,7 +302,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
 
   @Override
   public void unsubscribeConnectStateChanges(ConnectStateChangeListener listener) {
-    _zkClient.subscribeStateChanges(new StateChangeAdapter(listener));
+    _zkClient.subscribeStateChanges(new StateChangeListenerAdapter(listener));
   }
 
   @Override

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/StateChangeAdapter.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/StateChangeAdapter.java
@@ -1,0 +1,75 @@
+package org.apache.helix.metaclient.impl.zk.adapter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.metaclient.api.ConnectStateChangeListener;
+import org.apache.helix.metaclient.exception.MetaClientTimeoutException;
+import org.apache.helix.metaclient.impl.zk.util.ZkMetaClientUtil;
+import org.apache.helix.zookeeper.zkclient.IZkStateListener;
+import org.apache.helix.zookeeper.zkclient.exception.ZkInterruptedException;
+import org.apache.zookeeper.Watcher;
+
+
+public class StateChangeAdapter implements IZkStateListener {
+  private final ConnectStateChangeListener _listener;
+
+  public StateChangeAdapter(ConnectStateChangeListener listener) {
+    _listener = listener;
+  }
+
+  @Override
+  public void handleStateChanged(Watcher.Event.KeeperState state) throws Exception {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void handleNewSession(String sessionId) throws Exception {
+  }
+
+  @Override
+  public void handleSessionEstablishmentError(Throwable error) throws Exception {
+      _listener.handleConnectionEstablishmentError(error);
+  }
+
+  @Override
+  public void handleStateChanged(Watcher.Event.KeeperState prevState,
+      Watcher.Event.KeeperState curState) throws Exception {
+    _listener.handleConnectStateChanged(
+        ZkMetaClientUtil.translateKeeperStateToMetaClientConnectState(prevState),
+        ZkMetaClientUtil.translateKeeperStateToMetaClientConnectState(curState));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    StateChangeAdapter that = (StateChangeAdapter) o;
+    return _listener.equals(that._listener);
+  }
+
+  @Override
+  public int hashCode() {
+    return _listener.hashCode();
+  }
+}

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/StateChangeListenerAdapter.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/StateChangeListenerAdapter.java
@@ -20,17 +20,15 @@ package org.apache.helix.metaclient.impl.zk.adapter;
  */
 
 import org.apache.helix.metaclient.api.ConnectStateChangeListener;
-import org.apache.helix.metaclient.exception.MetaClientTimeoutException;
 import org.apache.helix.metaclient.impl.zk.util.ZkMetaClientUtil;
 import org.apache.helix.zookeeper.zkclient.IZkStateListener;
-import org.apache.helix.zookeeper.zkclient.exception.ZkInterruptedException;
 import org.apache.zookeeper.Watcher;
 
 
-public class StateChangeAdapter implements IZkStateListener {
+public class StateChangeListenerAdapter implements IZkStateListener {
   private final ConnectStateChangeListener _listener;
 
-  public StateChangeAdapter(ConnectStateChangeListener listener) {
+  public StateChangeListenerAdapter(ConnectStateChangeListener listener) {
     _listener = listener;
   }
 
@@ -41,6 +39,9 @@ public class StateChangeAdapter implements IZkStateListener {
 
   @Override
   public void handleNewSession(String sessionId) throws Exception {
+    // This function will be invoked when connection is established. It is a  no-op for metaclient.
+    // MetaClient will expose this to user as 'handleStateChanged' already covers state change
+    // notification for new connection establishment.
   }
 
   @Override
@@ -64,7 +65,7 @@ public class StateChangeAdapter implements IZkStateListener {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    StateChangeAdapter that = (StateChangeAdapter) o;
+    StateChangeListenerAdapter that = (StateChangeListenerAdapter) o;
     return _listener.equals(that._listener);
   }
 

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
@@ -42,6 +42,7 @@ import org.apache.helix.zookeeper.zkclient.exception.ZkTimeoutException;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Op;
+import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.server.EphemeralType;
@@ -52,7 +53,7 @@ public class ZkMetaClientUtil {
   private static final List<ACL> DEFAULT_ACL =
       Collections.unmodifiableList(ZooDefs.Ids.OPEN_ACL_UNSAFE);
 
-  private ZkMetaClientUtil(){
+  private ZkMetaClientUtil() {
   }
 
   /**
@@ -237,6 +238,29 @@ public class ZkMetaClientUtil {
       return new MetaClientInterruptException(e);
     }
     return new MetaClientException(e);
+  }
+
+  public static MetaClientInterface.ConnectState translateKeeperStateToMetaClientConnectState(
+      Watcher.Event.KeeperState keeperState) {
+    if (keeperState == null)
+      return MetaClientInterface.ConnectState.NOT_CONNECTED;
+    switch (keeperState) {
+      case AuthFailed:
+        return MetaClientInterface.ConnectState.AUTH_FAILED;
+      case Closed:
+        return MetaClientInterface.ConnectState.CLOSED_BY_CLIENT;
+      case Disconnected:
+        return MetaClientInterface.ConnectState.DISCONNECTED;
+      case Expired:
+        return MetaClientInterface.ConnectState.EXPIRED;
+      case SaslAuthenticated:
+        return MetaClientInterface.ConnectState.AUTHENTICATED;
+      case SyncConnected:
+      case ConnectedReadOnly:
+        return MetaClientInterface.ConnectState.CONNECTED;
+      default:
+        throw new IllegalArgumentException(keeperState + " is not a supported.");
+    }
   }
 
   /**

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -19,43 +19,29 @@ package org.apache.helix.metaclient.impl.zk;
  * under the License.
  */
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-
-import org.apache.helix.metaclient.api.DataUpdater;
-import org.apache.helix.metaclient.api.MetaClientInterface;
-import org.apache.helix.metaclient.exception.MetaClientException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.helix.metaclient.api.DataUpdater;
-import org.apache.helix.metaclient.api.DirectChildChangeListener;
-import org.apache.helix.metaclient.api.MetaClientInterface;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.helix.metaclient.api.ConnectStateChangeListener;
 import org.apache.helix.metaclient.api.DataChangeListener;
+import org.apache.helix.metaclient.api.DataUpdater;
+import org.apache.helix.metaclient.api.DirectChildChangeListener;
+import org.apache.helix.metaclient.api.MetaClientInterface;
 import org.apache.helix.metaclient.api.Op;
 import org.apache.helix.metaclient.api.OpResult;
 import org.apache.helix.metaclient.exception.MetaClientException;
 import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
-import org.apache.helix.zookeeper.zkclient.IDefaultNameSpace;
-import org.apache.helix.zookeeper.zkclient.ZkServer;
 import org.apache.zookeeper.KeeperException;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.apache.helix.metaclient.api.MetaClientInterface.EntryMode.CONTAINER;
@@ -331,6 +317,36 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
       Thread.sleep(500);
       zkMetaClient.create(basePath + "/child_3", "test-data");
       Assert.assertTrue(countDownLatch.await(5000, TimeUnit.MILLISECONDS));
+    }
+  }
+
+  @Test
+  public void testConnectStateChangeListener() throws Exception {
+    final String basePath = "/TestZkMetaClient_testConnectionStateChangeListener";
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      CountDownLatch countDownLatch = new CountDownLatch(1);
+      final MetaClientInterface.ConnectState[] connectState =
+          new MetaClientInterface.ConnectState[2];
+      ConnectStateChangeListener listener = new ConnectStateChangeListener() {
+        @Override
+        public void handleConnectStateChanged(MetaClientInterface.ConnectState prevState,
+            MetaClientInterface.ConnectState currentState) throws Exception {
+          System.out.println("from: " + prevState + " to State: " + currentState);
+          connectState[0] = prevState;
+          connectState[1] = currentState;
+          countDownLatch.countDown();
+        }
+
+        @Override
+        public void handleConnectionEstablishmentError(Throwable error) throws Exception {
+
+        }
+      };
+      Assert.assertTrue(zkMetaClient.subscribeStateChanges(listener));
+      zkMetaClient.connect();
+      countDownLatch.await(5000, TimeUnit.SECONDS);
+      Assert.assertEquals(connectState[0], MetaClientInterface.ConnectState.NOT_CONNECTED);
+      Assert.assertEquals(connectState[1], MetaClientInterface.ConnectState.CONNECTED);
     }
   }
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -331,7 +331,6 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
         @Override
         public void handleConnectStateChanged(MetaClientInterface.ConnectState prevState,
             MetaClientInterface.ConnectState currentState) throws Exception {
-          System.out.println("from: " + prevState + " to State: " + currentState);
           connectState[0] = prevState;
           connectState[1] = currentState;
           countDownLatch.countDown();

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkStateListener.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkStateListener.java
@@ -58,4 +58,8 @@ public interface IZkStateListener {
    *             On any error.
    */
   void handleSessionEstablishmentError(final Throwable error) throws Exception;
+
+  default void handleStateChanged(KeeperState prevState, KeeperState curState) throws Exception {
+    handleStateChanged(curState);
+  }
 }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2237 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change add support for connect state change in ZkMetaClient

### Tests

- [X] The following tests are written for this issue:

TestZkMetaClient.testConnectStateChangeListener

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 232.597 s - in org.apache.helix.monitoring.TestClusterStatusMonitorLifecycle
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

```
### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
