### PR TITLE
Fix stoppable parallel instances API swallowing error, add error handling to REST config getBaseUrl

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/RESTConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/RESTConfig.java
@@ -19,6 +19,7 @@ package org.apache.helix.model;
  * under the License.
  */
 
+import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
@@ -67,12 +68,19 @@ public class RESTConfig extends HelixProperty {
    */
   public String getBaseUrl(String instance) {
     String baseUrl = get(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL);
+
     // pre-assumption of the url, must be format of "http://*/path", the wildcard is replaceable by
     // the instance vip
-    assert baseUrl.contains("*");
-    // pre-assumption of the instance name, must be format of <instanceVip>_<port>
-    assert instance.contains("_");
-    String instanceVip = instance.substring(0, instance.indexOf('_'));
+    if (baseUrl == null || !baseUrl.contains("*")) {
+      throw new HelixException("Invalid CUSTOMIZED_HEALTH_URL in REST config: " + baseUrl);
+    }
+
+    String instanceVip = instance;
+    // instance name format could be <instanceVip>_<port> so we need to extract the instance vip
+    if (instance.contains("_")) {
+      instanceVip = instance.substring(0, instance.indexOf('_'));
+    }
+
     return baseUrl.replace("*", instanceVip);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/model/TestRESTConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestRESTConfig.java
@@ -1,0 +1,46 @@
+package org.apache.helix.model;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.HelixException;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestRESTConfig {
+  @Test
+  public void testGetBaseUrlValid() {
+    ZNRecord record = new ZNRecord("test");
+    record.setSimpleField(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL.name(), "http://*:8080");
+    RESTConfig restConfig = new RESTConfig(record);
+    Assert.assertEquals(restConfig.getBaseUrl("instance0"), "http://instance0:8080");
+    Assert.assertEquals(restConfig.getBaseUrl("instance1_9090"), "http://instance1:8080");
+  }
+
+  @Test(expectedExceptions = HelixException.class)
+  public void testGetBaseUrlInvalid() {
+    ZNRecord record = new ZNRecord("test");
+    record.setSimpleField(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL.name(), "http://foo:8080");
+    RESTConfig restConfig = new RESTConfig(record);
+    restConfig.getBaseUrl("instance0");
+  }
+}

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -538,8 +537,11 @@ public class MaintenanceManagementService {
           // will be checked in the next round
           instancesForNextCheck.add(instance);
         }
-      } catch (InterruptedException | ExecutionException e) {
-        LOG.error("Failed to get StoppableChecks in parallel. Instance: {}", instance, e);
+      } catch (Exception e) {
+        String errorMessage =
+            String.format("Failed to get StoppableChecks in parallel. Instance: %s", instance);
+        LOG.error(errorMessage, e);
+        throw new HelixException(errorMessage);
       }
     }
 


### PR DESCRIPTION
- Fix stoppable parallel instances API swallowing error
- Add proper error handling for RESTConfig getBaseUrl method(asserts may not throw AssertionException if assertEnabled is specifically enabled in jvm config)
- Remove assumption that instance name contains port information while maintaining backwards compatibility

### Issues
NA

### Description

When fetching the result of StoppableChecks fails, helix-rest stoppable API will return a response with status 200; however, the instances passed to the API will not be in the `instance_stoppable_parallel` or `instance_not_stoppable_with_reasons` field. This is because we are catching the exception in `filterInstancesForNextCheck` and not raising an exception. We need to raise this exception to surface the issue to the caller.

RESTConfig model provides a method to generate the instance's baseUrl from the `CUSTOMIZED_HEALTH_URL` simpleField in REST Config znode. Previously, there were assert statements to check if baseUrl contained "*". This assert will not be executed at runtime unless assertEnabled jvm config is set to true. Instead we add error handling to check if baseUrl is null and if it has "*".

We cannot necessarily assume that all instance names contain the <instanceVip>_<port>. We remove this assumption while also preserving old logic if instance name has port.


### Tests

- [x] TestRESTConfig
  - [x] testGetBaseUrlValid for instance name without port and with port + valid CUSTOMIZED_HEALTH_URL
  - [x] testGetBaseUrlInvalid for invalid CUSTOMIZED_HEALTH_URL

- The following is the result of the "mvn test" command on the appropriate module:
```
➜  helix git:(fix_parallel_stoppable_api_swallows_exception) ✗ mvn test -o -Dtest=TestRESTConfig -pl=helix-core          
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.helix:metrics-common:bundle:1.3.1-SNAPSHOT
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.apache.helix:helix:1.3.1-SNAPSHOT, /Users/zapinto/Documents/git/zpinto/helix/pom.xml, line 678, column 17
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.helix:helix:pom:1.3.1-SNAPSHOT
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ line 678, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] 
[INFO] --------------------< org.apache.helix:helix-core >---------------------
[INFO] Building Apache Helix :: Core 1.3.1-SNAPSHOT
[INFO]   from pom.xml
[INFO] -------------------------------[ bundle ]-------------------------------
[INFO] 
[INFO] --- enforcer:1.4.1:enforce (enforce-maven-version) @ helix-core ---
[INFO] 
[INFO] --- enforcer:1.4.1:enforce (enforce-java-version) @ helix-core ---
[INFO] 
[INFO] --- enforcer:1.4.1:enforce (enforce-output-timestamp-property) @ helix-core ---
[INFO] 
[INFO] --- jacoco:0.8.6:prepare-agent (default) @ helix-core ---
[INFO] argLine set to -javaagent:/Users/zapinto/.m2/repository/org/jacoco/org.jacoco.agent/0.8.6/org.jacoco.agent-0.8.6-runtime.jar=destfile=/Users/zapinto/Documents/git/zpinto/helix/helix-core/target/jacoco.exec
[INFO] 
[INFO] --- remote-resources:1.7.0:process (process-resource-bundles) @ helix-core ---
[INFO] Preparing remote bundle org.apache:apache-jar-resource-bundle:1.4
[INFO] Copying 3 resources from 1 bundle.
[INFO] 
[INFO] --- resources:3.2.0:resources (default-resources) @ helix-core ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Using 'UTF-8' encoding to copy filtered properties files.
[INFO] Copying 4 resources
[INFO] Copying 0 resource
[INFO] Copying 3 resources
[INFO] The encoding used to copy filtered properties files have not been set. This means that the same encoding will be used to copy filtered properties files as when copying other filtered resources. This might not be what you want! Run your build with --debug to see which files might be affected. Read more at https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html
[INFO] 
[INFO] --- compiler:3.10.1:compile (default-compile) @ helix-core ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- bundle:5.1.4:manifest (bundle-manifest) @ helix-core ---
[WARNING] Manifest org.apache.helix:helix-core:bundle:1.3.1-SNAPSHOT : Unused Import-Package instructions: [org.apache.logging.log4j*, org.apache.logging.slf4j*] 
[INFO] Writing manifest: /Users/zapinto/Documents/git/zpinto/helix/helix-core/target/classes/META-INF/MANIFEST.MF
[INFO] 
[INFO] --- resources:3.2.0:testResources (default-testResources) @ helix-core ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Using 'UTF-8' encoding to copy filtered properties files.
[INFO] Copying 15 resources
[INFO] Copying 3 resources
[INFO] 
[INFO] --- compiler:3.10.1:testCompile (default-testCompile) @ helix-core ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- surefire:3.0.0-M3:test (default-test) @ helix-core ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.helix.model.TestRESTConfig
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.928 s - in org.apache.helix.model.TestRESTConfig
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/zapinto/Documents/git/zpinto/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 943 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.533 s
[INFO] Finished at: 2023-07-25T17:54:07-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
