### PR TITLE
CI Failure - Add 2 disabled test cases into a separate file.

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkHelixManager.java
@@ -1,0 +1,70 @@
+package org.apache.helix.integration.multizk;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Date;
+import org.apache.helix.*;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ *
+ * This test class will not set jvm routing zk config and test Helix functionality.
+ * Tests were similar to TestMultiZkHelixJavaApis but without "MSDS_SERVER_ENDPOINT_KEY"
+ * in system property
+ */
+public class TestMultiZkHelixManager extends TestMultiZkConnectionConfig {
+  private static final String _className = TestHelper.getTestClassName();
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    super.beforeClass();
+  }
+
+  /**
+   * Test creation of HelixManager and makes sure it connects correctly.
+   */
+  @Override
+  @Test
+  public void testZKHelixManager() throws Exception {
+    String methodName = TestHelper.getTestMethodName();
+
+    System.out.println("START " + _className + "_" + methodName + " at " + new Date(System.currentTimeMillis()));
+
+    super.testZKHelixManager();
+
+    System.out.println("END " + _className + "_" + methodName + " at " + new Date(System.currentTimeMillis()));
+  }
+
+  /**
+   * Test creation of HelixManager and makes sure it connects correctly.
+   */
+  @Override
+  @Test(dependsOnMethods = "testZKHelixManager")
+  public void testZKHelixManagerCloudConfig() throws Exception {
+    String methodName = TestHelper.getTestMethodName();
+    System.out.println("START " + _className + "_" + methodName + " at " + new Date(System.currentTimeMillis()));
+
+    super.testZKHelixManagerCloudConfig();
+
+    System.out.println("END " + _className + "_" + methodName + " at " + new Date(System.currentTimeMillis()));
+  }
+}


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:


### Description
This is an alternate approach to see if moving those 2 failed test cases to a different file and having explicit afterClass() cleanup helps.


- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:
Testing done:
[INFO] ------------------------------------------------------- [INFO]  T E S T S
[INFO] ------------------------------------------------------- [INFO] Running org.apache.helix.integration.multizk.TestMultiZkHelixManager Start zookeeper at localhost:8977 in thread main
Start zookeeper at localhost:8978 in thread main
Start zookeeper at localhost:8979 in thread main
...
START TestMultiZkConnectionConfig_testZKHelixManager at Thu Apr 06 19:42:44 PDT 2023 END TestMultiZkConnectionConfig_testZKHelixManager at Thu Apr 06 19:42:45 PDT 2023 END TestMultiZkHelixManager_testZKHelixManager at Thu Apr 06 19:42:45 PDT 2023 START TestMultiZkHelixManager_testZKHelixManagerCloudConfig at Thu Apr 06 19:42:45 PDT 2023 START TestMultiZkConnectionConfig_testZKHelixManagerCloudConfig at Thu Apr 06 19:42:45 PDT 2023 END TestMultiZkConnectionConfig_testZKHelixManagerCloudConfig at Thu Apr 06 19:42:46 PDT 2023 END TestMultiZkHelixManager_testZKHelixManagerCloudConfig at Thu Apr 06 19:42:46 PDT 2023 [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 328.3 s - in org.apache.helix.integration.multizk.TestMultiZkHelixManager [INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 [INFO]
[INFO]
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core --- [INFO] Loading execution data file /Users/kdesai/apache/helix/helix-core/target/jacoco.exec [INFO] Analyzed bundle 'Apache Helix :: Core' with 799 classes [INFO] ------------------------------------------------------------------------ [INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------ [INFO] Total time:  05:35 min
[INFO] Finished at: 2023-04-06T19:43:10-07:00
[INFO] ------------------------------------------------------------------------

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
