### PR TITLE
WAGED - Part 2 - Fix the core calculation for n - n+1 issue.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/InstanceCapacityDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/InstanceCapacityDataProvider.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public interface InstanceCapacityDataProvider {
 
  /**
-   * Get the instance remaining capacity. 
+   * Get the instance remaining capacity.
    * Capacity and weight both are represented as Key-Value.
    * Returns the capacity map of available head room for the instance.
    * @param instanceName - instance name to query
@@ -42,18 +42,10 @@ public interface InstanceCapacityDataProvider {
   /**
    * Check if partition can be placed on the instance.
    *
-   * @param instanceName - instance name 
+   * @param instanceName - instance name
    * @param partitionCapacity - Partition capacity expresed in capacity map.
    * @return boolean - True if the partition can be placed, False otherwise
    */
   public boolean isInstanceCapacityAvailable(String instanceName, Map<String, Integer> partitionCapacity);
 
-  /**
-   * Reduce the available capacity by specified Partition Capacity Map.
-   *
-   * @param instanceName - instance name 
-   * @param partitionCapacity - Partition capacity expresed in capacity map.
-   * @returns boolean - True if successfully updated partition capacity, false otherwise.
-   */
-  public boolean reduceAvailableInstanceCapacity(String instanceName, Map<String, Integer> partitionCapacity);
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -482,12 +482,24 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
     }
   }
 
+  /**
+   * Set the WAGED algorithm specific instance capacity provider and resource weight provider.
+   * @param capacityProvider - the capacity provider for instances
+   * @param resourceWeightProvider - the resource weight provider for partitions
+   */
   public void setWagedCapacityProviders(WagedInstanceCapacity capacityProvider, WagedResourceWeightsProvider resourceWeightProvider) {
     // WAGED specific capacity / weight provider
     _wagedInstanceCapacity = capacityProvider;
     _wagedPartitionWeightProvider = resourceWeightProvider;
   }
 
+  /**
+   * Check and reduce the capacity of an instance for a resource partition
+   * @param instance - the instance to check
+   * @param resourceName - the resource name
+   * @param partition - the partition name
+   * @return true if the capacity is reduced, false otherwise
+   */
   public boolean checkAndReduceCapacity(String instance, String resourceName, String partition) {
     if (_wagedPartitionWeightProvider == null || _wagedInstanceCapacity == null) {
       return true;

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -37,6 +37,8 @@ import org.apache.helix.common.caches.CustomizedViewCache;
 import org.apache.helix.common.caches.PropertyCache;
 import org.apache.helix.controller.LogUtil;
 import org.apache.helix.controller.pipeline.Pipeline;
+import org.apache.helix.controller.rebalancer.waged.WagedInstanceCapacity;
+import org.apache.helix.controller.rebalancer.waged.WagedResourceWeightsProvider;
 import org.apache.helix.controller.stages.MissingTopStateRecord;
 import org.apache.helix.model.CustomizedState;
 import org.apache.helix.model.CustomizedStateConfig;
@@ -88,6 +90,10 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
   // TODO: dependency. Note that this will change the cluster partition assignment and potentially
   // TODO: cause shuffling. So it is not backward compatible.
   private final Map<String, List<String>> _stablePartitionListCache = new HashMap<>();
+
+  // WAGED specific capacity / weight provider
+  WagedInstanceCapacity _wagedInstanceCapacity;
+  WagedResourceWeightsProvider _wagedPartitionWeightProvider;
 
   public ResourceControllerDataProvider() {
     this(AbstractDataCache.UNKNOWN_CLUSTER);
@@ -474,5 +480,25 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
         _stablePartitionListCache.put(resourceName, new ArrayList<>(newPartitionSet));
       }
     }
+  }
+
+  public void setWagedCapacityProviders(WagedInstanceCapacity capacityProvider, WagedResourceWeightsProvider resourceWeightProvider) {
+    // WAGED specific capacity / weight provider
+    _wagedInstanceCapacity = capacityProvider;
+    _wagedPartitionWeightProvider = resourceWeightProvider;
+  }
+
+  public boolean checkAndReduceCapacity(String instance, String resourceName, String partition) {
+    if (_wagedPartitionWeightProvider == null || _wagedInstanceCapacity == null) {
+      return true;
+    }
+    Map<String, Integer> partitionWeightMap =
+          _wagedPartitionWeightProvider.getPartitionWeights(resourceName, partition);
+    if (partitionWeightMap == null || partitionWeightMap.isEmpty()) {
+      return true;
+    }
+
+    return _wagedInstanceCapacity.checkAndReduceInstanceCapacity(instance, resourceName, partition,
+        partitionWeightMap);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
@@ -106,13 +106,24 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
       List<String> preferenceList = getPreferenceList(partition, idealState,
           Collections.unmodifiableSet(cache.getLiveInstances().keySet()));
       Map<String, String> bestStateForPartition =
-          computeBestPossibleStateForPartition(cache.getLiveInstances().keySet(), stateModelDef,
-              preferenceList, currentStateOutput, disabledInstancesForPartition, idealState,
-              cache.getClusterConfig(), partition,
-              cache.getAbnormalStateResolver(stateModelDefName));
+          computeBestPossibleStateForPartition(cache, stateModelDef, preferenceList,
+              currentStateOutput, disabledInstancesForPartition, idealState,
+              partition);
       partitionMapping.addReplicaMap(partition, bestStateForPartition);
     }
     return partitionMapping;
+  }
+
+  protected Map<String, String> computeBestPossibleStateForPartition(T cache,
+      StateModelDefinition stateModelDef, List<String> preferenceList,
+      CurrentStateOutput currentStateOutput, Set<String> disabledInstancesForPartition,
+      IdealState idealState, Partition partition) {
+
+    String stateModelDefName = idealState.getStateModelDefRef();
+    return computeBestPossibleStateForPartition(cache.getLiveInstances().keySet(), stateModelDef,
+        preferenceList, currentStateOutput, disabledInstancesForPartition, idealState,
+        cache.getClusterConfig(), partition,
+        cache.getAbnormalStateResolver(stateModelDefName));
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
@@ -74,9 +74,8 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
   }
 
   @Override
-  public abstract IdealState computeNewIdealState(
-      String resourceName, IdealState currentIdealState, CurrentStateOutput currentStateOutput,
-      T clusterData);
+  public abstract IdealState computeNewIdealState(String resourceName, IdealState currentIdealState,
+      CurrentStateOutput currentStateOutput, T clusterData);
 
   /**
    * Compute the best state for all partitions.
@@ -91,9 +90,8 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
    * @return
    */
   @Override
-  public ResourceAssignment computeBestPossiblePartitionState(
-      T cache, IdealState idealState, Resource resource,
-      CurrentStateOutput currentStateOutput) {
+  public ResourceAssignment computeBestPossiblePartitionState(T cache, IdealState idealState,
+      Resource resource, CurrentStateOutput currentStateOutput) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Processing resource:" + resource.getResourceName());
     }
@@ -106,24 +104,13 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
       List<String> preferenceList = getPreferenceList(partition, idealState,
           Collections.unmodifiableSet(cache.getLiveInstances().keySet()));
       Map<String, String> bestStateForPartition =
-          computeBestPossibleStateForPartition(cache, stateModelDef, preferenceList,
-              currentStateOutput, disabledInstancesForPartition, idealState,
-              partition);
+          computeBestPossibleStateForPartition(cache.getLiveInstances().keySet(), stateModelDef,
+              preferenceList, currentStateOutput, disabledInstancesForPartition, idealState,
+              cache.getClusterConfig(), partition,
+              cache.getAbnormalStateResolver(stateModelDefName), cache);
       partitionMapping.addReplicaMap(partition, bestStateForPartition);
     }
     return partitionMapping;
