### PR TITLE
Refactor TestRoutingTableProvider

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixException;
@@ -83,8 +82,6 @@ public class TestRoutingTableProvider extends ZkTestBase {
   private RoutingTableProvider _routingTableProvider_cs;
   private boolean _listenerTestResult = true;
 
-
-  //private static final AtomicBoolean customizedViewChangeCalled = new AtomicBoolean(false);
 
   class MockRoutingTableChangeListener implements RoutingTableChangeListener {
     boolean routingTableChangeReceived = false;

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProvider.java
@@ -303,7 +303,7 @@ public class TestRoutingTableProvider extends ZkTestBase {
     _spectator.getHelixDataAccessor().getBaseDataAccessor().set(customizedViewPath,
         customizedView.getRecord(), AccessOption.PERSISTENT);
 
-    Assert.assertTrue(countDownLatch.await(5000, TimeUnit.MILLISECONDS));
+    Assert.assertTrue(countDownLatch.await(WAIT_DURATION, TimeUnit.MILLISECONDS));
 
     _spectator.getHelixDataAccessor().getBaseDataAccessor().remove(customizedViewPath,
         AccessOption.PERSISTENT);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2472 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change refactor test `MockRoutingTableChangeListener`.

### Tests

- [X] The following tests are written for this issue:

NA

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.797 s - in org.apache.helix.monitoring.mbeans.TestClusterAggregateMetrics
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
