### PR TITLE
Skip one time listener re-register for exists

### DIFF
--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestZkMetaClient.java
@@ -517,12 +517,20 @@ public class TestZkMetaClient extends ZkMetaClientTestBase{
             throws Exception {
         }
       };
-      zkMetaClient.subscribeDataChange(basePath, listener, false);
+      DirectChildChangeListener cldListener = new DirectChildChangeListener() {
+
+        @Override
+        public void handleDirectChildChange(String key) throws Exception {
+
+        }
+      };
+      zkMetaClient.subscribeDataChange(basePath, listener, true);
       zkMetaClient.create(basePath, "");
       zkMetaClient.get(basePath);
       zkMetaClient.exists(basePath);
       zkMetaClient.getDataAndStat(basePath);
       zkMetaClient.getDirectChildrenKeys(basePath);
+      zkMetaClient.subscribeDirectChildChange(basePath, cldListener, true);
     }
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1474,7 +1474,7 @@ public class ZkClient implements Watcher {
   }
 
   public boolean exists(final String path) {
-    return exists(path, hasChildOrDataListeners(path));
+    return exists(path, (!_usePersistWatcher) && hasChildOrDataListeners(path));
   }
 
   protected boolean exists(final String path, final boolean watch) {


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2237 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR skips one time listener re-register for exists()

### Tests

- [X] The following tests are written for this issue:

testChangeListener

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
