### PR TITLE
TTL Node Lattice Implementation

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -75,7 +75,7 @@ public interface MetaClientInterface<T> {
   /**
    * Interface representing the metadata of an entry. It contains entry type and version number.
    * TODO: we will add session ID to entry stats in the future
-   * TODO: Add support for expiry node once it can be verified through testing.
+   * TODO: Add support for expiry time
    */
   class Stat {
     private final int _version;

--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -75,12 +75,18 @@ public interface MetaClientInterface<T> {
   /**
    * Interface representing the metadata of an entry. It contains entry type and version number.
    * TODO: we will add session ID to entry stats in the future
+   * TODO: Add support for expiry node once it can be verified through testing.
    */
   class Stat {
     private final int _version;
     private final EntryMode _entryMode;
+    // The expiry time of a TTL node in milliseconds. The default is -1 for nodes without expiry time.
     private long _expiryTime;
+
+    // The time when the node is created. Measured in milliseconds since the Unix epoch (January 1, 1970, 00:00:00 UTC).
     private long _creationTime;
+
+    // The time when the node was las modified. Measured in milliseconds since the Unix epoch when the node was last modified.
     private long _modifiedTime;
 
     public EntryMode getEntryType() {
@@ -149,7 +155,8 @@ public interface MetaClientInterface<T> {
 
   /**
    * Renews the specified TTL node adding its original expiry time
-   * to the current time.
+   * to the current time. Throws an exception if the key is not a valid path
+   * or isn't of type TTL.
    * @param key key to identify the entry
    */
   void renewTTLNode(final String key);
@@ -189,7 +196,7 @@ public interface MetaClientInterface<T> {
 
   /**
    * API for transaction. The list of operation will be executed as an atomic operation.
-   * @param ops a list of operations. These operations will all be executed or non of them.
+   * @param ops a list of operations. These operations will all be executed or none of them.
    * @return Return a list of OpResult.
    */
   List<OpResult> transactionOP(final Iterable<Op> ops);

--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -79,6 +79,9 @@ public interface MetaClientInterface<T> {
   class Stat {
     private final int _version;
     private final EntryMode _entryMode;
+    private long _expiryTime;
+    private long _creationTime;
+    private long _modifiedTime;
 
     public EntryMode getEntryType() {
       return _entryMode;
@@ -88,9 +91,30 @@ public interface MetaClientInterface<T> {
       return _version;
     }
 
+    public long getExpiryTime() {
+      return _expiryTime;
+    }
+
+    public long getCreationTime() {
+      return _creationTime;
+    }
+
+    public long getModifiedTime() {
+      return _modifiedTime;
+    }
+
     public Stat (EntryMode mode, int version) {
       _version = version;
       _entryMode = mode;
+      _expiryTime = -1;
+    }
+
+    public Stat (EntryMode mode, int version, long ctime, long mtime, long etime) {
+      _version = version;
+      _entryMode = mode;
+      _creationTime = ctime;
+      _modifiedTime = mtime;
+      _expiryTime = etime;
     }
   }
 
@@ -113,7 +137,22 @@ public interface MetaClientInterface<T> {
    */
   void create(final String key, final T data, final EntryMode mode);
 
-  // TODO: add TTL create and renew API
+  /**
+   * Create an entry of given EntryMode with given key, data, and expiry time (ttl).
+   * The entry will automatically purge when reached expiry time and has no children.
+   * The entry will not be created if there is an existing entry with the same key.
+   * @param key key to identify the entry
+   * @param data value of the entry
+   * @param ttl Time-to-live value of the node in milliseconds.
+   */
+  void createWithTTL(final String key, final T data, final long ttl);
+
+  /**
+   * Renews the specified TTL node adding its original expiry time
+   * to the current time.
+   * @param key key to identify the entry
+   */
+  void renewTTLNode(final String key);
 
   /**
    * Set the data for the entry of the given key if it exists and the given version matches the

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -90,12 +90,17 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
 
   @Override
   public void createWithTTL(String key, T data, long ttl) {
-    throw new UnsupportedOperationException("TTL nodes aren't yet supported.");
+    try{
+      _zkClient.createPersistentWithTTL(key, data, ttl);
+    } catch (ZkException e) {
+      throw translateZkExceptionToMetaclientException(e);
+    }
   }
 
+  //TODO: Implement logic for renewTTL once expiry time can be verified through testing.
   @Override
   public void renewTTLNode(String key) {
-    throw new UnsupportedOperationException("TTL nodes aren't yet supported.");
+    throw new NotImplementedException("Renew TTL node is not available yet.");
   }
 
   @Override

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -19,7 +19,6 @@ package org.apache.helix.metaclient.impl.zk;
  * under the License.
  */
 
-import java.security.Key;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -52,7 +51,6 @@ import org.apache.helix.zookeeper.zkclient.ZkConnection;
 import org.apache.helix.zookeeper.zkclient.exception.ZkException;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,11 +104,10 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
 
   @Override
   public void renewTTLNode(String key) {
-    if (!_zkClient.exists(key)) {
-      throw new MetaClientNoNodeException("Node at path " + key + " does not exist.");
+    T oldData = get(key);
+    if (oldData == null) {
+      throw new MetaClientNoNodeException("Node at " + key + " does not exist.");
     }
-
-    T oldData = _zkClient.readData(key, _zkClient.getStat(key));
     set(key, oldData, _zkClient.getStat(key).getVersion());
   }
 

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -89,6 +89,16 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
   }
 
   @Override
+  public void createWithTTL(String key, T data, long ttl) {
+    throw new UnsupportedOperationException("TTL nodes aren't yet supported.");
+  }
+
+  @Override
+  public void renewTTLNode(String key) {
+    throw new UnsupportedOperationException("TTL nodes aren't yet supported.");
+  }
+
+  @Override
   public void set(String key, T data, int version) {
     try {
       _zkClient.writeData(key, data, version);

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
@@ -37,7 +37,7 @@ import org.apache.helix.metaclient.exception.MetaClientTimeoutException;
 import org.apache.helix.zookeeper.zkclient.exception.ZkBadVersionException;
 import org.apache.helix.zookeeper.zkclient.exception.ZkException;
 import org.apache.helix.zookeeper.zkclient.exception.ZkInterruptedException;
-import org.apache.helix.zookeeper.zkclient.exception.ZkNodeExistsException;
+import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
 import org.apache.helix.zookeeper.zkclient.exception.ZkTimeoutException;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -226,7 +226,7 @@ public class ZkMetaClientUtil {
   }
 
   public static MetaClientException translateZkExceptionToMetaclientException(ZkException e) {
-    if (e instanceof ZkNodeExistsException) {
+    if (e instanceof ZkNoNodeException) {
       return new MetaClientNoNodeException(e);
     } else if (e instanceof ZkBadVersionException) {
       return new MetaClientBadVersionException(e);

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
@@ -218,9 +218,8 @@ public class ZkMetaClientUtil {
         return MetaClientInterface.EntryMode.CONTAINER;
       case NORMAL:
         return MetaClientInterface.EntryMode.EPHEMERAL;
-      // TODO: TTL is not supported now.
-      //case TTL:
-      //  return EntryMode.TTL;
+      case TTL:
+        return MetaClientInterface.EntryMode.TTL;
       default:
         throw new IllegalArgumentException(zkEphemeralType + " is not supported.");
     }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -19,12 +19,17 @@ package org.apache.helix.metaclient.impl.zk;
  * under the License.
  */
 
-import java.util.*;
-
 import org.apache.helix.metaclient.api.DataUpdater;
 import org.apache.helix.metaclient.api.MetaClientInterface;
 import org.apache.helix.metaclient.exception.MetaClientException;
 import org.apache.helix.metaclient.api.DirectChildChangeListener;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,9 +38,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.helix.metaclient.api.ConnectStateChangeListener;
 import org.apache.helix.metaclient.api.DataChangeListener;
-import org.apache.helix.metaclient.api.DataUpdater;
-import org.apache.helix.metaclient.api.DirectChildChangeListener;
-import org.apache.helix.metaclient.api.MetaClientInterface;
 import org.apache.helix.metaclient.api.Op;
 import org.apache.helix.metaclient.api.OpResult;
 import org.apache.helix.metaclient.exception.MetaClientNoNodeException;

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -95,7 +95,6 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
     }
   }
 
-  @Ignore("This test works when ZkClient setup invokes helix manager.")
   @Test
   public void testRenewTTL() {
     final String key = "/TestZkMetaClient_testRenewTTL_1";
@@ -106,11 +105,15 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
 
       MetaClientInterface.Stat stat = zkMetaClient.exists(key);
 
+      // Sleep for a small period of time for a bigger difference between
+      // creation and modified time.
       Thread.sleep(5000);
+
       zkMetaClient.renewTTLNode(key);
 
+      // Renewing a ttl node changes the nodes modified_time. Should be different
+      // from the time the node was created.
       Assert.assertNotSame(stat.getCreationTime(), stat.getModifiedTime());
-
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -19,8 +19,6 @@ package org.apache.helix.metaclient.impl.zk;
  * under the License.
  */
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,15 +28,8 @@ import java.util.Set;
 import org.apache.helix.metaclient.api.DataUpdater;
 import org.apache.helix.metaclient.api.MetaClientInterface;
 import org.apache.helix.metaclient.exception.MetaClientException;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.helix.metaclient.api.DataUpdater;
 import org.apache.helix.metaclient.api.DirectChildChangeListener;
-import org.apache.helix.metaclient.api.MetaClientInterface;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -48,14 +39,9 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.apache.helix.metaclient.api.DataChangeListener;
 import org.apache.helix.metaclient.api.Op;
 import org.apache.helix.metaclient.api.OpResult;
-import org.apache.helix.metaclient.exception.MetaClientException;
 import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
-import org.apache.helix.zookeeper.zkclient.IDefaultNameSpace;
-import org.apache.helix.zookeeper.zkclient.ZkServer;
 import org.apache.zookeeper.KeeperException;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.apache.helix.metaclient.api.MetaClientInterface.EntryMode.CONTAINER;
@@ -67,7 +53,7 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
   private static final String ZK_ADDR = "localhost:2183";
   private static final int DEFAULT_TIMEOUT_MS = 1000;
   private static final String ENTRY_STRING_VALUE = "test-value";
-  private static String TRANSACTION_TEST_PARENT_PATH = "/transactionOpTestPath";
+  private static final String TRANSACTION_TEST_PARENT_PATH = "/transactionOpTestPath";
   private static final String TEST_INVALID_PATH = "_invalid/a/b/c";
 
   private final Object _syncObject = new Object();
@@ -94,6 +80,16 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
     try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
       zkMetaClient.connect();
       zkMetaClient.create(key, ENTRY_STRING_VALUE, CONTAINER);
+      Assert.assertNotNull(zkMetaClient.exists(key));
+    }
+  }
+
+  @Test
+  public void testCreateTTL() {
+    final String key = "/TestZkMetaClient_testTTL";
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      zkMetaClient.connect();
+      zkMetaClient.createWithTTL(key, ENTRY_STRING_VALUE, 1000);
       Assert.assertNotNull(zkMetaClient.exists(key));
     }
   }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -41,6 +41,7 @@ import org.apache.helix.metaclient.api.Op;
 import org.apache.helix.metaclient.api.OpResult;
 import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
 import org.apache.zookeeper.KeeperException;
+import org.junit.Ignore;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -91,6 +92,27 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
       zkMetaClient.connect();
       zkMetaClient.createWithTTL(key, ENTRY_STRING_VALUE, 1000);
       Assert.assertNotNull(zkMetaClient.exists(key));
+    }
+  }
+
+  @Ignore("This test works when ZkClient setup invokes helix manager.")
+  @Test
+  public void testRenewTTL() {
+    final String key = "/TestZkMetaClient_testRenewTTL_1";
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      zkMetaClient.connect();
+      zkMetaClient.createWithTTL(key, ENTRY_STRING_VALUE, 10000);
+      Assert.assertNotNull(zkMetaClient.exists(key));
+
+      MetaClientInterface.Stat stat = zkMetaClient.exists(key);
+
+      Thread.sleep(5000);
+      zkMetaClient.renewTTLNode(key);
+
+      Assert.assertNotSame(stat.getCreationTime(), stat.getModifiedTime());
+
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -19,16 +19,11 @@ package org.apache.helix.metaclient.impl.zk;
  * under the License.
  */
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.helix.metaclient.api.DataUpdater;
 import org.apache.helix.metaclient.api.MetaClientInterface;
 import org.apache.helix.metaclient.exception.MetaClientException;
-import java.util.Map;
 import org.apache.helix.metaclient.api.DirectChildChangeListener;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -43,9 +38,9 @@ import org.apache.helix.metaclient.api.DirectChildChangeListener;
 import org.apache.helix.metaclient.api.MetaClientInterface;
 import org.apache.helix.metaclient.api.Op;
 import org.apache.helix.metaclient.api.OpResult;
+import org.apache.helix.metaclient.exception.MetaClientNoNodeException;
 import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
 import org.apache.zookeeper.KeeperException;
-import org.junit.Ignore;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -59,7 +54,7 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
   private static final int DEFAULT_TIMEOUT_MS = 1000;
   private static final String ENTRY_STRING_VALUE = "test-value";
   private static final String TRANSACTION_TEST_PARENT_PATH = "/transactionOpTestPath";
-  private static final String TEST_INVALID_PATH = "_invalid/a/b/c";
+  private static final String TEST_INVALID_PATH = "/_invalid/a/b/c";
 
   private final Object _syncObject = new Object();
 
@@ -106,20 +101,15 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
       zkMetaClient.connect();
       zkMetaClient.createWithTTL(key, ENTRY_STRING_VALUE, 10000);
       Assert.assertNotNull(zkMetaClient.exists(key));
-
       MetaClientInterface.Stat stat = zkMetaClient.exists(key);
-
-      // Sleep for a small period of time for a bigger difference between
-      // creation and modified time.
-      Thread.sleep(5000);
-
       zkMetaClient.renewTTLNode(key);
-
       // Renewing a ttl node changes the nodes modified_time. Should be different
       // from the time the node was created.
       Assert.assertNotSame(stat.getCreationTime(), stat.getModifiedTime());
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      try {
+        zkMetaClient.renewTTLNode(TEST_INVALID_PATH);
+      } catch (MetaClientNoNodeException ignored) {
+      }
     }
   }
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/ZkMetaClientTestBase.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/ZkMetaClientTestBase.java
@@ -49,6 +49,8 @@ public abstract class ZkMetaClientTestBase {
    */
   @BeforeSuite
   public void prepare() {
+    // Enable extended types and create a ZkClient
+    System.setProperty("zookeeper.extendedTypesEnabled", "true");
     // start local zookeeper server
     _zkServer = startZkServer(ZK_ADDR);
   }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

https://github.com/apache/helix/issues/2237

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Implementing TTL node create and renew methods. The `expiry_time` instance variable in the `MetaClient.Stat` is not implemented as the current way ZkClient is setup doesn't allow for it (needs a `ContainerManager`, see comment in `ZkMetaClientTestBase` for more information on this issue).  Ticket to fix the setup has been filed and will be picked up when there's available bandwidth.

Other minor fixes and removal of unnecessary imports.

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

`testCreateTTL()` and `testRenewTTL()` tests end to end behavior of a TTL node.


- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
