### PR TITLE
Fix the behavior when underlying ZK throws BadVersion exception

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -393,6 +393,9 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
           result._retCode = RetCode.ERROR;
           return result;
         }
+      } catch (ZkBadVersionException e) {
+        LOG.debug("Exception while setting path: " + path, e);
+        throw e;
       } catch (Exception e) {
         LOG.error("Exception while setting path: " + path, e);
         result._retCode = RetCode.ERROR;


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Fixes #2613 

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

We introduced change in behavior while handling 'doSet()' call on Helix ZkBaseDataAccessor.

As part of change: https://github.com/apache/helix/pull/2208, we removed the redundant error messages but only in one particular case, exception handling was removed.

Reverting the specific change.

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)
Added a new test case:
TestZkBaseDataAccessor_testDoSetWithException 

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

```
[TestNG] Running:
  /Users/kdesai/Library/Caches/JetBrains/LinkedInIdea222/temp-testng-customsuite.xml

Start zookeeper at localhost:2183 in thread main
START TestZkBaseDataAccessor_testDoSetWithException at Mon Sep 11 12:57:23 PDT 2023
END TestZkBaseDataAccessor_testDoSetWithException at Mon Sep 11 12:57:28 PDT 2023
AfterClass: TestZkBaseDataAccessor called.
Shut down zookeeper at port 2183 in thread main

===============================================
Default Suite
Total tests run: 1, Failures: 0, Skips: 0
===============================================
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