-  }
-
-  protected Map<String, String> computeBestPossibleStateForPartition(T cache,
-      StateModelDefinition stateModelDef, List<String> preferenceList,
-      CurrentStateOutput currentStateOutput, Set<String> disabledInstancesForPartition,
-      IdealState idealState, Partition partition) {
-
-    String stateModelDefName = idealState.getStateModelDefRef();
-    return computeBestPossibleStateForPartition(cache.getLiveInstances().keySet(), stateModelDef,
-        preferenceList, currentStateOutput, disabledInstancesForPartition, idealState,
-        cache.getClusterConfig(), partition,
-        cache.getAbnormalStateResolver(stateModelDefName));
   }
 
   /**
@@ -166,18 +153,16 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
     return map;
   }
 
-  protected RebalanceStrategy<T> getRebalanceStrategy(
-      String rebalanceStrategyName, List<String> partitions, String resourceName,
+  protected RebalanceStrategy<T> getRebalanceStrategy(String rebalanceStrategyName, List<String> partitions, String resourceName,
       LinkedHashMap<String, Integer> stateCountMap, int maxPartition) {
     RebalanceStrategy rebalanceStrategy;
-    if (rebalanceStrategyName == null || rebalanceStrategyName
-        .equalsIgnoreCase(RebalanceStrategy.DEFAULT_REBALANCE_STRATEGY)) {
+    if (rebalanceStrategyName == null || rebalanceStrategyName.equalsIgnoreCase(RebalanceStrategy.DEFAULT_REBALANCE_STRATEGY)) {
       rebalanceStrategy =
           new AutoRebalanceStrategy(resourceName, partitions, stateCountMap, maxPartition);
     } else {
       try {
-        rebalanceStrategy = RebalanceStrategy.class
-            .cast(HelixUtil.loadClass(getClass(), rebalanceStrategyName).newInstance());
+        rebalanceStrategy = RebalanceStrategy.class.cast(
+            HelixUtil.loadClass(getClass(), rebalanceStrategyName).newInstance());
         rebalanceStrategy.init(resourceName, partitions, stateCountMap, maxPartition);
       } catch (ClassNotFoundException ex) {
         throw new HelixException(
@@ -215,9 +200,35 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
       CurrentStateOutput currentStateOutput, Set<String> disabledInstancesForPartition,
       IdealState idealState, ClusterConfig clusterConfig, Partition partition,
       MonitoredAbnormalResolver monitoredResolver) {
+    return computeBestPossibleStateForPartition(liveInstances, stateModelDef, preferenceList,
+        currentStateOutput, disabledInstancesForPartition, idealState, clusterConfig, partition,
+        monitoredResolver, null);
+  }
+
+  /**
+   * Compute best state for partition in AUTO ideal state mode.
+   * @param liveInstances
+   * @param stateModelDef
+   * @param preferenceList
+   * @param currentStateOutput instance->state for each partition
+   * @param disabledInstancesForPartition
+   * @param idealState
+   * @param clusterConfig
+   * @param partition
+   * @param monitoredResolver
+   * @param cache
+   * @return
+   */
+  protected Map<String, String> computeBestPossibleStateForPartition(Set<String> liveInstances,
+      StateModelDefinition stateModelDef, List<String> preferenceList,
+      CurrentStateOutput currentStateOutput, Set<String> disabledInstancesForPartition,
+      IdealState idealState, ClusterConfig clusterConfig, Partition partition,
+      MonitoredAbnormalResolver monitoredResolver, T cache) {
+
     Optional<Map<String, String>> optionalOverwrittenStates =
         computeStatesOverwriteForPartition(stateModelDef, preferenceList, currentStateOutput,
             idealState, partition, monitoredResolver);
+
     if (optionalOverwrittenStates.isPresent()) {
       return optionalOverwrittenStates.get();
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -242,8 +242,6 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
       LOG.debug("Processing resource:" + resource.getResourceName());
     }
 
-    boolean isWagedResource = WagedValidationUtil.isWagedEnabled(idealState);
-
     Set<String> allNodes = cache.getEnabledInstances();
     Set<String> liveNodes = cache.getLiveInstances().keySet();
 
@@ -257,23 +255,17 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
     String stateModelDefName = idealState.getStateModelDefRef();
     StateModelDefinition stateModelDef = cache.getStateModelDef(stateModelDefName);
     ResourceAssignment partitionMapping = new ResourceAssignment(resource.getResourceName());
+
     for (Partition partition : resource.getPartitions()) {
       Set<String> disabledInstancesForPartition =
           cache.getDisabledInstancesForPartition(resource.getResourceName(), partition.toString());
       List<String> preferenceList = getPreferenceList(partition, idealState, activeNodes);
       Map<String, String> bestStateForPartition;
 
-      if (isWagedResource) {
-        bestStateForPartition =
+      bestStateForPartition =
           computeBestPossibleStateForPartition(cache, stateModelDef, preferenceList,
-              currentStateOutput, disabledInstancesForPartition, idealState, clusterConfig,
-              partition, cache.getAbnormalStateResolver(stateModelDefName));
-      } else {
-        bestStateForPartition =
-            computeBestPossibleStateForPartition(liveNodes, stateModelDef, preferenceList,
-                currentStateOutput, disabledInstancesForPartition, idealState, clusterConfig,
-                partition, cache.getAbnormalStateResolver(stateModelDefName));
-      }
+              currentStateOutput, disabledInstancesForPartition, idealState,
+              partition);
 
       partitionMapping.addReplicaMap(partition, bestStateForPartition);
     }
@@ -286,73 +278,39 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
     return partitionMapping;
   }
 
