### PR TITLE
Fixing the ZkServer.start() to just check for free port when starting ZK

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/NetworkUtil.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/NetworkUtil.java
@@ -22,76 +22,13 @@ package org.apache.helix.zookeeper.zkclient;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
-import java.net.NetworkInterface;
 import java.net.Socket;
 import java.net.SocketException;
 import java.net.UnknownHostException;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.Set;
 
 public class NetworkUtil {
 
     public final static String OVERWRITE_HOSTNAME_SYSTEM_PROPERTY = "zkclient.hostname.overwritten";
-
-    public static String[] getLocalHostNames() {
-        final Set<String> hostNames = new HashSet<String>();
-        // we add localhost to this set manually, because if the ip 127.0.0.1 is
-        // configured with more than one name in the /etc/hosts, only the first
-        // name
-        // is returned
-        hostNames.add("localhost");
-        try {
-            final Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
-            for (final Enumeration<NetworkInterface> ifaces = networkInterfaces; ifaces.hasMoreElements();) {
-                final NetworkInterface iface = ifaces.nextElement();
-                InetAddress ia = null;
-                for (final Enumeration<InetAddress> ips = iface.getInetAddresses(); ips.hasMoreElements();) {
-                    ia = ips.nextElement();
-                    hostNames.add(ia.getCanonicalHostName());
-                    hostNames.add(ipToString(ia.getAddress()));
-                }
-            }
-        } catch (final SocketException e) {
-            throw new RuntimeException("unable to retrieve host names of localhost");
-        }
-        return hostNames.toArray(new String[hostNames.size()]);
-    }
-
-    private static String ipToString(final byte[] bytes) {
-        final StringBuffer addrStr = new StringBuffer();
-        for (int cnt = 0; cnt < bytes.length; cnt++) {
-            final int uByte = bytes[cnt] < 0 ? bytes[cnt] + 256 : bytes[cnt];
-            addrStr.append(uByte);
-            if (cnt < 3)
-                addrStr.append('.');
-        }
-        return addrStr.toString();
-    }
-
-    public static int hostNamesInList(final String serverList, final String[] hostNames) {
-        final String[] serverNames = serverList.split(",");
-        for (int i = 0; i < hostNames.length; i++) {
-            final String hostname = hostNames[i];
-            for (int j = 0; j < serverNames.length; j++) {
-                final String serverNameAndPort = serverNames[j];
-                final String serverName = serverNameAndPort.split(":")[0];
-                if (serverName.equalsIgnoreCase(hostname)) {
-                    return j;
-                }
-            }
-        }
-        return -1;
-    }
-
-    public static boolean hostNameInArray(final String[] hostNames, final String hostName) {
-        for (final String name : hostNames) {
-            if (name.equalsIgnoreCase(hostName)) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     public static boolean isPortFree(int port) {
         try {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/NetworkUtil.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/NetworkUtil.java
@@ -22,13 +22,76 @@ package org.apache.helix.zookeeper.zkclient;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
+import java.net.NetworkInterface;
 import java.net.Socket;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
 
 public class NetworkUtil {
 
     public final static String OVERWRITE_HOSTNAME_SYSTEM_PROPERTY = "zkclient.hostname.overwritten";
+
+    public static String[] getLocalHostNames() {
+        final Set<String> hostNames = new HashSet<String>();
+        // we add localhost to this set manually, because if the ip 127.0.0.1 is
+        // configured with more than one name in the /etc/hosts, only the first
+        // name
+        // is returned
+        hostNames.add("localhost");
+        try {
+            final Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+            for (final Enumeration<NetworkInterface> ifaces = networkInterfaces; ifaces.hasMoreElements();) {
+                final NetworkInterface iface = ifaces.nextElement();
+                InetAddress ia = null;
+                for (final Enumeration<InetAddress> ips = iface.getInetAddresses(); ips.hasMoreElements();) {
+                    ia = ips.nextElement();
+                    hostNames.add(ia.getCanonicalHostName());
+                    hostNames.add(ipToString(ia.getAddress()));
+                }
+            }
+        } catch (final SocketException e) {
+            throw new RuntimeException("unable to retrieve host names of localhost");
+        }
+        return hostNames.toArray(new String[hostNames.size()]);
+    }
+
+    private static String ipToString(final byte[] bytes) {
+        final StringBuffer addrStr = new StringBuffer();
+        for (int cnt = 0; cnt < bytes.length; cnt++) {
+            final int uByte = bytes[cnt] < 0 ? bytes[cnt] + 256 : bytes[cnt];
+            addrStr.append(uByte);
+            if (cnt < 3)
+                addrStr.append('.');
+        }
+        return addrStr.toString();
+    }
+
+    public static int hostNamesInList(final String serverList, final String[] hostNames) {
+        final String[] serverNames = serverList.split(",");
+        for (int i = 0; i < hostNames.length; i++) {
+            final String hostname = hostNames[i];
+            for (int j = 0; j < serverNames.length; j++) {
+                final String serverNameAndPort = serverNames[j];
+                final String serverName = serverNameAndPort.split(":")[0];
+                if (serverName.equalsIgnoreCase(hostname)) {
+                    return j;
+                }
+            }
+        }
+        return -1;
+    }
+
+    public static boolean hostNameInArray(final String[] hostNames, final String hostName) {
+        for (final String name : hostNames) {
+            if (name.equalsIgnoreCase(hostName)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public static boolean isPortFree(int port) {
         try {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkServer.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkServer.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+
 import org.apache.helix.zookeeper.zkclient.exception.ZkException;
 import org.apache.helix.zookeeper.zkclient.exception.ZkInterruptedException;
 import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
@@ -87,6 +88,11 @@ public class ZkServer {
 
     private void startZooKeeperServer() {
         long startTime = System.currentTimeMillis();
+        /**
+         * Checking if the ZK hostname is present in the list of resolved ips/hostnames for
+         * all network interfaces on a machine is expensive. So, we start the ZK on any local
+         * address and just check if the port specified is free.
+         */
         if (NetworkUtil.isPortFree(_port)) {
             final File dataDir = new File(_dataDir);
             final File dataLogDir = new File(_logDir);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkServer.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkServer.java
@@ -22,19 +22,16 @@ package org.apache.helix.zookeeper.zkclient;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-
 import org.apache.helix.zookeeper.zkclient.exception.ZkException;
 import org.apache.helix.zookeeper.zkclient.exception.ZkInterruptedException;
 import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.SerializableSerializer;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ZkServer {
 
@@ -83,55 +80,25 @@ public class ZkServer {
 
     @PostConstruct
     public void start() {
-        final String[] localHostNames = NetworkUtil.getLocalHostNames();
-        String names = "";
-        for (int i = 0; i < localHostNames.length; i++) {
-            final String name = localHostNames[i];
-            names += " " + name;
-            if (i + 1 != localHostNames.length) {
-                names += ",";
-            }
-        }
-        LOG.info("Starting ZkServer on: [" + names + "] port " + _port + "...");
         startZooKeeperServer();
         _zkClient = new ZkClient(new ZkConnection("localhost:" + _port), 10000, -1, new BasicZkSerializer(new SerializableSerializer()), null, null, null, false);
         _defaultNameSpace.createDefaultNameSpace(_zkClient);
     }
 
     private void startZooKeeperServer() {
-        final String[] localhostHostNames = NetworkUtil.getLocalHostNames();
-        final String servers = "localhost:" + _port;
-        // check if this server needs to start a _client server.
-        int pos = -1;
-        LOG.debug("check if hostNames " + servers + " is in list: " + Arrays.asList(localhostHostNames));
-        if ((pos = NetworkUtil.hostNamesInList(servers, localhostHostNames)) != -1) {
-            // yes this server needs to start a zookeeper server
-            final String[] hosts = servers.split(",");
-            final String[] hostSplitted = hosts[pos].split(":");
-            int port = _port;
-            if (hostSplitted.length > 1) {
-                port = Integer.parseInt(hostSplitted[1]);
-            }
-            // check if this machine is already something running..
-            if (NetworkUtil.isPortFree(port)) {
-                final File dataDir = new File(_dataDir);
-                final File dataLogDir = new File(_logDir);
-                dataDir.mkdirs();
-                dataLogDir.mkdirs();
-
-                if (hosts.length > 1) {
-                    // multiple zk servers
-                    LOG.info("Start distributed zookeeper server...");
-                    throw new IllegalArgumentException("Unable to start distributed zookeeper server");
-                }
-                // single zk server
-                LOG.info("Start single zookeeper server...");
-                LOG.info("data dir: " + dataDir.getAbsolutePath());
-                LOG.info("data log dir: " + dataLogDir.getAbsolutePath());
-                startSingleZkServer(_tickTime, dataDir, dataLogDir, port);
-            } else {
-                throw new IllegalStateException("Zookeeper port " + port + " was already in use. Running in single machine mode?");
-            }
+        long startTime = System.currentTimeMillis();
+        if (NetworkUtil.isPortFree(_port)) {
+            final File dataDir = new File(_dataDir);
+            final File dataLogDir = new File(_logDir);
+            dataDir.mkdirs();
+            dataLogDir.mkdirs();
+            LOG.info(String.format("Starting single zookeeper server on port %d...", _port));
+            LOG.info("data dir: " + dataDir.getAbsolutePath());
+            LOG.info("data log dir: " + dataLogDir.getAbsolutePath());
+            startSingleZkServer(_tickTime, dataDir, dataLogDir, _port);
+            LOG.info(String.format("Started single zookeeper server on port %d in %d milliseconds", _port, System.currentTimeMillis() - startTime));
+        } else {
+            throw new IllegalStateException("Zookeeper port " + _port + " was already in use. Running in single machine mode?");
         }
     }
 


### PR DESCRIPTION
### Issues
- [X] My PR addresses the following Helix issues and references them in the PR description:

Starting a ZK server is very time consuming and it's affecting the time taken to debug the integration tests since each test run starts ZK. This PR aims to optimise the start time.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Currently `ZkServer.start()` queries all of the network interfaces to find if `localhost` is present in the interfaces whereas it will always be present since we manually add [localhost](https://github.com/apache/helix/blob/386a77d566f1dc0b480c3bcbdb4a2880a8b8a4a9/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/NetworkUtil.java#L43) to the list of resolved network ips and hostnames.  The call to `NetworkUtil.getLocalhostNames()` is expensive and it is the reason for the increased time to start the Zk server. We also invoke the same method twice one just for logging and other for verifying 😞 

Since ZKServer never accepts a Zk hostname to connect, the check to verify if the port is busy should be sufficient. 

### Tests
- [X] The following tests are written for this issue:

Since this is a helper class, no unit tests exist for this class. However, integration tests and helix examples cover this path. I verified that Helix examples were running all good.

- [X] The following is the result of the "mvn test" command on the appropriate module:

Since the test classes are spread across I ran the `PR_CI` workflow on this commit and below are the results of it's execution.
```
[info] ./helix-core/target/surefire-reports/TestSuite.txt: Tests run: 1325, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5,743.07 s - in TestSuite
[info] ./metadata-store-directory-common/target/surefire-reports/TestSuite.txt: Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.886 s - in TestSuite
[info] ./helix-common/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.405 s - in TestSuite
[info] ./metrics-common/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.384 s - in TestSuite
[info] ./helix-lock/target/surefire-reports/TestSuite.txt: Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 59.772 s - in TestSuite
[info] ./helix-view-aggregator/target/surefire-reports/TestSuite.txt: Tests run: 15, Failures: 1, Errors: 0, Skipped: 1, Time elapsed: 60.445 s <<< FAILURE! - in TestSuite
Error:  Test failed: testHelixViewAggregator(org.apache.helix.view.integration.TestHelixViewAggregator)  Time elapsed: 31.594 s  <<< FAILURE!
[info] ./helix-rest/target/surefire-reports/TestSuite.txt: Tests run: 209, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 166.17 s - in TestSuite
[info] ./zookeeper-api/target/surefire-reports/TestSuite.txt: Tests run: 85, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 158.15 s - in TestSuite
[info] ./recipes/task-execution/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.585 s - in TestSuite
[info] ./recipes/service-discovery/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.637 s - in TestSuite
[info] ./recipes/distributed-lock-manager/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.615 s - in TestSuite
[info] ./recipes/rsync-replicated-file-system/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.62 s - in TestSuite
[info] ./recipes/rabbitmq-consumer-group/target/surefire-reports/TestSuite.txt: Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.624 s - in TestSuite
```

### Commits

- [X] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation (Optional)

- [X] In case of new functionality, my PR adds documentation in the following wiki page:
N/A

### Code Quality

- [X] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)