### PR TITLE
Correctly state cluster is in maintenance mode when maintenance znode is empty

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -765,12 +765,17 @@ public class ClusterAccessor extends AbstractHelixResource {
   @GET
   @Path("{clusterId}/controller/maintenanceSignal")
   public Response getClusterMaintenanceSignal(@PathParam("clusterId") String clusterId) {
-    HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
-    MaintenanceSignal maintenanceSignal =
-        dataAccessor.getProperty(dataAccessor.keyBuilder().maintenance());
-    if (maintenanceSignal != null) {
-      Map<String, String> maintenanceInfo = maintenanceSignal.getRecord().getSimpleFields();
+    boolean inMaintenanceMode = getHelixAdmin().isInMaintenanceMode(clusterId);
+
+    if (inMaintenanceMode) {
+      HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
+      PropertyKey maintenanceKey = dataAccessor.keyBuilder().maintenance();
+      MaintenanceSignal maintenanceSignal = dataAccessor.getProperty(maintenanceKey);
+
+      Map<String, String> maintenanceInfo = (maintenanceSignal != null) ?
+          maintenanceSignal.getRecord().getSimpleFields() : new HashMap<>();
       maintenanceInfo.put(ClusterProperties.clusterName.name(), clusterId);
+
       return JSONRepresentation(maintenanceInfo);
     }
     return notFound(String.format("Cluster %s is not in maintenance mode!", clusterId));

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -769,8 +769,7 @@ public class ClusterAccessor extends AbstractHelixResource {
 
     if (inMaintenanceMode) {
       HelixDataAccessor dataAccessor = getDataAccssor(clusterId);
-      PropertyKey maintenanceKey = dataAccessor.keyBuilder().maintenance();
-      MaintenanceSignal maintenanceSignal = dataAccessor.getProperty(maintenanceKey);
+      MaintenanceSignal maintenanceSignal = dataAccessor.getProperty(dataAccessor.keyBuilder().maintenance());
 
       Map<String, String> maintenanceInfo = (maintenanceSignal != null) ?
           maintenanceSignal.getRecord().getSimpleFields() : new HashMap<>();

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -523,6 +523,33 @@ public class TestClusterAccessor extends AbstractTestClass {
   }
 
   @Test(dependsOnMethods = "testEnableDisableMaintenanceMode")
+  public void testEmptyMaintenanceSignal() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String cluster = _clusters.iterator().next();
+
+    // Create empty maintenance znode
+    ZNRecord record = new ZNRecord("test_maintenance_node");
+    ZKUtil.createOrUpdate(_gZkClient, "/"+cluster+"/CONTROLLER/MAINTENANCE", record, true, true);
+
+    // Verify maintenance mode enabled
+    Assert.assertTrue(isMaintenanceModeEnabled(cluster));
+    get("clusters/" + cluster + "/controller/maintenanceSignal", null,
+        Response.Status.OK.getStatusCode(), true);
+
+
+    // Disable maintenance mode
+    post("clusters/" + cluster, ImmutableMap.of("command", "disableMaintenanceMode"),
+        Entity.entity("", MediaType.APPLICATION_JSON_TYPE), Response.Status.OK.getStatusCode());
+
+    // Verify no longer in maintenance mode
+    Assert.assertFalse(isMaintenanceModeEnabled(cluster));
+    get("clusters/" + cluster + "/controller/maintenanceSignal", null,
+        Response.Status.NOT_FOUND.getStatusCode(), false);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+
+  }
+
+  @Test(dependsOnMethods = "testEmptyMaintenanceSignal")
   public void testGetControllerLeadershipHistory() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     String cluster = _clusters.iterator().next();


### PR DESCRIPTION
### Issues
Helix-rest's getClusterMaintenanceSignal will state the cluster is NOT in maintenance node if the maintenance znode has no data. Another function, getClusterMaintenanceMode, will return true in the above scenario. 
#2564

### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:

getClusterMaintenanceSignal currently attempts to retrieve the data of the Maintenance znode and will return that the cluster was not in maintenance mode if the returned data was null. This because dataAccessor.getProperty() will return null if the key does not exist in the snapshot. However, the returned value will also be null if the key corresponds to a null value. 

We should bring the functionality of getClusterMaintenanceSignal inline with getClusterMaintenanceMode, by first checking if the znode exists. 

### Tests

- [ ] The following tests are written for this issue:
 
testEmptyMaintenanceSignal() in TestClusterAccessor.java


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

N/A


### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)