### PR TITLE
Small bug fixes related to ZK disconnect and timeouts

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/TestZkConnectionLost.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestZkConnectionLost.java
@@ -132,7 +132,7 @@ public class TestZkConnectionLost extends TaskTestBase {
     };
     try {
       testThread.start();
-      testThread.join(10000);
+      testThread.join();
       Assert.assertTrue(disconnected.get());
       Assert.assertFalse(controllerManager.isConnected());
     } finally {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1968,7 +1968,7 @@ public class ZkClient implements Watcher {
     if (_monitor != null) {
       _monitor.increaseOutstandingRequestGauge();
     }
-    int retryCount = 1;
+    int retryCount = 0;
     long currTime = System.currentTimeMillis();
     try {
       while (true) {

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -832,7 +832,7 @@ public class TestRawZkClient extends ZkTestBase {
       final boolean creationThreadTerminated = countDownLatch.await(10L, TimeUnit.SECONDS);
       if (!creationThreadTerminated) {
         running.set(false);
-        creationThread.join(5000L);
+        creationThread.join();
         Assert.fail("Failed to receive a ConnectionLossException after zookeeper has shutdown.");
       }
     } finally {
@@ -893,7 +893,7 @@ public class TestRawZkClient extends ZkTestBase {
     final boolean creationThreadTerminated = countDownLatch.await(10, TimeUnit.SECONDS);
     if (!creationThreadTerminated) {
       running.set(false);
-      creationThread.join(5000L);
+      creationThread.join();
       Assert.fail("Failed to reconnect to zk server and create ephemeral node"
           + " after zk server is recovered.");
     }
@@ -966,7 +966,7 @@ public class TestRawZkClient extends ZkTestBase {
     final boolean creationThreadTerminated = countDownLatch.await(10, TimeUnit.SECONDS);
     if (!creationThreadTerminated) {
       running.set(false);
-      creationThread.join(5000L);
+      creationThread.join();
       Assert.fail("Failed to reconnect to zk server and create ephemeral node"
           + " after zk server is recovered.");
     }


### PR DESCRIPTION
### Issues

- [] My PR addresses the following Helix issues and references them in the PR description:

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
- Small bug fixes related to ZK disconnect.
    We added the fix where we retry with exponential backoff.
    There are some new failures in the test because tests have become underministic wrt time to wait.
    So let us remove randomness by explicitly waiting for thread to join.
    Also, retryCount should start with 0 and then increment it.
    This is the same behavior in other Exponential backoff call in other ZK API.

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)
    Testing Done: mvn test (in zookeeper-api as well as helix-core)
    [ERROR] Failures:
    [ERROR]   TestNoThrottleDisabledPartitions.testDisablingTopStateReplicaByDisablingInstance:98 expected:<false> but was:<true>
    [ERROR]   TestNoThrottleDisabledPartitions.testNoThrottleOnDisabledInstance:231->setupEnvironment:317->setupCluster:436 » ZkClient
    [ERROR]   TestP2PNoDuplicatedMessage.testP2PStateTransitionEnabled:180 expected:<true> but was:<false>
    [ERROR]   TestStateTransitionTimeout.testStateTransitionTimeOut:170 expected:<true> but was:<false>
    [ERROR]   TestWagedRebalanceTopologyAware.testAddZone:112->TestWagedRebalanceFaultZone.testAddZone:288 expected:<true> but was:<false>
    [ERROR] Tests run: 1326, Failures: 5, Errors: 0, Skipped: 0

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
