### PR TITLE
Add method to create full key path if it does not exist

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -157,9 +157,9 @@ public interface MetaClientInterface<T> {
    * hierarchy does not exist, then the parent node will attempt to be created. The entry will not be created if
    * there is an existing entry with the same full key.
    */
-  void createFullPath(final String key, final T Data, final EntryMode mode);
+  void recursiveCreate(final String key, final T Data, final EntryMode mode);
 
-  void createFullPathWithTTL(String key, T data, long ttl);
+  void recursiveCreateWithTTL(String key, T data, long ttl);
 
   /**
    * Create an entry of given EntryMode with given key, data, and expiry time (ttl).

--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -153,6 +153,15 @@ public interface MetaClientInterface<T> {
   void create(final String key, final T data, final EntryMode mode);
 
   /**
+   * Create an entry of given EntryMode with given key and data. If any parent node in the node
+   * hierarchy does not exist, then the parent node will attempt to be created. The entry will not be created if
+   * there is an existing entry with the same full key.
+   */
+  void createFullPath(final String key, final T Data, final EntryMode mode);
+
+  void createFullPathWithTTL(String key, T data, long ttl);
+
+  /**
    * Create an entry of given EntryMode with given key, data, and expiry time (ttl).
    * The entry will automatically purge when reached expiry time and has no children.
    * The entry will not be created if there is an existing entry with the same key.

--- a/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/api/MetaClientInterface.java
@@ -154,11 +154,17 @@ public interface MetaClientInterface<T> {
 
   /**
    * Create an entry of given EntryMode with given key and data. If any parent node in the node
-   * hierarchy does not exist, then the parent node will attempt to be created. The entry will not be created if
-   * there is an existing entry with the same full key.
+   * hierarchy does not exist, then the parent node will attempt to be created. The entry will not
+   * be created if there is an existing entry with the same full key. Ephemeral nodes cannot have
+   * children, so only the final child in the created path will be ephemeral.
    */
   void recursiveCreate(final String key, final T Data, final EntryMode mode);
 
+  /**
+   * Create a TTL entry with given key, data, and expiry time (ttl). If any parent node in the node
+   * hierarchy does not exist, then the parent node will attempt to be created. The entry will not be created if
+   * there is an existing entry with the same full key.
+   */
   void recursiveCreateWithTTL(String key, T data, long ttl);
 
   /**

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -58,7 +58,6 @@ import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.helix.zookeeper.zkclient.IZkStateListener;
 import org.apache.helix.zookeeper.zkclient.ZkConnection;
 import org.apache.helix.zookeeper.zkclient.exception.ZkException;
-import org.apache.helix.zookeeper.zkclient.exception.ZkNodeExistsException;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Watcher;

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -144,7 +144,8 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
           create(nodePaths.get(i), data, i == 0 ? mode : parentMode);
         }
         break;
-        // NoNodeException thrown when parent path does not exist. We want to
+        // NoNodeException thrown when parent path does not exist. We allow this and re-attempt
+        // creation of these nodes below
       } catch (MetaClientNoNodeException ignoredParentDoesntExistException) {
         i++;
       }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -121,6 +121,8 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
   public void createFullPath(String key, Object data, MetaClientInterface.EntryMode mode) {
 
     boolean retry;
+    MetaClientInterface.EntryMode parentMode = (EntryMode.EPHEMERAL.equals(mode) ?
+        EntryMode.PERSISTENT : mode);
     do {
       retry = false;
       try {
@@ -129,7 +131,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
         retry = true;
         String parentPath = getZkParentPath(key);
         try {
-          createFullPath(parentPath, null, mode);
+          createFullPath(parentPath, null, parentMode);
         } catch (MetaClientNodeExistsException e1) {
           return;
         }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -129,7 +129,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
 
   private void recursiveCreateHelper(String key, T data, EntryMode mode, long ttl) {
     boolean retry;
-    // Ephemeral nodes cannot have children, so we will creatie PERSISTENT nodes as the parents
+    // Ephemeral nodes cannot have children, so we will create PERSISTENT nodes as the parents
     EntryMode parentMode = (EntryMode.EPHEMERAL.equals(mode) ?
         EntryMode.PERSISTENT : mode);
 

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -161,7 +161,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
       }
     }
 
-    // Reattempt creation of children that failed due to NoNodeException
+    // Reattempt creation of children that failed due to parent not existing
     while (--i >= 0) {
       try {
         if (EntryMode.TTL.equals(mode)) {

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -150,7 +150,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
         // Race condition may occur where a  node is created by another thread in between loops.
         // We should not throw error if this occurs for parent nodes, only for the full node path.
         } catch (MetaClientNodeExistsException e) {
-          if (i != 0) {
+          if (i == 0) {
             throw e;
           }
         }
@@ -171,7 +171,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
         }
       // Catch same race condition as above
       } catch (MetaClientNodeExistsException e) {
-        if (i != 0) {
+        if (i == 0) {
           throw e;
         }
       }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
@@ -367,4 +367,16 @@ public class ZkMetaClientUtil {
     int idx = path.lastIndexOf('/');
     return idx == 0 ? "/" : path.substring(0, idx);
   }
+
+  // Splits a path into the paths for each node along the way.
+  // /a/b/c --> /a/b/c, /a/b, /a
+  public static List<String> separateIntoUniqueNodePaths(String path) {
+    ArrayList<String> nodePaths = new ArrayList<>();
+    String tempStr = path;
+    while (tempStr.length() > 1) {
+      nodePaths.add(tempStr);
+      tempStr = getZkParentPath(tempStr);
+    }
+    return nodePaths;
+  }
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
@@ -358,4 +358,13 @@ public class ZkMetaClientUtil {
         return MetaClientException.ReturnCode.DB_USER_ERROR;
     }
   }
+
+  public static String getZkParentPath(String path) {
+    if (path.equals("/")) {
+      return null;
+    }
+
+    int idx = path.lastIndexOf('/');
+    return idx == 0 ? "/" : path.substring(0, idx);
+  }
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/util/ZkMetaClientUtil.java
@@ -20,6 +20,7 @@ package org.apache.helix.metaclient.impl.zk.util;
  */
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -359,24 +360,27 @@ public class ZkMetaClientUtil {
     }
   }
 