+
   @Override
   protected Map<String, String> computeBestPossibleStateForPartition(Set<String> liveInstances,
       StateModelDefinition stateModelDef, List<String> preferenceList,
       CurrentStateOutput currentStateOutput, Set<String> disabledInstancesForPartition,
       IdealState idealState, ClusterConfig clusterConfig, Partition partition,
       MonitoredAbnormalResolver monitoredResolver) {
-    Optional<Map<String, String>> optionalOverwrittenStates =
-        computeStatesOverwriteForPartition(stateModelDef, preferenceList, currentStateOutput,
-            idealState, partition, monitoredResolver);
-    if (optionalOverwrittenStates.isPresent()) {
-      return optionalOverwrittenStates.get();
-    }
-    Map<String, String> currentStateMap = new HashMap<>(
-        currentStateOutput.getCurrentStateMap(idealState.getResourceName(), partition));
-    // Instances not in preference list but still have active replica, retain to avoid zero replica during movement
-    List<String> currentInstances = new ArrayList<>(currentStateMap.keySet());
-    Collections.sort(currentInstances);
-    Map<String, String> pendingStates =
-        new HashMap<>(currentStateOutput.getPendingStateMap(idealState.getResourceName(), partition));
-    for (String instance : pendingStates.keySet()) {
-      if (!currentStateMap.containsKey(instance)) {
-        currentStateMap.put(instance, stateModelDef.getInitialState());
-        currentInstances.add(instance);
-      }
+
+    // validate if anything has changed.
+    Map<String, String> overrideExists = optionalOverwriteStateExist(stateModelDef, preferenceList,
+        currentStateOutput, idealState, partition, monitoredResolver);
+
+    if (overrideExists != null) {
+      return overrideExists;
     }
 
-    Set<String> instancesToDrop = new HashSet<>();
-    Iterator<String> it = currentInstances.iterator();
-    while (it.hasNext()) {
-      String instance = it.next();
-      String state = currentStateMap.get(instance);
-      if (state == null) {
-        it.remove();
-        instancesToDrop.add(instance); // These instances should be set to DROPPED after we get bestPossibleStateMap;
-      }
-    }
-
-    // Sort the instancesToMove by their current partition state.
-    // Reason: because the states are assigned to instances in the order appeared in preferenceList, if we have
-    // [node1:Slave, node2:Master], we want to keep it that way, instead of assigning Master to node1.
-
+    // We can have empty list.
     if (preferenceList == null) {
       preferenceList = Collections.emptyList();
     }
-
-    int numExtraReplicas = getNumExtraReplicas(clusterConfig);
-
-    // TODO : Keep the behavior consistent with existing state count, change back to read from idealstate
-    // replicas
     int numReplicas = preferenceList.size();
-    List<String> instanceToAdd = new ArrayList<>(preferenceList);
-    instanceToAdd.removeAll(currentInstances);
+
+    Map<String, String> currentStateMap = new HashMap<>(
+        currentStateOutput.getCurrentStateMap(idealState.getResourceName(), partition));
+
     List<String> combinedPreferenceList = new ArrayList<>();
+    Set<String> instancesToDrop = new HashSet<>();
+    List<String> instanceToAdd = new ArrayList<>(preferenceList);
 
-    if (currentInstances.size() <= numReplicas
-        && numReplicas + numExtraReplicas - currentInstances.size() > 0) {
-      int subListSize = numReplicas + numExtraReplicas - currentInstances.size();
-      combinedPreferenceList.addAll(instanceToAdd
-          .subList(0, Math.min(subListSize, instanceToAdd.size())));
-    }
-
-    // Make all initial state instance not in preference list to be dropped.
-    Map<String, String> currentMapWithPreferenceList = new HashMap<>(currentStateMap);
-    currentMapWithPreferenceList.keySet().retainAll(preferenceList);
-
-    combinedPreferenceList.addAll(currentInstances);
-    combinedPreferenceList.sort(new PreferenceListNodeComparator(currentStateMap, stateModelDef, preferenceList));
+    Map<String, String> currentMapWithPreferenceList =
+      createStateMapWithPreferenceList(currentStateOutput, idealState, clusterConfig,
+        partition, stateModelDef, preferenceList, instancesToDrop,
+        instanceToAdd, currentStateMap, combinedPreferenceList);
 
     // Assign states to instances with the combined preference list.
     Map<String, String> bestPossibleStateMap =
@@ -363,27 +321,8 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
       bestPossibleStateMap.put(instance, HelixDefinedState.DROPPED.name());
     }
 
-    // If the load-balance finishes (all replica are migrated to new instances),
-    // we should drop all partitions from previous assigned instances.
-    if (!currentMapWithPreferenceList.values().contains(HelixDefinedState.ERROR.name())
-        && bestPossibleStateMap.size() > numReplicas && readyToDrop(currentStateMap,
-        bestPossibleStateMap, preferenceList, combinedPreferenceList)) {
-      for (int i = 0; i < combinedPreferenceList.size() - numReplicas; i++) {
-        String instanceToDrop = combinedPreferenceList.get(combinedPreferenceList.size() - i - 1);
-        bestPossibleStateMap.put(instanceToDrop, HelixDefinedState.DROPPED.name());
-      }
-    }
-
-    // Adding ERROR replica mapping to best possible
-    // ERROR assignment should be mutual excluded from DROPPED assignment because
-    // once there is an ERROR replica in the mapping, bestPossibleStateMap.size() > numReplicas prevents
-    // code entering the DROPPING stage.
-    for (String instance : combinedPreferenceList) {
-      if (currentStateMap.containsKey(instance) && currentStateMap.get(instance)
-          .equals(HelixDefinedState.ERROR.name())) {
-        bestPossibleStateMap.put(instance, HelixDefinedState.ERROR.name());
-      }
-    }
+    processBestPossibleState(bestPossibleStateMap, currentMapWithPreferenceList, currentStateMap,
+        preferenceList, combinedPreferenceList, numReplicas);
 
     return bestPossibleStateMap;
   }
@@ -421,82 +360,43 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
     return numExtraReplicas;
   }
 
