### PR TITLE
Replace deprecated verifier with new set of Verifiers

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestDistributedControllerManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestDistributedControllerManager.java
@@ -36,6 +36,7 @@ import org.apache.helix.mock.participant.MockMSModelFactory;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.tools.ClusterStateVerifier;
 import org.apache.helix.tools.ClusterStateVerifier.BestPossAndExtViewZkVerifier;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -71,9 +72,10 @@ public class TestDistributedControllerManager extends ZkTestBase {
           new MockMSModelFactory());
       distributedControllers[i].connect();
     }
+    BestPossibleExternalViewVerifier verifier = new BestPossibleExternalViewVerifier
+        .Builder(clusterName).setZkAddress(ZK_ADDR).build();
 
-    boolean result = ClusterStateVerifier
-        .verifyByZkCallback(new BestPossAndExtViewZkVerifier(ZK_ADDR, clusterName));
+    boolean result = verifier.verifyByZkCallback();
     Assert.assertTrue(result);
 
     // disconnect first distributed-controller, and verify second takes leadership
@@ -81,8 +83,7 @@ public class TestDistributedControllerManager extends ZkTestBase {
 
     // verify leader changes to localhost_12919
     Thread.sleep(100);
-    result = ClusterStateVerifier
-        .verifyByZkCallback(new BestPossAndExtViewZkVerifier(ZK_ADDR, clusterName));
+    result = verifier.verifyByZkCallback();
     Assert.assertTrue(result);
 
     ZKHelixDataAccessor accessor =
@@ -120,8 +121,9 @@ public class TestDistributedControllerManager extends ZkTestBase {
     LOG.debug("Expired distributedController: " + expireController.getInstanceName()
         + ", oldSessionId: " + oldSessionId + ", newSessionId: " + newSessionId);
 
-    boolean result = ClusterStateVerifier.verifyByPolling(
-        new ClusterStateVerifier.BestPossAndExtViewZkVerifier(ZK_ADDR, clusterName));
+    BestPossibleExternalViewVerifier verifier = new BestPossibleExternalViewVerifier
+        .Builder(clusterName).setZkAddress(ZK_ADDR).build();
+    boolean result = verifier.verifyByPolling();
     Assert.assertTrue(result);
 
     // verify leader changes to localhost_12919
@@ -172,9 +174,9 @@ public class TestDistributedControllerManager extends ZkTestBase {
           new MockMSModelFactory());
       distributedControllers[i].connect();
     }
-
-    boolean result = ClusterStateVerifier
-        .verifyByZkCallback(new BestPossAndExtViewZkVerifier(ZK_ADDR, clusterName));
+    BestPossibleExternalViewVerifier verifier = new BestPossibleExternalViewVerifier
+        .Builder(clusterName).setZkAddress(ZK_ADDR).build();
+    boolean result = verifier.verifyByZkCallback();
     Assert.assertTrue(result);
 
     // expire localhost_12918

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestDistributedControllerManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestDistributedControllerManager.java
@@ -82,8 +82,9 @@ public class TestDistributedControllerManager extends ZkTestBase {
     distributedControllers[0].disconnect();
 
     // verify leader changes to localhost_12919
-    Thread.sleep(100);
-    result = verifier.verifyByZkCallback();
+    result = TestHelper.verify(() -> {
+      return verifier.verifyByZkCallback();
+    }, 100);
     Assert.assertTrue(result);
 
     ZKHelixDataAccessor accessor =

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestDistributedControllerManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestDistributedControllerManager.java
@@ -81,10 +81,10 @@ public class TestDistributedControllerManager extends ZkTestBase {
     // disconnect first distributed-controller, and verify second takes leadership
     distributedControllers[0].disconnect();
 
+    Thread.sleep(100);
+
     // verify leader changes to localhost_12919
-    result = TestHelper.verify(() -> {
-      return verifier.verifyByZkCallback();
-    }, 100);
+    result = verifier.verifyByZkCallback();
     Assert.assertTrue(result);
 
     ZKHelixDataAccessor accessor =


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixes #2485 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
While debugging the failure for the test case in DistributedController test case, realized we are using deprecated verifier. So let us first use the right verifier and see if it helps with resolving the temporary failures. These are all integration tests which depends on ZK timing and so not sure if just replacing correct verifier will help. But first order problem is to use right code.


### Tests

- [] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:
I created a branch and ran the test 4 times to make sure that there is no regression with using different verifier.
Here is the link to the branch with testing:
https://github.com/desaikomal/helix/pull/2
- failure were in different test cases.

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
