### PR TITLE
Fix Helix-UI instance resource view misformatting on direct page load

### DIFF
--- a/helix-front/src/styles.scss
+++ b/helix-front/src/styles.scss
@@ -37,6 +37,10 @@
   // }
 }
 
+.datatable-scroll {
+  width: 100% !important;
+}
+
 body {
   font-family: Roboto, Arial, sans-serif;
   margin: 0;


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

#2651 

Resource view for instance does not get formatted correctly when you load it directly via the URL. 
https://<helix_ui_url>/<namespace>/<cluster>/instances/<instance_name>/resources

When you access the instance resources page directly via the url or by refreshing the page, the datatable's row widths do not seem to get properly configured and are instead set to 50px. Seems like the UI relies on the loaded content to determine the width of the "datatable-row-detail," and some interaction is causing the width to be determined prior to the content being populated..

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Force the datatable rows to use 100% of the parent width

<img width="729" alt="Screenshot 2023-10-10 at 6 26 55 PM" src="https://github.com/apache/helix/assets/80296166/6d430aee-b76c-4e41-bec4-6a039106c113">

The only negative of this change would be that if the page is stretched over a very long screen, the row would still use the entire width allocated to it and would be stretched as a result - the space between the "Partition" and "CurrentState" columns/values would increase.

### Tests

- [ ] The following tests are written for this issue:

Deployed helix front locally:
`yarn build`
`yarn start`

- The following is the result of the "mvn test" command on the appropriate module:

N/A.. No java code changes, only to the styling sheet (.scss)