-
-  private Map<String, String> computeBestPossibleStateForPartition(ResourceControllerDataProvider cache,
+  @Override
+  protected Map<String, String> computeBestPossibleStateForPartition(ResourceControllerDataProvider cache,
       StateModelDefinition stateModelDef, List<String> preferenceList,
       CurrentStateOutput currentStateOutput, Set<String> disabledInstancesForPartition,
-      IdealState idealState, ClusterConfig clusterConfig, Partition partition,
-      MonitoredAbnormalResolver monitoredResolver) {
+      IdealState idealState, Partition partition) {
 
-    Optional<Map<String, String>> optionalOverwrittenStates =
-        computeStatesOverwriteForPartition(stateModelDef, preferenceList, currentStateOutput,
-            idealState, partition, monitoredResolver);
-    if (optionalOverwrittenStates.isPresent()) {
-      return optionalOverwrittenStates.get();
+    // Check for any abnormal/override updates.
+    String stateModelDefName = idealState.getStateModelDefRef();
+    Map<String, String> overrideExists = optionalOverwriteStateExist(stateModelDef, preferenceList,
+        currentStateOutput, idealState, partition, cache.getAbnormalStateResolver(stateModelDefName));
+    if (overrideExists != null) {
+      return overrideExists;
     }
 
-    Map<String, String> currentStateMap = new HashMap<>(
-        currentStateOutput.getCurrentStateMap(idealState.getResourceName(), partition));
-    // Instances not in preference list but still have active replica, retain to avoid zero replica during movement
-    List<String> currentInstances = new ArrayList<>(currentStateMap.keySet());
-    Collections.sort(currentInstances);
-    Map<String, String> pendingStates =
-        new HashMap<>(currentStateOutput.getPendingStateMap(idealState.getResourceName(), partition));
-    for (String instance : pendingStates.keySet()) {
-      if (!currentStateMap.containsKey(instance)) {
-        currentStateMap.put(instance, stateModelDef.getInitialState());
-        currentInstances.add(instance);
-      }
-    }
-
-    Set<String> instancesToDrop = new HashSet<>();
-    Iterator<String> it = currentInstances.iterator();
-    while (it.hasNext()) {
-      String instance = it.next();
-      String state = currentStateMap.get(instance);
-      if (state == null) {
-        it.remove();
-        instancesToDrop.add(instance); // These instances should be set to DROPPED after we get bestPossibleStateMap;
-      }
-    }
-
-    // Sort the instancesToMove by their current partition state.
-    // Reason: because the states are assigned to instances in the order appeared in preferenceList, if we have
-    // [node1:Slave, node2:Master], we want to keep it that way, instead of assigning Master to node1.
-
+    // We can have empty list.
     if (preferenceList == null) {
       preferenceList = Collections.emptyList();
     }
 
     boolean isPreferenceListEmpty = preferenceList.isEmpty();
 
-    int numExtraReplicas = getNumExtraReplicas(clusterConfig);
-
-    // TODO : Keep the behavior consistent with existing state count, change back to read from idealstate
-    // replicas
     int numReplicas = preferenceList.size();
-    List<String> instanceToAdd = new ArrayList<>(preferenceList);
-    instanceToAdd.removeAll(currentInstances);
-
+    Map<String, String> currentStateMap = new HashMap<>(
+        currentStateOutput.getCurrentStateMap(idealState.getResourceName(), partition));
     List<String> combinedPreferenceList = new ArrayList<>();
+    List<String> instanceToAdd = new ArrayList<>(preferenceList);
+    Set<String> instancesToDrop = new HashSet<>();
 
-    if (currentInstances.size() <= numReplicas
-        && numReplicas + numExtraReplicas - currentInstances.size() > 0) {
-      int subListSize = numReplicas + numExtraReplicas - currentInstances.size();
-      combinedPreferenceList.addAll(instanceToAdd
-          .subList(0, Math.min(subListSize, instanceToAdd.size())));
-    }
+    Map<String, String> currentMapWithPreferenceList =
+      createStateMapWithPreferenceList(currentStateOutput, idealState,
+        cache.getClusterConfig(), partition, stateModelDef, preferenceList, instancesToDrop,
+        instanceToAdd, currentStateMap, combinedPreferenceList);
 
-    // Make all initial state instance not in preference list to be dropped.
-    Map<String, String> currentMapWithPreferenceList = new HashMap<>(currentStateMap);
-    currentMapWithPreferenceList.keySet().retainAll(preferenceList);
-
-    combinedPreferenceList.addAll(currentInstances);
-    combinedPreferenceList.sort(new PreferenceListNodeComparator(currentStateMap, stateModelDef, preferenceList));
-
-    // if preference list is not empty, and we do have new intanceToAdd, we 
+    // if preference list is not empty, and we do have new intanceToAdd, we
     // should check if it has capacity to hold the partition.
-    if (!isPreferenceListEmpty && instanceToAdd.size() > 0) {
+    boolean isWaged = WagedValidationUtil.isWagedEnabled(idealState);
+    if (!isWaged && !isPreferenceListEmpty && instanceToAdd.size() > 0) {
       // check instanceToAdd instance appears in combinedPreferenceList
       for (String instance : instanceToAdd) {
         if (combinedPreferenceList.contains(instance)) {
@@ -512,6 +412,7 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
         }
       }
     }
+
     // Assign states to instances with the combined preference list.
     Map<String, String> bestPossibleStateMap =
         computeBestPossibleMap(combinedPreferenceList, stateModelDef, currentStateMap,
@@ -521,9 +422,90 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
       bestPossibleStateMap.put(instance, HelixDefinedState.DROPPED.name());
     }
 
+    processBestPossibleState(bestPossibleStateMap, currentMapWithPreferenceList, currentStateMap,
+        preferenceList, combinedPreferenceList, numReplicas);
+
+    return bestPossibleStateMap;
+  }
+
+  private Map<String, String> optionalOverwriteStateExist(StateModelDefinition stateModelDef,
+      List<String> preferenceList, CurrentStateOutput currentStateOutput, IdealState idealState,
+      Partition partition, MonitoredAbnormalResolver abnormalStateResolver) {
+
+    Optional<Map<String, String>> optionalOverwrittenStates =
+        computeStatesOverwriteForPartition(stateModelDef, preferenceList, currentStateOutput,
+            idealState, partition, abnormalStateResolver);
+    if (optionalOverwrittenStates.isPresent()) {
+      return optionalOverwrittenStates.get();
+    }
+    return null;
+  }
+
+
+  private Map<String, String> createStateMapWithPreferenceList(
+      CurrentStateOutput currentStateOutput, IdealState idealState,
+      ClusterConfig clusterConfig, Partition partition, StateModelDefinition stateModelDef,
+      List<String> preferenceList, Set<String> instancesToDrop, List<String> instanceToAdd,
+      Map<String, String> currentStateMap, List<String> combinedPreferenceList) {
+
+    // Instances not in preference list but still have active replica,
+    // retain to avoid zero replica during movement
+    List<String> currentInstances = new ArrayList<>(currentStateMap.keySet());
+    Collections.sort(currentInstances);
+
+    Map<String, String> pendingStates =
+        new HashMap<>(currentStateOutput.getPendingStateMap(idealState.getResourceName(), partition));
+
+    for (String instance : pendingStates.keySet()) {
+      if (!currentStateMap.containsKey(instance)) {
+        currentStateMap.put(instance, stateModelDef.getInitialState());
+        currentInstances.add(instance);
+      }
+    }
+
+    Iterator<String> it = currentInstances.iterator();
+    while (it.hasNext()) {
+      String instance = it.next();
+      String state = currentStateMap.get(instance);
+      if (state == null) {
+        it.remove();
+        // These instances should be set to DROPPED after we get bestPossibleStateMap;
+        instancesToDrop.add(instance);
+      }
+    }
+
+    // Sort the instancesToMove by their current partition state.
+    // Reason: because the states are assigned to instances in the order appeared in preferenceList, if we have
+    // [node1:Slave, node2:Master], we want to keep it that way, instead of assigning Master to node1.
+    int numExtraReplicas = getNumExtraReplicas(clusterConfig);
+    int numReplicas = preferenceList.size();
+    instanceToAdd.removeAll(currentInstances);
+
+    if (currentInstances.size() <= numReplicas
+        && numReplicas + numExtraReplicas - currentInstances.size() > 0) {
+      int subListSize = numReplicas + numExtraReplicas - currentInstances.size();
+      combinedPreferenceList.addAll(instanceToAdd
+          .subList(0, Math.min(subListSize, instanceToAdd.size())));
+    }
+
+    // Make all initial state instance not in preference list to be dropped.
+    Map<String, String> currentMapWithPreferenceList = new HashMap<>(currentStateMap);
+    currentMapWithPreferenceList.keySet().retainAll(preferenceList);
+
+    combinedPreferenceList.addAll(currentInstances);
+    combinedPreferenceList.sort(new PreferenceListNodeComparator(currentStateMap, stateModelDef, preferenceList));
+    return currentMapWithPreferenceList;
+  }
+
+
+  // Clean up the dropped/error related states.
+  private void processBestPossibleState(Map<String, String> bestPossibleStateMap,
+      Map<String, String> currentMapWithPreferenceList, Map<String, String> currentStateMap,
+      List<String> preferenceList, List<String> combinedPreferenceList, int numReplicas) {
+
     // If the load-balance finishes (all replica are migrated to new instances),
     // we should drop all partitions from previous assigned instances.
-    if (!currentMapWithPreferenceList.values().contains(HelixDefinedState.ERROR.name())
+    if (!currentMapWithPreferenceList.containsValue(HelixDefinedState.ERROR.name())
         && bestPossibleStateMap.size() > numReplicas && readyToDrop(currentStateMap,
         bestPossibleStateMap, preferenceList, combinedPreferenceList)) {
       for (int i = 0; i < combinedPreferenceList.size() - numReplicas; i++) {
@@ -542,7 +524,5 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
         bestPossibleStateMap.put(instance, HelixDefinedState.ERROR.name());
       }
     }
-
-    return bestPossibleStateMap;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -372,6 +372,7 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
             LOG.info("Instance: {} has no capacity to hold resource: {}, partition: {}, removing "
                 + "it from combinedPreferenceList.", instance, idealState.getResourceName(),
                 partition.getPartitionName());
+            System.out.println("KKD: Removing instance: " + instance);
             combinedPreferenceList.remove(instance);
           }
         }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -494,9 +494,9 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
     combinedPreferenceList.addAll(currentInstances);
     combinedPreferenceList.sort(new PreferenceListNodeComparator(currentStateMap, stateModelDef, preferenceList));
 
-    // if preference list is not empty, and we do have new intanceToAdd, we should check if it has capacity to hold the partition.
-    // if (!isPreferenceListEmpty && combinedPreferenceList.size() > numReplicas && instanceToAdd.size() > 0) {
-      if (!isPreferenceListEmpty && instanceToAdd.size() > 0) {
+    // if preference list is not empty, and we do have new intanceToAdd, we 
+    // should check if it has capacity to hold the partition.
+    if (!isPreferenceListEmpty && instanceToAdd.size() > 0) {
       // check instanceToAdd instance appears in combinedPreferenceList
       for (String instance : instanceToAdd) {
         if (combinedPreferenceList.contains(instance)) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -372,7 +372,6 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
             LOG.info("Instance: {} has no capacity to hold resource: {}, partition: {}, removing "
                 + "it from combinedPreferenceList.", instance, idealState.getResourceName(),
                 partition.getPartitionName());
-            System.out.println("KKD: Removing instance: " + instance);
             combinedPreferenceList.remove(instance);
           }
         }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -260,9 +260,7 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
       Set<String> disabledInstancesForPartition =
           cache.getDisabledInstancesForPartition(resource.getResourceName(), partition.toString());
       List<String> preferenceList = getPreferenceList(partition, idealState, activeNodes);
-      Map<String, String> bestStateForPartition;
-
-      bestStateForPartition =
+      Map<String, String> bestStateForPartition =
           computeBestPossibleStateForPartition(cache, stateModelDef, preferenceList,
               currentStateOutput, disabledInstancesForPartition, idealState,
               partition);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/WagedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/WagedRebalanceUtil.java
@@ -62,11 +62,7 @@ public class WagedRebalanceUtil {
       ResourceConfig resourceConfig, ClusterConfig clusterConfig) {
     Map<String, Map<String, Integer>> capacityMap;
     try {
-      if (resourceConfig != null) {
-        capacityMap = resourceConfig.getPartitionCapacityMap();
-      } else {
-        capacityMap = new HashMap<>();
-        }
+      capacityMap = resourceConfig == null ? new HashMap<>() : resourceConfig.getPartitionCapacityMap();
     } catch (IOException ex) {
       throw new IllegalArgumentException(
           "Invalid partition capacity configuration of resource: " + resourceConfig

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/WagedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/WagedRebalanceUtil.java
@@ -20,6 +20,7 @@ package org.apache.helix.controller.rebalancer.util;
  */
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.controller.rebalancer.waged.RebalanceAlgorithm;
@@ -61,7 +62,11 @@ public class WagedRebalanceUtil {
       ResourceConfig resourceConfig, ClusterConfig clusterConfig) {
     Map<String, Map<String, Integer>> capacityMap;
     try {
-      capacityMap = resourceConfig.getPartitionCapacityMap();
+      if (resourceConfig != null) {
+        capacityMap = resourceConfig.getPartitionCapacityMap();
+      } else {
+        capacityMap = new HashMap<>();
+        }
     } catch (IOException ex) {
       throw new IllegalArgumentException(
           "Invalid partition capacity configuration of resource: " + resourceConfig

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedInstanceCapacity.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedInstanceCapacity.java
@@ -20,20 +20,27 @@ package org.apache.helix.controller.rebalancer.waged;
  */
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
+import org.apache.helix.HelixDefinedState;
 import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Partition;
+import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.controller.dataproviders.InstanceCapacityDataProvider;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
+import org.apache.helix.model.StateModelDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,79 +49,102 @@ public class WagedInstanceCapacity implements InstanceCapacityDataProvider {
 
   // Available Capacity per Instance
   private final Map<String, Map<String, Integer>> _instanceCapacityMap;
-  private final ResourceControllerDataProvider _cache;
+  private final Map<String, Map<String, Set<String>>> _allocatedPartitionsMap;
 
   public WagedInstanceCapacity(ResourceControllerDataProvider clusterData) {
-    _cache = clusterData;
     _instanceCapacityMap = new HashMap<>();
-
-    ClusterConfig clusterConfig = _cache.getClusterConfig();
-    for (InstanceConfig instanceConfig : _cache.getInstanceConfigMap().values()) {
-      Map<String, Integer> instanceCapacity =
-        WagedValidationUtil.validateAndGetInstanceCapacity(clusterConfig, instanceConfig);
+    _allocatedPartitionsMap = new HashMap<>();
+    ClusterConfig clusterConfig = clusterData.getClusterConfig();
+    for (InstanceConfig instanceConfig : clusterData.getInstanceConfigMap().values()) {
+      Map<String, Integer> instanceCapacity = WagedValidationUtil.validateAndGetInstanceCapacity(clusterConfig, instanceConfig);
       _instanceCapacityMap.put(instanceConfig.getInstanceName(), instanceCapacity);
+
+      _allocatedPartitionsMap.put(instanceConfig.getInstanceName(), new HashMap<>());
     }
   }
 
-  /**
-   * Create Default Capacity Map.
-   * This is a utility method to create a default capacity map matching instance capacity map for participants.
-   * This is required as non-WAGED partitions will be placed on same instance and we don't know their actual capacity.
-   * This will generate default values of 0 for all the capacity keys.
-   */
-  private Map<String, Integer> createDefaultParticipantWeight() {
-    // copy the value of first Instance capacity.
-    Map<String, Integer> partCapacity = new HashMap<>(_instanceCapacityMap.values().iterator().next());
+  // Helper methods.
+  private boolean isPartitionInAllocatedMap(String instance, String resource, String partition) {
+    return _allocatedPartitionsMap.get(instance).containsKey(resource)
+        && _allocatedPartitionsMap.get(instance).get(resource).contains(partition);
+  }
 
-    // Set the value of all capacity to -1.
-    for (String key : partCapacity.keySet()) {
-      partCapacity.put(key, -1);
-    }
-    return partCapacity;
+  public void process(ResourceControllerDataProvider cache, CurrentStateOutput currentStateOutput,
+      Map<String, Resource> resourceMap, WagedResourceWeightsProvider weightProvider) {
+    processPendingMessages(cache, currentStateOutput, resourceMap, weightProvider);
+    processCurrentState(cache, currentStateOutput, resourceMap, weightProvider);
   }
 
   /**
    * Process the pending messages based on the Current states
    * @param currentState - Current state of the resources.
    */
-  public void processPendingMessages(CurrentStateOutput currentState) {
-    Map<String, Map<Partition, Map<String, Message>>> pendingMsgs = currentState.getPendingMessages();
+  public void processPendingMessages(ResourceControllerDataProvider cache,
+      CurrentStateOutput currentState, Map<String, Resource> resourceMap,
+      WagedResourceWeightsProvider weightProvider) {
 
-    for (String resource : pendingMsgs.keySet()) {
-      Map<Partition, Map<String, Message>> partitionMsgs = pendingMsgs.get(resource);
+    for (Map.Entry<String, Resource> resourceEntry : resourceMap.entrySet()) {
+      String resName = resourceEntry.getKey();
+      Resource resource = resourceEntry.getValue();
+      // list of partitions in the resource
+      Collection<Partition> partitions = resource.getPartitions();
+      // State model definition for the resource
+      StateModelDefinition stateModelDef = cache.getStateModelDef(resource.getStateModelDefRef());
+      if (stateModelDef == null) {
+        LOG.warn("State Model Definition for resource: " + resName + " is null");
+        continue;
+      }
+      Map<String, Integer> statePriorityMap = stateModelDef.getStatePriorityMap();
 
-      for (Partition partition : partitionMsgs.keySet()) {
+      for (Partition partition : partitions) {
         String partitionName = partition.getPartitionName();
-
         // Get Partition Weight
-        Map<String, Integer> partCapacity = getPartitionCapacity(resource, partitionName);
+        Map<String, Integer> partCapacity = weightProvider.getPartitionWeights(resName, partitionName);
 
-        // TODO - check
-        Map<String, Message> msgs = partitionMsgs.get(partition);
-        // TODO - Check
-        for (String instance : msgs.keySet()) {
-           reduceAvailableInstanceCapacity(instance, partCapacity);
+        // Get the pending messages for the partition
+        Map<String, Message> pendingMessages = currentState.getPendingMessageMap(resName, partition);
+        if (pendingMessages != null && !pendingMessages.isEmpty()) {
+          for (Map.Entry<String, Message> entry :  pendingMessages.entrySet()) {
+            String instance = entry.getKey();
+            if (isPartitionInAllocatedMap(instance, resName, partitionName)) {
+              continue;
+            }
+            Message msg = entry.getValue();
+            if (statePriorityMap.get(msg.getFromState()) < statePriorityMap.get(msg.getToState())
+                && msg.getToState().equals(stateModelDef.getInitialState())
+                || msg.getToState().equals(HelixDefinedState.DROPPED.toString())) {
+              checkAndReduceInstanceCapacity(instance, resName, partitionName, partCapacity);
+            }
+          }
         }
       }
     }
   }
 
-  /**
-   * Get the partition capacity given Resource and Partition name.
-   */
-  private Map<String, Integer> getPartitionCapacity(String resource, String partition) {
-    ClusterConfig clusterConfig = _cache.getClusterConfig();
-    ResourceConfig resourceConfig = _cache.getResourceConfig(resource);
+  private void processCurrentState(ResourceControllerDataProvider cache,
+      CurrentStateOutput currentStateOutput, Map<String, Resource> resourceMap,
+      WagedResourceWeightsProvider weightProvider) {
 
+    // Iterate through all the resources
+    for (Map.Entry<String, Resource> entry : resourceMap.entrySet()) {
+      String resName = entry.getKey();
+      Resource resource = entry.getValue();
+      // list of partitions in the resource
+      Collection<Partition> partitions = resource.getPartitions();
 
-    // Parse the entire capacityMap from ResourceConfig
-    Map<String, Map<String, Integer>> capacityMap;
-    try {
-      capacityMap = resourceConfig.getPartitionCapacityMap();
-    } catch (IOException ex) {
-      return createDefaultParticipantWeight();
+      for (Partition partition : partitions) {
+        String partitionName = partition.getPartitionName();
+        // Get Partition Weight
+        Map<String, Integer> partCapacity = weightProvider.getPartitionWeights(resName, partitionName);
+        // Get the current state for the partition
+        Map<String, String> currentStateMap = currentStateOutput.getCurrentStateMap(resName, partition);
+        if (currentStateMap != null && !currentStateMap.isEmpty()) {
+          for (String instance : currentStateMap.keySet()) {
+            checkAndReduceInstanceCapacity(instance, resName, partitionName, partCapacity);
+          }
+        }
+      }
     }
-    return WagedValidationUtil.validateAndGetPartitionCapacity(partition, resourceConfig, capacityMap, clusterConfig);
   }
 
   /**
@@ -141,20 +171,32 @@ public class WagedInstanceCapacity implements InstanceCapacityDataProvider {
     return true;
   }
 
-  @Override
-  public boolean reduceAvailableInstanceCapacity(String instance, Map<String, Integer> partitionCapacity) {
+
+  public synchronized boolean checkAndReduceInstanceCapacity(String instance, String resName,
+      String partitionName, Map<String, Integer> partitionCapacity) {
+
+    if (isPartitionInAllocatedMap(instance, resName, partitionName)) {
+      return true;
+    }
+
     Map<String, Integer> instanceCapacity = _instanceCapacityMap.get(instance);
+    Map<String, Integer> processedCapacity = new HashMap<>();
     for (String key : instanceCapacity.keySet()) {
       if (partitionCapacity.containsKey(key)) {
-        int partCapacity = partitionCapacity.getOrDefault(key, 0);
-        if (partCapacity != 0 && instanceCapacity.get(key) < partCapacity) {
+        int partCapacity = partitionCapacity.get(key);
+        if (instanceCapacity.get(key) < partCapacity) {
+          // reset the processed capacity.
+          for (String processedKey : processedCapacity.keySet()) {
+            instanceCapacity.put(processedKey, instanceCapacity.get(processedKey) + processedCapacity.get(processedKey));
+          }
           return false;
         }
-        if (partCapacity != 0) {
-          instanceCapacity.put(key, instanceCapacity.get(key) - partCapacity);
-        }
+        instanceCapacity.put(key, instanceCapacity.get(key) - partCapacity);
+        processedCapacity.put(key, partCapacity);
       }
     }
+    _allocatedPartitionsMap.computeIfAbsent(instance, k -> new HashMap<>())
+        .computeIfAbsent(resName, k -> new HashSet<>()).add(partitionName);
     return true;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedInstanceCapacity.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedInstanceCapacity.java
@@ -71,8 +71,8 @@ public class WagedInstanceCapacity implements InstanceCapacityDataProvider {
 
   public void process(ResourceControllerDataProvider cache, CurrentStateOutput currentStateOutput,
       Map<String, Resource> resourceMap, WagedResourceWeightsProvider weightProvider) {
-    processPendingMessages(cache, currentStateOutput, resourceMap, weightProvider);
     processCurrentState(cache, currentStateOutput, resourceMap, weightProvider);
+    processPendingMessages(cache, currentStateOutput, resourceMap, weightProvider);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -241,6 +241,15 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     LOG.info("Start computing new ideal states for resources: {}", resourceMap.keySet().toString());
     validateInput(clusterData, resourceMap);
 
+    // Create Instance Capacity and Weight Providers
+    synchronized (this) {
+      WagedInstanceCapacity capacityProvider = new WagedInstanceCapacity(clusterData);
+      WagedResourceWeightsProvider weightProvider = new WagedResourceWeightsProvider(clusterData);
+
+      // Process the currentState and update the available instance capacity.
+      capacityProvider.process(clusterData, currentStateOutput, resourceMap, weightProvider);
+      clusterData.setWagedCapacityProviders(capacityProvider, weightProvider);
+    }
     Map<String, IdealState> newIdealStates;
     try {
       // Calculate the target assignment based on the current cluster status.

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -241,15 +241,6 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     LOG.info("Start computing new ideal states for resources: {}", resourceMap.keySet().toString());
     validateInput(clusterData, resourceMap);
 
-    // Create Instance Capacity and Weight Providers
-    synchronized (this) {
-      WagedInstanceCapacity capacityProvider = new WagedInstanceCapacity(clusterData);
-      WagedResourceWeightsProvider weightProvider = new WagedResourceWeightsProvider(clusterData);
-
-      // Process the currentState and update the available instance capacity.
-      capacityProvider.process(clusterData, currentStateOutput, resourceMap, weightProvider);
-      clusterData.setWagedCapacityProviders(capacityProvider, weightProvider);
-    }
     Map<String, IdealState> newIdealStates;
     try {
       // Calculate the target assignment based on the current cluster status.

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -35,6 +35,8 @@ import org.apache.helix.controller.pipeline.AbstractBaseStage;
 import org.apache.helix.controller.pipeline.StageException;
 import org.apache.helix.controller.rebalancer.util.ResourceUsageCalculator;
 import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
+import org.apache.helix.controller.rebalancer.waged.WagedInstanceCapacity;
+import org.apache.helix.controller.rebalancer.waged.WagedResourceWeightsProvider;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModelProvider;
@@ -110,6 +112,13 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
           currentStateOutput);
       reportResourcePartitionCapacityMetrics(dataProvider.getAsyncTasksThreadPool(),
           clusterStatusMonitor, dataProvider.getResourceConfigMap().values());
+
+      WagedInstanceCapacity capacityProvider = new WagedInstanceCapacity(dataProvider);
+      WagedResourceWeightsProvider weightProvider = new WagedResourceWeightsProvider(dataProvider);
+
+      // Process the currentState and update the available instance capacity.
+      capacityProvider.process(dataProvider, currentStateOutput, resourceMap, weightProvider);
+      dataProvider.setWagedCapacityProviders(capacityProvider, weightProvider);
     }
   }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -139,6 +139,9 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     when(clusterData.getRefreshedChangeTypes())
         .thenReturn(Collections.singleton(HelixConstants.ChangeType.CLUSTER_CONFIG));
 
+    when(clusterData.checkAndReduceCapacity(Mockito.any(), Mockito.any(),
+        Mockito.any())).thenReturn(true);
+
     Map<String, IdealState> newIdealStates =
         rebalancer.computeNewIdealStates(clusterData, resourceMap, new CurrentStateOutput());
     Map<String, ResourceAssignment> algorithmResult = _algorithm.getRebalanceResult();
@@ -894,7 +897,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
           return resource;
         }));
     WagedInstanceCapacity provider = new WagedInstanceCapacity(clusterData);
-   
+
     Map<String, Integer> weights1 = Map.of("item1", 20, "item2", 40, "item3", 30);
     Map<String, Integer> capacity = provider.getInstanceAvailableCapacity("testInstanceId");
     Assert.assertEquals(provider.getInstanceAvailableCapacity("testInstanceId"), weights1);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedClusterExpansion.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedClusterExpansion.java
@@ -1,0 +1,357 @@
+package org.apache.helix.integration.rebalancer.WagedRebalancer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional warnrmation
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.waged.AssignmentMetadataStore;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.manager.zk.ZkBucketDataAccessor;
+import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.Message;
+import org.apache.helix.model.ResourceAssignment;
+import org.apache.helix.model.ResourceConfig;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.participant.statemachine.StateModel;
+import org.apache.helix.participant.statemachine.StateModelFactory;
+import org.apache.helix.participant.statemachine.StateModelInfo;
+import org.apache.helix.participant.statemachine.Transition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * This test case is specially targeting for n - n+1 issue.
+ * Waged is constraint-based algorithm. The end-state of calculated ideal-state will
+ * always satisfy hard-constraint.
+ * The issue is in order to reach the ideal-state, we need to do intermediate
+ * state-transitions.
+ * During this phase, hard-constraints are not satisfied.
+ * This test case is trying to mimic this by having a very tightly constraint
+ * cluster and increasing the weight for some resource and checking if
+ * intermediate state satisfies the need or not.
+ */
+public class TestWagedClusterExpansion extends ZkTestBase {
+  protected final int NUM_NODE = 6;
+  protected static final int START_PORT = 13000;
+  protected static final int PARTITIONS = 10;
+
+  protected static final String CLASS_NAME = TestWagedClusterExpansion.class.getSimpleName();
+  protected static final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + CLASS_NAME;
+  protected ClusterControllerManager _controller;
+  protected AssignmentMetadataStore _assignmentMetadataStore;
+
+  List<MockParticipantManager> _participants = new ArrayList<>();
+
+  List<String> _nodes = new ArrayList<>();
+  private final Set<String> _allDBs = new HashSet<>();
+  private final int _replica = 3;
+  private final int INSTANCE_CAPACITY = 100;
+  private final int DEFAULT_PARTITION_CAPACITY = 6;
+  private final int INCREASED_PARTITION_CAPACITY = 10;
+  private final int DEFAULT_DELAY = 500; // 0.5 second
+  private final String  _testCapacityKey = "TestCapacityKey";
+  private final String  _resourceChanged = "Test-WagedDB-0";
+  private final Map<String, IdealState> _prevIdealState = new HashMap<>();
+
+  private static final Logger LOG = LoggerFactory.getLogger(CLASS_NAME);
+
+
+  // mock delay master-slave state model
+  @StateModelInfo(initialState = "OFFLINE", states = {
+      "MASTER", "SLAVE", "ERROR"
+  })
+  public static class WagedMasterSlaveModel extends StateModel {
+    private static final Logger LOG = LoggerFactory.getLogger(WagedMasterSlaveModel.class);
+    private final long _delay;
+
+    public WagedMasterSlaveModel(long delay) {
+      _delay = delay;
+    }
+
+    @Transition(to = "SLAVE", from = "OFFLINE")
+    public void onBecomeSlaveFromOffline(Message message, NotificationContext context) {
+      LOG.info("Become SLAVE from OFFLINE");
+    }
+
+    @Transition(to = "MASTER", from = "SLAVE")
+    public void onBecomeMasterFromSlave(Message message, NotificationContext context)
+        throws InterruptedException {
+      LOG.info("Become MASTER from SLAVE");
+    }
+
+    @Transition(to = "SLAVE", from = "MASTER")
+    public void onBecomeSlaveFromMaster(Message message, NotificationContext context) {
+      LOG.info("Become Slave from Master");
+    }
+
+    @Transition(to = "OFFLINE", from = "SLAVE")
+    public void onBecomeOfflineFromSlave(Message message, NotificationContext context) {
+      if (_delay > 0) {
+        try {
+          Thread.currentThread().sleep(_delay);
+        } catch (InterruptedException e) {
+          // ignore
+        }
+       }
+      LOG.info("Become OFFLINE from SLAVE");
+    }
+
+    @Transition(to = "DROPPED", from = "OFFLINE")
+    public void onBecomeDroppedFromOffline(Message message, NotificationContext context) {
+      if (_delay > 0) {
+        try {
+          Thread.currentThread().sleep(_delay);
+        } catch (InterruptedException e) {
+          // ignore
+        }
+      }
+      LOG.info("Become DROPPED FROM OFFLINE");
+    }
+  }
+
+  public class WagedDelayMSStateModelFactory extends StateModelFactory<WagedMasterSlaveModel> {
+    private long _delay;
+
+    @Override
+    public WagedMasterSlaveModel createNewStateModel(String resourceName,
+        String partitionKey) {
+      WagedMasterSlaveModel model = new WagedMasterSlaveModel(_delay);
+      return model;
+    }
+
+    public WagedDelayMSStateModelFactory setDelay(long delay) {
+      _delay = delay;
+      return this;
+    }
+  }
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    LOG.info("START " + CLASS_NAME + " at " + new Date(System.currentTimeMillis()));
+
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+    // create 6 node cluster
+    for (int i = 0; i < NUM_NODE; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      _gSetupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+      _nodes.add(storageNodeName);
+    }
+    // ST downward message will get delayed by 5sec.
+    startParticipants(DEFAULT_DELAY);
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    enablePersistBestPossibleAssignment(_gZkClient, CLUSTER_NAME, true);
+
+    _assignmentMetadataStore =
+        new AssignmentMetadataStore(new ZkBucketDataAccessor(ZK_ADDR), CLUSTER_NAME) {
+          public Map<String, ResourceAssignment> getBaseline() {
+            // Ensure this metadata store always read from the ZK without using cache.
+            super.reset();
+            return super.getBaseline();
+          }
+
+          public synchronized Map<String, ResourceAssignment> getBestPossibleAssignment() {
+            // Ensure this metadata store always read from the ZK without using cache.
+            super.reset();
+            return super.getBestPossibleAssignment();
+          }
+        };
+
+    // Set test instance capacity and partition weights
+    HelixDataAccessor dataAccessor = new ZKHelixDataAccessor(CLUSTER_NAME, _baseAccessor);
+    ClusterConfig clusterConfig =
+        dataAccessor.getProperty(dataAccessor.keyBuilder().clusterConfig());
+
+    clusterConfig.setInstanceCapacityKeys(Collections.singletonList(_testCapacityKey));
+    clusterConfig.setDefaultInstanceCapacityMap(Collections.singletonMap(_testCapacityKey, INSTANCE_CAPACITY));
+    clusterConfig.setDefaultPartitionWeightMap(Collections.singletonMap(_testCapacityKey, DEFAULT_PARTITION_CAPACITY));
+    dataAccessor.setProperty(dataAccessor.keyBuilder().clusterConfig(), clusterConfig);
+
+    // Create 3 resources with 10 partitions each.
+    for (int i = 0; i < 3; i++) {
+      String db = "Test-WagedDB-" + i;
+      createResourceWithWagedRebalance(CLUSTER_NAME, db, BuiltInStateModelDefinitions.MasterSlave.name(),
+          PARTITIONS, _replica, _replica);
+      _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _replica);
+      _allDBs.add(db);
+    }
+  }
+
+  private void startParticipants(int delay) {
+    // start dummy participants
+    for (String node : _nodes) {
+      MockParticipantManager participant = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, node);
+      StateMachineEngine stateMach = participant.getStateMachineEngine();
+      TestWagedClusterExpansion.WagedDelayMSStateModelFactory delayFactory =
+          new TestWagedClusterExpansion.WagedDelayMSStateModelFactory().setDelay(delay);
+      stateMach.registerStateModelFactory("MasterSlave", delayFactory);
+      participant.syncStart();
+      _participants.add(participant);
+    }
+  }
+
+  // This test case, first adds a new instance which will cause STs.
+  // Next, it will try to increase the default weight for one resource.
+  @Test
+  public void testIncreaseResourcePartitionWeight() throws Exception {
+    // For this test, let us record our initial prevIdealState.
+    for (String db : _allDBs) {
+      IdealState is =
+          _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
+      _prevIdealState.put(db, is);
+    }
+
+    // Let us add one more instance
+    String storageNodeName = PARTICIPANT_PREFIX + "_" + (START_PORT + NUM_NODE);
+    _gSetupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    _nodes.add(storageNodeName);
+
+    // Start the participant.
+    MockParticipantManager participant = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, storageNodeName);
+    StateMachineEngine stateMach = participant.getStateMachineEngine();
+    TestWagedClusterExpansion.WagedDelayMSStateModelFactory delayFactory =
+        new TestWagedClusterExpansion.WagedDelayMSStateModelFactory().setDelay(DEFAULT_DELAY);
+    stateMach.registerStateModelFactory("MasterSlave", delayFactory);
+    participant.syncStart();
+    _participants.add(participant);
+
+    // Check modified time for external view of the first resource.
+    // if pipeline is run, then external view would be persisted.
+    waitForPipeline(100, 3000);
+
+    LOG.info("After adding the new instance");
+    validateIdealState(false /* afterWeightChange */);
+
+    // Update the weight for one of the resource.
+    HelixDataAccessor dataAccessor = new ZKHelixDataAccessor(CLUSTER_NAME, _baseAccessor);
+    String db = _resourceChanged;
+    ResourceConfig resourceConfig = dataAccessor.getProperty(dataAccessor.keyBuilder().resourceConfig(db));
+    if (resourceConfig == null) {
+      resourceConfig = new ResourceConfig(db);
+    }
+    Map<String, Integer> capacityDataMap = ImmutableMap.of(_testCapacityKey, INCREASED_PARTITION_CAPACITY);
+    resourceConfig.setPartitionCapacityMap(
+        Collections.singletonMap(ResourceConfig.DEFAULT_PARTITION_KEY, capacityDataMap));
+    dataAccessor.setProperty(dataAccessor.keyBuilder().resourceConfig(db), resourceConfig);
+
+    // Make sure pipeline is run.
+    waitForPipeline(100, 10000); // 10 sec. max timeout.
+
+    LOG.info("After changing resource partition weight");
+    validateIdealState(true /* afterWeightChange */);
+    waitForPipeline(100, 3000); // this is for ZK to sync up.
+  }
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    try {
+      if (_controller != null && _controller.isConnected()) {
+        _controller.syncStop();
+      }
+      for (MockParticipantManager p : _participants) {
+        if (p != null && p.isConnected()) {
+          p.syncStop();
+        }
+      }
+      deleteCluster(CLUSTER_NAME);
+    } catch (Exception e) {
+      LOG.info("After class throwing exception, {}", e);
+    }
+  }
+
+  private void waitForPipeline(long stepSleep, long maxTimeout) {
+    // Check modified time for external view of the first resource.
+    // if pipeline is run, then external view would be persisted.
+    long startTime = System.currentTimeMillis();
+    while (System.currentTimeMillis() - startTime < maxTimeout) {
+      String db = _allDBs.iterator().next();
+      long modifiedTime = _gSetupTool.getClusterManagementTool().
+          getResourceExternalView(CLUSTER_NAME, db).getRecord().getModifiedTime();
+      if (modifiedTime - startTime > maxTimeout) {
+        break;
+      }
+      try {
+        Thread.currentThread().sleep(stepSleep);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private void validateIdealState(boolean afterWeightChange) {
+    // Calculate the instance to partition mapping based on previous and new ideal state.
+
+    Map<String, Set<String>> instanceToPartitionMap = new HashMap<>();
+    for (String db : _allDBs) {
+      IdealState newIdealState =
+          _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
+      for (String partition : newIdealState.getPartitionSet()) {
+        Map<String, String> assignmentMap = newIdealState.getRecord().getMapField(partition);
+        for (String instance : assignmentMap.keySet()) {
+          if (!instanceToPartitionMap.containsKey(instance)) {
+            instanceToPartitionMap.put(instance, new HashSet<>());
+          }
+          instanceToPartitionMap.get(instance).add(partition);
+        }
+      }
+    }
+    // Now, let us validate the instance to partition mapping.
+    for (String instance : instanceToPartitionMap.keySet()) {
+      int usedInstanceCapacity = 0;
+      for (String partition : instanceToPartitionMap.get(instance)) {
+        LOG.info("\tPartition: " + partition);
+        if (afterWeightChange && partition.startsWith(_resourceChanged)) {
+            usedInstanceCapacity += INCREASED_PARTITION_CAPACITY;
+        } else {
+          usedInstanceCapacity += DEFAULT_PARTITION_CAPACITY;
+        }
+      }
+      LOG.error("\tInstance: " + instance + " used capacity: " + usedInstanceCapacity);
+      // For now, this has to be disabled as this test case is negative scenario.
+      if (usedInstanceCapacity > INSTANCE_CAPACITY) {
+        LOG.error(instanceToPartitionMap.get(instance).toString());
+      }
+      Assert.assertTrue(usedInstanceCapacity <= INSTANCE_CAPACITY);
+    }
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedClusterExpansion.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedClusterExpansion.java
@@ -327,7 +327,11 @@ public class TestWagedClusterExpansion extends ZkTestBase {
           _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
       for (String partition : newIdealState.getPartitionSet()) {
         Map<String, String> assignmentMap = newIdealState.getRecord().getMapField(partition);
+        List<String> preferenceList = newIdealState.getRecord().getListField(partition);
         for (String instance : assignmentMap.keySet()) {
+          if (!preferenceList.contains(instance)) {
+            LOG.error("Instance: " + instance + " is not in preference list for partition: " + partition);
+          }
           if (!instanceToPartitionMap.containsKey(instance)) {
             instanceToPartitionMap.put(instance, new HashSet<>());
           }

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalanceHardConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalanceHardConstraint.java
@@ -197,7 +197,6 @@ public class TestWagedRebalanceHardConstraint extends ZkTestBase {
     Thread.currentThread().sleep(2000);
 
     LOG.info("After changing resource partition weight");
-    validate();
     validateIdealState(true);
     printCurrentState();
   }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes #2493 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This change is focused on changes to core logic where during assigning the STATE to the instances, we decide if instance has the required capacity.

This change NOW combines - core logic, code-consolidation, moving processing of pending message/current state to Data Process stage.  

I also combined the pending test-case review and enabled the Assert to ensure we never cross the capacity.  

The core logic is as follows:
Pre-Compute stage
------------------
- in WAGED rebalancer: computeNewIdealState, we create 'WagedInstanceCapacity' which tracks instance capacity and WeightProvider for partitions. These changes were introduced in Part-1.
- We process the pending messages for the resources where if we are moving out partition but not yet moved, we reduce the capacity.

Once we compute the ideal state, we go through preference list sorting. There are no changes to the pure computational change.

Post-compute stage
------------------
We look at the current-state as well as ideal state, we combine the list and do the sorting of the nodes. We then pick up only the required numReplica nodes.

This is where we look at the nodes which are "NEW" (ie. not in currentState) and check if it has the required capacity to hold the new partition. If not, we remove it from combined list.


### Tests

- [x] The following tests are written for this issue:
New test: TestWagedClusterExpansion has been added. 

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:
Testing done:
Have run through the mvn test (10 times)
In another change, I have added a new test case and verified that it works. [ERROR] Failures:
[ERROR]   TestNoThrottleDisabledPartitions.testDisablingTopStateReplicaByDisablingInstance:98 expected:<false> but was:<true>
[ERROR]   TestClusterMaintenanceMode.testMaintenanceHistory:412 expected:<EXIT> but was:<ENTER>
[ERROR]   TestParticipantFreeze.testUnfreezeParticipant:228 expected:<true> but was:<false>
[ERROR]   TestRecurringJobQueue.testDeletingRecurrentQueueWithHistory:298 expected:<true> but was:<false>
[ERROR] Tests run: 1335, Failures: 4, Errors: 0, Skipped: 0

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
