### PR TITLE
Force clean Znodes in after class when tests failed to clean up

### DIFF
--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -83,7 +83,7 @@ public class TestRawZkClient extends ZkTestBase {
 
   @AfterClass
   public void afterClass() {
-    _zkClient.delete(TEST_ROOT);
+    _zkClient.deleteRecursively(TEST_ROOT);
     _zkClient.deleteRecursively("/tmp");
     _zkClient.deleteRecursively("/my_cluster");
     _zkClient.close();


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
#2395   


### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

When test in `TestRawZkClient` throws exception, created ZNode in those tests may not be correctly removed. Afterclass need to be able to adapt that to clean up.

### Tests

- [X] The following tests are written for this issue:
- NA

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
