### PR TITLE
[apache/helix] -- fixes #2590 Removed resetting of the missingTopStatePartitionsBeyondThresholdGauge to avoid incorrect accounting.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
@@ -494,6 +494,9 @@ public class TopStateHandoffReportStage extends AbstractBaseStage {
 
     // In case of recovery after failure, we should decrement the missingTopStateBeyondThresholdGauge value.
     if (clusterStatusMonitor != null && record.isFailed()) {
+      LogUtil.logInfo(LOG, _eventId, String.format(
+          "Missing top state recovered for resource %s and partition %s. Decrementing missingTopStateBeyondThresholdGauge.",
+          resourceName, partition.getPartitionName()));
       clusterStatusMonitor.decrementMissingTopStateBeyondThresholdGauge(resourceName);
     }
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -480,7 +480,6 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   public void resetMaxTopStateHandoffGauge() {
     if (_lastResetTime + DEFAULT_RESET_INTERVAL_MS <= System.currentTimeMillis()) {
       _maxSinglePartitionTopStateHandoffDuration.updateValue(0L);
-      _missingTopStatePartitionsBeyondThresholdGauge.updateValue(0L);
       _lastResetTime = System.currentTimeMillis();
     }
   }
@@ -491,7 +490,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   }
 
   public void decrementMissingTopStateBeyondThresholdGauge() {
-    _missingTopStatePartitionsBeyondThresholdGauge.updateValue(_missingTopStatePartitionsBeyondThresholdGauge.getValue() - 1);
+    _missingTopStatePartitionsBeyondThresholdGauge.updateValue(Math.max(0, _missingTopStatePartitionsBeyondThresholdGauge.getValue() - 1));
     _lastResetTime = System.currentTimeMillis();
   }
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
#2590

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
We encountered that with resetting of the the `missingTopStatePartitionsBeyondThresholdGauge` to 0 have created several problems:
* Missed Events to Ingraphs: If the value of `missingTopStatePartitionsBeyondThresholdGauge` gets reset to 0 before the refresh rate of Ingraph metric collector.
* Negative Value in Metrics: If the top-state instance bounces back after the reset, the decrement will bring the value to Negative. We have also added a check to ensure that no negative value ever gets set.

### Tests
- [X] The following tests are written for this issue:
* Updated TestTopStateHandoffMetrics.testTopStateFailedHandoff
* Added TestTopStateHandoffMetrics.testTopStateFailedUnrecoveredHandoff

- The following is the result of the "mvn test" command on the appropriate module:
```console
[INFO] Results:
[INFO] 
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 799 classes
[WARNING] Classes in bundle 'Apache Helix :: Core' do not match with execution data. For report generation the same class files must be used as at runtime.
[WARNING] Execution data for class org/apache/helix/controller/rebalancer/waged/WagedRebalancer does not match.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  27.585 s
[INFO] Finished at: 2023-08-21T17:30:55-07:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
