### PR TITLE
Support persist instance info collected by CloudInstanceInformationProcessor during auto-reg

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/api/cloud/CloudInstanceInformationV2.java
+++ b/helix-core/src/main/java/org/apache/helix/api/cloud/CloudInstanceInformationV2.java
@@ -1,0 +1,32 @@
+package org.apache.helix.api.cloud;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.common.collect.ImmutableMap;
+
+public interface CloudInstanceInformationV2 extends CloudInstanceInformation {
+  /**
+   * Get all the key value pairs of a specific cloud instance
+   * @return A map of all the key value pairs
+   */
+  ImmutableMap<String, String> getAll();
+}

--- a/helix-core/src/main/java/org/apache/helix/api/cloud/CloudInstanceInformationV2.java
+++ b/helix-core/src/main/java/org/apache/helix/api/cloud/CloudInstanceInformationV2.java
@@ -23,6 +23,12 @@ package org.apache.helix.api.cloud;
 
 import com.google.common.collect.ImmutableMap;
 
+/**
+ * Generic interface for cloud instance information which builds on top of CloudInstanceInformation.
+ * This interface adds a new method, getAll(), which returns all the key value pairs of a specific cloud instance.
+ * We call suffix the name of this interface with V2 to preserve backwards compatibility for all classes
+ * that implement CloudInstanceInformation.
+ */
 public interface CloudInstanceInformationV2 extends CloudInstanceInformation {
   /**
    * Get all the key value pairs of a specific cloud instance

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -60,6 +60,7 @@ public class InstanceConfig extends HelixProperty {
     DOMAIN,
     DELAY_REBALANCE_ENABLED,
     MAX_CONCURRENT_TASK,
+    INSTANCE_INFO_MAP,
     INSTANCE_CAPACITY_MAP,
     TARGET_TASK_THREAD_POOL_SIZE,
     INSTANCE_OPERATION
@@ -608,6 +609,29 @@ public class InstanceConfig extends HelixProperty {
   }
 
   /**
+   * Get the instance information map from the map fields.
+   * @return data map if it exists, or empty map
+   */
+  public Map<String, String> getInstanceInfoMap() {
+    Map<String, String> instanceInfoMap =
+        _record.getMapField(InstanceConfigProperty.INSTANCE_INFO_MAP.name());
+    return instanceInfoMap != null ? instanceInfoMap : Collections.emptyMap();
+  }
+
+  /**
+   * Set instanceInfoMap to map of information about the instance that can be used
+   * to construct the DOMAIN field.
+   * @param instanceInfoMap Map of information about the instance. ie: { 'rack': 'rack-1', 'host': 'host-1' }
+   */
+  private void setInstanceInfoMap(Map<String, String> instanceInfoMap) {
+    if (instanceInfoMap == null) {
+      _record.getMapFields().remove(InstanceConfigProperty.INSTANCE_INFO_MAP.name());
+    } else {
+      _record.setMapField(InstanceConfigProperty.INSTANCE_INFO_MAP.name(), instanceInfoMap);
+    }
+  }
+
+  /**
    * Get the instance capacity information from the map fields.
    * @return data map if it exists, or empty map
    */
@@ -748,6 +772,7 @@ public class InstanceConfig extends HelixProperty {
     private int _weight = WEIGHT_NOT_SET;
     private List<String> _tags = new ArrayList<>();
     private boolean _instanceEnabled = HELIX_ENABLED_DEFAULT_VALUE;
+    private Map<String, String> _instanceInfoMap;
     private Map<String, Integer> _instanceCapacityMap;
 
     /**
@@ -792,6 +817,10 @@ public class InstanceConfig extends HelixProperty {
 
       if (_instanceEnabled != HELIX_ENABLED_DEFAULT_VALUE) {
         instanceConfig.setInstanceEnabled(_instanceEnabled);
+      }
+
+      if (_instanceInfoMap != null) {
+        instanceConfig.setInstanceInfoMap(_instanceInfoMap);
       }
 
       if (_instanceCapacityMap != null) {
@@ -858,6 +887,31 @@ public class InstanceConfig extends HelixProperty {
      */
     public Builder setInstanceEnabled(boolean instanceEnabled) {
       _instanceEnabled = instanceEnabled;
+      return this;
+    }
+
+    /**
+     * Set the INSTANCE_INFO_MAP for this instance
+     * @param instanceInfoMap the instance info map
+     * @return InstanceConfig.Builder
+     */
+    public Builder setInstanceInfoMap(Map<String, String> instanceInfoMap) {
+      _instanceInfoMap = instanceInfoMap;
+      return this;
+    }
+
+    /**
+     * Add instance info to the INSTANCE_INFO_MAP.
+     * Only adds if the key does not already exist.
+     * @param key the key for the information
+     * @param value the value the information
+     * @return InstanceConfig.Builder
+     */
+    public Builder addInstanceInfo(String key, String value) {
+      if (_instanceInfoMap == null) {
+        _instanceInfoMap = new HashMap<>();
+      }
+      _instanceInfoMap.putIfAbsent(key, value);
       return this;
     }
 

--- a/helix-core/src/main/java/org/apache/helix/util/ConfigStringUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/ConfigStringUtil.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 public final class ConfigStringUtil {
   private static final String CONCATENATE_CONFIG_SPLITTER = ",";
-  private static final String CONCATENATE_CONFIG_JOINER = "=";
+  public static final String CONCATENATE_CONFIG_JOINER = "=";
 
   private ConfigStringUtil() {
     throw new java.lang.UnsupportedOperationException(

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformation.java
@@ -19,24 +19,34 @@ package org.apache.helix.integration.paticipant;
  * under the License.
  */
 
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
 import org.apache.helix.api.cloud.CloudInstanceInformation;
+import org.apache.helix.api.cloud.CloudInstanceInformationV2;
 
 /**
  * This is a custom implementation of CloudInstanceInformation. It is used to test the functionality
  * of Helix node auto-registration.
  */
-public class CustomCloudInstanceInformation implements CloudInstanceInformation {
-  private final String _faultDomain;
+public class CustomCloudInstanceInformation implements CloudInstanceInformationV2 {
 
-  public CustomCloudInstanceInformation(String faultDomain) {
-    _faultDomain = faultDomain;
+  public static final Map<String, String> _cloudInstanceInfo =
+      ImmutableMap.of(CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name(),
+          "mz=0, host=localhost, container=containerId", "MAINTENANCE_ZONE", "0", "INSTANCE_NAME",
+          "localhost_something");
+  ;
+
+  public CustomCloudInstanceInformation() {
   }
 
   @Override
   public String get(String key) {
-    if (key.equals(CloudInstanceField.FAULT_DOMAIN.name())) {
-      return _faultDomain;
-    }
-    return null;
+    return _cloudInstanceInfo.get(key);
+  }
+
+  @Override
+  public Map<String, String> getAll() {
+    return _cloudInstanceInfo;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformation.java
@@ -19,8 +19,6 @@ package org.apache.helix.integration.paticipant;
  * under the License.
  */
 
-import java.util.Map;
-
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.api.cloud.CloudInstanceInformation;
 import org.apache.helix.api.cloud.CloudInstanceInformationV2;
@@ -31,7 +29,7 @@ import org.apache.helix.api.cloud.CloudInstanceInformationV2;
  */
 public class CustomCloudInstanceInformation implements CloudInstanceInformationV2 {
 
-  public static final Map<String, String> _cloudInstanceInfo =
+  public static final ImmutableMap<String, String> _cloudInstanceInfo =
       ImmutableMap.of(CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name(),
           "mz=0, host=localhost, container=containerId", "MAINTENANCE_ZONE", "0", "INSTANCE_NAME",
           "localhost_something");
@@ -45,7 +43,7 @@ public class CustomCloudInstanceInformation implements CloudInstanceInformationV
   }
 
   @Override
-  public Map<String, String> getAll() {
+  public ImmutableMap<String, String> getAll() {
     return _cloudInstanceInfo;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformation.java
@@ -35,7 +35,6 @@ public class CustomCloudInstanceInformation implements CloudInstanceInformationV
       ImmutableMap.of(CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name(),
           "mz=0, host=localhost, container=containerId", "MAINTENANCE_ZONE", "0", "INSTANCE_NAME",
           "localhost_something");
-  ;
 
   public CustomCloudInstanceInformation() {
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformationProcessor.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/CustomCloudInstanceInformationProcessor.java
@@ -31,6 +31,7 @@ import org.apache.helix.api.cloud.CloudInstanceInformationProcessor;
  * It is used to test the functionality of Helix node auto-registration.
  */
 public class CustomCloudInstanceInformationProcessor implements CloudInstanceInformationProcessor<String> {
+
   public CustomCloudInstanceInformationProcessor(HelixCloudProperty helixCloudProperty) {
   }
 
@@ -41,6 +42,6 @@ public class CustomCloudInstanceInformationProcessor implements CloudInstanceInf
 
   @Override
   public CloudInstanceInformation parseCloudInstanceInformation(List<String> responses) {
-    return new CustomCloudInstanceInformation("rack=A:123, host=");
+    return new CustomCloudInstanceInformation();
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestInstanceAutoJoin.java
@@ -8,6 +8,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerProperty;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.TestHelper;
+import org.apache.helix.api.cloud.CloudInstanceInformation;
 import org.apache.helix.cloud.constants.CloudProvider;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.common.ZkStandAloneCMTestBase;
@@ -211,8 +212,11 @@ public class TestInstanceAutoJoin extends ZkStandAloneCMTestBase {
       // Check that live instance is added and instance config is populated with correct domain.
       return null != manager.getHelixDataAccessor()
           .getProperty(accessor.keyBuilder().liveInstance(instance5)) && manager.getConfigAccessor()
-          .getInstanceConfig(CLUSTER_NAME, instance5).getDomainAsString()
-          .equals("rack=A:123, host=" + instance5);
+          .getInstanceConfig(CLUSTER_NAME, instance5).getDomainAsString().equals(
+              CustomCloudInstanceInformation._cloudInstanceInfo.get(
+                  CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN.name()))
+          && manager.getConfigAccessor().getInstanceConfig(CLUSTER_NAME, instance5)
+          .getInstanceInfoMap().equals(CustomCloudInstanceInformation._cloudInstanceInfo);
     }, 2000));
 
     autoParticipant.syncStop();

--- a/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
@@ -20,6 +20,7 @@ package org.apache.helix.model;
  */
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
@@ -173,11 +174,16 @@ public class TestInstanceConfig {
 
   @Test
   public void testInstanceConfigBuilder() {
+
+    Map<String, String> instanceInfoMap = new HashMap<>();
+    instanceInfoMap.put("CAGE", "H");
     Map<String, Integer> capacityDataMap = ImmutableMap.of("weight1", 1);
     InstanceConfig instanceConfig =
         new InstanceConfig.Builder().setHostName("testHost").setPort("1234").setDomain("foo=bar")
             .setWeight(100).setInstanceEnabled(true).addTag("tag1").addTag("tag2")
-            .setInstanceEnabled(false).setInstanceCapacityMap(capacityDataMap).build("instance1");
+            .setInstanceEnabled(false).setInstanceInfoMap(instanceInfoMap)
+            .addInstanceInfo("CAGE", "G").addInstanceInfo("CABINET", "30")
+            .setInstanceCapacityMap(capacityDataMap).build("instance1");
 
     Assert.assertEquals(instanceConfig.getId(), "instance1");
     Assert.assertEquals(instanceConfig.getHostName(), "testHost");
@@ -187,6 +193,8 @@ public class TestInstanceConfig {
     Assert.assertTrue(instanceConfig.getTags().contains("tag1"));
     Assert.assertTrue(instanceConfig.getTags().contains("tag2"));
     Assert.assertFalse(instanceConfig.getInstanceEnabled());
+    Assert.assertEquals(instanceConfig.getInstanceInfoMap().get("CAGE"), "H");
+    Assert.assertEquals(instanceConfig.getInstanceInfoMap().get("CABINET"), "30");
     Assert.assertEquals(instanceConfig.getInstanceCapacityMap().get("weight1"), Integer.valueOf(1));
   }
 }


### PR DESCRIPTION
Add support to persist all instance information collected by CloudInstanceInformationProcessor in CloudInstanceInformation object. Add ability for CloudInstanceInformationProcessor to produce full DOMAIN field instead of appending _instanceName unless last character in CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN is '='.

### Description

Typically the information collected by the CloudInstanceInformationProcessor is used for constructing the DOMAIN field in InstanceConfig. There are some usecases where a customer wants to override the DOMAIN field from what was originally generated from auto-registration. When this happens, all the collected topology information is lost. In order to prevent losing this data, we will persist it in a new field called INSTANCE_INFO_MAP.

Possible usecase steps:
1. node comes online for first time using auto-reg and defaultInstanceConfig that has HELIX_ENABLED = false
2. All topology information is collected with CloudInstanceInformationProcessor and returned as CloudInstanceInformation
3. All information in CloudInstanceInformation is persisted into INSTANCE_INFO_MAP
4. DOMAIN is generated from CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN field
5. node has joined the cluster in disabled state
6. customers external hook can now run to override the DOMAIN field with whatever they want and set HELIX_ENABLED = true

### Tests

- [x] TestInstanceConfig updated to test new INSTANCE_INFO_MAP field
- [x] TestParticipantAutoJoin updated to verify that INSTANCE_INFO_MAP is populated and DOMAIN is constructed without appending _instanceName in case that CloudInstanceInformationProcessor constructs the full domain(signified when there is not = at the end of CloudInstanceInformation.CloudInstanceField.FAULT_DOMAIN)

```
➜  helix git:(support_persist_instance_info) mvn test -o -Dtest=TestInstanceConfig -pl=helix-core 
...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.helix.model.TestInstanceConfig
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.012 s - in org.apache.helix.model.TestInstanceConfig
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/zapinto/Documents/git/zpinto/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 947 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  9.512 s
[INFO] Finished at: 2023-09-19T18:05:33-07:00
[INFO] ------------------------------------------------------------------------


➜  helix git:(support_persist_instance_info) mvn test -o -Dtest=TestInstanceAutoJoin -pl=helix-core
...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.helix.integration.paticipant.TestInstanceAutoJoin
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 34.07 s - in org.apache.helix.integration.paticipant.TestInstanceAutoJoin
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/zapinto/Documents/git/zpinto/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 947 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  43.920 s
[INFO] Finished at: 2023-09-19T18:04:52-07:00
[INFO] ------------------------------------------------------------------------

```

### Changes that Break Backward Compatibility (Optional)

NA

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
