### PR TITLE
Add exception for register ZK one time watcher when _usePersistWatcher flag is on

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -36,7 +36,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 import javax.management.JMException;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.constant.ZkSystemPropertyKeys;
 import org.apache.helix.zookeeper.datamodel.SessionAwareZNRecord;
@@ -1360,7 +1359,6 @@ public class ZkClient implements Watcher {
     return getChildren(path, (!_usePersistWatcher) && hasListeners(path));
   }
 
-  @VisibleForTesting
   protected List<String> getChildren(final String path, final boolean watch) {
     // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
     // is subscribed as persist watcher, resubscribing the same object as onw time watcher will
@@ -1432,7 +1430,6 @@ public class ZkClient implements Watcher {
     return exists(path, hasListeners(path));
   }
 
-  @VisibleForTesting
   protected boolean exists(final String path, final boolean watch) {
     // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
     // is subscribed as persist watcher, resubscribing the same object as onw time watcher will
@@ -1469,7 +1466,6 @@ public class ZkClient implements Watcher {
     return getStat(path, false);
   }
 
-  @VisibleForTesting
   private Stat getStat(final String path, final boolean watch) {
     // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
     // is subscribed as persist watcher, resubscribing the same object as onw time watcher will

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1360,13 +1360,7 @@ public class ZkClient implements Watcher {
   }
 
   protected List<String> getChildren(final String path, final boolean watch) {
-    // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
-    // is subscribed as persist watcher, resubscribing the same object as onw time watcher will
-    // over write the persist watcher causing missing following event.
-    if (_usePersistWatcher && watch) {
-      throw new IllegalArgumentException(
-          "Can not subscribe one time watcher when ZkClient is using PersistWatcher");
-    }
+    validateNativeZkWatcherType(watch);
     long startT = System.currentTimeMillis();
 
     try {
@@ -1431,13 +1425,7 @@ public class ZkClient implements Watcher {
   }
 
   protected boolean exists(final String path, final boolean watch) {
-    // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
-    // is subscribed as persist watcher, resubscribing the same object as onw time watcher will
-    // over write the persist watcher causing missing following event.
-    if (_usePersistWatcher && watch) {
-      throw new IllegalArgumentException(
-          "Can not subscribe one time watcher when ZkClient is using PersistWatcher");
-    }
+    validateNativeZkWatcherType(watch);
     long startT = System.currentTimeMillis();
     try {
       boolean exists = retryUntilConnected(new Callable<Boolean>() {
@@ -1467,13 +1455,7 @@ public class ZkClient implements Watcher {
   }
 
   private Stat getStat(final String path, final boolean watch) {
-    // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
-    // is subscribed as persist watcher, resubscribing the same object as onw time watcher will
-    // over write the persist watcher causing missing following event.
-    if (_usePersistWatcher && watch) {
-      throw new IllegalArgumentException(
-          "Can not subscribe one time watcher when ZkClient is using PersistWatcher");
-    }
+    validateNativeZkWatcherType(watch);
     long startT = System.currentTimeMillis();
     final Stat stat;
     try {
@@ -2173,13 +2155,7 @@ public class ZkClient implements Watcher {
 
   @SuppressWarnings("unchecked")
   public <T extends Object> T readData(final String path, final Stat stat, final boolean watch) {
-    // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
-    // is subscribed as persist watcher, resubscribing the same object as onw time watcher will
-    // over write the persist watcher causing missing following event.
-    if (_usePersistWatcher && watch) {
-      throw new IllegalArgumentException(
-          "Can not subscribe one time watcher when ZkClient is using PersistWatcher");
-    }
+    validateNativeZkWatcherType(watch);
     long startT = System.currentTimeMillis();
     byte[] data = null;
     try {
@@ -3073,6 +3049,18 @@ public class ZkClient implements Watcher {
       throw new ZkException(ex);
     } finally {
       _persistListenerMutex.unlock();
+    }
+  }
+
+  /*
+    Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
+    is subscribed as persist watcher, resubscribing the same object as onw time watcher will
+    over write the persist watcher causing missing following event.
+   */
+  private void validateNativeZkWatcherType(boolean watch) {
+    if (_usePersistWatcher && watch) {
+      throw new IllegalArgumentException(
+          "Can not subscribe one time watcher when ZkClient is using PersistWatcher");
     }
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -36,6 +36,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 import javax.management.JMException;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.helix.zookeeper.api.client.ChildrenSubscribeResult;
 import org.apache.helix.zookeeper.constant.ZkSystemPropertyKeys;
 import org.apache.helix.zookeeper.datamodel.SessionAwareZNRecord;
@@ -1359,6 +1360,7 @@ public class ZkClient implements Watcher {
     return getChildren(path, (!_usePersistWatcher) && hasListeners(path));
   }
 
+  @VisibleForTesting
   protected List<String> getChildren(final String path, final boolean watch) {
     // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
     // is subscribed as persist watcher, resubscribing the same object as onw time watcher will
@@ -1430,6 +1432,7 @@ public class ZkClient implements Watcher {
     return exists(path, hasListeners(path));
   }
 
+  @VisibleForTesting
   protected boolean exists(final String path, final boolean watch) {
     // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
     // is subscribed as persist watcher, resubscribing the same object as onw time watcher will
@@ -1466,6 +1469,7 @@ public class ZkClient implements Watcher {
     return getStat(path, false);
   }
 
+  @VisibleForTesting
   private Stat getStat(final String path, final boolean watch) {
     // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
     // is subscribed as persist watcher, resubscribing the same object as onw time watcher will

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1360,6 +1360,13 @@ public class ZkClient implements Watcher {
   }
 
   protected List<String> getChildren(final String path, final boolean watch) {
+    // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
+    // is subscribed as persist watcher, resubscribing the same object as onw time watcher will
+    // over write the persist watcher causing missing following event.
+    if (_usePersistWatcher && watch) {
+      throw new IllegalArgumentException(
+          "Can not subscribe one time watcher when ZkClient is using PersistWatcher");
+    }
     long startT = System.currentTimeMillis();
 
     try {
@@ -1424,6 +1431,13 @@ public class ZkClient implements Watcher {
   }
 
   protected boolean exists(final String path, final boolean watch) {
+    // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
+    // is subscribed as persist watcher, resubscribing the same object as onw time watcher will
+    // over write the persist watcher causing missing following event.
+    if (_usePersistWatcher && watch) {
+      throw new IllegalArgumentException(
+          "Can not subscribe one time watcher when ZkClient is using PersistWatcher");
+    }
     long startT = System.currentTimeMillis();
     try {
       boolean exists = retryUntilConnected(new Callable<Boolean>() {
@@ -1453,6 +1467,13 @@ public class ZkClient implements Watcher {
   }
 
   private Stat getStat(final String path, final boolean watch) {
+    // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
+    // is subscribed as persist watcher, resubscribing the same object as onw time watcher will
+    // over write the persist watcher causing missing following event.
+    if (_usePersistWatcher && watch) {
+      throw new IllegalArgumentException(
+          "Can not subscribe one time watcher when ZkClient is using PersistWatcher");
+    }
     long startT = System.currentTimeMillis();
     final Stat stat;
     try {
@@ -2152,6 +2173,13 @@ public class ZkClient implements Watcher {
 
   @SuppressWarnings("unchecked")
   public <T extends Object> T readData(final String path, final Stat stat, final boolean watch) {
+    // Throws exception when try to subscribe watch when using _usePersistWatcher. When ZkClient
+    // is subscribed as persist watcher, resubscribing the same object as onw time watcher will
+    // over write the persist watcher causing missing following event.
+    if (_usePersistWatcher && watch) {
+      throw new IllegalArgumentException(
+          "Can not subscribe one time watcher when ZkClient is using PersistWatcher");
+    }
     long startT = System.currentTimeMillis();
     byte[] data = null;
     try {

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/TestZooKeeperConnection.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/TestZooKeeperConnection.java
@@ -1,0 +1,68 @@
+package org.apache.helix.zookeeper.impl;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.helix.zookeeper.zkclient.IZkConnection;
+import org.apache.helix.zookeeper.zkclient.ZkClient;
+import org.apache.zookeeper.AddWatchMode;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestZooKeeperConnection extends ZkTestBase {
+  final int count = 100;
+  final int[] get_count = {0};
+  CountDownLatch countDownLatch = new CountDownLatch(count*2);
+
+
+  /*
+  This function tests persist watchers' behavior in {@link org.apache.helix.zookeeper.zkclient.ZkConnection}
+  1. Register a persist watcher on a path and create 100 children Znode, edit the ZNode for 100 times.
+  Expecting 200 events.
+  2. register a one time listener on the path. Make the same change and count the total number of event.
+  */
+  @Test
+  void testPersistWatcher() throws Exception {
+    Watcher watcher1 = new PersistWatcher();
+    ZkClient zkClient =   new org.apache.helix.zookeeper.impl.client.ZkClient(ZK_ADDR);
+    IZkConnection _zk = zkClient.getConnection();
+    String path="/testPersistWatcher";
+    _zk.create(path, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    // register a persist listener on a path, change the ZNode 100 times, create 100 child ZNode,
+    // and expecting 200 events
+    _zk.addWatch(path, watcher1, AddWatchMode.PERSISTENT);
+    for (int i=0; i<count; ++i) {
+      _zk.writeData(path, "datat".getBytes(), -1);
+      _zk.create(path+"/c1_" +i, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    }
+    Assert.assertTrue(countDownLatch.await(50000, TimeUnit.MILLISECONDS));
+
+    // register a one time listener on the path. Count the total number of event.
+    // ZK will over write the persist watcher and only trigger event once for child and data change.
+    _zk.readData(path, null, true);
+    _zk.getChildren(path, true);
+    for (int i=0; i<200; ++i) {
+      _zk.writeData(path, ("datat"+i).getBytes(), -1);
+      _zk.create(path+"/c2_" +i, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    }
+    Assert.assertTrue(TestHelper.verify(() -> {
+          return (get_count[0] == 202);
+        }, TestHelper.WAIT_DURATION));
+    System.out.println("testPersistWatcher received event count: " + get_count[0]);
+    zkClient.close();
+  }
+
+  class PersistWatcher implements Watcher {
+    @Override
+    public void process(WatchedEvent watchedEvent) {
+      get_count[0]++;
+      countDownLatch.countDown();
+    }
+  }
+
+}


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2237 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

When Zk Client register a one time listener on a path hat has already a persist watcher registered. ZK will over write the persist watcher and only trigger event once when change happen. In Helix ZkClient, we should disable one time wacher registration when _usePersistWatcher is set to true.

### Tests

- [X] The following tests are written for this issue:

testZooKeeperConnection.testPersistWatcher - test native zk client behavior
TestZkClientPersistWatcher.testSubscribeOneTimeChangeWhenUsingPersistWatcher - test throw exception

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
