### PR TITLE
Add recursive persist listener API in ZkClient and test native ZK - API only

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -19,7 +19,6 @@ package org.apache.helix.metaclient.impl.zk;
  * under the License.
  */
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -41,6 +40,7 @@ import org.apache.helix.metaclient.api.Op;
 import org.apache.helix.metaclient.api.OpResult;
 import org.apache.helix.metaclient.exception.MetaClientException;
 import org.apache.helix.metaclient.exception.MetaClientNoNodeException;
+import org.apache.helix.metaclient.impl.zk.adapter.ChildListenerAdapter;
 import org.apache.helix.metaclient.impl.zk.adapter.DataListenerAdapter;
 import org.apache.helix.metaclient.impl.zk.adapter.DirectChildListenerAdapter;
 import org.apache.helix.metaclient.impl.zk.adapter.StateChangeListenerAdapter;
@@ -334,6 +334,11 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
 
   @Override
   public boolean subscribeChildChanges(String key, ChildChangeListener listener, boolean skipWatchingNonExistNode) {
+    try {
+      _zkClient.subscribePersistRecursiveWatcher(key, new ChildListenerAdapter(listener));
+    } catch (KeeperException.UnimplementedException e) {
+      e.printStackTrace();
+    }
     return false;
   }
 
@@ -349,7 +354,10 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
 
   @Override
   public void unsubscribeChildChanges(String key, ChildChangeListener listener) {
-
+    try{
+    _zkClient.unsubscribePersistRecursiveWatcher(key, new ChildListenerAdapter(listener));} catch (KeeperException.UnimplementedException e) {
+      e.printStackTrace();
+    }
   }
 
   @Override

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -332,12 +332,13 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
     return true;
   }
 
+  // TODO: add impl and remove UnimplementedException
   @Override
   public boolean subscribeChildChanges(String key, ChildChangeListener listener, boolean skipWatchingNonExistNode) {
     try {
       _zkClient.subscribePersistRecursiveWatcher(key, new ChildListenerAdapter(listener));
     } catch (KeeperException.UnimplementedException e) {
-      e.printStackTrace();
+      LOG.error(e.getLocalizedMessage());
     }
     return false;
   }
@@ -352,11 +353,13 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
     _zkClient.unsubscribeChildChanges(key, new DirectChildListenerAdapter(listener));
   }
 
+  // TODO: add impl and remove UnimplementedException
   @Override
   public void unsubscribeChildChanges(String key, ChildChangeListener listener) {
     try{
-    _zkClient.unsubscribePersistRecursiveWatcher(key, new ChildListenerAdapter(listener));} catch (KeeperException.UnimplementedException e) {
-      e.printStackTrace();
+    _zkClient.unsubscribePersistRecursiveWatcher(key, new ChildListenerAdapter(listener));
+    } catch (KeeperException.UnimplementedException e) {
+      LOG.error(e.getLocalizedMessage());
     }
   }
 

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/ChildListenerAdapter.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/ChildListenerAdapter.java
@@ -22,29 +22,18 @@ package org.apache.helix.metaclient.impl.zk.adapter;
 import java.util.List;
 import org.apache.helix.metaclient.api.ChildChangeListener;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+import org.apache.helix.zookeeper.zkclient.RecursivePersistListener;
 import org.apache.zookeeper.Watcher;
 
 
 /**
  * A adapter class to transform {@link ChildChangeListener} to {@link IZkChildListener}.
  */
