### PR TITLE
Instance Evacuation operation sanity check

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -265,14 +265,14 @@ public class InstanceConfig extends HelixProperty {
    */
   public void setInstanceEnabled(boolean enabled) {
     // set instance operation only when we need to change InstanceEnabled value.
-    // When enabling an instance where HELIX_ENABLED is false, we update INSTANCE_OPERATION to 'ENABLE'
-    // When disabling and instance where HELIX_ENABLED is false, we overwrite what current operation and
+    // When enabling an instance where current HELIX_ENABLED is false, we update INSTANCE_OPERATION to 'ENABLE'
+    // When disabling and instance where current HELIX_ENABLED is false, we overwrite what current operation and
     // update INSTANCE_OPERATION to 'DISABLE'.
     String instanceOperationKey = InstanceConfigProperty.INSTANCE_OPERATION.toString();
-    if (enabled != getInstanceEnabled() && _record.getSimpleField(instanceOperationKey) != null) {
+    if (enabled != getInstanceEnabled()) {
       _record.setSimpleField(instanceOperationKey,
-          enabled ? InstanceConstants.InstanceOperation.ENABLE.toString()
-              : InstanceConstants.InstanceOperation.DISABLE.toString());
+          enabled ? InstanceConstants.InstanceOperation.ENABLE.name()
+              : InstanceConstants.InstanceOperation.DISABLE.name());
     }
     setInstanceEnabledHelper(enabled);
   }
@@ -345,11 +345,9 @@ public class InstanceConfig extends HelixProperty {
 
   public void setInstanceOperation(InstanceConstants.InstanceOperation operation) {
     if (operation != InstanceConstants.InstanceOperation.DISABLE
-        && operation != InstanceConstants.InstanceOperation.ENABLE) {
-      if (!getInstanceEnabled()) {
-        throw new HelixException(
-            "setting non enable/disable operation (e.g. evacuate, swap) to helix disabled instance is not allowed");
-      }
+        && operation != InstanceConstants.InstanceOperation.ENABLE && !getInstanceEnabled()) {
+      throw new HelixException(
+          "setting non enable/disable operation (e.g. evacuate, swap) to helix disabled instance is not allowed");
     } else {
       setInstanceEnabledHelper(operation == InstanceConstants.InstanceOperation.ENABLE);
     }

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -264,9 +264,22 @@ public class InstanceConfig extends HelixProperty {
    * @param enabled true to enable, false to disable
    */
   public void setInstanceEnabled(boolean enabled) {
+    // set instance operation only when we need to change InstanceEnabled value.
+    // When enabling an instance where HELIX_ENABLED is false, we update INSTANCE_OPERATION to 'ENABLE'
+    // When disabling and instance where HELIX_ENABLED is false, we overwrite what current operation and
+    // update INSTANCE_OPERATION to 'DISABLE'.
+    String instanceOperationKey = InstanceConfigProperty.INSTANCE_OPERATION.toString();
+    if (enabled != getInstanceEnabled() && _record.getSimpleField(instanceOperationKey) != null) {
+      _record.setSimpleField(instanceOperationKey,
+          enabled ? InstanceConstants.InstanceOperation.ENABLE.toString()
+              : InstanceConstants.InstanceOperation.DISABLE.toString());
+    }
+    setInstanceEnabledHelper(enabled);
+  }
+
+  private void setInstanceEnabledHelper(boolean enabled) {
     _record.setBooleanField(InstanceConfigProperty.HELIX_ENABLED.toString(), enabled);
-    _record.setLongField(InstanceConfigProperty.HELIX_ENABLED_TIMESTAMP.name(),
-        System.currentTimeMillis());
+    _record.setLongField(InstanceConfigProperty.HELIX_ENABLED_TIMESTAMP.name(), System.currentTimeMillis());
     if (enabled) {
       resetInstanceDisabledTypeAndReason();
     }
@@ -331,10 +344,17 @@ public class InstanceConfig extends HelixProperty {
   }
 
   public void setInstanceOperation(InstanceConstants.InstanceOperation operation) {
-    // TODO: also setInstanceEnabled after sanity check.
+    if (operation != InstanceConstants.InstanceOperation.DISABLE
+        && operation != InstanceConstants.InstanceOperation.ENABLE) {
+      if (!getInstanceEnabled()) {
+        throw new HelixException(
+            "setting non enable/disable operation (e.g. evacuate, swap) to helix disabled instance is not allowed");
+      }
+    } else {
+      setInstanceEnabledHelper(operation == InstanceConstants.InstanceOperation.ENABLE);
+    }
 
-    _record.setSimpleField(InstanceConfigProperty.INSTANCE_OPERATION.name(),
-        operation.name());
+    _record.setSimpleField(InstanceConfigProperty.INSTANCE_OPERATION.toString(), operation.toString());
   }
 
   public String getInstanceOperation() {
@@ -361,6 +381,7 @@ public class InstanceConfig extends HelixProperty {
 
   /**
    * Check if this instance is enabled for a given partition
+   *
    * @param partition the partition name to check
    * @return true if the instance is enabled for the partition, false otherwise
    */

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -345,9 +345,11 @@ public class InstanceConfig extends HelixProperty {
 
   public void setInstanceOperation(InstanceConstants.InstanceOperation operation) {
     if (operation != InstanceConstants.InstanceOperation.DISABLE
-        && operation != InstanceConstants.InstanceOperation.ENABLE && !getInstanceEnabled()) {
-      throw new HelixException(
-          "setting non enable/disable operation (e.g. evacuate, swap) to helix disabled instance is not allowed");
+        && operation != InstanceConstants.InstanceOperation.ENABLE ){
+       if( !getInstanceEnabled()) {
+         throw new HelixException(
+             "setting non enable/disable operation (e.g. evacuate, swap) to helix disabled instance is not allowed");
+       }
     } else {
       setInstanceEnabledHelper(operation == InstanceConstants.InstanceOperation.ENABLE);
     }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -497,6 +497,27 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
         .expectedReturnStatusCode(Response.Status.NOT_FOUND.getStatusCode()).format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
     new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=setInstanceOperation")
         .expectedReturnStatusCode(Response.Status.BAD_REQUEST.getStatusCode()).format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
+    // TODO: enable the following test when we add sanity check.
+    // set operation to be DISABLE
+    new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=setInstanceOperation&instanceOperation=DISABLE")
+        .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
+    instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME);
+    Assert.assertEquals(
+        instanceConfig.getInstanceOperation(), InstanceConstants.InstanceOperation.DISABLE.toString());
+    Assert.assertTrue(!instanceConfig.getInstanceEnabled());
+
+    // set operation to EVACUATE, expect error
+    new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=setInstanceOperation&instanceOperation=EVACUATE")
+        .expectedReturnStatusCode(Response.Status.BAD_REQUEST.getStatusCode())
+        .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
+    // set back to enable
+    new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=setInstanceOperation&instanceOperation=ENABLE")
+        .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
+    instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME);
+    Assert.assertEquals(
+        instanceConfig.getInstanceOperation(), InstanceConstants.InstanceOperation.ENABLE.toString());
+    Assert.assertTrue(instanceConfig.getInstanceEnabled());
+
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2589

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR add sanity check when user set instance operation.

### Tests

- [X] The following tests are written for this issue:

TestPerInstanceAccessor.updateInstance

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
