### PR TITLE
Fixing the TestClusterStatusMonitorLifecyle integration test

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -793,13 +793,14 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
 
   @Override
   public void connect() throws Exception {
-    LOG.info("ClusterManager.connect()");
     if (isConnected()) {
       LOG.warn("Cluster manager: " + _instanceName + " for cluster: " + _clusterName
           + " already connected. skip connect");
       return;
     }
 
+    LOG.info("Connecting cluster manager: " + _instanceName + " of instance type: " + _instanceType
+        + " for cluster: " + _clusterName);
     switch (_instanceType) {
     case CONTROLLER:
     case CONTROLLER_PARTICIPANT:

--- a/helix-core/src/main/java/org/apache/helix/participant/DistClusterControllerStateModel.java
+++ b/helix-core/src/main/java/org/apache/helix/participant/DistClusterControllerStateModel.java
@@ -114,6 +114,8 @@ public class DistClusterControllerStateModel extends AbstractHelixLeaderStandbyS
   public void reset() {
     synchronized (_controllerOpt) {
       if (_controllerOpt.isPresent()) {
+        logger.info("Disconnecting controller: " + _controllerOpt.get().getInstanceName() + " for "
+            + _controllerOpt.get().getClusterName());
         _controllerOpt.get().disconnect();
         _controllerOpt = Optional.empty();
       }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/TestClusterStatusMonitorLifecycle.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/TestClusterStatusMonitorLifecycle.java
@@ -37,20 +37,12 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.tools.ClusterSetup;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.apache.logging.log4j.Level.ERROR;
-import static org.apache.logging.log4j.Level.INFO;
-
 public class TestClusterStatusMonitorLifecycle extends ZkTestBase {
-  public static final String HELIX_LOGGER_NAME = "org.apache.helix";
   MockParticipantManager[] _participants;
   ClusterDistributedController[] _controllers;
   String _controllerClusterName;
@@ -63,8 +55,6 @@ public class TestClusterStatusMonitorLifecycle extends ZkTestBase {
 
   @BeforeClass
   public void beforeClass() throws Exception {
-    // enabling info level for helix logs to help with debugging
-    updateLog4jLevel(INFO, HELIX_LOGGER_NAME);
     String className = TestHelper.getTestClassName();
     _clusterNamePrefix = className;
 
@@ -101,7 +91,7 @@ public class TestClusterStatusMonitorLifecycle extends ZkTestBase {
         "LeaderStandby", true); // do rebalance
 
     // start distributed cluster controllers
-    _controllers = new ClusterDistributedController[n + n];
+    _controllers = new ClusterDistributedController[n];
     for (int i = 0; i < n; i++) {
       _controllers[i] =
           new ClusterDistributedController(ZK_ADDR, _controllerClusterName, "controller_" + i);
@@ -129,24 +119,6 @@ public class TestClusterStatusMonitorLifecycle extends ZkTestBase {
         new BestPossibleExternalViewVerifier.Builder(_firstClusterName).setZkClient(_gZkClient)
             .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
             .build();
-    Assert.assertTrue(firstClusterVerifier.verifyByPolling(), "first cluster NOT in ideal state");
-
-    // add more controllers to controller cluster
-    ClusterSetup setupTool = new ClusterSetup(ZK_ADDR);
-    for (int i = 0; i < n; i++) {
-      String controller = "controller_" + (n + i);
-      setupTool.addInstanceToCluster(_controllerClusterName, controller);
-    }
-    setupTool.rebalanceStorageCluster(_controllerClusterName, _clusterNamePrefix + "0", 6);
-    for (int i = n; i < 2 * n; i++) {
-      _controllers[i] =
-          new ClusterDistributedController(ZK_ADDR, _controllerClusterName, "controller_" + i);
-      _controllers[i].syncStart();
-    }
-
-    // verify controller cluster
-    Assert.assertTrue(controllerClusterVerifier.verifyByPolling(),
-        "Controller cluster NOT in ideal state");
 
     // verify first cluster
     Assert.assertTrue(firstClusterVerifier.verifyByPolling(), "first cluster NOT in ideal state");
@@ -164,17 +136,11 @@ public class TestClusterStatusMonitorLifecycle extends ZkTestBase {
   @AfterClass
   public void afterClass() throws Exception {
     System.out.println("Cleaning up...");
-    for (int i = 0; i < 2 * n; i++) {
-      if (_controllers[i] != null) {
-        _controllers[i].syncStop();
-      }
-    }
     for (MockParticipantManager participant : _participants) {
       if (participant != null) {
         participant.syncStop();
       }
     }
-    cleanupControllers();
     deleteCluster(_controllerClusterName);
 
     for (String cluster : _clusters) {
@@ -182,28 +148,29 @@ public class TestClusterStatusMonitorLifecycle extends ZkTestBase {
     }
 
     System.out.println("END " + _clusterNamePrefix + " at " + new Date(System.currentTimeMillis()));
-    // restoring error level for helix logs
-    updateLog4jLevel(ERROR, HELIX_LOGGER_NAME);
-  }
-
-  private void cleanupControllers() {
-    for (ClusterDistributedController controller : _controllers) {
-      controller.syncStop();
-    }
   }
 
   /**
-   * Updates the log level for the specified logger.
-   * @param level Log level to update.
-   * @param loggerName Name of the logger for which the level will be updated.
+   * Disconnects all the controllers one by one.
+   * NOTE: Invoking this method multiple times won't disconnect the controllers multiple times.
    */
-  private void updateLog4jLevel(org.apache.logging.log4j.Level level, String loggerName) {
-    LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-    Configuration config = ctx.getConfiguration();
-    LoggerConfig loggerConfig =
-        config.getLoggerConfig(String.valueOf(LogManager.getLogger(loggerName)));
-    loggerConfig.setLevel(level);
-    ctx.updateLoggers();
+  private void cleanupControllers() {
+    for (int i = 0; i < n; i++) {
+      ClusterDistributedController controller = _controllers[i];
+      if (controller != null) {
+        ZkHelixClusterVerifier controllerClusterVerifier =
+            new BestPossibleExternalViewVerifier.Builder(controller.getClusterName()).setZkClient(
+                    _gZkClient).setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+                .build();
+        Assert.assertTrue(controllerClusterVerifier.verifyByPolling(),
+            "Controller cluster NOT in ideal state");
+        System.out.println(String.format("Disconnecting controller %s from cluster %s at %s",
+            controller.getInstanceName(), controller.getClusterName(),
+            new Date(System.currentTimeMillis())));
+        controller.syncStop();
+        _controllers[i] = null;
+      }
+    }
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/monitoring/TestClusterStatusMonitorLifecycle.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/TestClusterStatusMonitorLifecycle.java
@@ -136,6 +136,7 @@ public class TestClusterStatusMonitorLifecycle extends ZkTestBase {
   @AfterClass
   public void afterClass() throws Exception {
     System.out.println("Cleaning up...");
+    cleanupControllers();
     for (MockParticipantManager participant : _participants) {
       if (participant != null) {
         participant.syncStop();


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
* #2200, #2387

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

#### Brief overview of the integration test
In a nutshell, the integration test verifies that he metrics for the `ClusterStatus` are emitted correctly when participants/controller_participants are added/removed.

#### What's the failure?
Towards the end of the test, we disconnect all the controller from the super cluster and ensure that there are 0 metrics related to the `ClusterStatus` being emitted.

#### Analysis
Upon debugging the test failure from the logs, I found a race condition for the last controller `controller_9(CONTROLLER_PARTICIPANT) ` in the super cluster disconnect process which can be explained from the logs below:

```
--- Disconnect initiated for **controller_9[CONTROLLER_PARTICPANT]**
2023-05-09T17:14:02.0244076Z 5813977 [ClusterManager_Watcher_CONTROLLER_TestClusterStatusMonitorLifecycle_controller_9_CONTROLLER_PARTICIPANT_11918] INFO  org.apache.helix.manager.zk.ZKHelixManager [] - disconnect controller_9(CONTROLLER_PARTICIPANT) from CONTROLLER_TestClusterStatusMonitorLifecycle

--- Message to become leader sent by the **controller_9**
2023-05-09T17:14:02.2758113Z 5814083 [HelixController-pipeline-default-CONTROLLER_TestClusterStatusMonitorLifecycle-(075feaf2_DEFAULT)] INFO  org.apache.helix.controller.stages.MessageDispatchStage [] - Event 075feaf2_DEFAULT : Sending Message 1495e9e6-e04c-4e43-b565-8aa64f22039e to
 controller_9 transit TestClusterStatusMonitorLifecycle0.TestClusterStatusMonitorLifecycle0_9|[] from:STANDBY to:LEADER, relayMessages: 0

--- **controller_9** attempts to become leader for **TestClusterStatusMonitorLifecycle0_9** due to the StateModel transition
2023-05-09T17:14:02.4001289Z 5814212 [HelixTaskExecutor-message_handle_STATE_TRANSITION] INFO  org.apache.helix.participant.DistClusterControllerStateModel [] - controller_9 becoming leader from standby for TestClusterStatusMonitorLifecycle0_9

--- Rest the state model which disconnects **controller_9** from being the controller for **TestClusterStatusMonitorLifecycle0_9**
2023-05-09T17:14:02.4037210Z 5814273 [ClusterManager_Watcher_CONTROLLER_TestClusterStatusMonitorLifecycle_controller_9_CONTROLLER_PARTICIPANT_11918] INFO  org.apache.helix.participant.HelixStateMachineEngine [] - Operating on TestClusterStatusMonitorLifecycle0::TestClusterStatusMonitorLifecycle0_9

--- *controller_9** becomes leader for **TestClusterStatusMonitorLifecycle0_9** due to the StateModel transition
2023-05-09T17:14:03.9794014Z 5815598 [HelixTaskExecutor-message_handle_STATE_TRANSITION] INFO  org.apache.helix.participant.AbstractHelixLeaderStandbyStateModel [] - Helix Service Controller for cluster TestClusterStatusMonitorLifecycle0_9 on instance controller_9 became LEADER from STANDBY
```

Based on the above logs, reset for `TestClusterStatusMonitorLifecycle0_9` happens before the `controller_9` transitions to being leader [NOTE: Timestamps are very close, and since it's separate thread trying to invoke different methods there is race over here too, which results in reset being processed first] for `TestClusterStatusMonitorLifecycle0_9` which results in disconnect being not [invoked](https://github.com/apache/helix/blob/1f5c5c82fb5bc8273f3d6e04b4cc245e77ece2c8/helix-core/src/main/java/org/apache/helix/participant/DistClusterControllerStateModel.java#L116) as reset only works if the controller is the leader for that resource partition. So, this leaves `controller_9` be the leader despite it's disconnected. 

#### Solution
We should wait for the cluster to stabilize before we disconnect it especially when are taking controllers from the super cluster one after another. 
**NOTE: This is not fixing the actual race condition. Fixing the race condition will be prioritized later since it's a larger and complex effort.**

### Tests

- [X] The following tests are written for this issue:

Ran the `TestClusterStatusMonitorLifecyle` integration test locally 10 times in a loop successfully.

### Changes that Break Backward Compatibility (Optional)
N/A

### Documentation (Optional)

N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
