### PR TITLE
Fix partitionAssignment API failing due to NPE when no resource config

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
@@ -359,8 +359,10 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
     ConfigAccessor cfgAccessor = getConfigAccessor();
     List<ResourceConfig> wagedResourceConfigs = new ArrayList<>();
     for (IdealState idealState : wagedResourceIdealState) {
-      wagedResourceConfigs
-          .add(cfgAccessor.getResourceConfig(clusterId, idealState.getResourceName()));
+      ResourceConfig resourceConfig = cfgAccessor.getResourceConfig(clusterId, idealState.getResourceName());
+      if (resourceConfig != null) {
+        wagedResourceConfigs.add(resourceConfig);
+      }
     }
 
     Map<String, ResourceAssignment> wagedAssignmentResult;


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

The PartitionAssignment API fails for waged clusters where a resource does not have a respective resource config defined for it in ZK. 

This is the error that is shown to users:
```
{
  "error" : "Failed to compute partition assignment: org.apache.helix.HelixException: getIdealAssignmentForWagedFullAuto(): Calculation failed: Failed to compute BestPossibleState!"
}
```

This is the error that is found in helix-rest logs (truncated)
```
2023/10/11 03:20:59.336 ERROR [HelixUtil] [qtp1938380262-5394685] [helix-rest] [] getIdealAssignmentForWagedFullAuto(): Failed to compute ResourceAssignments!
java.lang.NullPointerException: null
at java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:177) ~[?:?]
at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169) ~[?:?]
at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655) ~[?:?]
at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]
at org.apache.helix.util.HelixUtil.getAssignmentForWagedFullAutoImpl(HelixUtil.java:318) ~[helix-core-1.1.1-dev-202303311728.jar:1.1.1-dev-202303311728]
at org.apache.helix.util.HelixUtil.getTargetAssignmentForWagedFullAuto(HelixUtil.java:219) ~[helix-core-1.1.1-dev-202303311728.jar:1.1.1-dev-202303311728]
```

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

partitionAssignment API fails for clusters where resource configs aren't set due to NPE. This NPE occurs because getResourceConfig() will return null if the resource config does not exist, which is then added into the wagedResourceConfigs list. The below code is where the NPE occurs as one of the items in the list is null.

```
      dataProvider.setResourceConfigMap(resourceConfigs.stream()
          .collect(Collectors.toMap(ResourceConfig::getResourceName, Function.identity())));
```

### Tests

- [ ] The following tests are written for this issue:
No new unit tests. But I did test this by deploying helix-rest locally to confirm that the partitionAssignment API worked after the change

- The following is the result of the "mvn test" command on the appropriate module:

$mvn test -o -Dtest=TestResourceAssignmentOptimizerAccessor -pl=helix-rest
```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /Users/gspencer/Desktop/git-repos/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 92 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  54.333 s
[INFO] Finished at: 2023-10-10T21:11:40-07:00
[INFO] ------------------------------------------------------------------------

```