### PR TITLE
Simplify thread naming in TaskStateModelFactory"

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
@@ -25,11 +25,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.atomic.AtomicInteger;
 import javax.management.JMException;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
 import org.apache.helix.SystemPropertyKeys;
@@ -45,7 +44,6 @@ import org.apache.helix.zookeeper.impl.client.FederatedZkClient;
 import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * Factory class for {@link TaskStateModel}.
@@ -193,6 +191,6 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
         "Obtained target thread pool size: {} from cluster {} for instance {}. Creating thread pool.",
         targetThreadPoolSize, manager.getClusterName(), manager.getInstanceName());
     return Executors.newScheduledThreadPool(targetThreadPoolSize,
-        new BasicThreadFactory.Builder().namingPattern("TaskStateModelFactory-task_thread-%d").build());
+            new ThreadFactoryBuilder().setNameFormat("TaskStateModelFactory-task_thread-%d").build());
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/task/TaskStateModelFactory.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.management.JMException;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
 import org.apache.helix.SystemPropertyKeys;
@@ -191,13 +192,7 @@ public class TaskStateModelFactory extends StateModelFactory<TaskStateModel> {
     LOG.info(
         "Obtained target thread pool size: {} from cluster {} for instance {}. Creating thread pool.",
         targetThreadPoolSize, manager.getClusterName(), manager.getInstanceName());
-    return Executors.newScheduledThreadPool(targetThreadPoolSize, new ThreadFactory() {
-      private AtomicInteger threadId = new AtomicInteger(0);
-
-      @Override
-      public Thread newThread(Runnable r) {
-        return new Thread(r, "TaskStateModelFactory-task_thread-" + threadId.getAndIncrement());
-      }
-    });
+    return Executors.newScheduledThreadPool(targetThreadPoolSize,
+        new BasicThreadFactory.Builder().namingPattern("TaskStateModelFactory-task_thread-%d").build());
   }
 }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fixes #325 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
In TaskStateModelFactory class, we want to name our thread with a sequence number to uniquely identify threads. The mechanics can be simplified by using the BasicThreadPoolFactory which has way for explicitly naming the thread. 

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:
mvn -q test run is in progress, will update it as soon as I get the results.

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
