### PR TITLE
Implement the WAGED resource weights provider

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/WagedValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/WagedValidationUtil.java
@@ -85,8 +85,7 @@ public class WagedValidationUtil {
     if (!partitionCapacity.keySet().containsAll(requiredCapacityKeys)) {
       throw new HelixException(String.format(
           "The required capacity keys: %s are not fully configured in the resource: %s, partition: %s, weight map: %s.",
-          requiredCapacityKeys.toString(), resourceConfig.getResourceName(), partitionName,
-          partitionCapacity.toString()));
+          requiredCapacityKeys, resourceConfig.getResourceName(), partitionName, partitionCapacity));
     }
     return partitionCapacity;
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedResourceWeightsProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedResourceWeightsProvider.java
@@ -1,0 +1,49 @@
+package org.apache.helix.controller.rebalancer.waged;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.rebalancer.util.WagedRebalanceUtil;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.ResourceConfig;
+
+
+/**
+ * A weights data provider for waged resources.
+ */
+public class WagedResourceWeightsProvider {
+
+  private final ResourceControllerDataProvider _clusterData;
+
+  public WagedResourceWeightsProvider(ResourceControllerDataProvider clusterData) {
+    _clusterData = clusterData;
+  }
+
+  public Map<String, Integer> getPartitionWeights(String resourceName, String partition) {
+    @Nullable ResourceConfig resourceConfig = _clusterData.getResourceConfig(resourceName);
+    IdealState is = _clusterData.getIdealState(resourceName);
+    ResourceConfig mergedResourceConfig =
+        ResourceConfig.mergeIdealStateWithResourceConfig(resourceConfig, is);
+
+    return WagedRebalanceUtil.fetchCapacityUsage(partition, mergedResourceConfig, _clusterData.getClusterConfig());
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableReplica.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableReplica.java
@@ -19,13 +19,9 @@ package org.apache.helix.controller.rebalancer.waged.model;
  * under the License.
  */
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import org.apache.helix.HelixException;
-import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
+import org.apache.helix.controller.rebalancer.util.WagedRebalanceUtil;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
@@ -68,7 +64,7 @@ public class AssignableReplica implements Comparable<AssignableReplica> {
     _replicaState = replicaState;
     _statePriority = statePriority;
     _resourceName = resourceConfig.getResourceName();
-    _capacityUsage = fetchCapacityUsage(partitionName, resourceConfig, clusterConfig);
+    _capacityUsage = WagedRebalanceUtil.fetchCapacityUsage(partitionName, resourceConfig, clusterConfig);
     _resourceInstanceGroupTag = resourceConfig.getInstanceGroupTag();
     _resourceMaxPartitionsPerInstance = resourceConfig.getMaxPartitionsPerInstance();
     _replicaKey = generateReplicaKey(_resourceName, _partitionName,_replicaState);
@@ -143,25 +139,5 @@ public class AssignableReplica implements Comparable<AssignableReplica> {
 
   public static String generateReplicaKey(String resourceName, String partitionName, String state) {
     return String.format("%s-%s-%s", resourceName, partitionName, state);
-  }
-
-  /**
-   * Parse the resource config for the partition weight.
-   */
-  private Map<String, Integer> fetchCapacityUsage(String partitionName,
-      ResourceConfig resourceConfig, ClusterConfig clusterConfig) {
-    Map<String, Map<String, Integer>> capacityMap;
-    try {
-      capacityMap = resourceConfig.getPartitionCapacityMap();
-    } catch (IOException ex) {
-      throw new IllegalArgumentException(
-          "Invalid partition capacity configuration of resource: " + resourceConfig
-              .getResourceName(), ex);
-    }
-    Map<String, Integer> partitionCapacity = WagedValidationUtil
-        .validateAndGetPartitionCapacity(partitionName, resourceConfig, capacityMap, clusterConfig);
-    // Remove the non-required capacity items.
-    partitionCapacity.keySet().retainAll(clusterConfig.getInstanceCapacityKeys());
-    return partitionCapacity;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -854,4 +854,15 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
       }
     }
   }
+
+  @Test
+  public void testResourceWeightProvider() throws IOException {
+    ResourceControllerDataProvider testCache = setupClusterDataCache();
+    WagedResourceWeightsProvider dataProvider = new WagedResourceWeightsProvider(testCache);
+    Map<String, Integer> weights1 = Map.of("item1", 3, "item2", 6, "item3", 0);
+    Assert.assertEquals(dataProvider.getPartitionWeights("Resource1", "Partition1"), weights1);
+    Assert.assertEquals(dataProvider.getPartitionWeights("Resource1", "Partition2"), weights1);
+    Map<String, Integer> weights2 = Map.of("item1", 5, "item2", 10, "item3", 0);
+    Assert.assertEquals(dataProvider.getPartitionWeights("Resource2", "Partition2"), weights2);
+  }
 }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

https://github.com/apache/helix/issues/2468

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Implement a WAGED resource weights provider, this is related to https://github.com/apache/helix/pull/2463, and this will implements interface `ResourceWeightsDataProvider`.

### Tests

- [X] The following tests are written for this issue:

New test in `TestWagedRebalancer.java`

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
