### PR TITLE
Add _deserializedPartitionCapacityMap to ResourceConfig model to ensure that the partition capacity map is only deserialized one time

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
@@ -392,7 +392,7 @@ public class ResourceConfig extends HelixProperty {
   public Map<String, Map<String, Integer>> getPartitionCapacityMap() throws IOException {
     // It is very expensive to deserialize the partition capacity map every time this is called.
     // Cache the deserialized map to avoid the overhead.
-    if (_deserializedPartitionCapacityMap != null) {
+    if (_deserializedPartitionCapacityMap != null && !_deserializedPartitionCapacityMap.isEmpty()) {
       return _deserializedPartitionCapacityMap;
     }
 
@@ -410,7 +410,7 @@ public class ResourceConfig extends HelixProperty {
     }
 
     // Only set the deserialized map when the deserialization succeeds, so we don't have the potential
-    // of having a partially contracted map.
+    // of having a partially populated map.
     _deserializedPartitionCapacityMap = partitionCapacityMap;
     return _deserializedPartitionCapacityMap;
   }
@@ -434,6 +434,9 @@ public class ResourceConfig extends HelixProperty {
     }
 
     Map<String, String> newCapacityRecord = new HashMap<>();
+    // We want a copy of the partitionCapacityMap, so that the caller can no longer modify the
+    // _deserializedPartitionCapacityMap after this call through their reference to partitionCapacityMap.
+    Map<String, Map<String, Integer>> newDeserializedPartitionCapacityMap = new HashMap<>();
     for (String partition : partitionCapacityMap.keySet()) {
       Map<String, Integer> capacities = partitionCapacityMap.get(partition);
       // Verify the input is valid
@@ -445,11 +448,12 @@ public class ResourceConfig extends HelixProperty {
             String.format("Capacity Data contains a negative value:%s", capacities.toString()));
       }
       newCapacityRecord.put(partition, _objectMapper.writeValueAsString(capacities));
+      newDeserializedPartitionCapacityMap.put(partition, Map.copyOf(capacities));
     }
 
     _record.setMapField(ResourceConfigProperty.PARTITION_CAPACITY_MAP.name(), newCapacityRecord);
     // Set deserialize map after we have successfully added it to the record.
-    _deserializedPartitionCapacityMap = partitionCapacityMap;
+    _deserializedPartitionCapacityMap = newDeserializedPartitionCapacityMap;
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableReplica.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableReplica.java
@@ -71,8 +71,14 @@ public class TestAssignableReplica {
     Map<String, Integer> capacityDataMapResource2 = new HashMap<>();
     capacityDataMapResource2.put("item1", 5);
     capacityDataMapResource2.put("item2", 10);
+
+    // We should not directly modify the contents returned by getPartitionCapacityMap()
+    // This will not guard against the modification of the kv pairs in the inner maps as this
+    // is not creating a deepCopy but will ensure we don't override top level kv pairs in
+    // testResourceConfigResource.
     Map<String, Map<String, Integer>> capacityMap =
-        testResourceConfigResource.getPartitionCapacityMap();
+        new HashMap<>(testResourceConfigResource.getPartitionCapacityMap());
+
     String partitionName2 = partitionNamePrefix + 2;
     capacityMap.put(partitionName2, capacityDataMapResource2);
     testResourceConfigResource.setPartitionCapacityMap(capacityMap);


### PR DESCRIPTION
Add _deserializedPartitionCapacityMap to ResourceConfig model to ensure that the partition capacity map is only deserialized one time. This will lead to major performance gains as this was previously called in several parts of BestPossibleStateCalculation and CurrentStateComputation.

### Issues
* [x]  My PR addresses the following Helix issues and references them in the PR description:
   [Optimize WagedInstanceCapacity Calculation to improve Helix Controller Pipeline #2646](https://github.com/apache/helix/issues/2646)

### Description

During profiling we realized that the majority(up to 90%) of the CurrentStateComputationStage is taken up by `_objectMapper.readValue`.

After investigating further, this problem is not only seen in CurrentStateComputationStage. By only deserializing on the first call to `getPartitionCapacityMap` we can **tremendously** improve the pipeline performance in more than one place.

Where is this called:
- CurrentStateComputationStage
  -  For every resource when reporting resource capacity metrics
  -  For every  partition of WAGED resource when checkAndReduceInstanceCapacity based of currentStateMap
  -  Every pending STATE_TRANSITION message for WAGED replica to checkAndReduceInstanceCapacity (n + 1 respect capacity solution)
- BestPossibleStateCalcStage 
  -  For checkAndReduceCapacity of every instanceToAdd for all partitions of WAGED resources (n + 1 respect capacity solution)
  - Called for the creation of every single AssignableReplica for all replicas of WAGED resources

Basically, every time(unbounded as cluster grows) getPartitionCapacityWeightMap is called it is deserializing the PARTITION_CAPACITY_MAP mapField in the ResourceConfig over and over again. This change makes sure that deserialize only happens once per resource and will save lots of time.

### Tests

No behavior changes, so will rely on current tests and CI to validate.

### Changes that Break Backward Compatibility (Optional)

NA

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
