### PR TITLE
Add support for pluggable external CloudInfoProcessor and CustomizedCloudProperties

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
@@ -128,8 +128,8 @@ public class HelixCloudProperty {
           setCloudInfoSources(cloudConfig.getCloudInfoSources());
           setCloudInfoProcessorName(cloudConfig.getCloudInfoProcessorName());
           // Although it is unlikely that cloudInfoProcessorPackageName is null, when using the CUSTOMIZED
-          // if cloudInfoProcessorPackageName is null, we will look for the processor class in helix
-          // cloud package to preserves the backwards compatibility.
+          // cloud provider, we will look for the processor class in helix cloud package to preserves the
+          // backwards compatibility.
           setCloudInfoProcessorFullyQualifiedClassName(
               cloudConfig.getCloudInfoProcessorPackageName() != null ?
                   cloudConfig.getCloudInfoProcessorPackageName() + "."

--- a/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixCloudProperty.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 public class HelixCloudProperty {
   private static final Logger LOG = LoggerFactory.getLogger(HelixCloudProperty.class.getName());
   private static final String AZURE_CLOUD_PROPERTY_FILE = SystemPropertyKeys.AZURE_CLOUD_PROPERTIES;
+  private static final String CLOUD_PROCESSOR_PATH_PREFIX = "org.apache.helix.cloud.";
   private static final String CLOUD_INFO_SOURCE = "cloud_info_source";
   private static final String CLOUD_INFO_PROCESSOR_NAME = "cloud_info_processor_name";
   private static final String CLOUD_MAX_RETRY = "cloud_max_retry";
@@ -58,7 +59,12 @@ public class HelixCloudProperty {
   private List<String> _cloudInfoSources;
 
   // The name of the function that will fetch and parse cloud instance information.
+  @Deprecated
   private String _cloudInfoProcessorName;
+
+  // The fully qualified class name for the class which contains implementation to fetch
+  // and parse cloud instance information.
+  private String _cloudInfoProcessorFullyQualifiedClassName;
 
   // Http max retry times when querying the cloud instance information from cloud environment.
   private int _cloudMaxRetry;
@@ -93,6 +99,7 @@ public class HelixCloudProperty {
     String cloudProviderStr = cloudConfig.getCloudProvider();
     setCloudProvider(cloudProviderStr);
     if (cloudProviderStr != null) {
+      String cloudInfoProcessorName = null;
       switch (CloudProvider.valueOf(cloudProviderStr)) {
         case AZURE:
           Properties azureProperties = new Properties();
@@ -108,6 +115,7 @@ public class HelixCloudProperty {
           LOG.info("Successfully loaded Helix Azure cloud properties: {}", azureProperties);
           setCloudInfoSources(
               Collections.singletonList(azureProperties.getProperty(CLOUD_INFO_SOURCE)));
+          cloudInfoProcessorName = azureProperties.getProperty(CLOUD_INFO_PROCESSOR_NAME);
           setCloudInfoProcessorName(azureProperties.getProperty(CLOUD_INFO_PROCESSOR_NAME));
           setCloudMaxRetry(Integer.valueOf(azureProperties.getProperty(CLOUD_MAX_RETRY)));
           setCloudConnectionTimeout(
@@ -116,11 +124,27 @@ public class HelixCloudProperty {
           break;
         case CUSTOMIZED:
           setCloudInfoSources(cloudConfig.getCloudInfoSources());
+          cloudInfoProcessorName = cloudConfig.getCloudInfoProcessorName();
           setCloudInfoProcessorName(cloudConfig.getCloudInfoProcessorName());
           break;
         default:
           throw new HelixException(
               String.format("Unsupported cloud provider: %s", cloudConfig.getCloudProvider()));
+      }
+
+      if (cloudInfoProcessorName != null) {
+        // If the cloud provider is not customized or a fully qualified class name isn't provided,
+        // use the default cloud processor path prefix and cloudProviderStr to construct the fully
+        // qualified class name. Otherwise, use the provided cloudInfoProcessorName directly. (Most common
+        // case if CUSTOMIZED cloud provider is used.
+        setCloudInfoProcessorFullyQualifiedClassName(
+            CloudProvider.valueOf(cloudProviderStr) != CloudProvider.CUSTOMIZED
+                || !cloudInfoProcessorName.contains(".") ? CLOUD_PROCESSOR_PATH_PREFIX
+                + cloudProviderStr.toLowerCase() + "." + cloudInfoProcessorName
+                : cloudInfoProcessorName);
+      } else {
+        throw new HelixException(String.format("No cloudInfoProcessorName is provided for: %s",
+            cloudConfig.getCloudProvider()));
       }
     }
   }
@@ -141,8 +165,17 @@ public class HelixCloudProperty {
     return _cloudInfoSources;
   }
 
+  @Deprecated
   public String getCloudInfoProcessorName() {
     return _cloudInfoProcessorName;
+  }
+
+  /**
+   * Get the fully qualified class name for the class which contains implementation to fetch
+   * and parse cloud instance information.
+   */
+  public String getCloudInfoProcessorFullyQualifiedClassName() {
+    return _cloudInfoProcessorFullyQualifiedClassName;
   }
 
   public int getCloudMaxRetry() {
@@ -185,8 +218,18 @@ public class HelixCloudProperty {
     _cloudInfoSources = sources;
   }
 
+  @Deprecated
   public void setCloudInfoProcessorName(String cloudInfoProcessorName) {
     _cloudInfoProcessorName = cloudInfoProcessorName;
+  }
+
+  /**
+   * Set the fully qualified class name of the cloud info processor.
+   * @param cloudInfoProcessorFullyQualifiedClassName
+   */
+  public void setCloudInfoProcessorFullyQualifiedClassName(
+      String cloudInfoProcessorFullyQualifiedClassName) {
+    _cloudInfoProcessorFullyQualifiedClassName = cloudInfoProcessorFullyQualifiedClassName;
   }
 
   public void setCloudMaxRetry(int cloudMaxRetry) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -242,13 +242,17 @@ public class ParticipantManager {
         _helixManagerProperty.getHelixCloudProperty().getCloudInfoProcessorName();
     try {
       // fetch cloud instance information for the instance
-      String cloudInstanceInformationProcessorClassName = CLOUD_PROCESSOR_PATH_PREFIX
-          + _helixManagerProperty.getHelixCloudProperty().getCloudProvider().toLowerCase() + "."
-          + cloudInstanceInformationProcessorName;
+      String cloudInstanceInformationProcessorClassName =
+          // If the class name is already fully qualified, use it directly.
+          cloudInstanceInformationProcessorName.contains(".")
+              ? cloudInstanceInformationProcessorName
+              : CLOUD_PROCESSOR_PATH_PREFIX + _helixManagerProperty.getHelixCloudProperty()
+                  .getCloudProvider().toLowerCase() + "." + cloudInstanceInformationProcessorName;
       Class processorClass = Class.forName(cloudInstanceInformationProcessorClassName);
       Constructor constructor = processorClass.getConstructor(HelixCloudProperty.class);
-      CloudInstanceInformationProcessor processor = (CloudInstanceInformationProcessor) constructor
-          .newInstance(_helixManagerProperty.getHelixCloudProperty());
+      CloudInstanceInformationProcessor processor =
+          (CloudInstanceInformationProcessor) constructor.newInstance(
+              _helixManagerProperty.getHelixCloudProperty());
       List<String> responses = processor.fetchCloudInstanceInformation();
 
       // parse cloud instance information for the participant

--- a/helix-core/src/main/java/org/apache/helix/model/CloudConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/CloudConfig.java
@@ -50,7 +50,7 @@ public class CloudConfig extends HelixProperty {
     CLOUD_INFO_SOURCE, // the source for retrieving the cloud information.
     CLOUD_INFO_PROCESSOR_NAME, // the name of the function that processes the fetching and parsing of
     // cloud information.
-    CLOUD_INFO_PROCESSOR_PACKAGE_NAME // the package name of for the CLOUD_INFO_PROCESSOR_NAME Class
+    CLOUD_INFO_PROCESSOR_PACKAGE // the package of for the CLOUD_INFO_PROCESSOR_NAME Class
   }
 
   /* Default values */
@@ -153,12 +153,12 @@ public class CloudConfig extends HelixProperty {
   }
 
   /**
-   * Get the CLOUD_INFO_PROCESSOR_PACKAGE_NAME field. This could be null
+   * Get the CLOUD_INFO_PROCESSOR_PACKAGE field. This could be null
    * if the user is using a supported cloud provider.
-   * @return CLOUD_INFO_PROCESSOR_PACKAGE_NAME field.
+   * @return CLOUD_INFO_PROCESSOR_PACKAGE field.
    */
-  public String getCloudInfoProcessorPackageName() {
-    return _record.getSimpleField(CloudConfigProperty.CLOUD_INFO_PROCESSOR_PACKAGE_NAME.name());
+  public String getCloudInfoProcessorPackage() {
+    return _record.getSimpleField(CloudConfigProperty.CLOUD_INFO_PROCESSOR_PACKAGE.name());
   }
 
   /**
@@ -237,14 +237,14 @@ public class CloudConfig extends HelixProperty {
     }
 
     /**
-     * Set the CLOUD_INFO_PROCESSOR_PACKAGE_NAME field. This is primarily used when the user
+     * Set the CLOUD_INFO_PROCESSOR_PACKAGE field. This is primarily used when the user
      * is using a customized cloud provider.
-     * @param cloudInfoProcessorPackageName
+     * @param cloudInfoProcessorPackage
      * @return Builder
      */
-    public Builder setCloudInfoProcessorPackageName(String cloudInfoProcessorPackageName) {
-      _record.setSimpleField(CloudConfigProperty.CLOUD_INFO_PROCESSOR_PACKAGE_NAME.name(),
-          cloudInfoProcessorPackageName);
+    public Builder setCloudInfoProcessorPackageName(String cloudInfoProcessorPackage) {
+      _record.setSimpleField(CloudConfigProperty.CLOUD_INFO_PROCESSOR_PACKAGE.name(),
+          cloudInfoProcessorPackage);
       return this;
     }
 

--- a/helix-core/src/main/java/org/apache/helix/model/CloudConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/CloudConfig.java
@@ -48,8 +48,9 @@ public class CloudConfig extends HelixProperty {
     // If user uses Helix supported default provider, the below entries will not be shown in
     // CloudConfig.
     CLOUD_INFO_SOURCE, // the source for retrieving the cloud information.
-    CLOUD_INFO_PROCESSOR_NAME // the name of the function that processes the fetching and parsing of
-                              // cloud information.
+    CLOUD_INFO_PROCESSOR_NAME, // the name of the function that processes the fetching and parsing of
+    // cloud information.
+    CLOUD_INFO_PROCESSOR_PACKAGE_NAME // the package name of for the CLOUD_INFO_PROCESSOR_NAME Class
   }
 
   /* Default values */
@@ -152,13 +153,21 @@ public class CloudConfig extends HelixProperty {
   }
 
   /**
+   * Get the CLOUD_INFO_PROCESSOR_PACKAGE_NAME field. This could be null
+   * if the user is using a supported cloud provider.
+   * @return CLOUD_INFO_PROCESSOR_PACKAGE_NAME field.
+   */
+  public String getCloudInfoProcessorPackageName() {
+    return _record.getSimpleField(CloudConfigProperty.CLOUD_INFO_PROCESSOR_PACKAGE_NAME.name());
+  }
+
+  /**
    * Get the CLOUD_PROVIDER field.
    * @return CLOUD_PROVIDER field.
    */
   public String getCloudProvider() {
     return _record.getSimpleField(CloudConfigProperty.CLOUD_PROVIDER.name());
   }
-
 
   public static class Builder {
     private ZNRecord _record;
@@ -224,6 +233,18 @@ public class CloudConfig extends HelixProperty {
     public Builder setCloudInfoProcessorName(String cloudInfoProcessorName) {
       _record.setSimpleField(CloudConfigProperty.CLOUD_INFO_PROCESSOR_NAME.name(),
           cloudInfoProcessorName);
+      return this;
+    }
+
+    /**
+     * Set the CLOUD_INFO_PROCESSOR_PACKAGE_NAME field. This is primarily used when the user
+     * is using a customized cloud provider.
+     * @param cloudInfoProcessorPackageName
+     * @return Builder
+     */
+    public Builder setCloudInfoProcessorPackageName(String cloudInfoProcessorPackageName) {
+      _record.setSimpleField(CloudConfigProperty.CLOUD_INFO_PROCESSOR_PACKAGE_NAME.name(),
+          cloudInfoProcessorPackageName);
       return this;
     }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestHelixCloudProperty.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestHelixCloudProperty.java
@@ -1,0 +1,83 @@
+package org.apache.helix.integration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+
+import org.apache.helix.HelixCloudProperty;
+import org.apache.helix.cloud.constants.CloudProvider;
+import org.apache.helix.model.CloudConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestHelixCloudProperty {
+  @Test
+  public void testHelixCloudPropertyAzure() {
+    CloudConfig azureCloudConfig =
+        new CloudConfig("cluster_foo", true, CloudProvider.AZURE, "azure1",
+            Collections.singletonList("foo"), "foo");
+    HelixCloudProperty azureCloudProperty = new HelixCloudProperty(azureCloudConfig);
+
+    Assert.assertTrue(azureCloudProperty.getCloudEnabled());
+    Assert.assertEquals(azureCloudProperty.getCloudId(), "azure1");
+    Assert.assertEquals(azureCloudProperty.getCloudProvider(), CloudProvider.AZURE.name());
+    Assert.assertEquals(azureCloudProperty.getCloudInfoSources(), Collections.singletonList(
+        "http://169.254.169.254/metadata/instance?api-version=2019-06-04"));
+    Assert.assertEquals(azureCloudProperty.getCloudMaxRetry(), 5);
+    Assert.assertEquals(azureCloudProperty.getCloudConnectionTimeout(), 5000);
+    Assert.assertEquals(azureCloudProperty.getCloudRequestTimeout(), 5000);
+    Assert.assertEquals(azureCloudProperty.getCloudInfoProcessorFullyQualifiedClassName(),
+        "org.apache.helix.cloud.azure.AzureCloudInstanceInformationProcessor");
+  }
+
+  @Test
+  public void testHelixCloudPropertyCustomizedFullyQualified() {
+    CloudConfig customCloudConfig =
+        new CloudConfig("cluster_foo", true, CloudProvider.CUSTOMIZED, "custom1",
+            Collections.singletonList("https://custom-cloud.com"),
+            "com.linkedin.cloudinfo.CustomCloudInstanceInfoProcessor");
+    HelixCloudProperty customCloudProperty = new HelixCloudProperty(customCloudConfig);
+
+    Assert.assertTrue(customCloudProperty.getCloudEnabled());
+    Assert.assertEquals(customCloudProperty.getCloudId(), "custom1");
+    Assert.assertEquals(customCloudProperty.getCloudProvider(), CloudProvider.CUSTOMIZED.name());
+    Assert.assertEquals(customCloudProperty.getCloudInfoSources(),
+        Collections.singletonList("https://custom-cloud.com"));
+    Assert.assertEquals(customCloudProperty.getCloudInfoProcessorFullyQualifiedClassName(),
+        "com.linkedin.cloudinfo.CustomCloudInstanceInfoProcessor");
+  }
+
+  @Test
+  public void testHelixCloudPropertyClassName() {
+    CloudConfig customCloudConfig =
+        new CloudConfig("cluster_foo", true, CloudProvider.CUSTOMIZED, "custom1",
+            Collections.singletonList("https://custom-cloud.com"),
+            "CustomCloudInstanceInfoProcessor");
+    HelixCloudProperty customCloudProperty = new HelixCloudProperty(customCloudConfig);
+
+    Assert.assertTrue(customCloudProperty.getCloudEnabled());
+    Assert.assertEquals(customCloudProperty.getCloudId(), "custom1");
+    Assert.assertEquals(customCloudProperty.getCloudProvider(), CloudProvider.CUSTOMIZED.name());
+    Assert.assertEquals(customCloudProperty.getCloudInfoSources(),
+        Collections.singletonList("https://custom-cloud.com"));
+    Assert.assertEquals(customCloudProperty.getCloudInfoProcessorFullyQualifiedClassName(),
+        "org.apache.helix.cloud.customized.CustomCloudInstanceInfoProcessor");
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/TestHelixCloudProperty.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestHelixCloudProperty.java
@@ -31,12 +31,13 @@ public class TestHelixCloudProperty {
   @Test
   public void testHelixCloudPropertyAzure() {
     CloudConfig azureCloudConfig =
-        new CloudConfig("cluster_foo", true, CloudProvider.AZURE, "azure1",
-            Collections.singletonList("foo"), "foo");
+        new CloudConfig.Builder().setCloudEnabled(true).setCloudID("AzureTestId1")
+            .setCloudProvider(CloudProvider.AZURE).build();
+
     HelixCloudProperty azureCloudProperty = new HelixCloudProperty(azureCloudConfig);
 
     Assert.assertTrue(azureCloudProperty.getCloudEnabled());
-    Assert.assertEquals(azureCloudProperty.getCloudId(), "azure1");
+    Assert.assertEquals(azureCloudProperty.getCloudId(), "AzureTestId1");
     Assert.assertEquals(azureCloudProperty.getCloudProvider(), CloudProvider.AZURE.name());
     Assert.assertEquals(azureCloudProperty.getCloudInfoSources(), Collections.singletonList(
         "http://169.254.169.254/metadata/instance?api-version=2019-06-04"));
@@ -50,30 +51,31 @@ public class TestHelixCloudProperty {
   @Test
   public void testHelixCloudPropertyCustomizedFullyQualified() {
     CloudConfig customCloudConfig =
-        new CloudConfig("cluster_foo", true, CloudProvider.CUSTOMIZED, "custom1",
-            Collections.singletonList("https://custom-cloud.com"),
-            "com.linkedin.cloudinfo.CustomCloudInstanceInfoProcessor");
+        new CloudConfig.Builder().setCloudEnabled(true).setCloudProvider(CloudProvider.CUSTOMIZED)
+            .setCloudInfoProcessorPackageName("org.apache.foo.bar")
+            .setCloudInfoProcessorName("CustomCloudInstanceInfoProcessor")
+            .setCloudInfoSources(Collections.singletonList("https://custom-cloud.com")).build();
+
     HelixCloudProperty customCloudProperty = new HelixCloudProperty(customCloudConfig);
 
     Assert.assertTrue(customCloudProperty.getCloudEnabled());
-    Assert.assertEquals(customCloudProperty.getCloudId(), "custom1");
     Assert.assertEquals(customCloudProperty.getCloudProvider(), CloudProvider.CUSTOMIZED.name());
     Assert.assertEquals(customCloudProperty.getCloudInfoSources(),
         Collections.singletonList("https://custom-cloud.com"));
     Assert.assertEquals(customCloudProperty.getCloudInfoProcessorFullyQualifiedClassName(),
-        "com.linkedin.cloudinfo.CustomCloudInstanceInfoProcessor");
+        "org.apache.foo.bar.CustomCloudInstanceInfoProcessor");
   }
 
   @Test
-  public void testHelixCloudPropertyClassName() {
+  public void testHelixCloudPropertyClassNameOnly() {
     CloudConfig customCloudConfig =
-        new CloudConfig("cluster_foo", true, CloudProvider.CUSTOMIZED, "custom1",
-            Collections.singletonList("https://custom-cloud.com"),
-            "CustomCloudInstanceInfoProcessor");
+        new CloudConfig.Builder().setCloudEnabled(true).setCloudProvider(CloudProvider.CUSTOMIZED)
+            .setCloudInfoProcessorName("CustomCloudInstanceInfoProcessor")
+            .setCloudInfoSources(Collections.singletonList("https://custom-cloud.com")).build();
+
     HelixCloudProperty customCloudProperty = new HelixCloudProperty(customCloudConfig);
 
     Assert.assertTrue(customCloudProperty.getCloudEnabled());
-    Assert.assertEquals(customCloudProperty.getCloudId(), "custom1");
     Assert.assertEquals(customCloudProperty.getCloudProvider(), CloudProvider.CUSTOMIZED.name());
     Assert.assertEquals(customCloudProperty.getCloudInfoSources(),
         Collections.singletonList("https://custom-cloud.com"));

--- a/helix-core/src/test/java/org/apache/helix/integration/TestHelixCloudProperty.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestHelixCloudProperty.java
@@ -44,6 +44,10 @@ public class TestHelixCloudProperty {
     Assert.assertEquals(azureCloudProperty.getCloudMaxRetry(), 5);
     Assert.assertEquals(azureCloudProperty.getCloudConnectionTimeout(), 5000);
     Assert.assertEquals(azureCloudProperty.getCloudRequestTimeout(), 5000);
+    Assert.assertEquals(azureCloudProperty.getCloudInfoProcessorPackage(),
+        "org.apache.helix.cloud.azure");
+    Assert.assertEquals(azureCloudProperty.getCloudInfoProcessorName(),
+        "AzureCloudInstanceInformationProcessor");
     Assert.assertEquals(azureCloudProperty.getCloudInfoProcessorFullyQualifiedClassName(),
         "org.apache.helix.cloud.azure.AzureCloudInstanceInformationProcessor");
   }
@@ -62,6 +66,9 @@ public class TestHelixCloudProperty {
     Assert.assertEquals(customCloudProperty.getCloudProvider(), CloudProvider.CUSTOMIZED.name());
     Assert.assertEquals(customCloudProperty.getCloudInfoSources(),
         Collections.singletonList("https://custom-cloud.com"));
+    Assert.assertEquals(customCloudProperty.getCloudInfoProcessorPackage(), "org.apache.foo.bar");
+    Assert.assertEquals(customCloudProperty.getCloudInfoProcessorName(),
+        "CustomCloudInstanceInfoProcessor");
     Assert.assertEquals(customCloudProperty.getCloudInfoProcessorFullyQualifiedClassName(),
         "org.apache.foo.bar.CustomCloudInstanceInfoProcessor");
   }
@@ -79,6 +86,10 @@ public class TestHelixCloudProperty {
     Assert.assertEquals(customCloudProperty.getCloudProvider(), CloudProvider.CUSTOMIZED.name());
     Assert.assertEquals(customCloudProperty.getCloudInfoSources(),
         Collections.singletonList("https://custom-cloud.com"));
+    Assert.assertEquals(customCloudProperty.getCloudInfoProcessorPackage(),
+        "org.apache.helix.cloud.customized");
+    Assert.assertEquals(customCloudProperty.getCloudInfoProcessorName(),
+        "CustomCloudInstanceInfoProcessor");
     Assert.assertEquals(customCloudProperty.getCloudInfoProcessorFullyQualifiedClassName(),
         "org.apache.helix.cloud.customized.CustomCloudInstanceInfoProcessor");
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformation.java
@@ -1,5 +1,24 @@
 package org.apache.helix.integration.paticipant;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import org.apache.helix.api.cloud.CloudInstanceInformation;
 
 /**

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformation.java
@@ -1,0 +1,23 @@
+package org.apache.helix.integration.paticipant;
+
+import org.apache.helix.api.cloud.CloudInstanceInformation;
+
+/**
+ * This is a custom implementation of CloudInstanceInformation. It is used to test the functionality
+ * of Helix node auto-registration.
+ */
+public class CustomCloudInstanceInformation implements CloudInstanceInformation {
+  private final String _faultDomain;
+
+  public CustomCloudInstanceInformation(String faultDomain) {
+    _faultDomain = faultDomain;
+  }
+
+  @Override
+  public String get(String key) {
+    if (key.equals(CloudInstanceField.FAULT_DOMAIN.name())) {
+      return _faultDomain;
+    }
+    return null;
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformationProcessor.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformationProcessor.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.apache.helix.HelixCloudProperty;
 import org.apache.helix.api.cloud.CloudInstanceInformation;
 import org.apache.helix.api.cloud.CloudInstanceInformationProcessor;
-import org.apache.helix.cloud.azure.AzureCloudInstanceInformation;
 
 /**
  * This is a custom implementation of CloudInstanceInformationProcessor.
@@ -23,6 +22,6 @@ public class CustomCloudInstanceInformationProcessor implements CloudInstanceInf
 
   @Override
   public CloudInstanceInformation parseCloudInstanceInformation(List<String> responses) {
-    return new AzureCloudInstanceInformation.Builder().setFaultDomain("rack=A:123, host=").build();
+    return new CustomCloudInstanceInformation("rack=A:123, host=");
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformationProcessor.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformationProcessor.java
@@ -1,0 +1,28 @@
+package org.apache.helix.integration.paticipant;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.helix.HelixCloudProperty;
+import org.apache.helix.api.cloud.CloudInstanceInformation;
+import org.apache.helix.api.cloud.CloudInstanceInformationProcessor;
+import org.apache.helix.cloud.azure.AzureCloudInstanceInformation;
+
+/**
+ * This is a custom implementation of CloudInstanceInformationProcessor.
+ * It is used to test the functionality of Helix node auto-registration.
+ */
+public class CustomCloudInstanceInformationProcessor implements CloudInstanceInformationProcessor<String> {
+  public CustomCloudInstanceInformationProcessor(HelixCloudProperty helixCloudProperty) {
+  }
+
+  @Override
+  public List<String> fetchCloudInstanceInformation() {
+    return Collections.singletonList("response");
+  }
+
+  @Override
+  public CloudInstanceInformation parseCloudInstanceInformation(List<String> responses) {
+    return new AzureCloudInstanceInformation.Builder().setFaultDomain("rack=A:123, host=").build();
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformationProcessor.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformationProcessor.java
@@ -1,5 +1,24 @@
 package org.apache.helix.integration.paticipant;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.util.Collections;
 import java.util.List;
 

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
@@ -150,8 +150,8 @@ public class TestInstanceAutoJoin extends ZkStandAloneCMTestBase {
     // Create CloudConfig object for CUSTOM cloud provider.
     CloudConfig cloudConfig =
         new CloudConfig.Builder().setCloudEnabled(true).setCloudProvider(CloudProvider.CUSTOMIZED)
-            .setCloudInfoProcessorName(
-                "org.apache.helix.integration.paticipant.CustomCloudInstanceInformationProcessor")
+            .setCloudInfoProcessorPackageName("org.apache.helix.integration.paticipant")
+            .setCloudInfoProcessorName("CustomCloudInstanceInformationProcessor")
             .setCloudInfoSources(Collections.singletonList("https://cloud.com")).build();
 
     // Update CloudConfig to Zookeeper.

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
@@ -1,5 +1,7 @@
 package org.apache.helix.integration.paticipant;
 
+import java.util.Collections;
+
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
@@ -12,8 +14,10 @@ import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.manager.zk.ZKHelixManager;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.ConfigScope;
+import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState.RebalanceMode;
 import org.apache.helix.model.builder.ConfigScopeBuilder;
+import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -91,8 +95,7 @@ public class TestInstanceAutoJoin extends ZkStandAloneCMTestBase {
     HelixManager manager = _participants[0];
     HelixDataAccessor accessor = manager.getHelixDataAccessor();
 
-    _gSetupTool.addResourceToCluster(CLUSTER_NAME, db3, 60, "OnlineOffline",
-        RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, db3, 60, "OnlineOffline", RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
     _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db3, 1);
     String instance3 = "localhost_279700";
 
@@ -120,8 +123,53 @@ public class TestInstanceAutoJoin extends ZkStandAloneCMTestBase {
         return true;
       }, 2000));
     } catch (HelixException e) {
-      Assert.assertNull(manager.getHelixDataAccessor().getProperty(accessor.keyBuilder().liveInstance(instance3)));
+      Assert.assertNull(manager.getHelixDataAccessor()
+          .getProperty(accessor.keyBuilder().liveInstance(instance3)));
     }
+
+    autoParticipant.syncStop();
+  }
+
+  /**
+   * Test auto registration with customized cloud info processor specified with fully qualified
+   * class name.
+   * @throws Exception
+   */
+  @Test
+  public void testAutoRegistrationCustomizedFullyQualifiedInfoProcessorPath() throws Exception {
+    HelixManager manager = _participants[0];
+    HelixDataAccessor accessor = manager.getHelixDataAccessor();
+    String instance4 = "localhost_279707";
+
+    // Enable cluster auto join.
+    HelixConfigScope scope =
+        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(
+            CLUSTER_NAME).build();
+    manager.getConfigAccessor().set(scope, ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, "true");
+
+    // Create CloudConfig object for CUSTOM cloud provider.
+    CloudConfig cloudConfig =
+        new CloudConfig.Builder().setCloudEnabled(true).setCloudProvider(CloudProvider.CUSTOMIZED)
+            .setCloudInfoProcessorName(
+                "org.apache.helix.integration.paticipant.CustomCloudInstanceInformationProcessor")
+            .setCloudInfoSources(Collections.singletonList("https://cloud.com")).build();
+
+    // Update CloudConfig to Zookeeper.
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    accessor.setProperty(keyBuilder.cloudConfig(), cloudConfig);
+
+    // Create and start a new participant.
+    MockParticipantManager autoParticipant =
+        new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instance4);
+    autoParticipant.syncStart();
+
+    Assert.assertTrue(TestHelper.verify(() -> {
+      // Check that live instance is added and instance config is populated with correct domain.
+      return null != manager.getHelixDataAccessor()
+          .getProperty(accessor.keyBuilder().liveInstance(instance4)) && manager.getConfigAccessor()
+          .getInstanceConfig(CLUSTER_NAME, instance4).getDomainAsString()
+          .equals("rack=A:123, host=" + instance4);
+    }, 2000));
 
     autoParticipant.syncStop();
   }

--- a/helix-core/src/test/java/org/apache/helix/model/cloud/TestCloudConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/cloud/TestCloudConfig.java
@@ -20,16 +20,17 @@ package org.apache.helix.model.cloud;
  */
 
 import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.PropertyKey.Builder;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZkUnitTestBase;
+import org.apache.helix.cloud.constants.CloudProvider;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.CloudConfig;
-import org.apache.helix.cloud.constants.CloudProvider;
-import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -139,6 +140,7 @@ public class TestCloudConfig extends ZkUnitTestBase {
     builder.addCloudInfoSource("TestURL0");
     builder.addCloudInfoSource("TestURL1");
     builder.setCloudInfoProcessorName("TestProcessor");
+    builder.setCloudInfoProcessorPackageName("org.apache.foo.bar");
 
     // Check builder getter methods
     Assert.assertTrue(builder.getCloudEnabled());
@@ -167,6 +169,7 @@ public class TestCloudConfig extends ZkUnitTestBase {
     Assert.assertEquals(listUrlFromZk.get(0), "TestURL0");
     Assert.assertEquals(listUrlFromZk.get(1), "TestURL1");
     Assert.assertEquals(cloudConfigFromZk.getCloudInfoProcessorName(), "TestProcessor");
+    Assert.assertEquals(cloudConfigFromZk.getCloudInfoProcessorPackageName(), "org.apache.foo.bar");
   }
 
   @Test(dependsOnMethods = "testCloudConfigBuilder")

--- a/helix-core/src/test/java/org/apache/helix/model/cloud/TestCloudConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/cloud/TestCloudConfig.java
@@ -169,7 +169,7 @@ public class TestCloudConfig extends ZkUnitTestBase {
     Assert.assertEquals(listUrlFromZk.get(0), "TestURL0");
     Assert.assertEquals(listUrlFromZk.get(1), "TestURL1");
     Assert.assertEquals(cloudConfigFromZk.getCloudInfoProcessorName(), "TestProcessor");
-    Assert.assertEquals(cloudConfigFromZk.getCloudInfoProcessorPackageName(), "org.apache.foo.bar");
+    Assert.assertEquals(cloudConfigFromZk.getCloudInfoProcessorPackage(), "org.apache.foo.bar");
   }
 
   @Test(dependsOnMethods = "testCloudConfigBuilder")


### PR DESCRIPTION
## Summary

Add support for pluggable external CloudInfoProcessor and CustomizedCloudProperties.

<!--
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)
-->

### Description

Helix currently has cloud support for Azure and CUSTOMIZED cloud provider. In the current state it is difficult to take advantage of CUSTOMIZED cloud provider, as Helix is only able to load implementations of CloudInstanceInfoProcessor which are in `org.apache.helix.cloud.`. This means that folks who wish to implement custom CloudInstanceInfoProcessor need to fork apache/helix add their custom implementation and consume the forked version.

To make CUSTOMIZED cloud provider more flexible, we can allow the dynamic import of any class implementing CloudInstanceInfoProcessor on the classpath. This will allow consumers to write their custom implementation as a separate dependency from apache/helix.

Users can leverage this feature by specifying the fully qualified class name in the `CLOUD_INFO_PROCESSOR_NAME` cloud-config. This can be updated using the helix-rest:

```
curl -X PUT -H "Content-Type: application/json" http://helix-rest/admin/v2/clusters/myCluster/addCloudConfig -d '
{
    "simpleFields": 
    {
        "CLOUD_ENABLED": "true",
        "CLOUD_PROVIDER": "CUSTOMIZED",
        "CLOUD_INFO_SOURCE": ["some_source"],
        "CLOUD_INFO_PROCESSOR_NAME": "com.foo.bar.cloudinfo.CustomInstanceInformationProcessor"
    }
}'

```

### Tests

- [x] TestInstanceAutoJoin#testAutoRegistrationCustomizedFullyQualifiedInfoProcessorPath: Added an end to end integration test which validates custom implementation is dynamically located and properly populates DOMAIN field in instance config
- [x] TestHelixCloudProperty: Added a test for HelixCloudProperty when loading Azure and CUSTOM CloudConfigs

./scripts/runSingleTest.sh TestInstanceAutoJoin#testAutoRegistrationCustomizedFullyQualifiedInfoProcessorPath 10
All were passes.


<!-- (If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.) -->

### Changes that Break Backward Compatibility (Optional)

Change is not backwards incompatible.



<!--
- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)
 -->

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
