### PR TITLE
MissingTopState when the leader comes back on the same host

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
@@ -67,10 +67,9 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
     // TODO: remove this if-else after splitting controller
     if (cache instanceof WorkflowControllerDataProvider) {
       throw new StageException("TopStateHandoffReportStage can only be used in resource pipeline");
-    } else {
-      updateTopStateStatus((ResourceControllerDataProvider) cache, clusterStatusMonitor,
-          resourceMap, currentStateOutput, lastPipelineFinishTimestamp);
-    }
+    } 
+    updateTopStateStatus((ResourceControllerDataProvider) cache, clusterStatusMonitor,
+        resourceMap, currentStateOutput, lastPipelineFinishTimestamp);
   }
 
   private void updateTopStateStatus(ResourceControllerDataProvider cache,
@@ -218,6 +217,8 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
       // we observed an entire top state handoff process
       reportSingleTopStateHandoff(cache, lastTopStateInstance, currentTopStateInstance,
           resourceName, partition, clusterStatusMonitor, lastPipelineFinishTimestamp);
+    } else if (lastTopStateInstance != null && lastTopStateInstance.equals(currentTopStateInstance)) {
+      reportSameInstanceTopStateHandoff(cache, currentTopStateInstance, resourceName, partition, clusterStatusMonitor, lastPipelineFinishTimestamp);
     } else {
       // else, there is not top state change, or top state first came up, do nothing
       LogUtil.logDebug(LOG, _eventId, String.format(
@@ -242,6 +243,7 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
   private void reportSingleTopStateHandoff(ResourceControllerDataProvider cache, String lastTopStateInstance,
       String curTopStateInstance, String resourceName, Partition partition,
       ClusterStatusMonitor clusterStatusMonitor, long lastPipelineFinishTimestamp) {
+
     if (curTopStateInstance.equals(lastTopStateInstance)) {
       return;
     }
@@ -509,5 +511,55 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
     LogUtil.logInfo(LOG, _eventId, String.format(
         "Missing top state duration is %s/%s (helix latency / end to end latency) for partition %s. Graceful: %s",
         helixLatency, totalDuration, partitionName, isGraceful));
+  }
+
+
+  /**
+   * This function is similar to reportSingleTopStateHandoff, except the
+   * top-state was recovered on the same instance. 
+   *
+   * @param cache ResourceControllerDataProvider
+   * @param curTopStateInstance Name of current top state instance we refreshed from ZK
+   * @param resourceName resource name
+   * @param partition partition object
+   * @param clusterStatusMonitor cluster state monitor object
+   * @param lastPipelineFinishTimestamp last pipeline run finish timestamp
+   */
+  private void reportSameInstanceTopStateHandoff(ResourceControllerDataProvider cache,
+      String curTopStateInstance, String resourceName, Partition partition,
+      ClusterStatusMonitor clusterStatusMonitor, long lastPipelineFinishTimestamp) {
+    if (clusterStatusMonitor == null) {
+      LogUtil.logWarn(LOG, _eventId, "ClusterStatusMonitor is null, Can not report metrics");
+      return;
+    }
+
+    // Current state output generation logic guarantees that current top state instance
+    // must be a live instance
+    String curTopStateSession = cache.getLiveInstances().get(curTopStateInstance).getEphemeralOwner();
+    long endTime =
+        cache.getCurrentState(curTopStateInstance, curTopStateSession).get(resourceName)
+            .getEndTime(partition.getPartitionName());
+    long toTopStateuserLatency =
+        endTime - cache.getCurrentState(curTopStateInstance, curTopStateSession).get(resourceName)
+            .getStartTime(partition.getPartitionName());
+
+    long startTime = lastPipelineFinishTimestamp;
+    long fromTopStateUserLatency = DEFAULT_HANDOFF_USER_LATENCY;
+
+    if (startTime > endTime) {
+      // Top state handoff finished before end of last pipeline run, and instance contains
+      // previous top state is no longer alive, so our best guess did not work, ignore the
+      // data point for now.
+      LogUtil.logWarn(LOG, _eventId, String
+          .format("Cannot confirm top state missing start time. %s:%s->%s. Likely it was very fast",
+              partition.getPartitionName(), curTopStateInstance, curTopStateInstance));
+      return;
+    }
+
+    long duration = endTime - startTime;
+    long helixLatency = duration - fromTopStateUserLatency - toTopStateuserLatency;
+    logMissingTopStateInfo(duration, helixLatency, true, partition.getPartitionName());
+    clusterStatusMonitor.updateMissingTopStateDurationStats(resourceName,
+      duration, helixLatency, true, true);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestTopStateHandoffMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestTopStateHandoffMetrics.java
@@ -228,6 +228,7 @@ public class TestTopStateHandoffMetrics extends BaseStageTest {
     //       missingTopStatePartitionsThresholdGuage will be set to 1.
     //   2. localhost_0 looses top-state at 15000 and it's NEVER recovered. In this scenario as well both failed counter
     //      as well as missingTopStatePartitionsThresholdGuage should be set to 1.
+    //   3. localhost_0 looses top-state at 15000 and recovers at 18000.
     ClusterConfig clusterConfig = new ClusterConfig(_clusterName);
     clusterConfig.setMissTopStateDurationThreshold(5000L);
     setClusterConfig(clusterConfig);

--- a/helix-core/src/test/resources/TestTopStateHandoffMetrics.json
+++ b/helix-core/src/test/resources/TestTopStateHandoffMetrics.json
@@ -316,6 +316,71 @@
       "Duration": 0,
       "HelixLatency": 0,
       "IsGraceful": false
+    },
+    {
+      "InitialCurrentStates": {
+        "localhost_0": {
+          "CurrentState": "MASTER",
+          "PreviousState": "SLAVE",
+          "StartTime": 10000,
+          "EndTime": 11000
+        },
+        "localhost_1": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": 8000,
+          "EndTime": 10000
+        },
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": 8000,
+          "EndTime": 10000
+        }
+      },
+      "MissingTopStates": {
+        "localhost_0": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "MASTER",
+          "StartTime": 15000,
+          "EndTime": 18000
+        },
+        "localhost_1": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": 8000,
+          "EndTime": 10000
+        },
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": 8000,
+          "EndTime": 10000
+        }
+      },
+      "HandoffCurrentStates": {
+        "localhost_0": {
+          "CurrentState": "MASTER",
+          "PreviousState": "SLAVE",
+          "StartTime": 20000,
+          "EndTime": 21000
+        },
+        "localhost_1": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": 8000,
+          "EndTime": 10000
+        },
+        "localhost_2": {
+          "CurrentState": "SLAVE",
+          "PreviousState": "OFFLINE",
+          "StartTime": 8000,
+          "EndTime": 10000
+        }
+      },
+      "Duration": 0,
+      "HelixLatency": 0,
+      "IsGraceful": false
     }
   ],
   "fast": [


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes #2521 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We currently don't handle the case where if the user has only one replica and the leader partition comes back on the same host as there are no other replica.


(Write a concise description including what, why, how)

### Tests

- [x] The following tests are written for this issue:
Testing done:
Added a test scenario in the JSON config file where the partition is brought oneline on the same host and validated that the test passes.

TestTopStateHandoffMetrics::failed configuration has one additional test scenario added. 

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)
mvn test is in progress (it got interrupted, so will send it once completes)
[ERROR] Failures:
[ERROR]   TestNoThrottleDisabledPartitions.testDisablingTopStateReplicaByDisablingInstance:98 expected:<false> but was:<true>
[ERROR]   TestNoThrottleDisabledPartitions.testNoThrottleOnDisabledInstance:231->setupEnvironment:317->setupCluster:436 » ZkClient
[ERROR]   TestZkConnectionLost.testDisconnectWhenConnectionBreak:140 » ThreadTimeout Met...
[ERROR]   TestZkConnectionLost.testLostZkConnection:179 » Helix Workflow testLostZkConne...
[ERROR]   TestClusterMaintenanceMode.testMaintenanceHistory:412 expected:<EXIT> but was:<ENTER>
[ERROR]   TestRecurringJobQueue.testDeletingRecurrentQueueWithHistory:298 expected:<true> but was:<false>



### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
