### PR TITLE
retryUntilConnected - add exponential backoff

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -33,6 +33,9 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.management.JMException;
+
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.constant.ZkSystemPropertyKeys;
 import org.apache.helix.zookeeper.datamodel.SessionAwareZNRecord;
@@ -2037,6 +2040,7 @@ public class ZkClient implements Watcher {
     }
   }
 
+  @VisibleForTesting
   public void setCurrentState(KeeperState currentState) {
     getEventLock().lock();
     try {

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -924,7 +924,7 @@ public class TestRawZkClient extends ZkTestBase {
    * 4. Restarts zk server and Zk session is recovered
    * 5. zk client reconnects successfully and creates an ephemeral node
    */
-  @Test(timeOut = 5 * 60 * 1000L)
+  @Test(timeOut = 5 * 60 * 1000L, dependsOnMethods = "testRetryUntilConnectedAfterConnectionLoss")
   public void testRetryUntilConnectedWithZkCleanupStuck() throws Exception {
     final String methodName = TestHelper.getTestMethodName();
 


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:



### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
In our internal test environment, we ran into a bug where during actual ZK connection disconnect,  the Apache ZK client didn't get chance to mark the status of the ZK connection as disconnected as it was busy draining the outgoing message queue in its cleanup() method. 
Helix ZKClient provides a useful method to customer where we retryUntilConnected() - ie. we will keep retrying till the connection is re-established.  Lot of Helix CRUD operations use this underlying method. But in the above scenario where Apache ZK client didn't get a chance ever to clean up the queue, we will take long time to converge. 

Fix is to retry the request after waiting using exponential back-off. 

### Tests

- [ ] The following tests are written for this issue:
testRetryUntilConnectedWithZkCleanupStuck() 

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:
- The TestRawZKClient has been run in loop for 10 times. 
- mvn -q test (running in progres).
(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