+  // Returns null if no parent path
   public static String getZkParentPath(String path) {
-    if (path.equals("/")) {
-      return null;
-    }
-
     int idx = path.lastIndexOf('/');
-    return idx == 0 ? "/" : path.substring(0, idx);
+    return idx == 0 ? null : path.substring(0, idx);
   }
 
   // Splits a path into the paths for each node along the way.
   // /a/b/c --> /a/b/c, /a/b, /a
   public static List<String> separateIntoUniqueNodePaths(String path) {
-    ArrayList<String> nodePaths = new ArrayList<>();
-    String tempStr = path;
-    while (tempStr.length() > 1) {
-      nodePaths.add(tempStr);
-      tempStr = getZkParentPath(tempStr);
+    if (path == null || "/".equals(path)) {
+      return null;
     }
-    return nodePaths;
+
+    String[] subPath = path.split("/");
+    String[] nodePaths = new String[subPath.length-1];
+    StringBuilder tempPath = new StringBuilder();
+    for (int i = 1; i < subPath.length; i++) {
+      tempPath.append( "/");
+      tempPath.append(subPath[i]);
+      nodePaths[subPath.length - 1 - i] = tempPath.toString();
+    }
+    return Arrays.asList(nodePaths);
   }
 }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestStressZkClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestStressZkClient.java
@@ -19,8 +19,6 @@ package org.apache.helix.metaclient.impl.zk;
  * under the License.
  */
 
