### PR TITLE
[apache/helix] -- Fixed - Make Helix Java-8 complaint

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -19,6 +19,7 @@ package org.apache.helix.controller.rebalancer;
  * under the License.
  */
 
+import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -55,7 +56,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceControllerDataProvider> {
   private static final Logger LOG = LoggerFactory.getLogger(DelayedAutoRebalancer.class);
-   public static final Set<String> INSTANCE_OPERATION_TO_EXCLUDE_FROM_ASSIGNMENT = Set.of("EVACUATE", "SWAP_IN");
+   public static final Set<String> INSTANCE_OPERATION_TO_EXCLUDE_FROM_ASSIGNMENT = ImmutableSet.of("EVACUATE", "SWAP_IN");
 
   @Override
   public IdealState computeNewIdealState(String resourceName,

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
@@ -19,6 +19,7 @@ package org.apache.helix.controller.rebalancer.util;
  * under the License.
  */
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -400,7 +401,7 @@ public class DelayedRebalanceUtil {
       Map<String, ResourceAssignment> currentAssignment) {
     return currentAssignment.entrySet()
         .parallelStream()
-        .map(e -> Map.entry(e.getKey(), findPartitionsMissingMinActiveReplica(clusterData, e.getValue())))
+        .map(e -> new HashMap.SimpleEntry<>(e.getKey(), findPartitionsMissingMinActiveReplica(clusterData, e.getValue())))
         .filter(e -> !e.getValue().isEmpty())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -19,6 +19,7 @@ package org.apache.helix.controller.rebalancer.waged;
  * under the License.
  */
 
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -79,7 +80,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
           .getInstance(ClusterConfig.DEFAULT_GLOBAL_REBALANCE_PREFERENCE);
   // These failure types should be propagated to caller of computeNewIdealStates()
   private static final List<HelixRebalanceException.Type> FAILURE_TYPES_TO_PROPAGATE =
-      List.of(HelixRebalanceException.Type.INVALID_REBALANCER_STATUS, HelixRebalanceException.Type.UNKNOWN_FAILURE);
+      ImmutableList.of(HelixRebalanceException.Type.INVALID_REBALANCER_STATUS, HelixRebalanceException.Type.UNKNOWN_FAILURE);
 
   private final HelixManager _manager;
   private final MappingCalculator<ResourceControllerDataProvider> _mappingCalculator;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -100,7 +100,7 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
           getNodeWithHighestPoints(replica, nodes, clusterModel.getContext(), busyInstances,
               optimalAssignment);
       // stop immediately if any replica cannot find best assignable node
-      if (maybeBestNode.isEmpty() || optimalAssignment.hasAnyFailure()) {
+      if (!maybeBestNode.isPresent() || optimalAssignment.hasAnyFailure()) {
         String errorMessage = String.format(
             "Unable to find any available candidate node for partition %s; Fail reasons: %s",
             replica.getPartitionName(), optimalAssignment.getFailures());

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -581,7 +581,7 @@ public class ClusterModelProvider {
           }
         }
       }
-      return Map.entry(resourceName, replicas);
+      return new HashMap.SimpleEntry<>(resourceName, replicas);
     }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -20,6 +20,7 @@ package org.apache.helix.controller.rebalancer.waged;
  */
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -737,7 +738,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     instances.add(offlineInstance);
     when(clusterData.getAllInstances()).thenReturn(instances);
     when(clusterData.getEnabledInstances()).thenReturn(instances);
-    when(clusterData.getEnabledLiveInstances()).thenReturn(Set.of(instance0, instance1, instance2));
+    when(clusterData.getEnabledLiveInstances()).thenReturn(ImmutableSet.of(instance0, instance1, instance2));
     Map<String, Long> instanceOfflineTimeMap = new HashMap<>();
     instanceOfflineTimeMap.put(offlineInstance, System.currentTimeMillis() + Integer.MAX_VALUE);
     when(clusterData.getInstanceOfflineTimeMap()).thenReturn(instanceOfflineTimeMap);
@@ -862,10 +863,10 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
   public void testResourceWeightProvider() throws IOException {
     ResourceControllerDataProvider testCache = setupClusterDataCache();
     WagedResourceWeightsProvider dataProvider = new WagedResourceWeightsProvider(testCache);
-    Map<String, Integer> weights1 = Map.of("item1", 3, "item2", 6, "item3", 0);
+    Map<String, Integer> weights1 = ImmutableMap.of("item1", 3, "item2", 6, "item3", 0);
     Assert.assertEquals(dataProvider.getPartitionWeights("Resource1", "Partition1"), weights1);
     Assert.assertEquals(dataProvider.getPartitionWeights("Resource1", "Partition2"), weights1);
-    Map<String, Integer> weights2 = Map.of("item1", 5, "item2", 10, "item3", 0);
+    Map<String, Integer> weights2 = ImmutableMap.of("item1", 5, "item2", 10, "item3", 0);
     Assert.assertEquals(dataProvider.getPartitionWeights("Resource2", "Partition2"), weights2);
   }
 
@@ -898,7 +899,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
         }));
     WagedInstanceCapacity provider = new WagedInstanceCapacity(clusterData);
 
-    Map<String, Integer> weights1 = Map.of("item1", 20, "item2", 40, "item3", 30);
+    Map<String, Integer> weights1 = ImmutableMap.of("item1", 20, "item2", 40, "item3", 30);
     Map<String, Integer> capacity = provider.getInstanceAvailableCapacity("testInstanceId");
     Assert.assertEquals(provider.getInstanceAvailableCapacity("testInstanceId"), weights1);
     Assert.assertEquals(provider.getInstanceAvailableCapacity("testInstanceId1"), weights1);

--- a/pom.xml
+++ b/pom.xml
@@ -554,7 +554,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.10.1</version>
           <configuration>
-            <release>11</release>
+            <release>8</release>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
#2627 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
We have noticed that some of the consumers have not moved away from Java8, and due to this compilation issues happened when they moved to latest versions. In this PR, we are adding Java-8 compatibility back to support those use cases.

### Tests
- [x] The following tests are written for this issue:
N/A

- The following is the result of the "mvn test" command on the appropriate module:

```console
[INFO] Installing org/apache/helix/meta-client/1.3.1-SNAPSHOT/meta-client-1.3.1-SNAPSHOT.jar
[INFO] Writing OBR metadata
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Helix 1.3.1-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  1.688 s]
[INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  1.906 s]
[INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [  0.872 s]
[INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [  1.635 s]
[INFO] Apache Helix :: Helix Common ....................... SUCCESS [  0.991 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [  8.826 s]
[INFO] Apache Helix :: Admin Webapp ....................... SUCCESS [  0.995 s]
[INFO] Apache Helix :: Restful Interface .................. SUCCESS [  2.091 s]
[INFO] Apache Helix :: Distributed Lock ................... SUCCESS [  0.386 s]
[INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  0.658 s]
[INFO] Apache Helix :: Front End .......................... SUCCESS [01:10 min]
[INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.018 s]
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  0.475 s]
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  0.476 s]
[INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  0.364 s]
[INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  0.369 s]
[INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  0.364 s]
[INFO] Apache Helix :: View Aggregator .................... SUCCESS [  0.683 s]
[INFO] Apache Helix :: Meta Client ........................ SUCCESS [  0.532 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:34 min
[INFO] Finished at: 2023-09-21T10:27:31-07:00
[INFO] ------------------------------------------------------------------------
```
### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
