### PR TITLE
Add comment and description for ZkMetaClient reconnect handling

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -450,9 +450,10 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
   }
 
   /**
-   * MetaClient uses ZkClient to connect underlying metadata services. ZkClient current do auto
-   * reconnect infinitely. We use monitor thread in ZkMetaClient to monitor reconnect status and
-   * close ZkClient when the client still is in disconnected state when it reach reconnect timeout.
+   * MetaClient uses Helix ZkClient (@see org.apache.helix.zookeeper.impl.client.ZkClient) to connect
+   * to ZK. Current implementation of ZkClient auto-reconnects infinitely. We use monitor thread
+   * in ZkMetaClient to monitor reconnect status and close ZkClient when the client still is in
+   * disconnected state when it reach reconnect timeout.
    *
    *
    * case 1: Start the monitor thread when ZkMetaClient gets disconnected even to check connect state


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
#2237

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
ZkMetaClient uses a separate thread to monitor the reconnect state of ZkClient. There are 3 different cases for reconnect result and we handle them differently. 
This change adds detailed comments and thread interaction graph for clarity. 

### Tests

- [X] The following tests are written for this issue:

NA 

- The following is the result of the "mvn test" command on the appropriate module:

rerun failed CI
```
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 294.266 s - in org.apache.helix.rest.server.TestPerInstanceAccessor
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
