### PR TITLE
helix-rest parallel stoppable instances zone_order re-order fix

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -298,10 +298,12 @@ public class InstancesAccessor extends AbstractHelixResource {
   private List<String> getZoneBasedInstances(List<String> instances, List<String> orderedZones,
       Map<String, Set<String>> zoneMapping) {
 
+    // If the orderedZones is not specified, we will order all zones in alphabetical order.
     if (orderedZones == null) {
       orderedZones = new ArrayList<>(zoneMapping.keySet());
+      Collections.sort(orderedZones);
     }
-    Collections.sort(orderedZones);
+
     if (orderedZones.isEmpty()) {
       return orderedZones;
     }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -46,6 +46,34 @@ public class TestInstancesAccessor extends AbstractTestClass {
   private final static String CLUSTER_NAME = "TestCluster_0";
 
   @Test
+  public void testInstanceStoppable_zoneBased_zoneOrder() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    // Select instances with zone based
+    String content = String.format(
+        "{\"%s\":\"%s\",\"%s\":[\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\", \"%s\"], \"%s\":[\"%s\",\"%s\"]}",
+        InstancesAccessor.InstancesProperties.selection_base.name(),
+        InstancesAccessor.InstanceHealthSelectionBase.zone_based.name(),
+        InstancesAccessor.InstancesProperties.instances.name(), "instance0", "instance1",
+        "instance2", "instance3", "instance4", "instance5", "invalidInstance",
+        InstancesAccessor.InstancesProperties.zone_order.name(), "zone2", "zone1");
+    Response response =
+        new JerseyUriRequestBuilder("clusters/{}/instances?command=stoppable").format(
+            STOPPABLE_CLUSTER).post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
+    JsonNode jsonNode = OBJECT_MAPPER.readTree(response.readEntity(String.class));
+    Assert.assertFalse(
+        jsonNode.withArray(InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name())
+            .elements().hasNext());
+    JsonNode nonStoppableInstances = jsonNode.get(
+        InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
+    Assert.assertEquals(getStringSet(nonStoppableInstances, "instance5"),
+        ImmutableSet.of("HELIX:EMPTY_RESOURCE_ASSIGNMENT", "HELIX:INSTANCE_NOT_ALIVE",
+            "HELIX:INSTANCE_NOT_STABLE"));
+    Assert.assertEquals(getStringSet(nonStoppableInstances, "invalidInstance"),
+        ImmutableSet.of("HELIX:INSTANCE_NOT_EXIST"));
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testInstanceStoppable_zoneBased_zoneOrder")
   public void testInstancesStoppable_zoneBased() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     // Select instances with zone based
@@ -55,15 +83,15 @@ public class TestInstancesAccessor extends AbstractTestClass {
             InstancesAccessor.InstanceHealthSelectionBase.zone_based.name(),
             InstancesAccessor.InstancesProperties.instances.name(), "instance0", "instance1",
             "instance2", "instance3", "instance4", "instance5", "invalidInstance");
-    Response response = new JerseyUriRequestBuilder("clusters/{}/instances?command=stoppable")
-        .format(STOPPABLE_CLUSTER)
-        .post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
+    Response response =
+        new JerseyUriRequestBuilder("clusters/{}/instances?command=stoppable").format(
+            STOPPABLE_CLUSTER).post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
     JsonNode jsonNode = OBJECT_MAPPER.readTree(response.readEntity(String.class));
     Assert.assertFalse(
         jsonNode.withArray(InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name())
             .elements().hasNext());
-    JsonNode nonStoppableInstances = jsonNode
-        .get(InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
+    JsonNode nonStoppableInstances = jsonNode.get(
+        InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
     Assert.assertEquals(getStringSet(nonStoppableInstances, "instance0"),
         ImmutableSet.of("HELIX:MIN_ACTIVE_REPLICA_CHECK_FAILED"));
     Assert.assertEquals(getStringSet(nonStoppableInstances, "instance1"),
@@ -76,8 +104,7 @@ public class TestInstancesAccessor extends AbstractTestClass {
     Assert.assertEquals(getStringSet(nonStoppableInstances, "instance4"),
         ImmutableSet.of("HELIX:EMPTY_RESOURCE_ASSIGNMENT", "HELIX:INSTANCE_NOT_ALIVE",
             "HELIX:INSTANCE_NOT_STABLE"));
-    Assert.assertEquals(getStringSet(nonStoppableInstances, "invalidInstance"),
-        ImmutableSet.of("HELIX:INSTANCE_NOT_EXIST"));
+    Assert.assertEquals(getStringSet(nonStoppableInstances, "invalidInstance"), ImmutableSet.of("HELIX:INSTANCE_NOT_EXIST"));
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 


### PR DESCRIPTION
Fix for parallel instances stoppable API reordering the zoneList when a user provides their own zone_order.

### Issues
- NA/new issue

### Description

When a user provides their own zone_order when using the parallel instances stoppable API in helix-rest, that order should be respected when selecting the zone to check. This will fix that by ensuring the provided zone_order is not alphabetically re-ordered as it is when a zone_order is not provided.

### Tests

- [x] TestInstancesAccessor#testInstanceStoppable_zoneBased_zoneOrder
   - Ensures that zone2 is selected when provided a zone_order of zone2,zone1


- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- NA

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
