### PR TITLE
CUSTOM_INSTANCE_CHECK and(or) CUSTOM_PARTITION_CHECK optional for stoppable APIs

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/json/instance/StoppableCheck.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/json/instance/StoppableCheck.java
@@ -19,8 +19,10 @@ package org.apache.helix.rest.server.json.instance;
  * under the License.
  */
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -41,6 +43,12 @@ public class StoppableCheck {
 
     public String getPrefix() {
       return prefix;
+    }
+
+    public static Set<Category> categorySetFromCommaSeperatedString(String categories)
+        throws IllegalArgumentException {
+      return Arrays.stream(categories.split(",")).map(StoppableCheck.Category::valueOf)
+          .collect(Collectors.toSet());
     }
   }
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -56,9 +56,9 @@ public class TestInstancesAccessor extends AbstractTestClass {
         InstancesAccessor.InstancesProperties.instances.name(), "instance0", "instance1",
         "instance2", "instance3", "instance4", "instance5", "invalidInstance",
         InstancesAccessor.InstancesProperties.zone_order.name(), "zone2", "zone1");
-    Response response =
-        new JerseyUriRequestBuilder("clusters/{}/instances?command=stoppable").format(
-            STOPPABLE_CLUSTER).post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
+    Response response = new JerseyUriRequestBuilder(
+        "clusters/{}/instances?command=stoppable&skipHealthCheckCategories=CUSTOM_INSTANCE_CHECK,CUSTOM_PARTITION_CHECK").format(
+        STOPPABLE_CLUSTER).post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
     JsonNode jsonNode = OBJECT_MAPPER.readTree(response.readEntity(String.class));
     Assert.assertFalse(
         jsonNode.withArray(InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name())

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -62,12 +62,13 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     Map<String, String> params = ImmutableMap.of("client", "espresso");
     Entity entity =
         Entity.entity(OBJECT_MAPPER.writeValueAsString(params), MediaType.APPLICATION_JSON_TYPE);
-    Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}/stoppable")
-        .format(STOPPABLE_CLUSTER, "instance1").post(this, entity);
+    Response response = new JerseyUriRequestBuilder(
+        "clusters/{}/instances/{}/stoppable?skipHealthCheckCategories=CUSTOM_INSTANCE_CHECK,CUSTOM_PARTITION_CHECK").format(
+        STOPPABLE_CLUSTER, "instance1").post(this, entity);
     String stoppableCheckResult = response.readEntity(String.class);
     Map<String, Object> actualMap = OBJECT_MAPPER.readValue(stoppableCheckResult, Map.class);
-    List<String> failedChecks = Arrays
-        .asList("HELIX:EMPTY_RESOURCE_ASSIGNMENT", "HELIX:INSTANCE_NOT_ENABLED",
+    List<String> failedChecks =
+        Arrays.asList("HELIX:EMPTY_RESOURCE_ASSIGNMENT", "HELIX:INSTANCE_NOT_ENABLED",
             "HELIX:INSTANCE_NOT_STABLE");
     Map<String, Object> expectedMap =
         ImmutableMap.of("stoppable", false, "failedChecks", failedChecks);


### PR DESCRIPTION
Allow for callers to helix-rest stoppable APIs to skip running CUSTOM_INSTANCE_CHECK and(or) CUSTOM_PARTITION_CHECK, as they may not have the need to implement additional custom checks.

### Description
Customers are required to implement custom stoppable checks to use helix-rest stoppable APIs. Making these skippable removes that requirement.

### Tests

- [x] testGetInstanceStoppableCheckWhenCustomInstanceCheckAndCustomPartitionCheckDisabled
   - Verifies none of the custom checks cause stoppable to be false
- [x] testGetInstanceStoppableCheckWhenCustomPartitionCheckDisabled
   - Verifies instance custom check causes stoppable to be false
- [x] testGetInstanceStoppableCheckWhenCustomInstanceCheckDisabled
   - Verifies partition custom check causes stoppable to be false
- [x] Update TestPerInstanceAccessor and TestInstanceAccessor to make sure they can parse skipHealthCheckCategories

```
➜  helix git:(custom_stoppable_checks_optional) ✗ mvn clean install -Dmaven.test.skip.exec=true && mvn test -o -Dtest=TestMaintenanceManagementService,TestInstancesAccessor,TestPerInstanceAccessor -pl=helix-rest

...

[INFO] Tests run: 37, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 127.184 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 37, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /Users/zapinto/Documents/git/zpinto/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 92 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:19 min
[INFO] Finished at: 2023-10-04T18:59:33-07:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- Changes are backwards compatible

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
