### PR TITLE
Add API for getDataAndStat

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.helix.metaclient.exception.MetaClientInterruptException;
+import org.apache.helix.metaclient.exception.MetaClientNoNodeException;
 import org.apache.helix.metaclient.exception.MetaClientTimeoutException;
 
 
@@ -203,9 +204,9 @@ public interface MetaClientInterface<T> {
 
   /**
    * Fetch the data and stat for a given key.
-   * TODO: define exception type when key does not exist
    * @param key key to identify the entry
-   * @return Return an ImmutablePair of data and stat for the entry. Return null if data does not exists.
+   * @return Return an ImmutablePair of data and stat for the entry.
+   * @throws MetaClientNoNodeException if no such entry
    */
   ImmutablePair<T, Stat> getDataAndStat(final String key);
 

--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.helix.metaclient.exception.MetaClientInterruptException;
 import org.apache.helix.metaclient.exception.MetaClientTimeoutException;
 
@@ -195,11 +196,18 @@ public interface MetaClientInterface<T> {
 
   /**
    * Fetch the data for a given key.
-   * TODO: define exception type when key does not exist
    * @param key key to identify the entry
-   * @return Return data of the entry
+   * @return Return data of the entry. Return null if data does not exists.
    */
   T get(final String key);
+
+  /**
+   * Fetch the data and stat for a given key.
+   * TODO: define exception type when key does not exist
+   * @param key key to identify the entry
+   * @return Return an ImmutablePair of data and stat for the entry. Return null if data does not exists.
+   */
+  ImmutablePair<T, Stat> getDataAndStat(final String key);
 
   /**
    * API for transaction. The list of operation will be executed as an atomic operation.

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -181,9 +181,13 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
 
   @Override
   public ImmutablePair<T, Stat> getDataAndStat(final String key) {
-    org.apache.zookeeper.data.Stat zkStat = new org.apache.zookeeper.data.Stat();
-    T data = _zkClient.readData(key, zkStat);
-    return ImmutablePair.of(data, ZkMetaClientUtil.convertZkStatToStat(zkStat));
+    try {
+      org.apache.zookeeper.data.Stat zkStat = new org.apache.zookeeper.data.Stat();
+      T data = _zkClient.readData(key, zkStat);
+      return ImmutablePair.of(data, ZkMetaClientUtil.convertZkStatToStat(zkStat));
+    } catch (ZkException e) {
+      throw translateZkExceptionToMetaclientException(e);
+    }
   }
 
   @Override

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -28,6 +28,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.helix.metaclient.api.AsyncCallback;
 import org.apache.helix.metaclient.api.ChildChangeListener;
 import org.apache.helix.metaclient.api.ConnectStateChangeListener;
@@ -166,8 +167,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
       if (zkStats == null) {
         return null;
       }
-      return new Stat(convertZkEntryModeToMetaClientEntryMode(zkStats.getEphemeralOwner()),
-          zkStats.getVersion(), zkStats.getCtime(), zkStats.getMtime(), -1);
+      return ZkMetaClientUtil.convertZkStatToStat(zkStats);
     } catch (ZkException e) {
       throw translateZkExceptionToMetaclientException(e);
     }
@@ -176,6 +176,14 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
   @Override
   public T get(String key) {
     return _zkClient.readData(key, true);
+  }
+
+
+  @Override
+  public ImmutablePair<T, Stat> getDataAndStat(final String key) {
+    org.apache.zookeeper.data.Stat zkStat = new org.apache.zookeeper.data.Stat();
+    T data = _zkClient.readData(key, zkStat);
+    return ImmutablePair.of(data, ZkMetaClientUtil.convertZkStatToStat(zkStat));
   }
 
   @Override

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
@@ -262,6 +262,14 @@ public class ZkMetaClientUtil {
     }
   }
 
+  public static MetaClientInterface.Stat convertZkStatToStat(
+      org.apache.zookeeper.data.Stat zkStat) {
+    return new MetaClientInterface.Stat(
+        convertZkEntryModeToMetaClientEntryMode(zkStat.getEphemeralOwner()), zkStat.getVersion(),
+        zkStat.getCtime(), zkStat.getMtime(),
+        EphemeralType.TTL.getValue(zkStat.getEphemeralOwner()));
+  }
+
   /**
    * This function translate and group Zk exception code to metaclient code.
    * It currently includes all ZK code on 3.6.3.

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -19,6 +19,7 @@ package org.apache.helix.metaclient.impl.zk;
  * under the License.
  */
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.helix.metaclient.api.ChildChangeListener;
 import org.apache.helix.metaclient.api.DataUpdater;
 import org.apache.helix.metaclient.api.MetaClientInterface;
@@ -205,6 +206,25 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
       Assert.assertEquals(entryStat.getVersion(), 2);
       Assert.assertEquals((int) newData, (int) initValue + 2);
       zkMetaClient.delete(key);
+    }
+  }
+
+  @Test
+  public void testGetDataAndStat() {
+    final String key = "/TestZkMetaClient_testGetDataAndStat";
+    ZkMetaClientConfig config =
+        new ZkMetaClientConfig.ZkMetaClientConfigBuilder().setConnectionAddress(ZK_ADDR).build();
+    try (ZkMetaClient<Integer> zkMetaClient = new ZkMetaClient<>(config)) {
+      zkMetaClient.connect();
+      int initValue = 3;
+      zkMetaClient.create(key, initValue);
+      MetaClientInterface.Stat entryStat = zkMetaClient.exists(key);
+      Assert.assertEquals(entryStat.getVersion(), 0);
+      zkMetaClient.set(key, initValue+1, -1);
+      ImmutablePair<Integer, MetaClientInterface.Stat> touple = zkMetaClient.getDataAndStat(key);
+      Assert.assertEquals(touple.right.getVersion(), 1);
+      zkMetaClient.delete(key);
+
     }
   }
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -225,6 +225,14 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
       Assert.assertEquals(touple.right.getVersion(), 1);
       zkMetaClient.delete(key);
 
+      // test non exist key
+      try{
+        zkMetaClient.getDataAndStat(key);
+      } catch (MetaClientException ex){
+        Assert.assertEquals(ex.getClass().getName(),
+            "org.apache.helix.metaclient.exception.MetaClientNoNodeException");
+      }
+
     }
   }
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2237 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change add a new API getDataAndStat to metaclient. It returns the data and it's stats.
This API is needed when doing check and then delete/create in transactional setting, check operation requires version parameter. Having `getDataAndStat` allows user to read data, check if current data meet requirement, and use the version in following transaction operation. 

### Tests

- [X] The following tests are written for this issue:
testGetDataAndStat

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
