### PR TITLE
Lattice Puppy Stress Test Race Condition Fix and Code Cleanup

### DIFF
--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/CreatePuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/CreatePuppy.java
@@ -64,8 +64,7 @@ public class CreatePuppy extends AbstractPuppy {
 
   @Override
   protected void cleanup() {
-    // Implement the recovery logic by deleting the created documents
-    _metaclient.recursiveDelete(_parentPath);
+    // Cleanup logic in test case
   }
 
   private boolean shouldIntroduceError() {

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/DeletePuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/DeletePuppy.java
@@ -58,7 +58,7 @@ public class DeletePuppy extends AbstractPuppy {
 
   @Override
   protected void cleanup() {
-    _metaclient.recursiveDelete(_parentPath);
+    // Do nothing
   }
 
   private boolean shouldIntroduceError() {

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/GetPuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/GetPuppy.java
@@ -59,7 +59,6 @@ public class GetPuppy extends AbstractPuppy {
 
   @Override
   protected void cleanup() {
-    _metaclient.recursiveDelete(_parentPath);
   }
 
   private boolean shouldIntroduceError() {

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/SetPuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/SetPuppy.java
@@ -61,7 +61,6 @@ public class SetPuppy extends AbstractPuppy {
 
   @Override
   protected void cleanup() {
-    _metaclient.recursiveDelete(_parentPath);
   }
 
   private boolean shouldIntroduceError() {

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/TestMultiThreadStressZKClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/TestMultiThreadStressZKClient.java
@@ -52,7 +52,8 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
   public void testCreatePuppy() {
     _zkMetaClient.create(zkParentKey, "test");
 
-    PuppySpec puppySpec = new org.apache.helix.metaclient.puppy.PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
+    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f,
+        new ExecDelay(5000, 0.1f), 5);
     CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
     CreatePuppy createPuppy2 = new CreatePuppy(_zkMetaClient, puppySpec);
     CreatePuppy createPuppy3 = new CreatePuppy(_zkMetaClient, puppySpec);
@@ -75,7 +76,8 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
   public void testDeletePuppy() {
     _zkMetaClient.create(zkParentKey, "test");
 
-    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
+    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f,
+        new ExecDelay(5000, 0.1f), 5);
     CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
     DeletePuppy deletePuppy = new DeletePuppy(_zkMetaClient, puppySpec);
 
@@ -96,7 +98,8 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
   public void testGetPuppy() {
     _zkMetaClient.create(zkParentKey, "test");
 
-    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
+    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f,
+        new ExecDelay(5000, 0.1f), 5);
     CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
     GetPuppy getPuppy = new GetPuppy(_zkMetaClient, puppySpec);
 
@@ -117,7 +120,8 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
   public void testSetPuppy() {
     _zkMetaClient.create(zkParentKey, "test");
 
-    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
+    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f,
+        new ExecDelay(5000, 0.1f), 5);
     CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
     SetPuppy setPuppy = new SetPuppy(_zkMetaClient, puppySpec);
 
@@ -138,7 +142,8 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
   public void testUpdatePuppy() {
     _zkMetaClient.create(zkParentKey, "test");
 
-    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
+    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f,
+        new ExecDelay(5000, 0.1f), 5);
     CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
     UpdatePuppy updatePuppy = new UpdatePuppy(_zkMetaClient, puppySpec);
 
@@ -159,7 +164,8 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
   public void testCrudPuppies() {
     _zkMetaClient.create(zkParentKey, "test");
 
-    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
+    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f,
+        new ExecDelay(5000, 0.1f), 5);
     CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
     GetPuppy getPuppy = new GetPuppy(_zkMetaClient, puppySpec);
     DeletePuppy deletePuppy = new DeletePuppy(_zkMetaClient, puppySpec);
@@ -189,12 +195,14 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     AtomicInteger globalChildChangeCounter = new AtomicInteger();
     ChildChangeListener childChangeListener = (changedPath, changeType) -> {
       globalChildChangeCounter.addAndGet(1);
-      System.out.println("-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: " + globalChildChangeCounter.get());
+      System.out.println("-------------- Child change detected: " + changeType
+          + " at path: " + changedPath + ". Number of total changes: " + globalChildChangeCounter.get());
     };
 
     _zkMetaClient.subscribeChildChanges(zkParentKey, childChangeListener, false);
 
-    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
+    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f,
+        new ExecDelay(5000, 0.1f), 5);
     CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
 
     PuppyManager puppyManager = new PuppyManager();
@@ -217,13 +225,13 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     AtomicInteger globalChildChangeCounter = new AtomicInteger();
     ChildChangeListener childChangeListener = (changedPath, changeType) -> {
       globalChildChangeCounter.addAndGet(1);
-      System.out.println("-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: " + globalChildChangeCounter.get());
+      System.out.println("-------------- Child change detected: " + changeType
+          + " at path: " + changedPath + " number of changes: " + globalChildChangeCounter.get());
     };
-
-
     _zkMetaClient.subscribeChildChanges(zkParentKey, childChangeListener, false);
 
-    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
+    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f,
+        new ExecDelay(5000, 0.1f), 5);
     CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
     GetPuppy getPuppy = new GetPuppy(_zkMetaClient, puppySpec);
     DeletePuppy deletePuppy = new DeletePuppy(_zkMetaClient, puppySpec);
@@ -253,7 +261,8 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
   public void testChildListenerPuppy() {
     _zkMetaClient.create(zkParentKey, "test");
     // Setting num diff paths to 3 until we find a better way of scaling listeners.
-    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 3);
+    PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f,
+        new ExecDelay(5000, 0.1f), 3);
     CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
     GetPuppy getPuppy = new GetPuppy(_zkMetaClient, puppySpec);
     DeletePuppy deletePuppy = new DeletePuppy(_zkMetaClient, puppySpec);
@@ -272,21 +281,24 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     AtomicInteger childChangeCounter0 = new AtomicInteger();
     ChildChangeListener childChangeListener0 = (changedPath, changeType) -> {
       childChangeCounter0.addAndGet(1);
-      System.out.println("-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: " + childChangeCounter0.get());
+      System.out.println("-------------- Child change detected: " + changeType
+          + " at path: " + changedPath + " number of changes: " + childChangeCounter0.get());
     };
     _zkMetaClient.subscribeChildChanges("/test/0", childChangeListener0, false);
 
     AtomicInteger childChangeCounter1 = new AtomicInteger();
     ChildChangeListener childChangeListener1 = (changedPath, changeType) -> {
       childChangeCounter1.addAndGet(1);
-      System.out.println("-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: " + childChangeCounter1.get());
+      System.out.println("-------------- Child change detected: " + changeType
+          + " at path: " + changedPath + " number of changes: " + childChangeCounter1.get());
     };
     _zkMetaClient.subscribeChildChanges("/test/1", childChangeListener1, false);
 
     AtomicInteger childChangeCounter2 = new AtomicInteger();
     ChildChangeListener childChangeListener2 = (changedPath, changeType) -> {
       childChangeCounter2.addAndGet(1);
-      System.out.println("-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: " + childChangeCounter2.get());
+      System.out.println("-------------- Child change detected: " + changeType
+          + " at path: " + changedPath + " number of changes: " + childChangeCounter2.get());
     };
     _zkMetaClient.subscribeChildChanges("/test/2", childChangeListener2, false);
 
@@ -311,9 +323,12 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     System.out.println("Child change counter 0: " + childChangeCounter0);
     System.out.println("Child change counter 1: " + childChangeCounter1);
     System.out.println("Child change counter 2: " + childChangeCounter2);
-    Assert.assertEquals(childChangeCounter0.get(), mergedEventChangeCounterMap.getOrDefault("0", 0).intValue());
-    Assert.assertEquals(childChangeCounter1.get(), mergedEventChangeCounterMap.getOrDefault("1", 0).intValue());
-    Assert.assertEquals(childChangeCounter2.get(), mergedEventChangeCounterMap.getOrDefault("2", 0).intValue());
+    Assert.assertEquals(childChangeCounter0.get(),
+        mergedEventChangeCounterMap.getOrDefault("0", 0).intValue());
+    Assert.assertEquals(childChangeCounter1.get(),
+        mergedEventChangeCounterMap.getOrDefault("1", 0).intValue());
+    Assert.assertEquals(childChangeCounter2.get(),
+        mergedEventChangeCounterMap.getOrDefault("2", 0).intValue());
 
     // cleanup
     _zkMetaClient.unsubscribeChildChanges("/test/0", childChangeListener0);

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/UpdatePuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/UpdatePuppy.java
@@ -64,7 +64,6 @@ public class UpdatePuppy extends AbstractPuppy {
 
   @Override
   protected void cleanup() {
-    _metaclient.recursiveDelete(_parentPath);
   }
 
   private boolean shouldIntroduceError() {

--- a/meta-client/src/test/java/org/apache/helix/metaclient/puppy/AbstractPuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/puppy/AbstractPuppy.java
@@ -55,27 +55,18 @@ public abstract class AbstractPuppy implements Runnable {
   @Override
   public void run() {
     try {
-      while (true) {
+      while (!Thread.currentThread().isInterrupted()) {
         try {
+          Thread.sleep(getPuppySpec().getExecDelay().getNextDelay());
           bark();
+        } catch (InterruptedException e) {
+          break;
         } catch (Exception e) {
           incrementUnhandledErrorCounter();
           e.printStackTrace();
         }
-
-        if (getPuppySpec().getMode() == PuppyMode.ONE_OFF) {
-          cleanup();
-          break;
-        } else {
-          try {
-            Thread.sleep(getPuppySpec().getExecDelay().getNextDelay());
-          } catch (InterruptedException e) {
-            cleanup();
-            break;
-            // Handle interruption if necessary
-          }
-        }
       }
+      cleanup();
     } catch (Exception e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

There was a race condition where the threads running the specific puppies would terminate, leading to the created znodes to be deleted. Because there were listeners on those nodes, they would increase the event change counter when the threads had already finished, causing the tests to fail.
Code cleanup stems from bug: https://github.com/apache/helix/issues/2577

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Removed the cleanup section of the CRUD puppies (as cleanup will happen in the test case). Many of the cleanups weren't necessary and the ones that were (for CreatePuppy) was what caused the race condition.
Re-structured code in AbstractPuppy for less redundancy and modified some print statements for easier readability.

### Tests

- [ ] The following tests are written for this issue:

TestMultiThreadStressZKClient.java

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
