### PR TITLE
WAGED - bugs fixes  in n - n + 1

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedClusterExpansion.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedClusterExpansion.java
@@ -292,8 +292,7 @@ public class TestWagedClusterExpansion extends ZkTestBase {
     waitForPipeline(100, 3000); // this is for ZK to sync up.
   }
 
-  // This test case, first adds a new instance which will cause STs.
-  // Next, it will try to increase the default weight for one resource.
+  // This test case reduces the capacity of one of the instance.
   @Test (dependsOnMethods = "testIncreaseResourcePartitionWeight")
   public void testReduceInstanceCapacity() throws Exception {
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedClusterExpansion.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedClusterExpansion.java
@@ -155,7 +155,7 @@ public class TestWagedClusterExpansion extends ZkTestBase {
     }
   }
 
-  public class WagedDelayMSStateModelFactory extends StateModelFactory<WagedMasterSlaveModel> {
+  public static class WagedDelayMSStateModelFactory extends StateModelFactory<WagedMasterSlaveModel> {
     private long _delay;
 
     @Override

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedClusterExpansion.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedClusterExpansion.java
@@ -40,6 +40,7 @@ import org.apache.helix.manager.zk.ZkBucketDataAccessor;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.model.ResourceConfig;
@@ -84,6 +85,8 @@ public class TestWagedClusterExpansion extends ZkTestBase {
   private final int INSTANCE_CAPACITY = 100;
   private final int DEFAULT_PARTITION_CAPACITY = 6;
   private final int INCREASED_PARTITION_CAPACITY = 10;
+
+  private final int REDUCED_INSTANCE_CAPACITY = 98;
   private final int DEFAULT_DELAY = 500; // 0.5 second
   private final String  _testCapacityKey = "TestCapacityKey";
   private final String  _resourceChanged = "Test-WagedDB-0";
@@ -106,6 +109,13 @@ public class TestWagedClusterExpansion extends ZkTestBase {
 
     @Transition(to = "SLAVE", from = "OFFLINE")
     public void onBecomeSlaveFromOffline(Message message, NotificationContext context) {
+      if (_delay > 0) {
+        try {
+          Thread.currentThread().sleep(_delay);
+        } catch (InterruptedException e) {
+          // ignore
+        }
+      }
       LOG.info("Become SLAVE from OFFLINE");
     }
 
@@ -279,6 +289,32 @@ public class TestWagedClusterExpansion extends ZkTestBase {
 
     LOG.info("After changing resource partition weight");
     validateIdealState(true /* afterWeightChange */);
+    waitForPipeline(100, 3000); // this is for ZK to sync up.
+  }
+
+  // This test case, first adds a new instance which will cause STs.
+  // Next, it will try to increase the default weight for one resource.
+  @Test (dependsOnMethods = "testIncreaseResourcePartitionWeight")
+  public void testReduceInstanceCapacity() throws Exception {
+
+    // Reduce capacity for one of the instance
+    String storageNodeName = PARTICIPANT_PREFIX + "_" + (START_PORT + NUM_NODE);
+
+    HelixDataAccessor dataAccessor = new ZKHelixDataAccessor(CLUSTER_NAME, _baseAccessor);
+    String db = _resourceChanged;
+    InstanceConfig config = dataAccessor.getProperty(dataAccessor.keyBuilder().instanceConfig(storageNodeName));
+    if (config == null) {
+      config = new InstanceConfig(storageNodeName);
+    }
+    Map<String, Integer> capacityDataMap = ImmutableMap.of(_testCapacityKey, REDUCED_INSTANCE_CAPACITY);
+    config.setInstanceCapacityMap(capacityDataMap);
+    dataAccessor.setProperty(dataAccessor.keyBuilder().instanceConfig(storageNodeName), config);
+
+    // Make sure pipeline is run.
+    waitForPipeline(100, 10000); // 10 sec. max timeout.
+
+    LOG.info("After changing instance capacity");
+    validateIdealState(true);
     waitForPipeline(100, 3000); // this is for ZK to sync up.
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedLoadedCluster.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedLoadedCluster.java
@@ -1,0 +1,277 @@
+package org.apache.helix.integration.rebalancer.WagedRebalancer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional warnrmation
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.waged.AssignmentMetadataStore;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.manager.zk.ZkBucketDataAccessor;
+import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.Message;
+import org.apache.helix.model.ResourceAssignment;
+import org.apache.helix.model.ResourceConfig;
+import org.apache.helix.participant.StateMachineEngine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * This test case is specially targeting for n - n+1 issue.
+ *
+ * Initially, all the partitions are equal size and equal weight
+ * from both CU, DISK.
+ * All the nodes are equally loaded.
+ * The test case will do the following:
+ *     For one resource, we will double its CU weight.
+ *     The rebalancer will be triggered.
+ *
+ * We have a monitoring thread which is constantly monitoring the instance capacity.
+ * - It looks at current state resource assignment + pending messages
+ * - it  has ASSERT in place to make sure we NEVER cross instance capacity (CU)
+ */
+public class TestWagedLoadedCluster extends ZkTestBase {
+  protected final int NUM_NODE = 6;
+  protected static final int START_PORT = 13000;
+  protected static final int PARTITIONS = 10;
+
+  protected static final String CLASS_NAME = TestWagedLoadedCluster.class.getSimpleName();
+  protected static final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + CLASS_NAME;
+  protected ClusterControllerManager _controller;
+  protected AssignmentMetadataStore _assignmentMetadataStore;
+  List<MockParticipantManager> _participants = new ArrayList<>();
+  List<String> _nodes = new ArrayList<>();
+  private final Set<String> _allDBs = new HashSet<>();
+
+  private CountDownLatch _completedTest = new CountDownLatch(1);
+  private CountDownLatch _weightUpdatedLatch = new CountDownLatch(1); // when 0, weight is updated
+  private final Map<String, Integer> _defaultInstanceCapacity =
+      ImmutableMap.of("CU", 50, "DISK", 50);
+
+  private final Map<String, Integer> _defaultPartitionWeight =
+      ImmutableMap.of("CU", 10, "DISK", 10);
+
+  private final Map<String, Integer> _newPartitionWeight =
+      ImmutableMap.of("CU", 20, "DISK", 10);
+  private final int DEFAULT_DELAY = 500; // 0.5 second
+  private static final Logger LOG = LoggerFactory.getLogger(CLASS_NAME);
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    LOG.info("START " + CLASS_NAME + " at " + new Date(System.currentTimeMillis()));
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+    // create 6 node cluster
+    for (int i = 0; i < NUM_NODE; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      _gSetupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+      _nodes.add(storageNodeName);
+    }
+    // ST downward message will get delayed by 5sec.
+    startParticipants(DEFAULT_DELAY);
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    enablePersistBestPossibleAssignment(_gZkClient, CLUSTER_NAME, true);
+
+    _assignmentMetadataStore =
+        new AssignmentMetadataStore(new ZkBucketDataAccessor(ZK_ADDR), CLUSTER_NAME) {
+          public Map<String, ResourceAssignment> getBaseline() {
+            // Ensure this metadata store always read from the ZK without using cache.
+            super.reset();
+            return super.getBaseline();
+          }
+
+          public synchronized Map<String, ResourceAssignment> getBestPossibleAssignment() {
+            // Ensure this metadata store always read from the ZK without using cache.
+            super.reset();
+            return super.getBestPossibleAssignment();
+          }
+        };
+
+    // Set test instance capacity and partition weights
+    HelixDataAccessor dataAccessor = new ZKHelixDataAccessor(CLUSTER_NAME, _baseAccessor);
+    ClusterConfig clusterConfig =
+        dataAccessor.getProperty(dataAccessor.keyBuilder().clusterConfig());
+
+    clusterConfig.setDefaultInstanceCapacityMap(_defaultInstanceCapacity);
+    clusterConfig.setDefaultPartitionWeightMap(_defaultPartitionWeight);
+    dataAccessor.setProperty(dataAccessor.keyBuilder().clusterConfig(), clusterConfig);
+
+    // Create 3 resources with 2 partitions each.
+    for (int i = 0; i < 3; i++) {
+      String db = "Test-WagedDB-" + i;
+      createResourceWithWagedRebalance(CLUSTER_NAME, db, BuiltInStateModelDefinitions.MasterSlave.name(),
+          2 /*numPartitions*/, 3 /*replicas*/, 3 /*minActiveReplicas*/);
+      _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, 3);
+      _allDBs.add(db);
+    }
+
+    // Start a thread which will keep validating instance usage using currentState and pending messages.
+    Thread validateInstanceUsageThread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        while (_completedTest.getCount() > 0) {
+          try {
+            validateInstanceUsage();
+            Thread.currentThread().sleep(100);
+          } catch (InterruptedException e) {
+            LOG.debug("Exception in validateInstanceUsageThread", e);
+          } catch (Exception e) {
+            LOG.error("Exception in validateInstanceUsageThread", e);
+          }
+
+        }
+      }
+    });
+    validateInstanceUsageThread.start();
+  }
+
+  public boolean validateInstanceUsage() {
+    try {
+      HelixDataAccessor dataAccessor = new ZKHelixDataAccessor(CLUSTER_NAME, _baseAccessor);
+      PropertyKey.Builder propertyKeyBuilder = dataAccessor.keyBuilder();
+      // For each instance, get the currentState map and pending messages.
+      for (MockParticipantManager participant : _participants) {
+        String instance = participant.getInstanceName();
+        int totalCUUsage = 0;
+        List<String> resourceNames = dataAccessor.
+            getChildNames(propertyKeyBuilder.currentStates(instance, participant.getSessionId()));
+        for (String resourceName : resourceNames) {
+          PropertyKey currentStateKey = propertyKeyBuilder.currentState(instance,
+              participant.getSessionId(), resourceName);
+          CurrentState currentState = dataAccessor.getProperty(currentStateKey);
+          if (currentState != null && currentState.getPartitionStateMap().size() > 0) {
+            if (_weightUpdatedLatch.getCount() == 0 && resourceName.equals("Test-WagedDB-0")) {
+              // For Test-WagedDB-0, the partition weight is updated to 20 CU.
+              totalCUUsage += currentState.getPartitionStateMap().size() * 20;
+            } else {
+              totalCUUsage += currentState.getPartitionStateMap().size() * 10;
+            }
+          }
+        }
+        List<Message> messages = dataAccessor.getChildValues(dataAccessor.keyBuilder().messages(instance), false);
+        for (Message m : messages) {
+          if (m.getFromState().equals("OFFLINE") && m.getToState().equals("SLAVE")) {
+            totalCUUsage += 10;
+          }
+        }
+        assert(totalCUUsage <= 50);
+      }
+    } catch (Exception e) {
+      LOG.error("Exception in validateInstanceUsage", e);
+      return false;
+    }
+    return true;
+  }
+
+  private void startParticipants(int delay) {
+    // start dummy participants
+    for (String node : _nodes) {
+      MockParticipantManager participant = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, node);
+      StateMachineEngine stateMach = participant.getStateMachineEngine();
+      TestWagedClusterExpansion.WagedDelayMSStateModelFactory delayFactory =
+          new TestWagedClusterExpansion.WagedDelayMSStateModelFactory().setDelay(delay);
+      stateMach.registerStateModelFactory("MasterSlave", delayFactory);
+      participant.syncStart();
+      _participants.add(participant);
+    }
+  }
+
+  @Test
+  public void testUpdateInstanceCapacity() throws Exception {
+
+    // Check modified time for external view of the first resource.
+    // if pipeline is run, then external view would be persisted.
+    Thread.currentThread().sleep(30000);
+    // Update the weight for one of the resource.
+    HelixDataAccessor dataAccessor = new ZKHelixDataAccessor(CLUSTER_NAME, _baseAccessor);
+    String db = "Test-WagedDB-0";
+    ResourceConfig resourceConfig = dataAccessor.getProperty(dataAccessor.keyBuilder().resourceConfig(db));
+    if (resourceConfig == null) {
+      resourceConfig = new ResourceConfig(db);
+    }
+    resourceConfig.setPartitionCapacityMap(
+        Collections.singletonMap(ResourceConfig.DEFAULT_PARTITION_KEY, _newPartitionWeight));
+    dataAccessor.setProperty(dataAccessor.keyBuilder().resourceConfig(db), resourceConfig);
+    Thread.currentThread().sleep(100);
+    _weightUpdatedLatch.countDown();
+    Thread.currentThread().sleep(60000);
+    _completedTest.countDown();
+  }
+
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    try {
+      if (_controller != null && _controller.isConnected()) {
+        _controller.syncStop();
+      }
+      for (MockParticipantManager p : _participants) {
+        if (p != null && p.isConnected()) {
+          p.syncStop();
+        }
+      }
+      deleteCluster(CLUSTER_NAME);
+    } catch (Exception e) {
+      LOG.info("After class throwing exception, {}", e);
+    }
+  }
+
+  private void waitForPipeline(long stepSleep, long maxTimeout) {
+    // Check modified time for external view of the first resource.
+    // if pipeline is run, then external view would be persisted.
+    long startTime = System.currentTimeMillis();
+    while (System.currentTimeMillis() - startTime < maxTimeout) {
+      String db = _allDBs.iterator().next();
+      long modifiedTime = _gSetupTool.getClusterManagementTool().
+          getResourceExternalView(CLUSTER_NAME, db).getRecord().getModifiedTime();
+      if (modifiedTime - startTime > maxTimeout) {
+        break;
+      }
+      try {
+        Thread.currentThread().sleep(stepSleep);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Issues
- [ ] My PR addresses the following Helix issues and references them in the PR description:

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:


WAGED n - n+1 - adds the logic whether to filter out the host from map-field of idealState if the host doesn't have capacity based on currentState and pending messages. 

Typically bootstrapping nodes don't appear in currentState and hence pendingMessages are required to be looked at.

There were 2 problems:
1. We were looking at CurrentStateOutput.pendingMessages. These messages are filtered from InstanceMessagesCache based on current state availability. Bootstrapping messages don't have CurrentState and hence they don't show up in pending message queue at all.
2. Second problem was StateModelDefinition priority  numeric values are in reverse order. MASTER is 0 while SLAVE value is 1. I was comparing 'from() < to()' state to indicate it is upward state change but given that actual priority value are in reverse order, i had to change.
Here is example of MasterSlaveSMD: https://github.com/apache/helix/blob/master/helix-core/src/main/java/org/apache/helix/model/MasterSlaveSMD.java#L56


### Tests

- [x] The following tests are written for this issue:
testReduceInstanceCapacity
Added new test: TestWagedLoadedCluster.java

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)
[ERROR] Failures:
[ERROR]   TestNoThrottleDisabledPartitions.testDisablingTopStateReplicaByDisablingInstance:98 expected:<false> but was:<true>
[ERROR]   TestClusterMaintenanceMode.testMaintenanceHistory:412 expected:<EXIT> but was:<ENTER>
[ERROR]   TestP2PNoDuplicatedMessage.testP2PStateTransitionEnabled:180 expected:<true> but was:<false>
[ERROR] Tests run: 1335, Failures: 3, Errors: 0, Skipped: 0
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project helix-core: There are test failures.


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
