### PR TITLE
check connnect only called once

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.management.JMException;
+
 import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.constant.ZkSystemPropertyKeys;
 import org.apache.helix.zookeeper.datamodel.SessionAwareZNRecord;
@@ -2508,11 +2509,17 @@ public class ZkClient implements Watcher {
    */
   public void connect(final long maxMsToWaitUntilConnected, Watcher watcher)
       throws ZkInterruptedException, ZkTimeoutException, IllegalStateException {
+    acquireEventLock();
+
     if (isClosed()) {
       throw new IllegalStateException("ZkClient already closed!");
     }
+    if (_currentState != null) {
+      throw new IllegalStateException(
+          "ZkClient is not in init state. connect() has already been called.");
+    }
+
     boolean started = false;
-    acquireEventLock();
     try {
       setShutdownTrigger(false);
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -2509,18 +2509,18 @@ public class ZkClient implements Watcher {
    */
   public void connect(final long maxMsToWaitUntilConnected, Watcher watcher)
       throws ZkInterruptedException, ZkTimeoutException, IllegalStateException {
-    acquireEventLock();
-
-    if (isClosed()) {
-      throw new IllegalStateException("ZkClient already closed!");
-    }
-    if (_currentState != null) {
-      throw new IllegalStateException(
-          "ZkClient is not in init state. connect() has already been called.");
-    }
-
     boolean started = false;
+
     try {
+      acquireEventLock();
+
+      if (isClosed()) {
+        throw new IllegalStateException("ZkClient already closed!");
+      }
+      if (_currentState != null) {
+        throw new IllegalStateException(
+            "ZkClient is not in init state. connect() has already been called.");
+      }
       setShutdownTrigger(false);
 
       IZkConnection zkConnection = getConnection();
@@ -2541,8 +2541,7 @@ public class ZkClient implements Watcher {
         zkConnection.connect(watcher);
         LOG.debug("zkclient{} Awaiting connection to Zookeeper server", _uid);
         if (!waitUntilConnected(maxMsToWaitUntilConnected, TimeUnit.MILLISECONDS)) {
-          throw new ZkTimeoutException(
-              "Unable to connect to zookeeper server within timeout: " + maxMsToWaitUntilConnected);
+          throw new ZkTimeoutException("Unable to connect to zookeeper server within timeout: " + maxMsToWaitUntilConnected);
         }
       } else {
         // if the client is not managing connection, the input connection is supposed to connect.


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2393

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
This change adds an extra check in ZkClient.connect so that it will only be invoked once.
Also avoid close called in between of `isclosed` check and connection establishment in connect().

### Tests

- [X] The following tests are written for this issue:

NA

- The following is the result of the "mvn test" command on the appropriate module:
```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 337.691 s - in org.apache.helix.rest.server.TestResourceAssignmentOptimizerAccessor
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 

```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
