### PR TITLE
Leader election client - Proactively send leader gone event when disconnect from ZK 

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionClient.java
@@ -258,6 +258,7 @@ public class LeaderElectionClient implements AutoCloseable {
     }
     // check if current participant is the leader
     // read data and stats, check, and multi check + delete
+    try{
     ImmutablePair<LeaderInfo, MetaClientInterface.Stat> tup = _metaClient.getDataAndStat(key);
     if (tup.left.getLeaderName().equalsIgnoreCase(_participant)) {
       int expectedVersion = tup.right.getVersion();
@@ -272,6 +273,8 @@ public class LeaderElectionClient implements AutoCloseable {
           LOG.info("Someone else is already leader");
         }
       }
+    }} catch (MetaClientNoNodeException ex) {
+      LOG.info("No Leader for participant pool {} when exit the pool", leaderPath);
     }
   }
 

--- a/meta-client/src/main/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionListenerInterfaceAdapter.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionListenerInterfaceAdapter.java
@@ -1,14 +1,18 @@
 package org.apache.helix.metaclient.recipes.leaderelection;
 
+import org.apache.helix.metaclient.api.ConnectStateChangeListener;
 import org.apache.helix.metaclient.api.DataChangeListener;
+import org.apache.helix.metaclient.api.MetaClientInterface;
 
 import static org.apache.helix.metaclient.recipes.leaderelection.LeaderElectionListenerInterface.ChangeType.*;
 
 
