### PR TITLE
use reconnect timeout for crud retry timeout

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientConstants.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/constants/MetaClientConstants.java
@@ -42,5 +42,8 @@ public final class MetaClientConstants {
   // Initial backoff window for exponential reconnect back off policy. by default is 500 ms.
   public static final long DEFAULT_INIT_EXP_BACKOFF_RETRY_INTERVAL_MS = 500;
 
+  // Auto Reconnect timeout
+  public static final long DEFAULT_AUTO_RECONNECT_TIMEOUT_MS = 30 * 60 * 1000;
+
   //public static final long DEFAULT_MAX_LINEAR_BACKOFF_RETRY_WINDOW_MS = 5*1000;
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/factory/ZkMetaClientConfig.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/factory/ZkMetaClientConfig.java
@@ -19,8 +19,8 @@ package org.apache.helix.metaclient.impl.zk.factory;
  * under the License.
  */
 
-import org.apache.helix.metaclient.policy.MetaClientReconnectPolicy;
 import org.apache.helix.metaclient.factories.MetaClientConfig;
+import org.apache.helix.metaclient.policy.MetaClientReconnectPolicy;
 import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.SerializableSerializer;
@@ -61,12 +61,11 @@ public class ZkMetaClientConfig extends MetaClientConfig {
   }
 
   protected ZkMetaClientConfig(String connectionAddress, long connectionInitTimeoutInMillis,
-      long operationRetryTimeoutInMillis, long sessionTimeoutInMillis,
-      MetaClientReconnectPolicy reconnectPolicy, boolean enableAuth, StoreType storeType,
-      String monitorType, String monitorKey, String monitorInstanceName,
+      long sessionTimeoutInMillis, MetaClientReconnectPolicy reconnectPolicy, boolean enableAuth,
+      StoreType storeType, String monitorType, String monitorKey, String monitorInstanceName,
       boolean monitorRootPathOnly, PathBasedZkSerializer zkSerializer) {
-    super(connectionAddress, connectionInitTimeoutInMillis, operationRetryTimeoutInMillis,
-        sessionTimeoutInMillis, reconnectPolicy, enableAuth, storeType);
+    super(connectionAddress, connectionInitTimeoutInMillis, sessionTimeoutInMillis, reconnectPolicy,
+        enableAuth, storeType);
     _zkSerializer = zkSerializer;
     _monitorType = monitorType;
     _monitorKey = monitorKey;
@@ -130,11 +129,10 @@ public class ZkMetaClientConfig extends MetaClientConfig {
 
     @Override
     public ZkMetaClientConfig build() {
-      if (_zkSerializer == null) {
-        _zkSerializer = new BasicZkSerializer(new SerializableSerializer());
-      }
+      validate();
+
       return new ZkMetaClientConfig(_connectionAddress, _connectionInitTimeoutInMillis,
-          _operationRetryTimeout, _sessionTimeoutInMillis, _metaClientReconnectPolicy, _enableAuth,
+          _sessionTimeoutInMillis, _metaClientReconnectPolicy, _enableAuth,
           MetaClientConfig.StoreType.ZOOKEEPER, _monitorType, _monitorKey, _monitorInstanceName,
           _monitorRootPathOnly, _zkSerializer);
     }
@@ -142,6 +140,9 @@ public class ZkMetaClientConfig extends MetaClientConfig {
     @Override
     protected void validate() {
       super.validate();
+      if (_zkSerializer == null) {
+        _zkSerializer = new BasicZkSerializer(new SerializableSerializer());
+      }
     }
   }
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/policy/MetaClientReconnectPolicy.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/policy/MetaClientReconnectPolicy.java
@@ -37,7 +37,6 @@ public interface MetaClientReconnectPolicy {
 
   RetryPolicyName getPolicyName();
 
-  // TODO: add reconnect timeout
   default  long getAutoReconnectTimeout() {
     return DEFAULT_AUTO_RECONNECT_TIMEOUT_MS;
   }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/policy/MetaClientReconnectPolicy.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/policy/MetaClientReconnectPolicy.java
@@ -19,6 +19,9 @@ package org.apache.helix.metaclient.policy;
  * under the License.
  */
 
+import static org.apache.helix.metaclient.constants.MetaClientConstants.DEFAULT_AUTO_RECONNECT_TIMEOUT_MS;
+
+
 /**
  * Policy to define client re-establish connection behavior when connection to underlying metadata
  * store is expired.
@@ -35,4 +38,7 @@ public interface MetaClientReconnectPolicy {
   RetryPolicyName getPolicyName();
 
   // TODO: add reconnect timeout
+  default  long getAutoReconnectTimeout() {
+    return DEFAULT_AUTO_RECONNECT_TIMEOUT_MS;
+  }
 }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2237

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Had an offline discussion with other committers. 
Since operation retry waits for connect state change event, it will retry when reconnect succeeded and retry will be canceled when reconnect errored or timed out. There is no need to have 2 configurable timeout for CRUD operation retry and reconnect retry.
This change remove crud operation retry timeout.

### Tests

- [X] The following tests are written for this issue:

NA

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
