### PR TITLE
CustomizedView need to handle ungraceful shutdown of instances

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManager.java
@@ -84,6 +84,8 @@ public interface HelixManager {
   String ALLOW_PARTICIPANT_AUTO_JOIN =
       ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN;
 
+  void deleteCustomizedStateRootForInstance(String instance);
+
   /**
    * Start participating in the cluster operations. All listeners will be
    * initialized and will be notified for every cluster state change This method

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -46,6 +46,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyKey.Builder;
+import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.api.exceptions.HelixMetaDataAccessException;
 import org.apache.helix.api.listeners.ClusterConfigChangeListener;
 import org.apache.helix.api.listeners.ControllerChangeListener;
@@ -99,6 +100,7 @@ import org.apache.helix.controller.stages.resource.ResourceMessageDispatchStage;
 import org.apache.helix.controller.stages.task.TaskMessageDispatchStage;
 import org.apache.helix.controller.stages.task.TaskPersistDataStage;
 import org.apache.helix.controller.stages.task.TaskSchedulingStage;
+import org.apache.helix.manager.zk.ZKUtil;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.CustomizedState;
@@ -1391,6 +1393,8 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
             manager.removeListener(keyBuilder.messages(instance), this);
             // remove customized state root listener for disconnected instances
             manager.removeListener(keyBuilder.customizedStatesRoot(instance), this);
+            // delete the customized state root path for disconnected instances
+            manager.deleteCustomizedStateRootForInstance(instance);
           }
         }
       }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -746,6 +746,14 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
     }
   }
 
+  @Override
+  public void deleteCustomizedStateRootForInstance(String instance) {
+    String path = PropertyPathBuilder.instanceCustomizedState(_clusterName, instance);
+    if (_zkclient.exists(path)) {
+      _zkclient.deleteRecursively(path);
+    }
+  }
+
   void createClient() throws Exception {
     final RealmAwareZkClient newClient = createSingleRealmZkClient();
 

--- a/helix-core/src/test/java/org/apache/helix/cloud/event/MockCloudEventAwareHelixManager.java
+++ b/helix-core/src/test/java/org/apache/helix/cloud/event/MockCloudEventAwareHelixManager.java
@@ -387,4 +387,7 @@ public class MockCloudEventAwareHelixManager implements HelixManager {
   public ParticipantHealthReportCollector getHealthReportCollector() {
     return null;
   }
+
+  @Override
+  public void deleteCustomizedStateRootForInstance(String instance) {};
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/DummyClusterManager.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/DummyClusterManager.java
@@ -386,4 +386,8 @@ public class DummyClusterManager implements HelixManager {
   protected void setSessionId(String sessionId) {
     _sessionId = sessionId;
   }
+
+  @Override
+  public void deleteCustomizedStateRootForInstance(String instance) {
+  }
 }

--- a/helix-core/src/test/java/org/apache/helix/mock/MockManager.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockManager.java
@@ -383,4 +383,7 @@ public class MockManager implements HelixManager {
     return 0L;
   }
 
+  @Override
+  public void deleteCustomizedStateRootForInstance(String instance) {};
+
 }

--- a/helix-core/src/test/java/org/apache/helix/participant/MockZKHelixManager.java
+++ b/helix-core/src/test/java/org/apache/helix/participant/MockZKHelixManager.java
@@ -383,4 +383,6 @@ public class MockZKHelixManager implements HelixManager {
     return 0L;
   }
 
+  @Override
+  public void deleteCustomizedStateRootForInstance(String instance) {}
 }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:


### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Helix Customized View allows customers to view aggregated view from various instances. When an instance ungracefully dies, the customizedState for that instance is not cleaned up. When this ungraceful instance comes back online, before it can reset the customizedState, Helix controller will report stale data from the previous session. 
During graceful shutdown, user explicitly resets the state in per-instance view but during ungraceful shutdown, it doesn't clean up. This change deletes the per-instance customized state in live-instance down callback listener.

### Tests

- [x] The following tests are written for this issue:
testDeleteInstanceCustomizedStateAggregation()

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:
mvn test is in progress will update it here as soon as it finishes it.
(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