-public class LeaderElectionListenerInterfaceAdapter implements DataChangeListener {
+public class LeaderElectionListenerInterfaceAdapter implements DataChangeListener, ConnectStateChangeListener {
+  private String _leaderPath;
   private final LeaderElectionListenerInterface _leaderElectionListener;
 
-  public LeaderElectionListenerInterfaceAdapter(LeaderElectionListenerInterface leaderElectionListener) {
+  public LeaderElectionListenerInterfaceAdapter(String leaderPath, LeaderElectionListenerInterface leaderElectionListener) {
+    _leaderPath = leaderPath;
     _leaderElectionListener = leaderElectionListener;
   }
 
@@ -16,11 +20,12 @@ public class LeaderElectionListenerInterfaceAdapter implements DataChangeListene
   public void handleDataChange(String key, Object data, ChangeType changeType) throws Exception {
     switch (changeType) {
       case  ENTRY_CREATED:
+      case ENTRY_UPDATE:
         String newLeader = ((LeaderInfo) data).getLeaderName();
-        _leaderElectionListener.onLeadershipChange(key, LEADER_ACQUIRED, newLeader);
+        _leaderElectionListener.onLeadershipChange(_leaderPath, LEADER_ACQUIRED, newLeader);
         break;
       case ENTRY_DELETED:
-        _leaderElectionListener.onLeadershipChange(key, LEADER_LOST, "");
+        _leaderElectionListener.onLeadershipChange(_leaderPath, LEADER_LOST, "");
     }
   }
 
@@ -39,5 +44,21 @@ public class LeaderElectionListenerInterfaceAdapter implements DataChangeListene
   @Override
   public int hashCode() {
     return _leaderElectionListener.hashCode();
+  }
+
+  @Override
+  public void handleConnectStateChanged(MetaClientInterface.ConnectState prevState,
+      MetaClientInterface.ConnectState currentState) throws Exception {
+    if (currentState == MetaClientInterface.ConnectState.DISCONNECTED) {
+      // when disconnected, notify leader lost even though the ephmeral node is not gone until expire
+      // Leader election client will touch the node if reconnect before expire
+      _leaderElectionListener.onLeadershipChange(_leaderPath, LEADER_LOST, "");
+    }
+
+  }
+
+  @Override
+  public void handleConnectionEstablishmentError(Throwable error) throws Exception {
+
   }
 }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestConnectStateChangeListenerAndRetry.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestConnectStateChangeListenerAndRetry.java
@@ -52,7 +52,7 @@ import static org.apache.helix.metaclient.impl.zk.TestUtil.*;
 
 
 public class TestConnectStateChangeListenerAndRetry  {
-  protected static final String ZK_ADDR = "localhost:2181";
+  protected static final String ZK_ADDR = "localhost:2184";
   protected static ZkServer _zkServer;
 
 
@@ -62,11 +62,6 @@ public class TestConnectStateChangeListenerAndRetry  {
     System.out.println("START TestConnectStateChangeListenerAndRetry at " + new Date(System.currentTimeMillis()));
     // start local zookeeper server
     _zkServer = ZkMetaClientTestBase.startZkServer(ZK_ADDR);
-  }
-
-  @AfterTest
-  public void cleanUp() {
-    System.out.println("END TestConnectStateChangeListenerAndRetry at " + new Date(System.currentTimeMillis()));
   }
 
   @Test

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestConnectStateChangeListenerAndRetry.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestConnectStateChangeListenerAndRetry.java
@@ -48,32 +48,14 @@ import org.testng.annotations.Test;
 
 import static org.apache.helix.metaclient.constants.MetaClientConstants.DEFAULT_INIT_EXP_BACKOFF_RETRY_INTERVAL_MS;
 import static org.apache.helix.metaclient.constants.MetaClientConstants.DEFAULT_MAX_EXP_BACKOFF_RETRY_INTERVAL_MS;
+import static org.apache.helix.metaclient.impl.zk.TestUtil.*;
 
 
 public class TestConnectStateChangeListenerAndRetry  {
   protected static final String ZK_ADDR = "localhost:2181";
   protected static ZkServer _zkServer;
 
-  private static final long AUTO_RECONNECT_TIMEOUT_MS_FOR_TEST = 3 * 1000;
-  private static final long AUTO_RECONNECT_WAIT_TIME_WITHIN = 1 * 1000;
-  private static final long AUTO_RECONNECT_WAIT_TIME_EXD = 5 * 1000;
 
-  /**
-   * Simulate a zk state change by calling {@link ZkClient#process(WatchedEvent)} directly
-   * This need to be done in a separate thread to simulate ZkClient eventThread.
-   */
-  private static void simulateZkStateReconnected(ZkClient zkClient) throws InterruptedException {
-      WatchedEvent event =
-          new WatchedEvent(Watcher.Event.EventType.None, Watcher.Event.KeeperState.Disconnected,
-              null);
-      zkClient.process(event);
-
-      Thread.sleep(AUTO_RECONNECT_WAIT_TIME_WITHIN);
-
-      event = new WatchedEvent(Watcher.Event.EventType.None, Watcher.Event.KeeperState.SyncConnected,
-          null);
-      zkClient.process(event);
-  }
 
   @BeforeTest
   public void prepare() {
@@ -115,7 +97,7 @@ public class TestConnectStateChangeListenerAndRetry  {
         @Override
         public void run() {
           try {
-            simulateZkStateReconnected(zkMetaClient.getZkClient());
+            simulateZkStateReconnected(zkMetaClient);
           } catch (InterruptedException e) {
            Assert.fail("Exception in simulateZkStateReconnected", e);
           }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestConnectStateChangeListenerAndRetry.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestConnectStateChangeListenerAndRetry.java
@@ -152,6 +152,7 @@ public class TestConnectStateChangeListenerAndRetry  {
       } catch (Exception ex) {
         Assert.assertTrue(ex instanceof IllegalStateException);
       }
+      zkMetaClient.unsubscribeConnectStateChanges(listener);
     }
     System.out.println("END TestConnectStateChangeListenerAndRetry.testConnectStateChangeListener at " + new Date(System.currentTimeMillis()));
   }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestStressZkClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestStressZkClient.java
@@ -48,7 +48,8 @@ public class TestStressZkClient extends ZkMetaClientTestBase {
   }
 
   @AfterTest
-  private void tearDown() {
+  @Override
+  public void cleanUp() {
     this._zkMetaClient.close();
   }
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionPuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionPuppy.java
@@ -82,6 +82,11 @@ public class LeaderElectionPuppy extends AbstractPuppy {
       _leaderElectionClient.exitLeaderElectionParticipantPool(_leaderGroup);
     } catch (MetaClientException ignore) {
       // already leave the pool. OK to throw exception.
+    } finally {
+      try {
+        _leaderElectionClient.close();
+      } catch (Exception e) {
+      }
     }
   }
 }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
@@ -34,7 +34,7 @@ public class TestLeaderElection extends ZkMetaClientTestBase {
   public void cleanUp() {
     ZkMetaClientConfig config = new ZkMetaClientConfig.ZkMetaClientConfigBuilder().setConnectionAddress(ZK_ADDR)
         .build();
-    try (ZkMetaClient<ZNRecord> client = new ZkMetaClient<>(config);) {
+    try (ZkMetaClient<ZNRecord> client = new ZkMetaClient<>(config)) {
       client.recursiveDelete(LEADER_PATH);
     }
   }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
@@ -75,7 +75,8 @@ public class TestLeaderElection extends ZkMetaClientTestBase {
     clt2.close();
     System.out.println("END TestLeaderElection.testAcquireLeadership");
   }
-/*
+
+
   @Test (dependsOnMethods = "testAcquireLeadership")
   public void testElectionPoolMembership() throws Exception {
     System.out.println("START TestLeaderElection.testElectionPoolMembership");
@@ -266,9 +267,9 @@ public class TestLeaderElection extends ZkMetaClientTestBase {
     Assert.assertEquals(clt2.getParticipantInfo(leaderPath, PARTICIPANT_NAME2).getSimpleField("Key2"), "value2");
     System.out.println("END TestLeaderElection.testSessionExpire");
   }
-  */
 
-  @Test //(dependsOnMethods = "testSessionExpire")
+
+  @Test (dependsOnMethods = "testSessionExpire")
   public void testClientDisconnectAndReconnectBeforeExpire() throws Exception {
     System.out.println("START TestLeaderElection.testClientDisconnectAndReconnectBeforeExpire");
     String leaderPath = LEADER_PATH + "/testClientDisconnectAndReconnectBeforeExpire";

--- a/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
@@ -31,10 +31,12 @@ public class TestLeaderElection extends ZkMetaClientTestBase {
   }
 
   @AfterTest
+  @Override
   public void cleanUp() {
     ZkMetaClientConfig config = new ZkMetaClientConfig.ZkMetaClientConfigBuilder().setConnectionAddress(ZK_ADDR)
         .build();
     try (ZkMetaClient<ZNRecord> client = new ZkMetaClient<>(config)) {
+      client.connect();
       client.recursiveDelete(LEADER_PATH);
     }
   }
@@ -123,6 +125,8 @@ public class TestLeaderElection extends ZkMetaClientTestBase {
     clt2.exitLeaderElectionParticipantPool(leaderPath);
 
     Assert.assertNull(clt2.getParticipantInfo(leaderPath, PARTICIPANT_NAME2));
+    clt1.close();
+    clt2.close();
     System.out.println("END TestLeaderElection.testElectionPoolMembership");
   }
 
@@ -233,6 +237,9 @@ public class TestLeaderElection extends ZkMetaClientTestBase {
     }, MetaClientTestUtil.WAIT_DURATION));
 
     clt2.exitLeaderElectionParticipantPool(leaderPath);
+    clt1.close();
+    clt2.close();
+    clt3.close();
     System.out.println("END TestLeaderElection.testRelinquishLeadership");
   }
 
@@ -273,6 +280,8 @@ public class TestLeaderElection extends ZkMetaClientTestBase {
     Assert.assertEquals(clt2.getParticipantInfo(leaderPath, PARTICIPANT_NAME1).getSimpleField("Key1"), "value1");
     Assert.assertEquals(clt1.getParticipantInfo(leaderPath, PARTICIPANT_NAME2).getSimpleField("Key2"), "value2");
     Assert.assertEquals(clt2.getParticipantInfo(leaderPath, PARTICIPANT_NAME2).getSimpleField("Key2"), "value2");
+    clt1.close();
+    clt2.close();
     System.out.println("END TestLeaderElection.testSessionExpire");
   }
 
@@ -326,6 +335,8 @@ public class TestLeaderElection extends ZkMetaClientTestBase {
 
     clt1.exitLeaderElectionParticipantPool(leaderPath);
     clt2.exitLeaderElectionParticipantPool(leaderPath);
+    clt1.close();
+    clt2.close();
     System.out.println("END TestLeaderElection.testClientDisconnectAndReconnectBeforeExpire");
   }
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestMultiClientLeaderElection.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestMultiClientLeaderElection.java
@@ -51,11 +51,14 @@ public class TestMultiClientLeaderElection extends ZkMetaClientTestBase {
     _zkMetaClient.create("/Parent/a", "");
   }
   @AfterTest
+  @Override
   public void cleanUp() {
     try {
       _zkMetaClient.recursiveDelete(_leaderElectionGroup);
     } catch (MetaClientException ex) {
       _zkMetaClient.recursiveDelete(_leaderElectionGroup);
+    } finally {
+      _zkMetaClient.close();
     }
   }
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2237 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

MetaClient may get disconnected from underlying storage and get reconnected before session expire. The leader ephemeral node get's deleted only when session expire. However, on client side, client will only get 'session expired' event when connection is re-established. It will be too late if we send leader gone event when we get expire event.
We need to Proactively send leader gone event to prevent to prevent double leader.

### Tests

- [X] The following tests are written for this issue:

testClientDisconnectAndReconnectBeforeExpire

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.751 s - in org.apache.helix.controller.strategy.crushMapping.TestCardDealingAdjustmentAlgorithmV2
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0


```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
