### PR TITLE
ZkClient - only register one time watcher for read data when not using persist listener.

### DIFF
--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -504,6 +504,28 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
     }
   }
 
+  @Test
+  public void testChangeListener() throws Exception {
+    final String basePath = "/TestZkMetaClient_ChangeListener";
+    final int count = 100;
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      zkMetaClient.connect();
+      DataChangeListener listener = new DataChangeListener() {
+
+        @Override
+        public void handleDataChange(String key, Object data, ChangeType changeType)
+            throws Exception {
+        }
+      };
+      zkMetaClient.subscribeDataChange(basePath, listener, false);
+      zkMetaClient.create(basePath, "");
+      zkMetaClient.get(basePath);
+      zkMetaClient.exists(basePath);
+      zkMetaClient.getDataAndStat(basePath);
+      zkMetaClient.getDirectChildrenKeys(basePath);
+    }
+  }
+
   /**
    * Transactional op calls zk.multi() with a set of ops (operations)
    * and the return values are converted into metaclient opResults.

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -2232,7 +2232,7 @@ public class ZkClient implements Watcher {
 
   @SuppressWarnings("unchecked")
   public <T extends Object> T readData(String path, Stat stat) {
-    return (T) readData(path, stat, hasChildOrDataListeners(path));
+    return (T) readData(path, stat, (!_usePersistWatcher) && hasChildOrDataListeners(path));
   }
 
   @SuppressWarnings("unchecked")

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientPersistWatcher.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientPersistWatcher.java
@@ -41,8 +41,7 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
   void testZkClientDataChange() throws Exception {
     org.apache.helix.zookeeper.impl.client.ZkClient.Builder builder =
         new org.apache.helix.zookeeper.impl.client.ZkClient.Builder();
-    builder.setZkServer(ZkTestBase.ZK_ADDR).setMonitorRootPathOnly(false)
-        .setUsePersistWatcher(true);
+    builder.setZkServer(ZkTestBase.ZK_ADDR).setMonitorRootPathOnly(false).setUsePersistWatcher(true);
     org.apache.helix.zookeeper.impl.client.ZkClient zkClient = builder.build();
     zkClient.setZkSerializer(new BasicZkSerializer(new SerializableSerializer()));
     int count = 1000;
@@ -63,8 +62,8 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
 
     zkClient.subscribeDataChanges(path, dataListener);
     zkClient.create(path, "datat", CreateMode.PERSISTENT);
-    for(int i=0; i<count; ++i) {
-      zkClient.writeData(path, ("datat"+i), -1);
+    for (int i = 0; i < count; ++i) {
+      zkClient.writeData(path, ("datat" + i), -1);
     }
 
     Assert.assertTrue(countDownLatch1.await(15000, TimeUnit.MILLISECONDS));
@@ -75,8 +74,7 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
   void testZkClientChildChange() throws Exception {
     org.apache.helix.zookeeper.impl.client.ZkClient.Builder builder =
         new org.apache.helix.zookeeper.impl.client.ZkClient.Builder();
-    builder.setZkServer(ZkTestBase.ZK_ADDR).setMonitorRootPathOnly(false)
-        .setUsePersistWatcher(true);
+    builder.setZkServer(ZkTestBase.ZK_ADDR).setMonitorRootPathOnly(false).setUsePersistWatcher(true);
     org.apache.helix.zookeeper.impl.client.ZkClient zkClient = builder.build();
     zkClient.setZkSerializer(new BasicZkSerializer(new SerializableSerializer()));
     int count = 100;
@@ -86,16 +84,14 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
     String path = "/testZkClientChildChange";
     IZkChildListener childListener = new IZkChildListener() {
       @Override
-      public void handleChildChange(String parentPath, List<String> currentChilds)
-          throws Exception {
+      public void handleChildChange(String parentPath, List<String> currentChilds) throws Exception {
         countDownLatch1.countDown();
-        event_count[0]++ ;
+        event_count[0]++;
       }
     };
     IZkChildListener childListener2 = new IZkChildListener() {
       @Override
-      public void handleChildChange(String parentPath, List<String> currentChilds)
-          throws Exception {
+      public void handleChildChange(String parentPath, List<String> currentChilds) throws Exception {
         countDownLatch2.countDown();
         event_count[0]++;
       }
@@ -108,6 +104,7 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
     }
     Assert.assertTrue(countDownLatch1.await(15000, TimeUnit.MILLISECONDS));
     Assert.assertTrue(countDownLatch2.await(15000, TimeUnit.MILLISECONDS));
+    zkClient.deleteRecursively(path);
     zkClient.close();
   }
 
@@ -115,8 +112,7 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
   void testZkClientPersistRecursiveChange() throws Exception {
     org.apache.helix.zookeeper.impl.client.ZkClient.Builder builder =
         new org.apache.helix.zookeeper.impl.client.ZkClient.Builder();
-    builder.setZkServer(ZkTestBase.ZK_ADDR).setMonitorRootPathOnly(false)
-        .setUsePersistWatcher(true);
+    builder.setZkServer(ZkTestBase.ZK_ADDR).setMonitorRootPathOnly(false).setUsePersistWatcher(true);
     org.apache.helix.zookeeper.impl.client.ZkClient zkClient = builder.build();
     zkClient.setZkSerializer(new BasicZkSerializer(new SerializableSerializer()));
     int count = 100;
@@ -124,39 +120,37 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
     final AtomicInteger[] event_count2 = {new AtomicInteger(0)};
     // for each iteration, we will edit a node, create a child, create a grand child, and
     // delete child. Expect 4 event per iteration. -> total event should be count*4
-    CountDownLatch countDownLatch1 = new CountDownLatch(count*4);
+    CountDownLatch countDownLatch1 = new CountDownLatch(count * 4);
     CountDownLatch countDownLatch2 = new CountDownLatch(count);
     String path = "/testZkClientPersistRecursiveChange";
     RecursivePersistListener rcListener = new RecursivePersistListener() {
       @Override
-      public void handleZNodeChange(String dataPath, Watcher.Event.EventType eventType)
-          throws Exception {
+      public void handleZNodeChange(String dataPath, Watcher.Event.EventType eventType) throws Exception {
         countDownLatch1.countDown();
-        event_count[0].incrementAndGet() ;
+        event_count[0].incrementAndGet();
       }
     };
     zkClient.create(path, "datat", CreateMode.PERSISTENT);
     zkClient.subscribePersistRecursiveListener(path, rcListener);
-    for (int i=0; i<count; ++i) {
+    for (int i = 0; i < count; ++i) {
       zkClient.writeData(path, "data7" + i, -1);
-      zkClient.create(path+"/c1_" +i , "datat", CreateMode.PERSISTENT);
-      zkClient.create(path+"/c1_" +i + "/c2", "datat", CreateMode.PERSISTENT);
-      zkClient.delete(path+"/c1_" +i + "/c2");
+      zkClient.create(path + "/c1_" + i, "datat", CreateMode.PERSISTENT);
+      zkClient.create(path + "/c1_" + i + "/c2", "datat", CreateMode.PERSISTENT);
+      zkClient.delete(path + "/c1_" + i + "/c2");
     }
     Assert.assertTrue(countDownLatch1.await(50000000, TimeUnit.MILLISECONDS));
 
     // subscribe a persist child watch, it should throw exception
     IZkChildListener childListener2 = new IZkChildListener() {
       @Override
-      public void handleChildChange(String parentPath, List<String> currentChilds)
-          throws Exception {
+      public void handleChildChange(String parentPath, List<String> currentChilds) throws Exception {
         countDownLatch2.countDown();
         event_count2[0].incrementAndGet();
       }
     };
     try {
       zkClient.subscribeChildChanges(path, childListener2, false);
-    } catch ( Exception ex) {
+    } catch (Exception ex) {
       Assert.assertEquals(ex.getClass().getName(), "java.lang.UnsupportedOperationException");
     }
 
@@ -164,14 +158,15 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
     zkClient.unsubscribePersistRecursiveListener(path, rcListener);
     zkClient.subscribeChildChanges(path, childListener2, false);
     // we should only get 100 event since only 100 direct child change.
-    for (int i=0; i<count; ++i) {
+    for (int i = 0; i < count; ++i) {
       zkClient.writeData(path, "data7" + i, -1);
-      zkClient.create(path+"/c2_" +i , "datat", CreateMode.PERSISTENT);
-      zkClient.create(path+"/c2_" +i + "/c3", "datat", CreateMode.PERSISTENT);
-      zkClient.delete(path+"/c2_" +i + "/c3");
+      zkClient.create(path + "/c2_" + i, "datat", CreateMode.PERSISTENT);
+      zkClient.create(path + "/c2_" + i + "/c3", "datat", CreateMode.PERSISTENT);
+      zkClient.delete(path + "/c2_" + i + "/c3");
     }
     Assert.assertTrue(countDownLatch2.await(50000000, TimeUnit.MILLISECONDS));
 
+    zkClient.deleteRecursively(path);
     zkClient.close();
   }
 
@@ -179,8 +174,7 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
   void testSubscribeOneTimeChangeWhenUsingPersistWatcher() {
     org.apache.helix.zookeeper.impl.client.ZkClient.Builder builder =
         new org.apache.helix.zookeeper.impl.client.ZkClient.Builder();
-    builder.setZkServer(ZkTestBase.ZK_ADDR).setMonitorRootPathOnly(false)
-        .setUsePersistWatcher(true);
+    builder.setZkServer(ZkTestBase.ZK_ADDR).setMonitorRootPathOnly(false).setUsePersistWatcher(true);
     ZkClient zkClient = builder.build();
     zkClient.setZkSerializer(new BasicZkSerializer(new SerializableSerializer()));
 
@@ -194,7 +188,7 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
     }
 
     try {
-      zkClient.readData(path, null,  true);
+      zkClient.readData(path, null, true);
       Assert.fail("Should throw exception when subscribe one time listener");
     } catch (Exception e) {
       Assert.assertEquals(e.getClass().getName(), "java.lang.IllegalArgumentException");
@@ -206,5 +200,24 @@ public class TestZkClientPersistWatcher extends ZkTestBase {
     } catch (Exception e) {
       Assert.assertEquals(e.getClass().getName(), "java.lang.IllegalArgumentException");
     }
+    zkClient.delete(path);
+    zkClient.close();
+  }
+
+  @Test
+  void testCrudOperationWithResubscribe() {
+    org.apache.helix.zookeeper.impl.client.ZkClient.Builder builder =
+        new org.apache.helix.zookeeper.impl.client.ZkClient.Builder();
+    builder.setZkServer(ZkTestBase.ZK_ADDR).setMonitorRootPathOnly(false).setUsePersistWatcher(false);
+    ZkClient zkClient = builder.build();
+    zkClient.setZkSerializer(new BasicZkSerializer(new SerializableSerializer()));
+
+    String path = "/testCrudOperationWithResubscribe";
+    zkClient.create(path, "datat", CreateMode.PERSISTENT);
+    zkClient.exists(path, true);
+    zkClient.readData(path, null, true);
+    zkClient.getChildren(path, true);
+    zkClient.delete(path);
+    zkClient.close();
   }
 }


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2554

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Fix issue 2554.
ZkClient tries to resubscribe one time watcher when reading an entry that has listener subscribed. In metaclient use case, we do not need to resubscribe as we are using persist watcher.
This change checks is persist watcher label is true. Only resubscribe if not using persist watcher.


### Tests

- [X] The following tests are written for this issue:
TestZkMetaclient.testChangeListener()
This new test was constantly failing before the fix.


- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
