### PR TITLE
Add hashCode() to AssignableReplica and fix logic in hash-based collection

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
@@ -300,15 +300,15 @@ public class DelayedRebalanceUtil {
    * @param allocatedReplicas The map from instance name to assigned replicas, the map is populated in this method.
    * @return The replicas that need to be assigned.
    */
-  public static Set<AssignableReplica> findToBeAssignedReplicasForMinActiveReplica(
+  public static List<AssignableReplica> findToBeAssignedReplicasForMinActiveReplica(
       ResourceControllerDataProvider clusterData,
       Set<String> resources,
       Set<String> liveEnabledInstances,
       Map<String, ResourceAssignment> currentAssignment,
-      Map<String, Set<AssignableReplica>> allocatedReplicas) {
+      Map<String, List<AssignableReplica>> allocatedReplicas) {
     Map<String, List<String>> partitionsMissingMinActiveReplicas =
         findPartitionsMissingMinActiveReplica(clusterData, currentAssignment);
-    Set<AssignableReplica> toBeAssignedReplicas = new HashSet<>();
+    List<AssignableReplica> toBeAssignedReplicas = new ArrayList<>();
 
     for (String resourceName : resources) {
       ResourceAssignment resourceAssignment = currentAssignment.get(resourceName);
@@ -321,7 +321,7 @@ public class DelayedRebalanceUtil {
       // keep all current assignment and add to allocated replicas
       resourceAssignment.getMappedPartitions().forEach(partition ->
           resourceAssignment.getReplicaMap(partition).forEach((instance, state) ->
-              allocatedReplicas.computeIfAbsent(instance, key -> new HashSet<>())
+              allocatedReplicas.computeIfAbsent(instance, key -> new ArrayList<>())
                   .add(new AssignableReplica(clusterData.getClusterConfig(), mergedResourceConfig,
                       partition.getPartitionName(), state, statePriorityMap.get(state)))));
       // only proceed for resource requiring delayed rebalance overwrites
@@ -433,7 +433,7 @@ public class DelayedRebalanceUtil {
    * @param liveEnabledInstances A set of live and enabled instances
    * @return A set of AssignableReplica
    */
-  private static Set<AssignableReplica> findAssignableReplicaForResource(
+  private static List<AssignableReplica> findAssignableReplicaForResource(
       ResourceControllerDataProvider clusterData,
       String resourceName,
       List<String> partitions,
@@ -448,7 +448,7 @@ public class DelayedRebalanceUtil {
         clusterData.getResourceConfig(resourceName), currentIdealState);
     final Map<String, Integer> statePriorityMap =
         clusterData.getStateModelDef(currentIdealState.getStateModelDefRef()).getStatePriorityMap();
-    final Set<AssignableReplica> toBeAssignedReplicas = new HashSet<>();
+    final List<AssignableReplica> toBeAssignedReplicas = new ArrayList<>();
 
     for (String partitionName : partitions) {
       // count current active replicas of the partition

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
@@ -163,9 +163,9 @@ public class AssignableNode implements Comparable<AssignableNode> {
   /**
    * @return A set of all assigned replicas on the node.
    */
-  Set<AssignableReplica> getAssignedReplicas() {
+  List<AssignableReplica> getAssignedReplicas() {
     return _currentAssignedReplicaMap.values().stream()
-        .flatMap(replicaMap -> replicaMap.values().stream()).collect(Collectors.toSet());
+        .flatMap(replicaMap -> replicaMap.values().stream()).sorted().collect(Collectors.toList());
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableReplica.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableReplica.java
@@ -20,30 +20,18 @@ package org.apache.helix.controller.rebalancer.waged.model;
  */
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import org.apache.helix.HelixException;
+import java.util.Objects;
 import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class represents a partition replication that needs to be allocated.
- *
- * TODO: This class is violating the contracts of {@link Object#hashCode()}
- *   If two objects are equal according to the equals(Object) method, then calling the hashCode method on each of the
- *   two objects must produce the same integer result.
- *   https://github.com/apache/helix/issues/2299
- *   This could be a tricky fix because this bug/feature is deeply coupled with the existing code logic
  */
 public class AssignableReplica implements Comparable<AssignableReplica> {
-  private static final Logger LOG = LoggerFactory.getLogger(AssignableReplica.class);
-
   private final String _replicaKey;
   private final String _partitionName;
   private final String _resourceName;
@@ -139,6 +127,11 @@ public class AssignableReplica implements Comparable<AssignableReplica> {
     } else {
       return false;
     }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_resourceName, _partitionName, _replicaState);
   }
 
   public static String generateReplicaKey(String resourceName, String partitionName, String state) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
@@ -19,6 +19,7 @@ package org.apache.helix.controller.rebalancer.waged.model;
  * under the License.
  */
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -63,7 +64,7 @@ public class ClusterContext {
    * @param replicaSet All the partition replicas that are managed by the rebalancer
    * @param nodeSet All the active nodes that are managed by the rebalancer
    */
-  ClusterContext(Set<AssignableReplica> replicaSet, Set<AssignableNode> nodeSet,
+  ClusterContext(Collection<AssignableReplica> replicaSet, Set<AssignableNode> nodeSet,
       Map<String, ResourceAssignment> baselineAssignment, Map<String, ResourceAssignment> bestPossibleAssignment) {
     int instanceCount = nodeSet.size();
     int totalReplicas = 0;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModel.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModel.java
@@ -20,6 +20,7 @@ package org.apache.helix.controller.rebalancer.waged.model;
  */
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,7 +33,7 @@ import org.apache.helix.HelixException;
 public class ClusterModel {
   private final ClusterContext _clusterContext;
   // Map to track all the assignable replications. <Resource Name, Set<Replicas>>
-  private final Map<String, Set<AssignableReplica>> _assignableReplicaMap;
+  private final Map<String, List<AssignableReplica>> _assignableReplicaMap;
   // The index to find the replication information with a certain state. <Resource, <Key(resource_partition_state), Replica>>
   // Note that the identical replicas are deduped in the index.
   private final Map<String, Map<String, AssignableReplica>> _assignableReplicaIndex;
@@ -44,13 +45,13 @@ public class ClusterModel {
    *                               Note that the replicas in this list shall not be included while initializing the context and assignable nodes.
    * @param assignableNodes        The active instances.
    */
-  ClusterModel(ClusterContext clusterContext, Set<AssignableReplica> assignableReplicas,
+  ClusterModel(ClusterContext clusterContext, List<AssignableReplica> assignableReplicas,
       Set<AssignableNode> assignableNodes) {
     _clusterContext = clusterContext;
 
     // Save all the to be assigned replication
     _assignableReplicaMap = assignableReplicas.stream()
-        .collect(Collectors.groupingBy(AssignableReplica::getResourceName, Collectors.toSet()));
+        .collect(Collectors.groupingBy(AssignableReplica::getResourceName, Collectors.toList()));
 
     // Index all the replicas to be assigned. Dedup the replica if two instances have the same resource/partition/state
     _assignableReplicaIndex = assignableReplicas.stream().collect(Collectors
@@ -70,7 +71,7 @@ public class ClusterModel {
     return _assignableNodeMap;
   }
 
-  public Map<String, Set<AssignableReplica>> getAssignableReplicaMap() {
+  public Map<String, List<AssignableReplica>> getAssignableReplicaMap() {
     return _assignableReplicaMap;
   }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
@@ -271,19 +271,21 @@ public abstract class AbstractTestClusterModel {
   /**
    * Generate the replica objects according to the provider information.
    */
-  protected Set<AssignableReplica> generateReplicas(ResourceControllerDataProvider dataProvider) {
+  protected List<AssignableReplica> generateReplicas(ResourceControllerDataProvider dataProvider) {
     // Create assignable replica based on the current state.
     Map<String, CurrentState> currentStatemap =
         dataProvider.getCurrentState(_testInstanceId, _sessionId);
-    Set<AssignableReplica> assignmentSet = new HashSet<>();
+    List<AssignableReplica> assignments = new ArrayList<>();
     for (CurrentState cs : currentStatemap.values()) {
       ResourceConfig resourceConfig = dataProvider.getResourceConfig(cs.getResourceName());
       // Construct one AssignableReplica for each partition in the current state.
-      cs.getPartitionStateMap().entrySet().stream().forEach(entry -> assignmentSet
-              .add(new AssignableReplica(dataProvider.getClusterConfig(), resourceConfig,
-                  entry.getKey(), entry.getValue(), entry.getValue().equals("MASTER") ? 1 : 2)));
+      cs.getPartitionStateMap()
+          .forEach((key, value) -> assignments.add(
+              new AssignableReplica(dataProvider.getClusterConfig(), resourceConfig, key, value,
+                  value.equals("MASTER") ? 1 : 2)));
     }
-    return assignmentSet;
+    Collections.sort(assignments);
+    return assignments;
   }
 
   protected Set<AssignableNode> generateNodes(ResourceControllerDataProvider testCache) {

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelTestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelTestHelper.java
@@ -22,6 +22,7 @@ package org.apache.helix.controller.rebalancer.waged.model;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -38,7 +39,7 @@ public class ClusterModelTestHelper extends AbstractTestClusterModel {
   public ClusterModel getDefaultClusterModel() throws IOException {
     initialize();
     ResourceControllerDataProvider testCache = setupClusterDataCache();
-    Set<AssignableReplica> assignableReplicas = generateReplicas(testCache);
+    List<AssignableReplica> assignableReplicas = generateReplicas(testCache);
     Set<AssignableNode> assignableNodes = generateNodes(testCache);
 
     ClusterContext context =
@@ -64,7 +65,7 @@ public class ClusterModelTestHelper extends AbstractTestClusterModel {
     instanceConfigMap.put(TEST_INSTANCE_ID_1, testInstanceConfig1);
     instanceConfigMap.put(TEST_INSTANCE_ID_2, testInstanceConfig2);
     when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
-    Set<AssignableReplica> assignableReplicas = generateReplicas(testCache);
+    List<AssignableReplica> assignableReplicas = generateReplicas(testCache);
     Set<AssignableNode> assignableNodes = generateNodes(testCache);
 
     ClusterContext context =

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
@@ -49,8 +49,8 @@ public class TestAssignableNode extends AbstractTestClusterModel {
   public void testNormalUsage() throws IOException {
     // Test 1 - initialize based on the data cache and check with the expected result
     ResourceControllerDataProvider testCache = setupClusterDataCache();
-    Set<AssignableReplica> assignmentSet = generateReplicas(testCache);
-
+    List<AssignableReplica> assignments = generateReplicas(testCache);
+    Collections.sort(assignments);
     Set<String> expectedTopStateAssignmentSet1 = new HashSet<>(_partitionNames.subList(0, 1));
     Set<String> expectedTopStateAssignmentSet2 = new HashSet<>(_partitionNames.subList(2, 3));
     Set<String> expectedAssignmentSet1 = new HashSet<>(_partitionNames.subList(0, 2));
@@ -65,7 +65,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
 
     AssignableNode assignableNode = new AssignableNode(testCache.getClusterConfig(),
         testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
-    assignableNode.assignInitBatch(assignmentSet);
+    assignableNode.assignInitBatch(assignments);
     Assert.assertEquals(assignableNode.getAssignedPartitionsMap(), expectedAssignment);
     Assert.assertEquals(assignableNode.getAssignedReplicaCount(), 4);
     Assert.assertEquals(assignableNode.getGeneralProjectedHighestUtilization(Collections.EMPTY_MAP),
@@ -78,7 +78,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     Assert.assertEquals(assignableNode.getFaultZone(), _testFaultZoneId);
     Assert.assertEquals(assignableNode.getDisabledPartitionsMap(), _disabledPartitionsMap);
     Assert.assertEquals(assignableNode.getRemainingCapacity(), expectedCapacityMap);
-    Assert.assertEquals(assignableNode.getAssignedReplicas(), assignmentSet);
+    Assert.assertEquals(assignableNode.getAssignedReplicas(), assignments);
     Assert.assertEquals(assignableNode.getAssignedPartitionsByResource(_resourceNames.get(0)),
         expectedAssignmentSet1);
     Assert.assertEquals(assignableNode.getAssignedPartitionsByResource(_resourceNames.get(1)),
@@ -98,7 +98,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     expectedAssignment.get(_resourceNames.get(1)).remove(_partitionNames.get(2));
     expectedCapacityMap.put("item1", 9);
     expectedCapacityMap.put("item2", 18);
-    Iterator<AssignableReplica> iter = assignmentSet.iterator();
+    Iterator<AssignableReplica> iter = assignments.iterator();
     while (iter.hasNext()) {
       AssignableReplica replica = iter.next();
       if (replica.equals(removingReplica)) {
@@ -121,7 +121,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     Assert.assertEquals(assignableNode.getFaultZone(), _testFaultZoneId);
     Assert.assertEquals(assignableNode.getDisabledPartitionsMap(), _disabledPartitionsMap);
     Assert.assertEquals(assignableNode.getRemainingCapacity(), expectedCapacityMap);
-    Assert.assertEquals(assignableNode.getAssignedReplicas(), assignmentSet);
+    Assert.assertEquals(assignableNode.getAssignedReplicas(), assignments);
     Assert.assertEquals(assignableNode.getAssignedPartitionsByResource(_resourceNames.get(0)),
         expectedAssignmentSet1);
     Assert.assertEquals(assignableNode.getAssignedPartitionsByResource(_resourceNames.get(1)),
@@ -141,7 +141,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     expectedAssignment.get(_resourceNames.get(1)).add(_partitionNames.get(2));
     expectedCapacityMap.put("item1", 4);
     expectedCapacityMap.put("item2", 8);
-    assignmentSet.add(addingReplica);
+    assignments.add(addingReplica);
 
     assignableNode.assign(addingReplica);
 
@@ -157,7 +157,8 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     Assert.assertEquals(assignableNode.getFaultZone(), _testFaultZoneId);
     Assert.assertEquals(assignableNode.getDisabledPartitionsMap(), _disabledPartitionsMap);
     Assert.assertEquals(assignableNode.getRemainingCapacity(), expectedCapacityMap);
-    Assert.assertEquals(assignableNode.getAssignedReplicas(), assignmentSet);
+    Collections.sort(assignments);
+    Assert.assertEquals(assignableNode.getAssignedReplicas(), assignments);
     Assert.assertEquals(assignableNode.getAssignedPartitionsByResource(_resourceNames.get(0)),
         expectedAssignmentSet1);
     Assert.assertEquals(assignableNode.getAssignedPartitionsByResource(_resourceNames.get(1)),
@@ -189,11 +190,11 @@ public class TestAssignableNode extends AbstractTestClusterModel {
   @Test(expectedExceptions = HelixException.class, expectedExceptionsMessageRegExp = "Resource Resource1 already has a replica with state SLAVE from partition Partition1 on node testInstanceId")
   public void testAssignDuplicateReplica() throws IOException {
     ResourceControllerDataProvider testCache = setupClusterDataCache();
-    Set<AssignableReplica> assignmentSet = generateReplicas(testCache);
+    List<AssignableReplica> assignments = generateReplicas(testCache);
 
     AssignableNode assignableNode = new AssignableNode(testCache.getClusterConfig(),
         testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
-    assignableNode.assignInitBatch(assignmentSet);
+    assignableNode.assignInitBatch(assignments);
     AssignableReplica duplicateReplica = new AssignableReplica(testCache.getClusterConfig(),
         testCache.getResourceConfig(_resourceNames.get(0)), _partitionNames.get(0), "SLAVE", 2);
     assignableNode.assign(duplicateReplica);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
@@ -50,7 +50,6 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     // Test 1 - initialize based on the data cache and check with the expected result
     ResourceControllerDataProvider testCache = setupClusterDataCache();
     List<AssignableReplica> assignments = generateReplicas(testCache);
-    Collections.sort(assignments);
     Set<String> expectedTopStateAssignmentSet1 = new HashSet<>(_partitionNames.subList(0, 1));
     Set<String> expectedTopStateAssignmentSet2 = new HashSet<>(_partitionNames.subList(2, 3));
     Set<String> expectedAssignmentSet1 = new HashSet<>(_partitionNames.subList(0, 2));

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterContext.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterContext.java
@@ -22,6 +22,7 @@ package org.apache.helix.controller.rebalancer.waged.model;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -42,7 +43,7 @@ public class TestClusterContext extends AbstractTestClusterModel {
   public void testNormalUsage() throws IOException {
     // Test 1 - initialize the cluster context based on the data cache.
     ResourceControllerDataProvider testCache = setupClusterDataCache();
-    Set<AssignableReplica> assignmentSet = generateReplicas(testCache);
+    List<AssignableReplica> assignmentSet = generateReplicas(testCache);
 
     ClusterContext context =
         new ClusterContext(assignmentSet, generateNodes(testCache), new HashMap<>(),
@@ -85,7 +86,7 @@ public class TestClusterContext extends AbstractTestClusterModel {
   @Test(expectedExceptions = HelixException.class, expectedExceptionsMessageRegExp = "Resource Resource1 already has a replica from partition Partition1 in fault zone testZone")
   public void testDuplicateAssign() throws IOException {
     ResourceControllerDataProvider testCache = setupClusterDataCache();
-    Set<AssignableReplica> assignmentSet = generateReplicas(testCache);
+    List<AssignableReplica> assignmentSet = generateReplicas(testCache);
     ClusterContext context =
         new ClusterContext(assignmentSet, generateNodes(testCache), new HashMap<>(),
             new HashMap<>());

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModel.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModel.java
@@ -21,6 +21,7 @@ package org.apache.helix.controller.rebalancer.waged.model;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.helix.HelixException;
@@ -39,7 +40,7 @@ public class TestClusterModel extends AbstractTestClusterModel {
   public void testNormalUsage() throws IOException {
     // Test 1 - initialize the cluster model based on the data cache.
     ResourceControllerDataProvider testCache = setupClusterDataCache();
-    Set<AssignableReplica> assignableReplicas = generateReplicas(testCache);
+    List<AssignableReplica> assignableReplicas = generateReplicas(testCache);
     Set<AssignableNode> assignableNodes = generateNodes(testCache);
 
     ClusterContext context =

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModelProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModelProvider.java
@@ -22,9 +22,11 @@ package org.apache.helix.controller.rebalancer.waged.model;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -47,7 +49,7 @@ import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 public class TestClusterModelProvider extends AbstractTestClusterModel {
@@ -111,7 +113,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     Assert.assertEquals(
         DelayedRebalanceUtil.findToBeAssignedReplicasForMinActiveReplica(testCache, Collections.emptySet(),
             activeInstances, Collections.emptyMap(), new HashMap<>()),
-        Collections.emptySet());
+        Collections.emptyList());
 
     // test 1, one partition under minActiveReplica
     Map<String, Map<String, Map<String, String>>> input = ImmutableMap.of(
@@ -124,12 +126,12 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
             _partitionNames.get(2), ImmutableMap.of("MASTER", instance1),
             _partitionNames.get(3), ImmutableMap.of("SLAVE", instance1))
     );
-    Map<String, Set<AssignableReplica>> replicaMap = new HashMap<>(); // to populate
+    Map<String, List<AssignableReplica>> replicaMap = new HashMap<>(); // to populate
     Map<String, ResourceAssignment> currentAssignment = new HashMap<>(); // to populate
     prepareData(input, replicaMap, currentAssignment, testCache, 1);
 
-    Map<String, Set<AssignableReplica>> allocatedReplicas = new HashMap<>();
-    Set<AssignableReplica> toBeAssignedReplicas =
+    Map<String, List<AssignableReplica>> allocatedReplicas = new HashMap<>();
+    List<AssignableReplica> toBeAssignedReplicas =
         DelayedRebalanceUtil.findToBeAssignedReplicasForMinActiveReplica(testCache, replicaMap.keySet(), activeInstances,
             currentAssignment, allocatedReplicas);
 
@@ -223,7 +225,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
             _partitionNames.get(2), ImmutableMap.of("MASTER", instance1),
             _partitionNames.get(3), ImmutableMap.of("OFFLINE", offlineInstance)) // Partition4-MASTER
     );
-    Map<String, Set<AssignableReplica>> replicaMap = new HashMap<>(); // to populate
+    Map<String, List<AssignableReplica>> replicaMap = new HashMap<>(); // to populate
     Map<String, ResourceAssignment> currentAssignment = new HashMap<>(); // to populate
     prepareData(input, replicaMap, currentAssignment, testCache, 1);
 
@@ -296,7 +298,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
    * @param testCache The mock object to prepare
    */
   private void prepareData(Map<String, Map<String, Map<String, String>>> input,
-      Map<String, Set<AssignableReplica>> replicaMap,
+      Map<String, List<AssignableReplica>> replicaMap,
       Map<String, ResourceAssignment> currentAssignment,
       ResourceControllerDataProvider testCache,
       int minActiveReplica) {
@@ -330,7 +332,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     Map<String, Map<String, Map<String, String>>> stateByInstanceByResourceByPartition = new HashMap<>();
 
     for (String resource : input.keySet()) {
-      Set<AssignableReplica> replicas = new HashSet<>();
+      List<AssignableReplica> replicas = new ArrayList<>();
       replicaMap.put(resource, replicas);
       ResourceConfig resourceConfig = _resourceConfigMap.get(resource);
       for (String partition : input.get(resource).keySet()) {


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixes https://github.com/apache/helix/issues/2299 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Without the fix, the class `AssignableReplica` is breaking the contract in `Object.hashCode()`. If only override `equals()`, a hashset may contain two equaled objects. See also https://stackoverflow.com/questions/2265503/why-do-i-need-to-override-the-equals-and-hashcode-methods-in-java.

Overriding hashCode() in `AssignableReplica` to make it consistent with `equals()`.
Also changing the appearance of `Set<AssignableReplica>` to `List`, which is the way it should be. In most use cases there is a collection of replicas with same (resource, partition, state), using hashset is confusing to start with.

This class is fundamental to WAGED rebalancer. Using list also has performance improvement over set.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

[INFO] Tests run: 1326, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6,965.344 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1326, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/qqu/workspace/qqu-helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 797 classes
[INFO] 
[INFO] --- maven-bundle-plugin:5.1.4:bundle (default-bundle) @ helix-core ---

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
