### PR TITLE
 ZkClient add recursive persist listener implementation

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -335,12 +335,11 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
   // TODO: add impl and remove UnimplementedException
   @Override
   public boolean subscribeChildChanges(String key, ChildChangeListener listener, boolean skipWatchingNonExistNode) {
-    try {
-      _zkClient.subscribePersistRecursiveWatcher(key, new ChildListenerAdapter(listener));
-    } catch (KeeperException.UnimplementedException e) {
-      LOG.error(e.getLocalizedMessage());
+    if (skipWatchingNonExistNode && exists(key) == null) {
+      return false;
     }
-    return false;
+    _zkClient.subscribePersistRecursiveListener(key, new ChildListenerAdapter(listener));
+    return true;
   }
 
   @Override
@@ -356,11 +355,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
   // TODO: add impl and remove UnimplementedException
   @Override
   public void unsubscribeChildChanges(String key, ChildChangeListener listener) {
-    try{
-    _zkClient.unsubscribePersistRecursiveWatcher(key, new ChildListenerAdapter(listener));
-    } catch (KeeperException.UnimplementedException e) {
-      LOG.error(e.getLocalizedMessage());
-    }
+    _zkClient.unsubscribePersistRecursiveListener(key, new ChildListenerAdapter(listener));
   }
 
   @Override

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -338,12 +338,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
     if (skipWatchingNonExistNode && exists(key) == null) {
       return false;
     }
-    try {
-      _zkClient.subscribePersistRecursiveListener(key, new ChildListenerAdapter(listener));
-    } catch (ZkException ex) {
-      LOG.error("Failed to subscribe ChildChanges for path: " + key, ex);
-      return false;
-    }
+    _zkClient.subscribePersistRecursiveListener(key, new ChildListenerAdapter(listener));
     return true;
   }
 

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/ChildListenerAdapter.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/adapter/ChildListenerAdapter.java
@@ -39,7 +39,7 @@ public class ChildListenerAdapter implements RecursivePersistListener {
   private static ChildChangeListener.ChangeType convertType(Watcher.Event.EventType eventType) {
     switch (eventType) {
       case NodeCreated: return ChildChangeListener.ChangeType.ENTRY_CREATED;
-      case NodeChildrenChanged: return ChildChangeListener.ChangeType.ENTRY_DATA_CHANGE;
+      case NodeDataChanged: return ChildChangeListener.ChangeType.ENTRY_DATA_CHANGE;
       case NodeDeleted: return ChildChangeListener.ChangeType.ENTRY_DELETED;
       default: throw new IllegalArgumentException("EventType " + eventType + " is not supported.");
     }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -19,6 +19,7 @@ package org.apache.helix.metaclient.impl.zk;
  * under the License.
  */
 
+import org.apache.helix.metaclient.api.ChildChangeListener;
 import org.apache.helix.metaclient.api.DataUpdater;
 import org.apache.helix.metaclient.api.MetaClientInterface;
 import org.apache.helix.metaclient.exception.MetaClientException;
@@ -362,7 +363,6 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
   public void testDataChangeListener() throws Exception {
     final String basePath = "/TestZkMetaClient_testDataChangeListener";
     final int count = 200;
-    final int[] get_count = {0};
     try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
       zkMetaClient.connect();
       CountDownLatch countDownLatch = new CountDownLatch(count);
@@ -372,7 +372,6 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
         public void handleDataChange(String key, Object data, ChangeType changeType)
             throws Exception {
           if(changeType == ENTRY_UPDATE) {
-            get_count[0]++;
             countDownLatch.countDown();
           }
         }
@@ -397,7 +396,77 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
       zkMetaClient.unsubscribeDataChange(basePath, listener);
       // verify that no listener is registered on any path
       watchers = TestUtil.getZkWatch(zkMetaClient.getZkClient());
+      Assert.assertEquals(watchers.get("persistentWatches").size(), 0);
+      Assert.assertEquals(watchers.get("childWatches").size(), 0);
+      Assert.assertEquals(watchers.get("dataWatches").size(), 0);
+
+    }
+  }
+
+  @Test
+  public void testChildChangeListener() throws Exception {
+    final String basePath = "/TestZkMetaClient_testChildChangeListener";
+    final int count = 100;
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      zkMetaClient.connect();
+      CountDownLatch countDownLatch = new CountDownLatch(count*4);
+      ChildChangeListener listener = new ChildChangeListener() {
+
+        @Override
+        public void handleChildChange(String changedPath, ChangeType changeType) throws Exception {
+          countDownLatch.countDown();
+
+        }
+      };
+      zkMetaClient.create(basePath, "");
+      Assert.assertTrue(
+          zkMetaClient.subscribeChildChanges(basePath, listener, false)
+      );
+
+      DataChangeListener dummyDataListener = new DataChangeListener() {
+        @Override
+        public void handleDataChange(String key, Object data, ChangeType changeType)
+            throws Exception {
+        }
+      };
+      try {
+        zkMetaClient.subscribeDataChange(basePath, dummyDataListener, false);
+      } catch ( Exception ex) {
+        Assert.assertEquals(ex.getClass().getName(), "java.lang.UnsupportedOperationException");
+      }
+
+      DirectChildChangeListener dummyCldListener = new DirectChildChangeListener() {
+        @Override
+        public void handleDirectChildChange(String key) throws Exception {
+
+        }
+      };
+      try {
+        zkMetaClient.subscribeDirectChildChange(basePath, dummyCldListener, false);
+      } catch ( Exception ex) {
+        Assert.assertEquals(ex.getClass().getName(), "java.lang.UnsupportedOperationException");
+      }
+
+      // Verify no one time watcher is registered. Only one persist listener is registered.
+      Map<String, List<String>> watchers = TestUtil.getZkWatch(zkMetaClient.getZkClient());
+      Assert.assertEquals(watchers.get("persistentRecursiveWatches").size(), 1);
+      Assert.assertEquals(watchers.get("persistentRecursiveWatches").get(0), basePath);
+      Assert.assertEquals(watchers.get("persistentWatches").size(), 0);
+      Assert.assertEquals(watchers.get("childWatches").size(), 0);
+      Assert.assertEquals(watchers.get("dataWatches").size(), 0);
+
+      for (int i=0; i<count; ++i) {
+        zkMetaClient.set(basePath, "data7" + i, -1);
+        zkMetaClient.create(basePath+"/c1_" +i , "datat");
+        zkMetaClient.create(basePath+"/c1_" +i + "/c2", "datat");
+        zkMetaClient.delete(basePath+"/c1_" +i + "/c2");
+      }
+      Assert.assertTrue(countDownLatch.await(50000000, TimeUnit.MILLISECONDS));
+
+      zkMetaClient.unsubscribeChildChanges(basePath, listener);
+      // verify that no listener is registered on any path
       watchers = TestUtil.getZkWatch(zkMetaClient.getZkClient());
+      Assert.assertEquals(watchers.get("persistentRecursiveWatches").size(), 0);
       Assert.assertEquals(watchers.get("persistentWatches").size(), 0);
       Assert.assertEquals(watchers.get("childWatches").size(), 0);
       Assert.assertEquals(watchers.get("dataWatches").size(), 0);

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -56,6 +56,7 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
 
   private static final String TRANSACTION_TEST_PARENT_PATH = "/transactionOpTestPath";
   private static final String TEST_INVALID_PATH = "/_invalid/a/b/c";
+  private static final int DEFAULT_LISTENER_WAIT_TIMEOUT = 5000;
 
   private final Object _syncObject = new Object();
 
@@ -317,7 +318,7 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
         }
       }
       zkMetaClient.set(basePath + "_1", testData, -1);
