### PR TITLE
change undetermined check in unit test

### DIFF
--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/TestZooKeeperConnection.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/TestZooKeeperConnection.java
@@ -53,10 +53,11 @@ public class TestZooKeeperConnection extends ZkTestBase {
       _zk.writeData(path, ("datat"+i).getBytes(), -1);
       _zk.create(path+"/c2_" +i, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
     }
+    System.out.println("testPersistWatcher: rafter register one time listener, original listener received event count: " + get_count[0]);
+    // total number of event is 400. We will miss event now
     Assert.assertTrue(TestHelper.verify(() -> {
-          return (get_count[0].get() == 202);
-        }, TestHelper.WAIT_DURATION));
-    System.out.println("testPersistWatcher received event count: " + get_count[0]);
+      return (get_count[0].get() >= 202 & get_count[0].get() < 400);
+    }, TestHelper.WAIT_DURATION));
     zkClient.close();
   }
 
@@ -87,10 +88,11 @@ public class TestZooKeeperConnection extends ZkTestBase {
       _zk.writeData(path, ("datat"+i).getBytes(), -1);
       _zk.create(path+"/c2_" +i, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
     }
+    System.out.println("testRecursivePersistWatcherWithOneTimeWatcher: after register one time listener, original listener received event count: " + get_count[0]);
+    // total number of event is 500. We will miss event now
     Assert.assertTrue(TestHelper.verify(() -> {
-      return (get_count[0].get()== 302);
+      return (get_count[0].get() >= 302 && get_count[0].get() < 500);
     }, TestHelper.WAIT_DURATION));
-    System.out.println("testPersistWatcher received event count: " + get_count[0]);
     zkClient.close();
   }
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2237 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR changes an undetermined assertion in unit test.
Reason for undetermined assertion is because when subscribe one time watcher on a path with existing persist watcher, we know there will be event missing but the number of event is not determined. 

### Tests

- [X] The following tests are written for this issue:

NA

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
