### PR TITLE
Add support for providing default Instance Config to be used with auto-join and auto-reg

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
@@ -20,8 +20,10 @@ package org.apache.helix;
  */
 
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 import org.apache.helix.model.CloudConfig;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +37,7 @@ public class HelixManagerProperty {
   private String _version;
   private long _healthReportLatency;
   private HelixCloudProperty _helixCloudProperty;
+  private InstanceConfig _defaultInstanceConfig;
   private RealmAwareZkClient.RealmAwareZkConnectionConfig _zkConnectionConfig;
   private RealmAwareZkClient.RealmAwareZkClientConfig _zkClientConfig;
 
@@ -55,12 +58,13 @@ public class HelixManagerProperty {
   }
 
   private HelixManagerProperty(String version, long healthReportLatency,
-      HelixCloudProperty helixCloudProperty,
+      HelixCloudProperty helixCloudProperty, InstanceConfig defaultInstanceConfig,
       RealmAwareZkClient.RealmAwareZkConnectionConfig zkConnectionConfig,
       RealmAwareZkClient.RealmAwareZkClientConfig zkClientConfig) {
     _version = version;
     _healthReportLatency = healthReportLatency;
     _helixCloudProperty = helixCloudProperty;
+    _defaultInstanceConfig = defaultInstanceConfig;
     _zkConnectionConfig = zkConnectionConfig;
     _zkClientConfig = zkClientConfig;
   }
@@ -70,6 +74,11 @@ public class HelixManagerProperty {
       _helixCloudProperty = new HelixCloudProperty(new CloudConfig());
     }
     return _helixCloudProperty;
+  }
+
+  @Nullable
+  public InstanceConfig getDefaultInstanceConfig() {
+    return _defaultInstanceConfig;
   }
 
   public String getVersion() {
@@ -92,6 +101,7 @@ public class HelixManagerProperty {
     private String _version;
     private long _healthReportLatency;
     private HelixCloudProperty _helixCloudProperty;
+    private InstanceConfig _defaultInstanceConfig;
     private RealmAwareZkClient.RealmAwareZkConnectionConfig _zkConnectionConfig;
     private RealmAwareZkClient.RealmAwareZkClientConfig _zkClientConfig;
 
@@ -100,7 +110,7 @@ public class HelixManagerProperty {
 
     public HelixManagerProperty build() {
       return new HelixManagerProperty(_version, _healthReportLatency, _helixCloudProperty,
-          _zkConnectionConfig, _zkClientConfig);
+          _defaultInstanceConfig, _zkConnectionConfig, _zkClientConfig);
     }
 
     public Builder setVersion(String version) {
@@ -115,6 +125,11 @@ public class HelixManagerProperty {
 
     public Builder setHelixCloudProperty(HelixCloudProperty helixCloudProperty) {
       _helixCloudProperty = helixCloudProperty;
+      return this;
+    }
+
+    public Builder setDefaultInstanceConfig(InstanceConfig defaultInstanceConfig) {
+      _defaultInstanceConfig = defaultInstanceConfig;
       return this;
     }
 

--- a/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixManagerProperty.java
@@ -20,7 +20,6 @@ package org.apache.helix;
  */
 
 import java.util.Properties;
-import javax.annotation.Nullable;
 
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.InstanceConfig;
@@ -37,7 +36,7 @@ public class HelixManagerProperty {
   private String _version;
   private long _healthReportLatency;
   private HelixCloudProperty _helixCloudProperty;
-  private InstanceConfig _defaultInstanceConfig;
+  private InstanceConfig.Builder _defaultInstanceConfigBuilder;
   private RealmAwareZkClient.RealmAwareZkConnectionConfig _zkConnectionConfig;
   private RealmAwareZkClient.RealmAwareZkClientConfig _zkClientConfig;
 
@@ -58,13 +57,13 @@ public class HelixManagerProperty {
   }
 
   private HelixManagerProperty(String version, long healthReportLatency,
-      HelixCloudProperty helixCloudProperty, InstanceConfig defaultInstanceConfig,
+      HelixCloudProperty helixCloudProperty, InstanceConfig.Builder defaultInstanceConfig,
       RealmAwareZkClient.RealmAwareZkConnectionConfig zkConnectionConfig,
       RealmAwareZkClient.RealmAwareZkClientConfig zkClientConfig) {
     _version = version;
     _healthReportLatency = healthReportLatency;
     _helixCloudProperty = helixCloudProperty;
-    _defaultInstanceConfig = defaultInstanceConfig;
+    _defaultInstanceConfigBuilder = defaultInstanceConfig;
     _zkConnectionConfig = zkConnectionConfig;
     _zkClientConfig = zkClientConfig;
   }
@@ -76,9 +75,11 @@ public class HelixManagerProperty {
     return _helixCloudProperty;
   }
 
-  @Nullable
-  public InstanceConfig getDefaultInstanceConfig() {
-    return _defaultInstanceConfig;
+  public InstanceConfig.Builder getDefaultInstanceConfigBuilder() {
+    if (_defaultInstanceConfigBuilder == null) {
+      _defaultInstanceConfigBuilder = new InstanceConfig.Builder();
+    }
+    return _defaultInstanceConfigBuilder;
   }
 
   public String getVersion() {
@@ -101,7 +102,7 @@ public class HelixManagerProperty {
     private String _version;
     private long _healthReportLatency;
     private HelixCloudProperty _helixCloudProperty;
-    private InstanceConfig _defaultInstanceConfig;
+    private InstanceConfig.Builder _defaultInstanceConfigBuilder;
     private RealmAwareZkClient.RealmAwareZkConnectionConfig _zkConnectionConfig;
     private RealmAwareZkClient.RealmAwareZkClientConfig _zkClientConfig;
 
@@ -110,7 +111,7 @@ public class HelixManagerProperty {
 
     public HelixManagerProperty build() {
       return new HelixManagerProperty(_version, _healthReportLatency, _helixCloudProperty,
-          _defaultInstanceConfig, _zkConnectionConfig, _zkClientConfig);
+          _defaultInstanceConfigBuilder, _zkConnectionConfig, _zkClientConfig);
     }
 
     public Builder setVersion(String version) {
@@ -128,8 +129,9 @@ public class HelixManagerProperty {
       return this;
     }
 
-    public Builder setDefaultInstanceConfig(InstanceConfig defaultInstanceConfig) {
-      _defaultInstanceConfig = defaultInstanceConfig;
+    public Builder setDefaultInstanceConfigBuilder(
+        InstanceConfig.Builder defaultInstanceConfigBuilder) {
+      _defaultInstanceConfigBuilder = defaultInstanceConfigBuilder;
       return this;
     }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -215,14 +215,14 @@ public class ParticipantManager {
       if (!autoRegistration) {
         LOG.info(_instanceName + " is auto-joining cluster: " + _clusterName);
         instanceConfig = HelixUtil.composeInstanceConfig(_instanceName,
-            _helixManagerProperty.getDefaultInstanceConfig());
+            _helixManagerProperty.getDefaultInstanceConfigBuilder());
       } else {
         LOG.info(_instanceName + " is auto-registering cluster: " + _clusterName);
         CloudInstanceInformation cloudInstanceInformation = getCloudInstanceInformation();
         String domain = cloudInstanceInformation.get(
             CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name()) + _instanceName;
         instanceConfig = HelixUtil.composeInstanceConfig(_instanceName,
-            _helixManagerProperty.getDefaultInstanceConfig());
+            _helixManagerProperty.getDefaultInstanceConfigBuilder());
         instanceConfig.setDomain(domain);
       }
       instanceConfig

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -199,8 +199,7 @@ public class ParticipantManager {
     // Difference between auto join and auto registration is that the latter will also populate the
     // domain information in instance config
     try {
-      autoRegistration =
-          Boolean.valueOf(_helixManagerProperty.getHelixCloudProperty().getCloudEnabled());
+      autoRegistration = _helixManagerProperty.getHelixCloudProperty().getCloudEnabled();
       LOG.info("instance: " + _instanceName + " auto-registering " + _clusterName + " is "
           + autoRegistration);
     } catch (Exception e) {
@@ -215,13 +214,15 @@ public class ParticipantManager {
       }
       if (!autoRegistration) {
         LOG.info(_instanceName + " is auto-joining cluster: " + _clusterName);
-        instanceConfig = HelixUtil.composeInstanceConfig(_instanceName);
+        instanceConfig = HelixUtil.composeInstanceConfig(_instanceName,
+            _helixManagerProperty.getDefaultInstanceConfig());
       } else {
         LOG.info(_instanceName + " is auto-registering cluster: " + _clusterName);
         CloudInstanceInformation cloudInstanceInformation = getCloudInstanceInformation();
-        String domain = cloudInstanceInformation
-            .get(CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name()) + _instanceName;
-        instanceConfig = HelixUtil.composeInstanceConfig(_instanceName);
+        String domain = cloudInstanceInformation.get(
+            CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name()) + _instanceName;
+        instanceConfig = HelixUtil.composeInstanceConfig(_instanceName,
+            _helixManagerProperty.getDefaultInstanceConfig());
         instanceConfig.setDomain(domain);
       }
       instanceConfig

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -58,7 +58,6 @@ import org.apache.helix.participant.statemachine.StateModel;
 import org.apache.helix.participant.statemachine.StateModelFactory;
 import org.apache.helix.task.TaskConstants;
 import org.apache.helix.task.TaskUtil;
-import org.apache.helix.util.HelixUtil;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.ZNRecordBucketizer;
@@ -214,15 +213,15 @@ public class ParticipantManager {
       }
       if (!autoRegistration) {
         LOG.info(_instanceName + " is auto-joining cluster: " + _clusterName);
-        instanceConfig = HelixUtil.composeInstanceConfig(_instanceName,
-            _helixManagerProperty.getDefaultInstanceConfigBuilder());
+        instanceConfig =
+            _helixManagerProperty.getDefaultInstanceConfigBuilder().build(_instanceName);
       } else {
         LOG.info(_instanceName + " is auto-registering cluster: " + _clusterName);
         CloudInstanceInformation cloudInstanceInformation = getCloudInstanceInformation();
         String domain = cloudInstanceInformation.get(
             CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name()) + _instanceName;
-        instanceConfig = HelixUtil.composeInstanceConfig(_instanceName,
-            _helixManagerProperty.getDefaultInstanceConfigBuilder());
+        instanceConfig =
+            _helixManagerProperty.getDefaultInstanceConfigBuilder().build(_instanceName);
         instanceConfig.setDomain(domain);
       }
       instanceConfig

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -720,7 +720,6 @@ public class InstanceConfig extends HelixProperty {
 
     }
 
-    config.setInstanceEnabled(HELIX_ENABLED_DEFAULT_VALUE);
     if (config.getHostName() == null) {
       config.setHostName(instanceId);
     }
@@ -759,12 +758,24 @@ public class InstanceConfig extends HelixProperty {
     public InstanceConfig build(String instanceId) {
       InstanceConfig instanceConfig = new InstanceConfig(instanceId);
 
+      String proposedHostName = instanceId;
+      String proposedPort = "";
+      int lastPos = instanceId.lastIndexOf("_");
+      if (lastPos > 0) {
+        proposedHostName = instanceId.substring(0, lastPos);
+        proposedPort = instanceId.substring(lastPos + 1);
+      }
+
       if (_hostName != null) {
         instanceConfig.setHostName(_hostName);
+      } else {
+        instanceConfig.setHostName(proposedHostName);
       }
 
       if (_port != null) {
         instanceConfig.setPort(_port);
+      } else {
+        instanceConfig.setPort(proposedPort);
       }
 
       if (_domain != null) {

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -29,11 +29,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.helix.util.ConfigStringUtil;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.rebalancer.topology.Topology;
+import org.apache.helix.util.ConfigStringUtil;
 import org.apache.helix.util.HelixUtil;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.slf4j.Logger;
@@ -68,6 +68,7 @@ public class InstanceConfig extends HelixProperty {
   public static final int WEIGHT_NOT_SET = -1;
   public static final int MAX_CONCURRENT_TASK_NOT_SET = -1;
   private static final int TARGET_TASK_THREAD_POOL_SIZE_NOT_SET = -1;
+  private static final boolean HELIX_ENABLED_DEFAULT_VALUE = true;
 
   private static final Logger _logger = LoggerFactory.getLogger(InstanceConfig.class.getName());
 
@@ -254,7 +255,8 @@ public class InstanceConfig extends HelixProperty {
    * @return true if enabled, false if disabled
    */
   public boolean getInstanceEnabled() {
-    return _record.getBooleanField(InstanceConfigProperty.HELIX_ENABLED.toString(), true);
+    return _record.getBooleanField(InstanceConfigProperty.HELIX_ENABLED.toString(),
+        HELIX_ENABLED_DEFAULT_VALUE);
   }
 
   /**
@@ -718,7 +720,7 @@ public class InstanceConfig extends HelixProperty {
 
     }
 
-    config.setInstanceEnabled(true);
+    config.setInstanceEnabled(HELIX_ENABLED_DEFAULT_VALUE);
     if (config.getHostName() == null) {
       config.setHostName(instanceId);
     }
@@ -738,5 +740,126 @@ public class InstanceConfig extends HelixProperty {
     Topology.computeInstanceTopologyMap(clusterConfig, instanceName, this,
         false /*earlyQuitForFaultZone*/);
     return true;
+  }
+
+  public static class Builder {
+    private String _hostName;
+    private String _port;
+    private String _domain;
+    private int _weight = WEIGHT_NOT_SET;
+    private List<String> _tags = new ArrayList<>();
+    private boolean _instanceEnabled = HELIX_ENABLED_DEFAULT_VALUE;
+    private Map<String, Integer> _instanceCapacityMap;
+
+    /**
+     * Build a new InstanceConfig with given instanceId
+     * @param instanceId A unique ID for this instance
+     * @return InstanceConfig
+     */
+    public InstanceConfig build(String instanceId) {
+      InstanceConfig instanceConfig = new InstanceConfig(instanceId);
+
+      if (_hostName != null) {
+        instanceConfig.setHostName(_hostName);
+      }
+
+      if (_port != null) {
+        instanceConfig.setPort(_port);
+      }
+
+      if (_domain != null) {
+        instanceConfig.setDomain(_domain);
+      }
+
+      if (_weight != InstanceConfig.WEIGHT_NOT_SET) {
+        instanceConfig.setWeight(_weight);
+      }
+
+      for (String tag : _tags) {
+        instanceConfig.addTag(tag);
+      }
+
+      if (_instanceEnabled != HELIX_ENABLED_DEFAULT_VALUE) {
+        instanceConfig.setInstanceEnabled(_instanceEnabled);
+      }
+
+      instanceConfig.setInstanceEnabled(_instanceEnabled);
+
+      if (_instanceCapacityMap != null) {
+        instanceConfig.setInstanceCapacityMap(_instanceCapacityMap);
+      }
+
+      return instanceConfig;
+    }
+
+    /**
+     * Set the host name for this instance
+     * @param hostName the host name
+     * @return InstanceConfig.Builder
+     */
+    public Builder setHostName(String hostName) {
+      _hostName = hostName;
+      return this;
+    }
+
+    /**
+     * Set the port for this instance
+     * @param port the Helix port
+     * @return InstanceConfig.Builder
+     */
+    public Builder setPort(String port) {
+      _port = port;
+      return this;
+    }
+
+    /**
+     * Set the domain for this instance
+     * @param domain the domain
+     * @return InstanceConfig.Builder
+     */
+    public Builder setDomain(String domain) {
+      _domain = domain;
+      return this;
+    }
+
+    /**
+     * Set the weight for this instance
+     * @param weight the weight
+     * @return InstanceConfig.Builder
+     */
+    public Builder setWeight(int weight) {
+      _weight = weight;
+      return this;
+    }
+
+    /**
+     * Add a tag for this instance
+     * @param tag the tag
+     * @return InstanceConfig.Builder
+     */
+    public Builder addTag(String tag) {
+      _tags.add(tag);
+      return this;
+    }
+
+    /**
+     * Set the enabled status for this instance
+     * @param instanceEnabled true if enabled, false otherwise
+     * @return InstanceConfig.Builder
+     */
+    public Builder setInstanceEnabled(boolean instanceEnabled) {
+      _instanceEnabled = instanceEnabled;
+      return this;
+    }
+
+    /**
+     * Set the capacity map for this instance
+     * @param instanceCapacityMap the capacity map
+     * @return InstanceConfig.Builder
+     */
+    public Builder setInstanceCapacityMap(Map<String, Integer> instanceCapacityMap) {
+      _instanceCapacityMap = instanceCapacityMap;
+      return this;
+    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -93,7 +93,7 @@ public class InstanceConfig extends HelixProperty {
    * @return the host name
    */
   public String getHostName() {
-    return _record.getSimpleField(InstanceConfigProperty.HELIX_HOST.toString());
+    return _record.getSimpleField(InstanceConfigProperty.HELIX_HOST.name());
   }
 
   /**
@@ -101,7 +101,7 @@ public class InstanceConfig extends HelixProperty {
    * @param hostName the host name
    */
   public void setHostName(String hostName) {
-    _record.setSimpleField(InstanceConfigProperty.HELIX_HOST.toString(), hostName);
+    _record.setSimpleField(InstanceConfigProperty.HELIX_HOST.name(), hostName);
   }
 
   /**
@@ -109,7 +109,7 @@ public class InstanceConfig extends HelixProperty {
    * @return the port
    */
   public String getPort() {
-    return _record.getSimpleField(InstanceConfigProperty.HELIX_PORT.toString());
+    return _record.getSimpleField(InstanceConfigProperty.HELIX_PORT.name());
   }
 
   /**
@@ -117,7 +117,7 @@ public class InstanceConfig extends HelixProperty {
    * @param port the port
    */
   public void setPort(String port) {
-    _record.setSimpleField(InstanceConfigProperty.HELIX_PORT.toString(), port);
+    _record.setSimpleField(InstanceConfigProperty.HELIX_PORT.name(), port);
   }
 
   /**
@@ -201,7 +201,7 @@ public class InstanceConfig extends HelixProperty {
    * @return a list of tags
    */
   public List<String> getTags() {
-    List<String> tags = getRecord().getListField(InstanceConfigProperty.TAG_LIST.toString());
+    List<String> tags = getRecord().getListField(InstanceConfigProperty.TAG_LIST.name());
     if (tags == null) {
       tags = new ArrayList<String>(0);
     }
@@ -213,14 +213,14 @@ public class InstanceConfig extends HelixProperty {
    * @param tag an arbitrary property of the instance
    */
   public void addTag(String tag) {
-    List<String> tags = getRecord().getListField(InstanceConfigProperty.TAG_LIST.toString());
+    List<String> tags = getRecord().getListField(InstanceConfigProperty.TAG_LIST.name());
     if (tags == null) {
       tags = new ArrayList<String>(0);
     }
     if (!tags.contains(tag)) {
       tags.add(tag);
     }
-    getRecord().setListField(InstanceConfigProperty.TAG_LIST.toString(), tags);
+    getRecord().setListField(InstanceConfigProperty.TAG_LIST.name(), tags);
   }
 
   /**
@@ -228,7 +228,7 @@ public class InstanceConfig extends HelixProperty {
    * @param tag a property of this instance
    */
   public void removeTag(String tag) {
-    List<String> tags = getRecord().getListField(InstanceConfigProperty.TAG_LIST.toString());
+    List<String> tags = getRecord().getListField(InstanceConfigProperty.TAG_LIST.name());
     if (tags == null) {
       return;
     }
@@ -243,7 +243,7 @@ public class InstanceConfig extends HelixProperty {
    * @return true if the instance contains the tag, false otherwise
    */
   public boolean containsTag(String tag) {
-    List<String> tags = getRecord().getListField(InstanceConfigProperty.TAG_LIST.toString());
+    List<String> tags = getRecord().getListField(InstanceConfigProperty.TAG_LIST.name());
     if (tags == null) {
       return false;
     }
@@ -255,7 +255,7 @@ public class InstanceConfig extends HelixProperty {
    * @return true if enabled, false if disabled
    */
   public boolean getInstanceEnabled() {
-    return _record.getBooleanField(InstanceConfigProperty.HELIX_ENABLED.toString(),
+    return _record.getBooleanField(InstanceConfigProperty.HELIX_ENABLED.name(),
         HELIX_ENABLED_DEFAULT_VALUE);
   }
 
@@ -282,8 +282,8 @@ public class InstanceConfig extends HelixProperty {
    * Removes HELIX_DISABLED_REASON and HELIX_DISABLED_TYPE entry from simple field.
    */
   public void resetInstanceDisabledTypeAndReason() {
-    _record.getSimpleFields().remove(InstanceConfigProperty.HELIX_DISABLED_REASON.toString());
-    _record.getSimpleFields().remove(InstanceConfigProperty.HELIX_DISABLED_TYPE.toString());
+    _record.getSimpleFields().remove(InstanceConfigProperty.HELIX_DISABLED_REASON.name());
+    _record.getSimpleFields().remove(InstanceConfigProperty.HELIX_DISABLED_TYPE.name());
   }
 
   /**
@@ -292,7 +292,7 @@ public class InstanceConfig extends HelixProperty {
    */
   public void setInstanceDisabledReason(String disabledReason) {
      if (!getInstanceEnabled()) {
-     _record.setSimpleField(InstanceConfigProperty.HELIX_DISABLED_REASON.toString(), disabledReason);
+       _record.setSimpleField(InstanceConfigProperty.HELIX_DISABLED_REASON.name(), disabledReason);
      }
   }
 
@@ -302,8 +302,8 @@ public class InstanceConfig extends HelixProperty {
    */
   public void setInstanceDisabledType(InstanceConstants.InstanceDisabledType disabledType) {
     if (!getInstanceEnabled()) {
-      _record.setSimpleField(InstanceConfigProperty.HELIX_DISABLED_TYPE.toString(),
-          disabledType.toString());
+      _record.setSimpleField(InstanceConfigProperty.HELIX_DISABLED_TYPE.name(),
+          disabledType.name());
     }
   }
 
@@ -311,7 +311,7 @@ public class InstanceConfig extends HelixProperty {
    * @return Return instance disabled reason. Default is am empty string.
    */
   public String getInstanceDisabledReason() {
-    return _record.getStringField(InstanceConfigProperty.HELIX_DISABLED_REASON.toString(), "");
+    return _record.getStringField(InstanceConfigProperty.HELIX_DISABLED_REASON.name(), "");
   }
 
   /**
@@ -323,8 +323,8 @@ public class InstanceConfig extends HelixProperty {
     if (getInstanceEnabled()) {
       return InstanceConstants.INSTANCE_NOT_DISABLED;
     }
-    return _record.getStringField(InstanceConfigProperty.HELIX_DISABLED_TYPE.toString(),
-        InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE.toString());
+    return _record.getStringField(InstanceConfigProperty.HELIX_DISABLED_TYPE.name(),
+        InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE.name());
   }
 
   /**
@@ -470,7 +470,7 @@ public class InstanceConfig extends HelixProperty {
   @Deprecated
   public void setInstanceEnabledForPartition(String partitionName, boolean enabled) {
     List<String> list =
-        _record.getListField(InstanceConfigProperty.HELIX_DISABLED_PARTITION.toString());
+        _record.getListField(InstanceConfigProperty.HELIX_DISABLED_PARTITION.name());
     Set<String> disabledPartitions = new HashSet<String>();
     if (list != null) {
       disabledPartitions.addAll(list);
@@ -484,7 +484,7 @@ public class InstanceConfig extends HelixProperty {
 
     list = new ArrayList<String>(disabledPartitions);
     Collections.sort(list);
-    _record.setListField(InstanceConfigProperty.HELIX_DISABLED_PARTITION.toString(), list);
+    _record.setListField(InstanceConfigProperty.HELIX_DISABLED_PARTITION.name(), list);
   }
 
   public void setInstanceEnabledForPartition(String resourceName, String partitionName,

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -794,8 +794,6 @@ public class InstanceConfig extends HelixProperty {
         instanceConfig.setInstanceEnabled(_instanceEnabled);
       }
 
-      instanceConfig.setInstanceEnabled(_instanceEnabled);
-
       if (_instanceCapacityMap != null) {
         instanceConfig.setInstanceCapacityMap(_instanceCapacityMap);
       }

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -536,9 +536,8 @@ public final class HelixUtil {
    * @param instanceName the unique name of the instance
    * @return InstanceConfig
    */
-  @Deprecated
   public static InstanceConfig composeInstanceConfig(String instanceName) {
-    return composeInstanceConfig(instanceName, new InstanceConfig.Builder());
+    return new InstanceConfig.Builder().build(instanceName);
   }
 
   /**
@@ -549,23 +548,7 @@ public final class HelixUtil {
    */
   public static InstanceConfig composeInstanceConfig(String instanceName,
       InstanceConfig.Builder defaultInstanceConfigBuilder) {
-    InstanceConfig instanceConfig = defaultInstanceConfigBuilder.build(instanceName);
-    String proposedHostName = instanceName;
-    String proposedPort = "";
-    int lastPos = instanceName.lastIndexOf("_");
-    if (lastPos > 0) {
-      proposedHostName = instanceName.substring(0, lastPos);
-      proposedPort = instanceName.substring(lastPos + 1);
-    }
-
-    if (instanceConfig.getHostName() == null) {
-      instanceConfig.setHostName(proposedHostName);
-    }
-    if (instanceConfig.getPort() == null) {
-      instanceConfig.setPort(proposedPort);
-    }
-
-    return instanceConfig;
+    return defaultInstanceConfigBuilder.build(instanceName);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -533,11 +533,25 @@ public final class HelixUtil {
 
   /**
    * Compose the config for an instance
-   * @param instanceName
+   * @param instanceName the unique name of the instance
    * @return InstanceConfig
    */
+  @Deprecated
   public static InstanceConfig composeInstanceConfig(String instanceName) {
-    InstanceConfig instanceConfig = new InstanceConfig(instanceName);
+    return composeInstanceConfig(instanceName, new InstanceConfig(instanceName));
+  }
+
+  /**
+   * Compose the config for an instance with defaults if provided.
+   * @param instanceName the unique name of the instance
+   * @param defaultInstanceConfig default instance config
+   * @return InstanceConfig
+   */
+  public static InstanceConfig composeInstanceConfig(String instanceName,
+      InstanceConfig defaultInstanceConfig) {
+    InstanceConfig instanceConfig =
+        defaultInstanceConfig == null ? new InstanceConfig(instanceName) : defaultInstanceConfig;
+
     String hostName = instanceName;
     String port = "";
     int lastPos = instanceName.lastIndexOf("_");
@@ -545,9 +559,19 @@ public final class HelixUtil {
       hostName = instanceName.substring(0, lastPos);
       port = instanceName.substring(lastPos + 1);
     }
-    instanceConfig.setHostName(hostName);
-    instanceConfig.setPort(port);
-    instanceConfig.setInstanceEnabled(true);
+
+    if (instanceConfig.getHostName() == null) {
+      instanceConfig.setHostName(hostName);
+    }
+    if (instanceConfig.getPort() == null) {
+      instanceConfig.setPort(port);
+    }
+    // Check to see if the instance is enabled (InstanceConfig defaults to true if not set).
+    // If true, explicitly set it to true so that this is persisted in ZK.
+    if (instanceConfig.getInstanceEnabled()) {
+      instanceConfig.setInstanceEnabled(true);
+    }
+
     return instanceConfig;
   }
 

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -538,38 +538,31 @@ public final class HelixUtil {
    */
   @Deprecated
   public static InstanceConfig composeInstanceConfig(String instanceName) {
-    return composeInstanceConfig(instanceName, new InstanceConfig(instanceName));
+    return composeInstanceConfig(instanceName, new InstanceConfig.Builder());
   }
 
   /**
    * Compose the config for an instance with defaults if provided.
    * @param instanceName the unique name of the instance
-   * @param defaultInstanceConfig default instance config
+   * @param defaultInstanceConfigBuilder instance config builder filled with defaults
    * @return InstanceConfig
    */
   public static InstanceConfig composeInstanceConfig(String instanceName,
-      InstanceConfig defaultInstanceConfig) {
-    InstanceConfig instanceConfig =
-        defaultInstanceConfig == null ? new InstanceConfig(instanceName) : defaultInstanceConfig;
-
-    String hostName = instanceName;
-    String port = "";
+      InstanceConfig.Builder defaultInstanceConfigBuilder) {
+    InstanceConfig instanceConfig = defaultInstanceConfigBuilder.build(instanceName);
+    String proposedHostName = instanceName;
+    String proposedPort = "";
     int lastPos = instanceName.lastIndexOf("_");
     if (lastPos > 0) {
-      hostName = instanceName.substring(0, lastPos);
-      port = instanceName.substring(lastPos + 1);
+      proposedHostName = instanceName.substring(0, lastPos);
+      proposedPort = instanceName.substring(lastPos + 1);
     }
 
     if (instanceConfig.getHostName() == null) {
-      instanceConfig.setHostName(hostName);
+      instanceConfig.setHostName(proposedHostName);
     }
     if (instanceConfig.getPort() == null) {
-      instanceConfig.setPort(port);
-    }
-    // Check to see if the instance is enabled (InstanceConfig defaults to true if not set).
-    // If true, explicitly set it to true so that this is persisted in ZK.
-    if (instanceConfig.getInstanceEnabled()) {
-      instanceConfig.setInstanceEnabled(true);
+      instanceConfig.setPort(proposedPort);
     }
 
     return instanceConfig;

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -541,17 +541,6 @@ public final class HelixUtil {
   }
 
   /**
-   * Compose the config for an instance with defaults if provided.
-   * @param instanceName the unique name of the instance
-   * @param defaultInstanceConfigBuilder instance config builder filled with defaults
-   * @return InstanceConfig
-   */
-  public static InstanceConfig composeInstanceConfig(String instanceName,
-      InstanceConfig.Builder defaultInstanceConfigBuilder) {
-    return defaultInstanceConfigBuilder.build(instanceName);
-  }
-
-  /**
    * Checks whether or not the cluster is in management mode. It checks:
    * - pause signal
    * - live instances: whether any live instance is not in normal status, eg. frozen.

--- a/helix-core/src/test/java/org/apache/helix/TestConfigAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/TestConfigAccessor.java
@@ -116,12 +116,11 @@ public class TestConfigAccessor extends ZkUnitTestBase {
 
     keys = configAccessor.getKeys(ConfigScopeProperty.PARTICIPANT, clusterName, "localhost_12918");
     System.out.println((keys));
-    Assert.assertEquals(keys.size(), 5,
-        "should be [HELIX_ENABLED, HELIX_ENABLED_TIMESTAMP, HELIX_HOST, HELIX_PORT, participantConfigKey]");
-    Assert.assertEquals(keys.get(4), "participantConfigKey");
+    Assert.assertEquals(keys.size(), 3, "should be [HELIX_HOST, HELIX_PORT, participantConfigKey]");
+    Assert.assertEquals(keys.get(2), "participantConfigKey");
 
-    keys = configAccessor
-        .getKeys(ConfigScopeProperty.PARTITION, clusterName, "testResource", "testPartition");
+    keys = configAccessor.getKeys(ConfigScopeProperty.PARTITION, clusterName, "testResource",
+        "testPartition");
     Assert.assertEquals(keys.size(), 1, "should be [partitionConfigKey]");
     Assert.assertEquals(keys.get(0), "partitionConfigKey");
 

--- a/helix-core/src/test/java/org/apache/helix/TestHelixConfigAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/TestHelixConfigAccessor.java
@@ -111,23 +111,20 @@ public class TestHelixConfigAccessor extends ZkUnitTestBase {
     Assert.assertEquals(keys.size(), 1, "should be [resourceConfigKey]");
     Assert.assertTrue(keys.contains("resourceConfigKey"));
 
-    keys =
-        configAccessor.getKeys(new HelixConfigScopeBuilder(ConfigScopeProperty.CLUSTER).forCluster(
-            clusterName).build());
+    keys = configAccessor.getKeys(
+        new HelixConfigScopeBuilder(ConfigScopeProperty.CLUSTER).forCluster(clusterName).build());
     Assert.assertEquals(keys.size(), 1, "should be [clusterConfigKey]");
     Assert.assertTrue(keys.contains("clusterConfigKey"));
 
-    keys =
-        configAccessor.getKeys(new HelixConfigScopeBuilder(ConfigScopeProperty.PARTICIPANT)
-            .forCluster(clusterName).forParticipant("localhost_12918").build());
-    Assert.assertEquals(keys.size(), 5,
-        "should be [HELIX_ENABLED, HELIX_ENABLED_TIMESTAMP, HELIX_PORT, HELIX_HOST, participantConfigKey]");
+    keys = configAccessor.getKeys(
+        new HelixConfigScopeBuilder(ConfigScopeProperty.PARTICIPANT).forCluster(clusterName)
+            .forParticipant("localhost_12918").build());
+    Assert.assertEquals(keys.size(), 3, "should be [HELIX_PORT, HELIX_HOST, participantConfigKey]");
     Assert.assertTrue(keys.contains("participantConfigKey"));
 
-    keys =
-        configAccessor.getKeys(new HelixConfigScopeBuilder(ConfigScopeProperty.PARTITION)
-            .forCluster(clusterName).forResource("testResource").forPartition("testPartition")
-            .build());
+    keys = configAccessor.getKeys(
+        new HelixConfigScopeBuilder(ConfigScopeProperty.PARTITION).forCluster(clusterName)
+            .forResource("testResource").forPartition("testPartition").build());
     Assert.assertEquals(keys.size(), 1, "should be [partitionConfigKey]");
     Assert.assertEquals(keys.get(0), "partitionConfigKey");
 

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/MockParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/MockParticipantManager.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CountDownLatch;
 
 import org.apache.helix.HelixCloudProperty;
 import org.apache.helix.HelixManagerProperty;
+import org.apache.helix.HelixPropertyFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.manager.zk.CallbackHandler;
 import org.apache.helix.mock.participant.DummyProcess.DummyLeaderStandbyStateModelFactory;
@@ -58,7 +59,14 @@ public class MockParticipantManager extends ClusterManager {
 
   public MockParticipantManager(String zkAddr, String clusterName, String instanceName,
       int transDelay, HelixCloudProperty helixCloudProperty) {
-    super(zkAddr, clusterName, instanceName, InstanceType.PARTICIPANT);
+    this(zkAddr, clusterName, instanceName, transDelay, helixCloudProperty,
+        HelixPropertyFactory.getInstance().getHelixManagerProperty(zkAddr, clusterName));
+  }
+
+  public MockParticipantManager(String zkAddr, String clusterName, String instanceName,
+      int transDelay, HelixCloudProperty helixCloudProperty,
+      HelixManagerProperty helixManagerProperty) {
+    super(clusterName, instanceName, InstanceType.PARTICIPANT, zkAddr, null, helixManagerProperty);
     _transDelay = transDelay;
     _msModelFactory = new MockMSModelFactory(null);
     _lsModelFactory = new DummyLeaderStandbyStateModelFactory(_transDelay);
@@ -67,7 +75,8 @@ public class MockParticipantManager extends ClusterManager {
   }
 
   public MockParticipantManager(String clusterName, String instanceName,
-      HelixManagerProperty helixManagerProperty, int transDelay, HelixCloudProperty helixCloudProperty) {
+      HelixManagerProperty helixManagerProperty, int transDelay,
+      HelixCloudProperty helixCloudProperty) {
     super(clusterName, instanceName, InstanceType.PARTICIPANT, null, null, helixManagerProperty);
     _transDelay = transDelay;
     _msModelFactory = new MockMSModelFactory(null);

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
@@ -105,13 +105,12 @@ public class TestInstanceAutoJoin extends ZkStandAloneCMTestBase {
     manager.getConfigAccessor().set(scope, ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, "true");
 
     // Create and start a new participant with default instance config.
-    InstanceConfig defaultInstanceConfig = new InstanceConfig(instance3);
-    defaultInstanceConfig.setInstanceEnabled(false);
-    defaultInstanceConfig.setMaxConcurrentTask(100);
+    InstanceConfig.Builder defaultInstanceConfig =
+        new InstanceConfig.Builder().setInstanceEnabled(false).addTag("foo");
     MockParticipantManager autoParticipant =
         new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instance3, 10, null,
-            new HelixManagerProperty.Builder().setDefaultInstanceConfig(defaultInstanceConfig)
-                .build());
+            new HelixManagerProperty.Builder().setDefaultInstanceConfigBuilder(
+                defaultInstanceConfig).build());
     autoParticipant.syncStart();
 
     Assert.assertTrue(TestHelper.verify(() -> {
@@ -122,8 +121,8 @@ public class TestInstanceAutoJoin extends ZkStandAloneCMTestBase {
       }
       InstanceConfig composedInstanceConfig =
           manager.getConfigAccessor().getInstanceConfig(CLUSTER_NAME, instance3);
-      return !composedInstanceConfig.getInstanceEnabled()
-          && composedInstanceConfig.getMaxConcurrentTask() == 100;
+      return !composedInstanceConfig.getInstanceEnabled() && composedInstanceConfig.getTags()
+          .contains("foo");
     }, 2000));
 
     autoParticipant.syncStop();

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
@@ -173,4 +173,45 @@ public class TestInstanceAutoJoin extends ZkStandAloneCMTestBase {
 
     autoParticipant.syncStop();
   }
+
+//  /**
+//   * Test auto join with a defaultInstanceConfig.
+//   * @throws Exception
+//   */
+//  @Test
+//  public void testAutoJoinWithDefaultInstanceConfig() throws Exception {
+//    HelixManager manager = _participants[0];
+//    HelixDataAccessor accessor = manager.getHelixDataAccessor();
+//    String instance4 = "localhost_279707";
+//
+//    // Enable cluster auto join.
+//    HelixConfigScope scope =
+//        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(
+//            CLUSTER_NAME).build();
+//    manager.getConfigAccessor().set(scope, ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, "true");
+//
+//    // Create and start a new participant with default instance config.
+//    InstanceConfig defaultInstanceConfig = new InstanceConfig(instance4);
+//    defaultInstanceConfig.setInstanceEnabled(false);
+//    defaultInstanceConfig.setMaxConcurrentTask(100);
+//    MockParticipantManager autoParticipant =
+//        new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instance4, 10, null,
+//            new HelixManagerProperty.Builder().setDefaultInstanceConfig(defaultInstanceConfig)
+//                .build());
+//    autoParticipant.syncStart();
+//
+//    Assert.assertTrue(TestHelper.verify(() -> {
+//      // Check that live instance is added and instance config is populated with correct fields.
+//      if (manager.getHelixDataAccessor().getProperty(accessor.keyBuilder().liveInstance(instance4))
+//          == null) {
+//        return false;
+//      }
+//      InstanceConfig composedInstanceConfig =
+//          manager.getConfigAccessor().getInstanceConfig(CLUSTER_NAME, instance4);
+//      return !composedInstanceConfig.getInstanceEnabled()
+//          && composedInstanceConfig.getMaxConcurrentTask() == 100;
+//    }, 2000));
+//
+//    autoParticipant.syncStop();
+//  }
 }

--- a/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
@@ -160,13 +160,33 @@ public class TestInstanceConfig {
     InstanceConfig testConfig = new InstanceConfig("testConfig");
     testConfig.setTargetTaskThreadPoolSize(100);
 
-    Assert.assertEquals(testConfig.getRecord().getIntField(
-        InstanceConfig.InstanceConfigProperty.TARGET_TASK_THREAD_POOL_SIZE.name(), -1), 100);
+    Assert.assertEquals(testConfig.getRecord()
+            .getIntField(InstanceConfig.InstanceConfigProperty.TARGET_TASK_THREAD_POOL_SIZE.name(), -1),
+        100);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testSetTargetTaskThreadPoolSizeIllegalArgument() {
     InstanceConfig testConfig = new InstanceConfig("testConfig");
     testConfig.setTargetTaskThreadPoolSize(-1);
+  }
+
+  @Test
+  public void testInstanceConfigBuilder() {
+    Map<String, Integer> capacityDataMap = ImmutableMap.of("weight1", 1);
+    InstanceConfig instanceConfig =
+        new InstanceConfig.Builder().setHostName("testHost").setPort("1234").setDomain("foo=bar")
+            .setWeight(100).setInstanceEnabled(true).addTag("tag1").addTag("tag2")
+            .setInstanceEnabled(false).setInstanceCapacityMap(capacityDataMap).build("instance1");
+
+    Assert.assertEquals(instanceConfig.getId(), "instance1");
+    Assert.assertEquals(instanceConfig.getHostName(), "testHost");
+    Assert.assertEquals(instanceConfig.getPort(), "1234");
+    Assert.assertEquals(instanceConfig.getDomainAsString(), "foo=bar");
+    Assert.assertEquals(instanceConfig.getWeight(), 100);
+    Assert.assertTrue(instanceConfig.getTags().contains("tag1"));
+    Assert.assertTrue(instanceConfig.getTags().contains("tag2"));
+    Assert.assertFalse(instanceConfig.getInstanceEnabled());
+    Assert.assertEquals(instanceConfig.getInstanceCapacityMap().get("weight1"), Integer.valueOf(1));
   }
 }


### PR DESCRIPTION
Add support for setting a default InstanceConfig through HelixManagerProperty. This will allow InstanceConfig fields be able to have defaults while also allowing users to leverage autoJoin and autoRegistration.

### Description

Previously, you would only be able to use HelixUtil.composeInstanceConfig when leveraging auto-join and auto-registration. With this change, the user can provide a configured default InstanceConfig to be used when composeInstanceConfig is used by auto-join and auto-registration. One use case is allowing the node to auto-join the cluster in `HELIX_ENABLED=false`

The default InstanceConfig is configurable in HelixManagerProperty which is the configuration object passed in at the entrypoint when the ZkHelixManager is instantiated.

### Tests

- [x] testAutoJoinWithDefaultInstanceConfig
- [x] testInstanceConfigBuilder

```
➜  helix git:(default_instance_configs) ✗ mvn test -o -Dtest=TestInstanceAutoJoin -pl=helix-core
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.helix:metrics-common:bundle:1.3.1-SNAPSHOT
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.apache.helix:helix:1.3.1-SNAPSHOT, /Users/zapinto/Documents/git/zpinto/helix/pom.xml, line 678, column 17
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.helix:helix:pom:1.3.1-SNAPSHOT
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ line 678, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] 
[INFO] --------------------< org.apache.helix:helix-core >---------------------
[INFO] Building Apache Helix :: Core 1.3.1-SNAPSHOT
[INFO]   from pom.xml
[INFO] -------------------------------[ bundle ]-------------------------------
[INFO] 
[INFO] --- enforcer:1.4.1:enforce (enforce-maven-version) @ helix-core ---
[INFO] 
[INFO] --- enforcer:1.4.1:enforce (enforce-java-version) @ helix-core ---
[INFO] 
[INFO] --- enforcer:1.4.1:enforce (enforce-output-timestamp-property) @ helix-core ---
[INFO] 
[INFO] --- jacoco:0.8.6:prepare-agent (default) @ helix-core ---
[INFO] argLine set to -javaagent:/Users/zapinto/.m2/repository/org/jacoco/org.jacoco.agent/0.8.6/org.jacoco.agent-0.8.6-runtime.jar=destfile=/Users/zapinto/Documents/git/zpinto/helix/helix-core/target/jacoco.exec
[INFO] 
[INFO] --- remote-resources:1.7.0:process (process-resource-bundles) @ helix-core ---
[INFO] Preparing remote bundle org.apache:apache-jar-resource-bundle:1.4
[INFO] Copying 3 resources from 1 bundle.
[INFO] 
[INFO] --- resources:3.2.0:resources (default-resources) @ helix-core ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Using 'UTF-8' encoding to copy filtered properties files.
[INFO] Copying 4 resources
[INFO] Copying 0 resource
[INFO] Copying 3 resources
[INFO] The encoding used to copy filtered properties files have not been set. This means that the same encoding will be used to copy filtered properties files as when copying other filtered resources. This might not be what you want! Run your build with --debug to see which files might be affected. Read more at https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html
[INFO] 
[INFO] --- compiler:3.10.1:compile (default-compile) @ helix-core ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- bundle:5.1.4:manifest (bundle-manifest) @ helix-core ---
[WARNING] Manifest org.apache.helix:helix-core:bundle:1.3.1-SNAPSHOT : Unused Import-Package instructions: [org.apache.logging.log4j*, org.apache.logging.slf4j*] 
[INFO] Writing manifest: /Users/zapinto/Documents/git/zpinto/helix/helix-core/target/classes/META-INF/MANIFEST.MF
[INFO] 
[INFO] --- resources:3.2.0:testResources (default-testResources) @ helix-core ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Using 'UTF-8' encoding to copy filtered properties files.
[INFO] Copying 15 resources
[INFO] Copying 3 resources
[INFO] 
[INFO] --- compiler:3.10.1:testCompile (default-testCompile) @ helix-core ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- surefire:3.0.0-M3:test (default-test) @ helix-core ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.helix.integration.paticipant.TestInstanceAutoJoin

[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 32.231 s - in org.apache.helix.integration.paticipant.TestInstanceAutoJoin
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/zapinto/Documents/git/zpinto/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 943 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  42.206 s
[INFO] Finished at: 2023-08-29T08:02:06-07:00
[INFO] ------------------------------------------------------------------------
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.helix.model.TestInstanceConfig
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.868 s - in org.apache.helix.model.TestInstanceConfig
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/zapinto/Documents/git/zpinto/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 944 classes
[WARNING] Classes in bundle 'Apache Helix :: Core' do not match with execution data. For report generation the same class files must be used as at runtime.
[WARNING] Execution data for class org/apache/helix/HelixManagerProperty does not match.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.755 s
[INFO] Finished at: 2023-08-31T18:56:32-07:00
[INFO] ------------------------------------------------------------------------

```

### Changes that Break Backward Compatibility (Optional)

NA

### Documentation (Optional)

NA

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