-      Assert.assertTrue(countDownLatch.await(5000, TimeUnit.MILLISECONDS));
+      Assert.assertTrue(countDownLatch.await(DEFAULT_LISTENER_WAIT_TIMEOUT, TimeUnit.MILLISECONDS));
       Assert.assertTrue(dataExpected.get());
     }
   }
@@ -348,7 +349,7 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
       Assert.assertEquals(watchers.get("persistentWatches").get(0), basePath);
       Assert.assertEquals(watchers.get("childWatches").size(), 0);
       Assert.assertEquals(watchers.get("dataWatches").size(), 0);
-      Assert.assertTrue(countDownLatch.await(5000, TimeUnit.MILLISECONDS));
+      Assert.assertTrue(countDownLatch.await(DEFAULT_LISTENER_WAIT_TIMEOUT, TimeUnit.MILLISECONDS));
 
       zkMetaClient.unsubscribeDirectChildChange(basePath, listener);
       // verify that no listener is registered on any path
@@ -390,7 +391,7 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
       for (int i=0; i<200; ++i) {
         zkMetaClient.set(basePath, "data7" + i, -1);
       }
-      Assert.assertTrue(countDownLatch.await(5000, TimeUnit.MILLISECONDS));
+      Assert.assertTrue(countDownLatch.await(DEFAULT_LISTENER_WAIT_TIMEOUT, TimeUnit.MILLISECONDS));
 
 
       zkMetaClient.unsubscribeDataChange(basePath, listener);
