### PR TITLE
Lattice LockClient LockInfoSerializer Implementation

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/recipes/lock/LockClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/recipes/lock/LockClient.java
@@ -48,8 +48,7 @@ public class LockClient implements LockClientInterface, AutoCloseable {
     if (MetaClientConfig.StoreType.ZOOKEEPER.equals(config.getStoreType())) {
       ZkMetaClientConfig zkMetaClientConfig = new ZkMetaClientConfig.ZkMetaClientConfigBuilder().
           setConnectionAddress(config.getConnectionAddress())
-          // Currently only support ZNRecordSerializer. TODO: make this configurable
-          .setZkSerializer((new ZNRecordSerializer()))
+          .setZkSerializer((new LockInfoSerializer()))
           .build();
       _metaClient = new ZkMetaClientFactory().getMetaClient(zkMetaClientConfig);
       _metaClient.connect();
@@ -110,11 +109,7 @@ public class LockClient implements LockClientInterface, AutoCloseable {
     if (stat == null) {
       return null;
     }
-    //Create a new DataRecord from underlying record
-    DataRecord dataRecord = new DataRecord(_metaClient.get(key));
-    //Create a new LockInfo from DataRecord
-    LockInfo lockInfo = new LockInfo(dataRecord, stat);
-    return lockInfo;
+    return new LockInfo(_metaClient.get(key), stat);
   }
 
   @Override

--- a/meta-client/src/main/java/org/apache/helix/metaclient/recipes/lock/LockInfo.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/recipes/lock/LockInfo.java
@@ -39,7 +39,6 @@ public class LockInfo extends DataRecord {
   public static final long DEFAULT_LAST_RENEWED_AT_LONG = -1L;
   public static final long DEFAULT_TIMEOUT_DURATION = -1L;
   private static final String DEFAULT_LOCK_INFO = "lockInfo.";
-  private DataRecord _dataRecord;
 
   /**
    * The keys to lock information
@@ -59,7 +58,6 @@ public class LockInfo extends DataRecord {
    */
   public LockInfo() {
     super(DEFAULT_LOCK_INFO);
-    _dataRecord = new DataRecord(DEFAULT_LOCK_INFO);
     setLockInfoFields(DEFAULT_LOCK_ID_TEXT, DEFAULT_OWNER_ID_TEXT, DEFAULT_CLIENT_ID_TEXT, DEFAULT_CLIENT_DATA, DEFAULT_GRANTED_AT_LONG,
         DEFAULT_LAST_RENEWED_AT_LONG, DEFAULT_TIMEOUT_DURATION);
   }
@@ -140,7 +138,7 @@ public class LockInfo extends DataRecord {
    *               It is created by the lockClient and a new one is created for each time the lock is acquired.
    */
   public void setLockId(String lockId) {
-    _dataRecord.setSimpleField(LockInfoAttribute.LOCK_ID.name(), lockId == null ? DEFAULT_LOCK_ID_TEXT : lockId);
+    setSimpleField(LockInfoAttribute.LOCK_ID.name(), lockId == null ? DEFAULT_LOCK_ID_TEXT : lockId);
   }
 
   /**
@@ -150,7 +148,7 @@ public class LockInfo extends DataRecord {
    *                by the same owner.
    */
   public void setOwnerId(String ownerId) {
-    _dataRecord.setSimpleField(LockInfoAttribute.OWNER_ID.name(), ownerId == null ? DEFAULT_OWNER_ID_TEXT : ownerId);
+    setSimpleField(LockInfoAttribute.OWNER_ID.name(), ownerId == null ? DEFAULT_OWNER_ID_TEXT : ownerId);
   }
 
   /**
@@ -158,7 +156,7 @@ public class LockInfo extends DataRecord {
    * @param clientId Unique identifier that represents who will get the lock (the client).
    */
   public void setClientId(String clientId) {
-    _dataRecord.setSimpleField(LockInfoAttribute.CLIENT_ID.name(), clientId == null ? DEFAULT_CLIENT_ID_TEXT : clientId);
+    setSimpleField(LockInfoAttribute.CLIENT_ID.name(), clientId == null ? DEFAULT_CLIENT_ID_TEXT : clientId);
   }
 
   /**
@@ -166,7 +164,7 @@ public class LockInfo extends DataRecord {
    * @param clientData String representing the serialized data object
    */
   public void setClientData(String clientData) {
-    _dataRecord.setSimpleField(LockInfoAttribute.CLIENT_DATA.name(), clientData == null ? DEFAULT_CLIENT_DATA : clientData);
+    setSimpleField(LockInfoAttribute.CLIENT_DATA.name(), clientData == null ? DEFAULT_CLIENT_DATA : clientData);
   }
 
   /**
@@ -174,7 +172,7 @@ public class LockInfo extends DataRecord {
    * @param grantTime Long representing the time at which the lock was granted
    */
   public void setGrantedAt(Long grantTime) {
-    _dataRecord.setLongField(LockInfoAttribute.GRANTED_AT.name(), grantTime);
+    setLongField(LockInfoAttribute.GRANTED_AT.name(), grantTime);
   }
 
   /**
@@ -182,7 +180,7 @@ public class LockInfo extends DataRecord {
    * @param lastRenewalTime Long representing the time at which the lock was last renewed
    */
   public void setLastRenewedAt(Long lastRenewalTime) {
-    _dataRecord.setLongField(LockInfoAttribute.LAST_RENEWED_AT.name(), lastRenewalTime);
+    setLongField(LockInfoAttribute.LAST_RENEWED_AT.name(), lastRenewalTime);
   }
 
   /**
@@ -191,7 +189,7 @@ public class LockInfo extends DataRecord {
    */
   public void setTimeout(long timeout) {
     // Always store the timeout value in milliseconds for the sake of simplicity
-    _dataRecord.setLongField(LockInfoAttribute.TIMEOUT.name(), timeout);
+    setLongField(LockInfoAttribute.TIMEOUT.name(), timeout);
   }
 
   /**
@@ -199,7 +197,7 @@ public class LockInfo extends DataRecord {
    * @return the owner id of the lock, {@link #DEFAULT_OWNER_ID_TEXT} if there is no owner id set
    */
   public String getOwnerId() {
-    return _dataRecord.getStringField(LockInfoAttribute.OWNER_ID.name(), DEFAULT_OWNER_ID_TEXT);
+    return getStringField(LockInfoAttribute.OWNER_ID.name(), DEFAULT_OWNER_ID_TEXT);
   }
 
   /**
@@ -207,7 +205,7 @@ public class LockInfo extends DataRecord {
    * @return the client id of the lock, {@link #DEFAULT_CLIENT_ID_TEXT} if there is no client id set
    */
   public String getClientId() {
-    return _dataRecord.getStringField(LockInfoAttribute.CLIENT_ID.name(), DEFAULT_CLIENT_ID_TEXT);
+    return getStringField(LockInfoAttribute.CLIENT_ID.name(), DEFAULT_CLIENT_ID_TEXT);
   }
 
   /**
@@ -215,7 +213,7 @@ public class LockInfo extends DataRecord {
    * @return the id of the lock, {@link #DEFAULT_LOCK_ID_TEXT} if there is no lock id set
    */
   public String getLockId() {
-    return _dataRecord.getStringField(LockInfoAttribute.LOCK_ID.name(), DEFAULT_LOCK_ID_TEXT);
+    return getStringField(LockInfoAttribute.LOCK_ID.name(), DEFAULT_LOCK_ID_TEXT);
   }
 
   /**
@@ -224,7 +222,7 @@ public class LockInfo extends DataRecord {
    * if there is no client data set.
    */
   public String getClientData() {
-    return _dataRecord.getStringField(LockInfoAttribute.CLIENT_DATA.name(), DEFAULT_CLIENT_DATA);
+    return getStringField(LockInfoAttribute.CLIENT_DATA.name(), DEFAULT_CLIENT_DATA);
   }
 
   /**
@@ -233,7 +231,7 @@ public class LockInfo extends DataRecord {
    * if there is no grant time set
    */
   public Long getGrantedAt() {
-    return _dataRecord.getLongField(LockInfoAttribute.GRANTED_AT.name(), DEFAULT_GRANTED_AT_LONG);
+    return getLongField(LockInfoAttribute.GRANTED_AT.name(), DEFAULT_GRANTED_AT_LONG);
   }
 
   /**
@@ -242,7 +240,7 @@ public class LockInfo extends DataRecord {
    * if there is no renewal time set
    */
   public Long getLastRenewedAt() {
-    return _dataRecord.getLongField(LockInfoAttribute.LAST_RENEWED_AT.name(), DEFAULT_LAST_RENEWED_AT_LONG);
+    return getLongField(LockInfoAttribute.LAST_RENEWED_AT.name(), DEFAULT_LAST_RENEWED_AT_LONG);
   }
 
   /**
@@ -250,7 +248,7 @@ public class LockInfo extends DataRecord {
    * @return the expiring time of the lock, {@link #DEFAULT_TIMEOUT_DURATION} if there is no timeout set
    */
   public long getTimeout() {
-    return _dataRecord.getLongField(LockInfoAttribute.TIMEOUT.name(), DEFAULT_TIMEOUT_DURATION);
+    return getLongField(LockInfoAttribute.TIMEOUT.name(), DEFAULT_TIMEOUT_DURATION);
   }
 
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/recipes/lock/LockInfoSerializer.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/recipes/lock/LockInfoSerializer.java
@@ -22,10 +22,18 @@ package org.apache.helix.metaclient.recipes.lock;
 import org.apache.helix.metaclient.datamodel.DataRecord;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LockInfoSerializer extends ZNRecordSerializer {
+  private static final Logger LOG = LoggerFactory.getLogger(LockInfoSerializer.class);
   @Override
   public Object deserialize(byte[] bytes) {
-    return new LockInfo(new DataRecord((ZNRecord) super.deserialize(bytes)));
+    try {
+      return new LockInfo(new DataRecord((ZNRecord) super.deserialize(bytes)));
+    } catch (Exception e) {
+      LOG.error("Exception during deserialization of bytes: {}", new String(bytes), e);
+      return null;
+    }
   }
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/recipes/lock/LockInfoSerializer.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/recipes/lock/LockInfoSerializer.java
@@ -1,0 +1,31 @@
+package org.apache.helix.metaclient.recipes.lock;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.metaclient.datamodel.DataRecord;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
+
+public class LockInfoSerializer extends ZNRecordSerializer {
+  @Override
+  public Object deserialize(byte[] bytes) {
+    return new LockInfo(new DataRecord((ZNRecord) super.deserialize(bytes)));
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

LockClient currently uses ZNRecord serializer. Abstracting away any zookeeper specifics and keeping the code easier to understand, LockInfoSerializer is created to serialize and deserialize the LockInfo object used in LockClient.
Furthermore, the old LockInfo structure would show the simplefields as their own separate fields in ZooKeeper. Changing that so the ZNRecord represents all parameters of the lock in ZooKeeper as a field in SimpleFields.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Created the LockInfoSerializer which extends the ZNRecordSerializer. Modified LockClient to use this serializer and updated the LockClient test case to show that it works.
Modified the LockInfo object so that all fields appear as fields in simplefield in Zookeeper as opposed to it's own separate field.
### Tests

- [ ] The following tests are written for this issue:

LockClientTest.java

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
