### PR TITLE
Fix CI: TestWorkflowTermination::testWorkflowPausedTimeout

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowTermination.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/task/TestWorkflowTermination.java
@@ -157,7 +157,7 @@ public class TestWorkflowTermination extends TaskTestBase {
     Thread.sleep(100);
 
     // Pause the queue
-    _driver.waitToStop(workflowName, 10000L);
+    _driver.waitToStop(workflowName, 20000L);
 
     _driver.pollForJobState(workflowName, getJobNameToPoll(workflowName, JOB_NAME), 10000L,
         TaskState.STOPPED);


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes #2522 and #2527 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This test case failed just once and that too recently. We haven't changed any core logic in the code path of Task management.

The failure happened because:
2023-06-05T21:37:59.7170747Z [ERROR] testWorkflowPausedTimeout(org.apache.helix.integration.task.TestWorkflowTermination)  Time elapsed: 10.13 s  <<< FAILURE! 2023-06-05T21:37:59.7171834Z org.apache.helix.HelixException: Fail to stop the workflow/queue testWorkflowPausedTimeout with in 10000 milliseconds.

Indicating the timeout was not sufficient. So increased the timeout.


### Tests

- [ ] The following tests are written for this issue:

- The following is the result of the "mvn test" command on the appropriate module:
Testing done: since this is CI failure, ran into my private branch 3/4 times https://github.com/desaikomal/helix/actions/workflows/Helix-PR-CI.yml


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