@@ -431,8 +432,9 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
       };
       try {
         zkMetaClient.subscribeDataChange(basePath, dummyDataListener, false);
-      } catch ( Exception ex) {
-        Assert.assertEquals(ex.getClass().getName(), "java.lang.UnsupportedOperationException");
+        Assert.fail("subscribeDataChange should throw exception");
+      } catch (UnsupportedOperationException ex) {
+        // we are expecting a UnsupportedOperationException, continue with test.
       }
 
       DirectChildChangeListener dummyCldListener = new DirectChildChangeListener() {
@@ -461,7 +463,7 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
         zkMetaClient.create(basePath+"/c1_" +i + "/c2", "datat");
         zkMetaClient.delete(basePath+"/c1_" +i + "/c2");
       }
-      Assert.assertTrue(countDownLatch.await(50000000, TimeUnit.MILLISECONDS));
+      Assert.assertTrue(countDownLatch.await(5000, TimeUnit.MILLISECONDS));
 
       zkMetaClient.unsubscribeChildChanges(basePath, listener);
       // verify that no listener is registered on any path

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1849,7 +1849,7 @@ public class ZkClient implements Watcher {
       if (_usePersistWatcher) {
         Set<RecursivePersistListener> recListeners =
             _zkPathRecursiveWatcherTrie.getAllRecursiveListeners(path);
-        if (recListeners != null && !recListeners.isEmpty()) {
+        if (!recListeners.isEmpty()) {
           for (final RecursivePersistListener listener : recListeners) {
             _eventThread.send(
                 new ZkEventThread.ZkEvent("Data of " + path + " changed sent to " + listener) {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -386,7 +386,7 @@ public class ZkClient implements Watcher {
         // listener as of now.
         getConnection().removeWatches(path, this, WatcherType.Any);
       } catch (KeeperException.NoWatcherException e) {
-        LOG.warn("Persist watcher is already removed");
+        LOG.warn("Persist watcher is already removed on path: {}", path);
       }
     };
     executeWithInPersistListenerMutex(removeListeners);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -355,9 +355,15 @@ public class ZkClient implements Watcher {
         throw new UnsupportedOperationException(
             "Can not subscribe PersistRecursiveWatcher. There is an existing listener on " + path);
       }
+      // subscribe a PERSISTENT_RECURSIVE listener on path. It throws exception if not successful
+      retryUntilConnected(() -> {
+        getConnection().addWatch(path, ZkClient.this, AddWatchMode.PERSISTENT_RECURSIVE);
+        return null;
+      });
+
       _zkPathRecursiveWatcherTrie.addRecursiveListener(path, recursivePersistListener);
-      getConnection().addWatch(path, ZkClient.this, AddWatchMode.PERSISTENT_RECURSIVE);
     };
+
     executeWithInPersistListenerMutex(addListener);
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/util/ZkPathRecursiveWatcherTrie.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/util/ZkPathRecursiveWatcherTrie.java
@@ -164,7 +164,6 @@ public class ZkPathRecursiveWatcherTrie {
         result.addAll(cur.getRecursiveListeners());
       }
     }
-
     return result;
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/util/ZkPathRecursiveWatcherTrie.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/util/ZkPathRecursiveWatcherTrie.java
@@ -228,7 +228,7 @@ public class ZkPathRecursiveWatcherTrie {
    * @param path
    * @return
    */
-  public Boolean hasListenerOnPath(String path) {
+  public boolean hasListenerOnPath(String path) {
     Objects.requireNonNull(path, "Path cannot be null");
 
     final List<String> pathComponents = split(path);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/util/ZkPathRecursiveWatcherTrie.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/util/ZkPathRecursiveWatcherTrie.java
@@ -242,7 +242,7 @@ public class ZkPathRecursiveWatcherTrie {
         }
       }
     }
-    return cur!=null && !cur.getRecursiveListeners().isEmpty();
+    return cur != null && !cur.getRecursiveListeners().isEmpty();
   }
 
   /**

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/util/ZkPathRecursiveWatcherTrie.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/util/ZkPathRecursiveWatcherTrie.java
@@ -225,6 +225,30 @@ public class ZkPathRecursiveWatcherTrie {
   }
 
   /**
+   *
+   * @param path
+   * @return
+   */
+  public Boolean hasListenerOnPath(String path) {
+    Objects.requireNonNull(path, "Path cannot be null");
+
+    final List<String> pathComponents = split(path);
+    Set<RecursivePersistListener> result = new HashSet<>();
+    TrieNode cur;
+    synchronized (this) {
+      cur = _rootNode;
+      for (final String element : pathComponents) {
+        cur = cur.getChild(element);
+        if (cur == null) {
+          break;
+        }
+
+      }
+    }
+    return cur!=null && !cur.getRecursiveListeners().isEmpty();
+  }
+
+  /**
    * Clear all nodes in the trie.
    */
   public synchronized void clear() {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/util/ZkPathRecursiveWatcherTrie.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/util/ZkPathRecursiveWatcherTrie.java
@@ -224,7 +224,7 @@ public class ZkPathRecursiveWatcherTrie {
   }
 
   /**
-   *
+   * Return if there is listener on a particular path
    * @param path
    * @return
    */
@@ -232,7 +232,6 @@ public class ZkPathRecursiveWatcherTrie {
     Objects.requireNonNull(path, "Path cannot be null");
 
     final List<String> pathComponents = split(path);
-    Set<RecursivePersistListener> result = new HashSet<>();
     TrieNode cur;
     synchronized (this) {
       cur = _rootNode;
@@ -241,7 +240,6 @@ public class ZkPathRecursiveWatcherTrie {
         if (cur == null) {
           break;
         }
-
       }
     }
     return cur!=null && !cur.getRecursiveListeners().isEmpty();

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientPersistWatcher.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientPersistWatcher.java
@@ -116,34 +116,60 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
     org.apache.helix.zookeeper.impl.client.ZkClient.Builder builder =
         new org.apache.helix.zookeeper.impl.client.ZkClient.Builder();
     builder.setZkServer(ZkTestBase.ZK_ADDR).setMonitorRootPathOnly(false)
-        .setUsePersistWatcher(false);
+        .setUsePersistWatcher(true);
     org.apache.helix.zookeeper.impl.client.ZkClient zkClient = builder.build();
     zkClient.setZkSerializer(new BasicZkSerializer(new SerializableSerializer()));
     int count = 100;
     final AtomicInteger[] event_count = {new AtomicInteger(0)};
     final AtomicInteger[] event_count2 = {new AtomicInteger(0)};
-    CountDownLatch countDownLatch1 = new CountDownLatch(count);
-    CountDownLatch countDownLatch2 = new CountDownLatch(count/2);
-    String path = "/base/testZkClientChildChange";
+    CountDownLatch countDownLatch1 = new CountDownLatch(count*4);
+    CountDownLatch countDownLatch2 = new CountDownLatch(count);
+    String path = "/testZkClientPersistRecursiveChange";
     RecursivePersistListener rcListener = new RecursivePersistListener() {
       @Override
       public void handleZNodeChange(String dataPath, Watcher.Event.EventType eventType)
           throws Exception {
         countDownLatch1.countDown();
         event_count[0].incrementAndGet() ;
-        System.out.println("rcListener count " + event_count[0]);
       }
     };
+    zkClient.create(path, "datat", CreateMode.PERSISTENT);
+    zkClient.subscribePersistRecursiveListener(path, rcListener);
+    for (int i=0; i<count; ++i) {
+      zkClient.writeData(path, "data7" + i, -1);
+      zkClient.create(path+"/c1_" +i , "datat", CreateMode.PERSISTENT);
+      zkClient.create(path+"/c1_" +i + "/c2", "datat", CreateMode.PERSISTENT);
+      zkClient.delete(path+"/c1_" +i + "/c2");
+    }
+    Assert.assertTrue(countDownLatch1.await(50000000, TimeUnit.MILLISECONDS));
+
+    // subscribe a persist child watch, it should throw exception
     IZkChildListener childListener2 = new IZkChildListener() {
       @Override
       public void handleChildChange(String parentPath, List<String> currentChilds)
           throws Exception {
         countDownLatch2.countDown();
         event_count2[0].incrementAndGet();
-        System.out.println("childListener2 count " + event_count2[0]);
       }
     };
-    zkClient.subscribePersistRecursiveListener(path, rcListener);
+    try {
+      zkClient.subscribeChildChanges(path, childListener2, false);
+    } catch ( Exception ex) {
+      Assert.assertEquals(ex.getClass().getName(), "java.lang.UnsupportedOperationException");
+    }
+
+    // unsubscribe recursive persist watcher, and subscribe persist watcher should success.
+    zkClient.unsubscribePersistRecursiveListener(path, rcListener);
+    zkClient.subscribeChildChanges(path, childListener2, false);
+    // we should only get 100 event since only 100 direct child change.
+    for (int i=0; i<count; ++i) {
+      zkClient.writeData(path, "data7" + i, -1);
+      zkClient.create(path+"/c2_" +i , "datat", CreateMode.PERSISTENT);
+      zkClient.create(path+"/c2_" +i + "/c3", "datat", CreateMode.PERSISTENT);
+      zkClient.delete(path+"/c2_" +i + "/c3");
+    }
+    Assert.assertTrue(countDownLatch2.await(50000000, TimeUnit.MILLISECONDS));
+
     zkClient.close();
   }
 

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientPersistWatcher.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientPersistWatcher.java
@@ -143,12 +143,7 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
         System.out.println("childListener2 count " + event_count2[0]);
       }
     };
-    try {
-      zkClient.subscribePersistRecursiveWatcher(path, rcListener);
-    } catch (KeeperException.UnimplementedException e) {
-      e.printStackTrace();
-    }
-
+    zkClient.subscribePersistRecursiveListener(path, rcListener);
     zkClient.close();
   }
 

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientPersistWatcher.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientPersistWatcher.java
@@ -122,6 +122,8 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
     int count = 100;
     final AtomicInteger[] event_count = {new AtomicInteger(0)};
     final AtomicInteger[] event_count2 = {new AtomicInteger(0)};
+    // for each iteration, we will edit a node, create a child, create a grand child, and
+    // delete child. Expect 4 event per iteration. -> total event should be count*4
     CountDownLatch countDownLatch1 = new CountDownLatch(count*4);
     CountDownLatch countDownLatch2 = new CountDownLatch(count);
     String path = "/testZkClientPersistRecursiveChange";


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
#2237 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change adds recursive persist listener implementation to ZkClient and it is consumed by ZkMetaClient.

### Tests

- [X] The following tests are written for this issue:

testChildChangeListener
testZkClientPersistRecursiveChange

- The following is the result of the "mvn test" command on the appropriate module:

rerun failed test:
```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 195.155 s - in org.apache.helix.monitoring.TestClusterStatusMonitorLifecycle
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 

```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