-public class ChildListenerAdapter implements IZkChildListener {
+public class ChildListenerAdapter implements RecursivePersistListener {
   private final ChildChangeListener _listener;
 
   public ChildListenerAdapter(ChildChangeListener listener) {
     _listener = listener;
-  }
-
-  @Override
-  public void handleChildChange(String parentPath, List<String> currentChilds) throws Exception {
-    throw new UnsupportedOperationException("handleChildChange(String parentPath, List<String> currentChilds) "
-        + "is not supported");
-  }
-
-  @Override
-  public void handleChildChange(String parentPath, List<String> currentChilds, Watcher.Event.EventType eventType)
-      throws Exception {
-    _listener.handleChildChange(parentPath, convertType(eventType));
   }
 
   private static ChildChangeListener.ChangeType convertType(Watcher.Event.EventType eventType) {
@@ -71,5 +60,11 @@ public class ChildListenerAdapter implements IZkChildListener {
   @Override
   public int hashCode() {
     return _listener.hashCode();
+  }
+
+  @Override
+  public void handleZNodeChange(String dataPath, Watcher.Event.EventType eventType)
+      throws Exception {
+    _listener.handleChildChange(dataPath, convertType(eventType));
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -62,6 +62,7 @@ import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.apache.helix.zookeeper.zkclient.util.ExponentialBackoffStrategy;
+import org.apache.helix.zookeeper.zkclient.util.ZkPathRecursiveWatcherTrie;
 import org.apache.zookeeper.AddWatchMode;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -117,6 +118,8 @@ public class ZkClient implements Watcher {
   private final Map<String, Set<IZkChildListener>> _childListener = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, Set<IZkDataListenerEntry>> _dataListener =
       new ConcurrentHashMap<>();
+  private final ZkPathRecursiveWatcherTrie _zkPathRecursiveWatcherTrie =
+      new ZkPathRecursiveWatcherTrie();
   private final Set<IZkStateListener> _stateListener = new CopyOnWriteArraySet<>();
   private KeeperState _currentState;
   private final ZkLock _zkEventLock = new ZkLock();
@@ -326,14 +329,31 @@ public class ZkClient implements Watcher {
     return true;
   }
 
-   /**
-    * Subscribe the path and the listener will handle data events of the path
-    * WARNING: if the path is created after deletion, users need to re-subscribe the path
-    * @param path The zookeeper path
-    * @param listener Instance of {@link IZkDataListener}
-    */
+  /**
+   * Subscribe the path and the listener will handle data events of the path
+   * WARNING: if the path is created after deletion, users need to re-subscribe the path
+   * @param path The zookeeper path
+   * @param listener Instance of {@link IZkDataListener}
+   */
   public void subscribeDataChanges(String path, IZkDataListener listener) {
     subscribeDataChanges(path, listener, false);
+  }
+
+  /**
+   * Subscribe RecursivePersistListener for a particular path. User can only subscribe when
+   * `_usePersistWatcher` is set to true and there is no pre-existing watcher on the path.
+   */
+  // TODO: Add impl and remove exception
+  public boolean subscribePersistRecursiveWatcher(String path,
+      RecursivePersistListener recursivePersistListener)
+      throws KeeperException.UnimplementedException {
+    throw new KeeperException.UnimplementedException();
+  }
+
+  public boolean unsubscribePersistRecursiveWatcher(String path,
+      RecursivePersistListener recursivePersistListener)
+      throws KeeperException.UnimplementedException {
+    throw new KeeperException.UnimplementedException();
   }
 
   private boolean isPrefetchEnabled(IZkDataListener dataListener) {

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/TestZooKeeperConnection.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/TestZooKeeperConnection.java
@@ -18,6 +18,7 @@ public class TestZooKeeperConnection extends ZkTestBase {
   final int count = 100;
   final int[] get_count = {0};
   CountDownLatch countDownLatch = new CountDownLatch(count*2);
+  CountDownLatch countDownLatch2 = new CountDownLatch(count*3);
 
 
   /*
@@ -25,7 +26,8 @@ public class TestZooKeeperConnection extends ZkTestBase {
   1. Register a persist watcher on a path and create 100 children Znode, edit the ZNode for 100 times.
   Expecting 200 events.
   2. register a one time listener on the path. Make the same change and count the total number of event.
-  */
+ */
+
   @Test
   void testPersistWatcher() throws Exception {
     Watcher watcher1 = new PersistWatcher();
@@ -57,11 +59,53 @@ public class TestZooKeeperConnection extends ZkTestBase {
     zkClient.close();
   }
 
+  @Test (dependsOnMethods = "testPersistWatcher")
+  void testRecursivePersistWatcherWithOneTimeWatcher() throws Exception {
+    // reset counter
+    get_count[0] = 0;
+    Watcher watcher1 = new PersistRecurWatcher();
+    ZkClient zkClient =   new org.apache.helix.zookeeper.impl.client.ZkClient(ZK_ADDR);
+    IZkConnection _zk = zkClient.getConnection();
+    String path="/testRecursivePersistWatcher";
+    _zk.create(path, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    // register a persist listener on a path, change the ZNode 100 times, create 100 child ZNode,
+    // and expecting 200 events
+    _zk.addWatch(path, watcher1, AddWatchMode.PERSISTENT_RECURSIVE);
+    for (int i=0; i<count; ++i) {
+      _zk.writeData(path, "datat".getBytes(), -1);
+      _zk.create(path+"/c1_" +i, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+      _zk.create(path+"/c1_" +i + "/c2", null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    }
+    Assert.assertTrue(countDownLatch2.await(50000, TimeUnit.MILLISECONDS));
+
+    // register a one time listener on the path. Count the total number of event.
+    // ZK will over write the persist watcher and only trigger event once for child and data change.
+    _zk.readData(path, null, true);
+    _zk.getChildren(path, true);
+    for (int i=0; i<200; ++i) {
+      _zk.writeData(path, ("datat"+i).getBytes(), -1);
+      _zk.create(path+"/c2_" +i, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    }
+    Assert.assertTrue(TestHelper.verify(() -> {
+      return (get_count[0] == 302);
+    }, TestHelper.WAIT_DURATION));
+    System.out.println("testPersistWatcher received event count: " + get_count[0]);
+    zkClient.close();
+  }
+
   class PersistWatcher implements Watcher {
     @Override
     public void process(WatchedEvent watchedEvent) {
       get_count[0]++;
       countDownLatch.countDown();
+    }
+  }
+
+  class PersistRecurWatcher implements Watcher {
+    @Override
+    public void process(WatchedEvent watchedEvent) {
+      get_count[0]++;
+      countDownLatch2.countDown();
     }
   }
 

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientPersistWatcher.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientPersistWatcher.java
@@ -22,6 +22,7 @@ package org.apache.helix.zookeeper.zkclient;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.helix.zookeeper.impl.ZkTestBase;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
@@ -119,8 +120,8 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
     org.apache.helix.zookeeper.impl.client.ZkClient zkClient = builder.build();
     zkClient.setZkSerializer(new BasicZkSerializer(new SerializableSerializer()));
     int count = 100;
-    final int[] event_count = {0};
-    final int[] event_count2 = {0};
+    final AtomicInteger[] event_count = {new AtomicInteger(0)};
+    final AtomicInteger[] event_count2 = {new AtomicInteger(0)};
     CountDownLatch countDownLatch1 = new CountDownLatch(count);
     CountDownLatch countDownLatch2 = new CountDownLatch(count/2);
     String path = "/base/testZkClientChildChange";
@@ -129,7 +130,7 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
       public void handleZNodeChange(String dataPath, Watcher.Event.EventType eventType)
           throws Exception {
         countDownLatch1.countDown();
-        event_count[0]++ ;
+        event_count[0].incrementAndGet() ;
         System.out.println("rcListener count " + event_count[0]);
       }
     };
@@ -138,7 +139,7 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
       public void handleChildChange(String parentPath, List<String> currentChilds)
           throws Exception {
         countDownLatch2.countDown();
-        event_count2[0]++;
+        event_count2[0].incrementAndGet();
         System.out.println("childListener2 count " + event_count2[0]);
       }
     };


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2237 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change adds recursive persist listener API in ZkClient and test native ZK. 
Will have a follow up PR for implementation and test. 

This PR also add tests for native ZK recursive persist listener behavior.


### Tests

- [X] The following tests are written for this issue:

TestZooKeeperConnection.testRecursivePersistWatcherWithOneTimeWatcher

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)
```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.287 s - in org.apache.helix.integration.manager.TestConsecutiveZkSessionExpiry
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 

```
### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