-import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -137,7 +135,7 @@ public class TestStressZkClient extends ZkMetaClientTestBase {
     final String zkParentKey = "/stressZk_testCreateFullPath";
     _zkMetaClient.create(zkParentKey, ENTRY_STRING_VALUE);
 
-    int count = (int) Math.pow(TEST_ITERATION_COUNT, 1/3);
+    int count = (int) Math.pow(TEST_ITERATION_COUNT, 1/3d);
     for (int i = 0; i < count; i++) {
 
       for (int j = 0; j < count; j++) {
@@ -155,6 +153,7 @@ public class TestStressZkClient extends ZkMetaClientTestBase {
       }
     }
 
+    System.out.println("count is: " + count);
     // cleanup
     _zkMetaClient.recursiveDelete(zkParentKey);
     Assert.assertEquals(_zkMetaClient.countDirectChildren(zkParentKey), 0);

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestStressZkClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestStressZkClient.java
@@ -153,7 +153,6 @@ public class TestStressZkClient extends ZkMetaClientTestBase {
       }
     }
 
-    System.out.println("count is: " + count);
     // cleanup
     _zkMetaClient.recursiveDelete(zkParentKey);
     Assert.assertEquals(_zkMetaClient.countDirectChildren(zkParentKey), 0);

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestStressZkClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestStressZkClient.java
@@ -131,8 +131,8 @@ public class TestStressZkClient extends ZkMetaClientTestBase {
   }
 
   @Test
-  public void recursiveCreate() {
-    final String zkParentKey = "/stressZk_testCreateFullPath";
+  public void testRecursiveCreate() {
+    final String zkParentKey = "/stressZk_testRecursiveCreate";
     _zkMetaClient.create(zkParentKey, ENTRY_STRING_VALUE);
 
     int count = (int) Math.pow(TEST_ITERATION_COUNT, 1/3d);

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestStressZkClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestStressZkClient.java
@@ -131,7 +131,7 @@ public class TestStressZkClient extends ZkMetaClientTestBase {
   }
 
   @Test
-  public void testCreateFullPath() {
+  public void recursiveCreate() {
     final String zkParentKey = "/stressZk_testCreateFullPath";
     _zkMetaClient.create(zkParentKey, ENTRY_STRING_VALUE);
 
@@ -142,12 +142,12 @@ public class TestStressZkClient extends ZkMetaClientTestBase {
 
         for (int k = 0; k < count; k++) {
           String key = zkParentKey + "/" + i + "/" + j + "/" + k;
-          _zkMetaClient.createFullPath(key, String.valueOf(k), PERSISTENT);
+          _zkMetaClient.recursiveCreate(key, String.valueOf(k), PERSISTENT);
           Assert.assertEquals(String.valueOf(k), _zkMetaClient.get(key));
         }
       }
       try {
-        _zkMetaClient.createFullPath(zkParentKey + "/" + i, "should_fail", PERSISTENT);
+        _zkMetaClient.recursiveCreate(zkParentKey + "/" + i, "should_fail", PERSISTENT);
         Assert.fail("Should have failed due to node existing");
       } catch (MetaClientNodeExistsException ignoredException) {
       }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -106,21 +106,22 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
 
     try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
       zkMetaClient.connect();
+      MetaClientInterface.EntryMode mode = EPHEMERAL;
 
       // Should succeed even if one of the parent nodes exists
       String extendedPath = "/A" + path;
       zkMetaClient.create("/A", ENTRY_STRING_VALUE, PERSISTENT);
-      zkMetaClient.recursiveCreate(extendedPath, ENTRY_STRING_VALUE, EPHEMERAL);
+      zkMetaClient.recursiveCreate(extendedPath, ENTRY_STRING_VALUE, mode);
       Assert.assertNotNull(zkMetaClient.exists(extendedPath));
 
       // Should succeed if no parent nodes exist
-      zkMetaClient.recursiveCreate(path, ENTRY_STRING_VALUE, EPHEMERAL);
+      zkMetaClient.recursiveCreate(path, ENTRY_STRING_VALUE, mode);
       Assert.assertNotNull(zkMetaClient.exists(path));
       Assert.assertEquals(zkMetaClient.getDataAndStat("/Test").getRight().getEntryType(), PERSISTENT);
-      Assert.assertEquals(zkMetaClient.getDataAndStat(path).getRight().getEntryType(), EPHEMERAL);
+      Assert.assertEquals(zkMetaClient.getDataAndStat(path).getRight().getEntryType(), mode);
 
       // Should throw NodeExistsException if child node exists
-      zkMetaClient.recursiveCreate(path, ENTRY_STRING_VALUE, EPHEMERAL);
+      zkMetaClient.recursiveCreate(path, ENTRY_STRING_VALUE, mode);
       Assert.fail("Should have failed due to node already created");
     } catch (MetaClientException e) {
       Assert.assertEquals(e.getMessage(), "org.apache.helix.zookeeper.zkclient.exception.ZkNodeExistsException: org.apache.zookeeper.KeeperException$NodeExistsException: KeeperErrorCode = NodeExists for /Test/ZkMetaClient/_fullPath");

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -51,6 +51,7 @@ import org.testng.annotations.Test;
 
 import static org.apache.helix.metaclient.api.DataChangeListener.ChangeType.ENTRY_UPDATE;
 import static org.apache.helix.metaclient.api.MetaClientInterface.EntryMode.CONTAINER;
+import static org.apache.helix.metaclient.api.MetaClientInterface.EntryMode.EPHEMERAL;
 import static org.apache.helix.metaclient.api.MetaClientInterface.EntryMode.PERSISTENT;
 
 
@@ -111,7 +112,7 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
     // final String key = "/Test/ZkMetaClient/_fullPath";
     try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
       zkMetaClient.connect();
-      zkMetaClient.createFullPath(key, ENTRY_STRING_VALUE, PERSISTENT);
+      zkMetaClient.createFullPath(key, ENTRY_STRING_VALUE, EPHEMERAL);
       Assert.assertNotNull(zkMetaClient.exists(key));
     }
   }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -100,7 +100,7 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
   }
 
   @Test
-  public void testCreateFullPath() {
+  public void testRecursiveCreate() {
     final List<String> nodes = new ArrayList<>(Arrays.asList("Test", "ZkMetaClient", "_fullPath"));
     StringWriter sw = new StringWriter();
 
@@ -112,13 +112,20 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
     // final String key = "/Test/ZkMetaClient/_fullPath";
     try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
       zkMetaClient.connect();
-      zkMetaClient.createFullPath(key, ENTRY_STRING_VALUE, EPHEMERAL);
+      zkMetaClient.recursiveCreate(key, ENTRY_STRING_VALUE, EPHEMERAL);
       Assert.assertNotNull(zkMetaClient.exists(key));
+
+      zkMetaClient.recursiveCreate(key, ENTRY_STRING_VALUE, EPHEMERAL);
+      Assert.fail("Should have failed due to node already created");
+    } catch (MetaClientException e) {
+      Assert.assertEquals(e.getMessage(), "org.apache.helix.zookeeper.zkclient.exception.ZkNodeExistsException: org.apache.zookeeper.KeeperException$NodeExistsException: KeeperErrorCode = NodeExists for /Test/ZkMetaClient/_fullPath");
+      System.out.println(e.getMessage());
     }
+
   }
 
   @Test
-  public void testCreateFullPathWithTTL() {
+  public void testRecursiveCreateWithTTL() {
     final List<String> nodes = new ArrayList<>(Arrays.asList("Test", "ZkMetaClient", "_fullPath"));
     StringWriter sw = new StringWriter();
     for (String node : nodes) {
@@ -129,7 +136,7 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
 
     try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
       zkMetaClient.connect();
-      zkMetaClient.createFullPathWithTTL(key, ENTRY_STRING_VALUE, 1000);
+      zkMetaClient.recursiveCreateWithTTL(key, ENTRY_STRING_VALUE, 1000);
       Assert.assertNotNull(zkMetaClient.exists(key));
     }
   }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -26,6 +26,8 @@ import org.apache.helix.metaclient.api.MetaClientInterface;
 import org.apache.helix.metaclient.exception.MetaClientException;
 import org.apache.helix.metaclient.api.DirectChildChangeListener;
 
+import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -93,6 +95,41 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
     try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
       zkMetaClient.connect();
       zkMetaClient.createWithTTL(key, ENTRY_STRING_VALUE, 1000);
+      Assert.assertNotNull(zkMetaClient.exists(key));
+    }
+  }
+
+  @Test
+  public void testCreateFullPath() {
+    final List<String> nodes = new ArrayList<>(Arrays.asList("Test", "ZkMetaClient", "_fullPath"));
+    StringWriter sw = new StringWriter();
+
+    for (String node : nodes) {
+      sw.write("/");
+      sw.write(node);
+    }
+    final String key = sw.toString();
+    // final String key = "/Test/ZkMetaClient/_fullPath";
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      zkMetaClient.connect();
+      zkMetaClient.createFullPath(key, ENTRY_STRING_VALUE, PERSISTENT);
+      Assert.assertNotNull(zkMetaClient.exists(key));
+    }
+  }
+
+  @Test
+  public void testCreateFullPathWithTTL() {
+    final List<String> nodes = new ArrayList<>(Arrays.asList("Test", "ZkMetaClient", "_fullPath"));
+    StringWriter sw = new StringWriter();
+    for (String node : nodes) {
+      sw.write("/");
+      sw.write(node);
+    }
+    final String key = sw.toString();
+
+    try (ZkMetaClient<String> zkMetaClient = createZkMetaClient()) {
+      zkMetaClient.connect();
+      zkMetaClient.createFullPathWithTTL(key, ENTRY_STRING_VALUE, 1000);
       Assert.assertNotNull(zkMetaClient.exists(key));
     }
   }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -40,7 +40,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.helix.metaclient.api.ConnectStateChangeListener;
 import org.apache.helix.metaclient.api.DataChangeListener;
 import org.apache.helix.metaclient.api.Op;
 import org.apache.helix.metaclient.api.OpResult;


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Metaclient currently does not offer the functionality of attempting to create a key's parents if they do not exist.
I'd like to expose a method that does the following:
Assume no nodes have been created
createFullPath("/a/b/c/d", data)
This would then create nodes /a, /b, and /c with null values and lastly create node /d with the data passed in.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add functionality to create the full path to a key if the path does not already exist. 

### Tests

- [x] The following tests are written for this issue:

Added unit tests to both TestStressZkClient.Java and TestZkMetaClient.java

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

None. Only new method

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

No documentation added

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
