### PR TITLE
HelixAdmin APIs and pipeline changes to support Helix Node Swap 

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -763,7 +763,7 @@ public interface HelixAdmin {
    * @param instanceName The instance that is being swapped out or swapped in
    * @return True if the swap is ready to be completed, false otherwise.
    */
-  boolean isSwapReadyToComplete(String clusterName, String instanceName);
+  boolean canSwapBeCompleted(String clusterName, String instanceName);
 
   /**
    * Check to see if swapping between two instances is ready to be completed and completed it if
@@ -774,7 +774,7 @@ public interface HelixAdmin {
    * @return True if the swap is ready to be completed and was completed successfully, false
    * otherwise.
    */
-  boolean completeSwapIfReady(String clusterName, String instanceName);
+  boolean completeSwapIfPossible(String clusterName, String instanceName);
 
   /**
    * Return if instance is ready for preparing joining cluster. The instance should have no current state,

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import org.apache.helix.api.status.ClusterManagementMode;
 import org.apache.helix.api.status.ClusterManagementModeRequest;
 import org.apache.helix.api.topology.ClusterTopology;
@@ -302,8 +304,15 @@ public interface HelixAdmin {
    */
   void enableInstance(String clusterName, List<String> instances, boolean enabled);
 
-  void setInstanceOperation(String clusterName, String instance,
-      InstanceConstants.InstanceOperation instanceOperation);
+  /**
+   * Set the instanceOperation field.
+   *
+   * @param clusterName       The cluster name
+   * @param instanceName      The instance name
+   * @param instanceOperation The instance operation
+   */
+  void setInstanceOperation(String clusterName, String instanceName,
+      @Nullable InstanceConstants.InstanceOperation instanceOperation);
 
   /**
    * Disable or enable a resource
@@ -746,6 +755,26 @@ public interface HelixAdmin {
    * @return Return true if there is no current state nor pending message on the instance.
    */
   boolean isEvacuateFinished(String clusterName, String instancesNames);
+
+  /**
+   * Check to see if swapping between two instances is ready to be completed. Either the swapOut or
+   * swapIn instance can be passed in.
+   * @param clusterName  The cluster name
+   * @param instanceName The instance that is being swapped out or swapped in
+   * @return True if the swap is ready to be completed, false otherwise.
+   */
+  boolean isSwapReadyToComplete(String clusterName, String instanceName);
+
+  /**
+   * Check to see if swapping between two instances is ready to be completed and completed it if
+   * ready. Either the swapOut or swapIn instance can be passed in.
+   *
+   * @param clusterName  The cluster name
+   * @param instanceName The instance that is being swapped out or swapped in
+   * @return True if the swap is ready to be completed and was completed successfully, false
+   * otherwise.
+   */
+  boolean completeSwapIfReady(String clusterName, String instanceName);
 
   /**
    * Return if instance is ready for preparing joining cluster. The instance should have no current state,

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -757,7 +757,7 @@ public interface HelixAdmin {
   boolean isEvacuateFinished(String clusterName, String instancesNames);
 
   /**
-   * Check to see if swapping between two instances is ready to be completed. Either the swapOut or
+   * Check to see if swapping between two instances can be completed. Either the swapOut or
    * swapIn instance can be passed in.
    * @param clusterName  The cluster name
    * @param instanceName The instance that is being swapped out or swapped in
@@ -766,8 +766,8 @@ public interface HelixAdmin {
   boolean canSwapBeCompleted(String clusterName, String instanceName);
 
   /**
-   * Check to see if swapping between two instances is ready to be completed and completed it if
-   * ready. Either the swapOut or swapIn instance can be passed in.
+   * Check to see if swapping between two instances is ready to be completed and complete it if
+   * possible. Either the swapOut or swapIn instance can be passed in.
    *
    * @param clusterName  The cluster name
    * @param instanceName The instance that is being swapped out or swapped in

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -763,7 +763,7 @@ public interface HelixAdmin {
    * @param instanceName The instance that is being swapped out or swapped in
    * @return True if the swap is ready to be completed, false otherwise.
    */
-  boolean canSwapBeCompleted(String clusterName, String instanceName);
+  boolean canCompleteSwap(String clusterName, String instanceName);
 
   /**
    * Check to see if swapping between two instances is ready to be completed and complete it if

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -888,10 +888,17 @@ public class BaseControllerDataProvider implements ControlContextProvider {
 
   private void updateSwappingInstances(Collection<InstanceConfig> instanceConfigs,
       Set<String> liveEnabledInstances, ClusterConfig clusterConfig) {
-    ClusterTopologyConfig clusterTopologyConfig =
-        ClusterTopologyConfig.createFromClusterConfig(clusterConfig);
     _swapOutInstanceNameToSwapInInstanceName.clear();
     _enabledLiveSwapInInstanceNames.clear();
+
+    if (clusterConfig == null) {
+      logger.warn("Skip refreshing swapping instances because clusterConfig is null.");
+      return;
+    }
+
+    ClusterTopologyConfig clusterTopologyConfig =
+        ClusterTopologyConfig.createFromClusterConfig(clusterConfig);
+
     Map<String, String> swapOutLogicalIdsByInstanceName = new HashMap<>();
     Map<String, String> swapInInstancesByLogicalId = new HashMap<>();
     instanceConfigs.forEach(instanceConfig -> {

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -626,7 +626,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
   }
 
   /**
-   * This method allows one to fetch the active swapping instance pairs.
+   * Get all swapping instance pairs.
    *
    * @return a map of SWAP_OUT instanceNames and their corresponding SWAP_IN instanceNames.
    */
@@ -635,7 +635,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
   }
 
   /**
-   * This method allows one to fetch the active SWAP_IN instances.
+   * Get all the enabled and live SWAP_IN instances.
    *
    * @return a set of SWAP_IN instanceNames that have a corresponding SWAP_OUT instance.
    */

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -46,10 +46,12 @@ import org.apache.helix.common.caches.InstanceMessagesCache;
 import org.apache.helix.common.caches.PropertyCache;
 import org.apache.helix.common.caches.TaskCurrentStateCache;
 import org.apache.helix.common.controllers.ControlContextProvider;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.LogUtil;
 import org.apache.helix.controller.rebalancer.constraint.MonitoredAbnormalResolver;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ClusterConstraints;
+import org.apache.helix.model.ClusterTopologyConfig;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
@@ -116,6 +118,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
   private Map<String, Map<String, String>> _idealStateRuleMap;
   private final Map<String, Map<String, Set<String>>> _disabledInstanceForPartitionMap = new HashMap<>();
   private final Set<String> _disabledInstanceSet = new HashSet<>();
+  private final Map<String, String> _swapOutInstanceNameToSwapInInstanceName = new HashMap<>();
+  private final Set<String> _enabledLiveSwapInInstanceNames = new HashSet<>();
   private final Map<String, MonitoredAbnormalResolver> _abnormalStateResolverMap = new HashMap<>();
   private final Set<String> _timedOutInstanceDuringMaintenance = new HashSet<>();
   private Map<String, LiveInstance> _liveInstanceExcludeTimedOutForMaintenance = new HashMap<>();
@@ -437,6 +441,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
 
     updateIdealRuleMap(getClusterConfig());
     updateDisabledInstances(getInstanceConfigMap().values(), getClusterConfig());
+    updateSwappingInstances(getInstanceConfigMap().values(), getEnabledLiveInstances(),
+        getClusterConfig());
 
     return refreshedTypes;
   }
@@ -471,6 +477,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     refreshAbnormalStateResolverMap(_clusterConfig);
     updateIdealRuleMap(_clusterConfig);
     updateDisabledInstances(getInstanceConfigMap().values(), _clusterConfig);
+    updateSwappingInstances(getInstanceConfigMap().values(), getEnabledLiveInstances(),
+        _clusterConfig);
   }
 
   @Override
@@ -617,6 +625,24 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     return Collections.unmodifiableSet(_disabledInstanceSet);
   }
 
+  /**
+   * This method allows one to fetch the active swapping instance pairs.
+   *
+   * @return a map of SWAP_OUT instanceNames and their corresponding SWAP_IN instanceNames.
+   */
+  public Map<String, String> getSwapOutToSwapInInstancePairs() {
+    return Collections.unmodifiableMap(_swapOutInstanceNameToSwapInInstanceName);
+  }
+
+  /**
+   * This method allows one to fetch the active SWAP_IN instances.
+   *
+   * @return a set of SWAP_IN instanceNames that have a corresponding SWAP_OUT instance.
+   */
+  public Set<String> getEnabledLiveSwapInInstanceNames() {
+    return Collections.unmodifiableSet(_enabledLiveSwapInInstanceNames);
+  }
+
   public synchronized void setLiveInstances(List<LiveInstance> liveInstances) {
     _liveInstanceCache.setPropertyMap(HelixProperty.convertListToMap(liveInstances));
     _updateInstanceOfflineTime = true;
@@ -750,6 +776,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
   public void setInstanceConfigMap(Map<String, InstanceConfig> instanceConfigMap) {
     _instanceConfigCache.setPropertyMap(instanceConfigMap);
     updateDisabledInstances(instanceConfigMap.values(), getClusterConfig());
+    updateSwappingInstances(instanceConfigMap.values(), getEnabledLiveInstances(),
+        getClusterConfig());
   }
 
   /**
@@ -856,6 +884,42 @@ public class BaseControllerDataProvider implements ControlContextProvider {
         }
       }
     }
+  }
+
+  private void updateSwappingInstances(Collection<InstanceConfig> instanceConfigs,
+      Set<String> liveEnabledInstances, ClusterConfig clusterConfig) {
+    ClusterTopologyConfig clusterTopologyConfig =
+        ClusterTopologyConfig.createFromClusterConfig(clusterConfig);
+    _swapOutInstanceNameToSwapInInstanceName.clear();
+    _enabledLiveSwapInInstanceNames.clear();
+    Map<String, String> swapOutLogicalIdsByInstanceName = new HashMap<>();
+    Map<String, String> swapInInstancesByLogicalId = new HashMap<>();
+    instanceConfigs.forEach(instanceConfig -> {
+      if (instanceConfig == null) {
+        return;
+      }
+      if (instanceConfig.getInstanceOperation()
+          .equals(InstanceConstants.InstanceOperation.SWAP_OUT.name())) {
+        swapOutLogicalIdsByInstanceName.put(instanceConfig.getInstanceName(),
+            instanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType()));
+      }
+      if (instanceConfig.getInstanceOperation()
+          .equals(InstanceConstants.InstanceOperation.SWAP_IN.name())) {
+        swapInInstancesByLogicalId.put(
+            instanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType()),
+            instanceConfig.getInstanceName());
+      }
+    });
+
+    swapOutLogicalIdsByInstanceName.forEach((swapOutInstanceName, value) -> {
+      String swapInInstanceName = swapInInstancesByLogicalId.get(value);
+      if (swapInInstanceName != null) {
+        _swapOutInstanceNameToSwapInInstanceName.put(swapOutInstanceName, swapInInstanceName);
+        if (liveEnabledInstances.contains(swapInInstanceName)) {
+          _enabledLiveSwapInInstanceNames.add(swapInInstanceName);
+        }
+      }
+    });
   }
 
   /*

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -165,14 +165,15 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
         getRebalanceStrategy(currentIdealState.getRebalanceStrategy(), allPartitions, resourceName,
             stateCountMap, maxPartition);
 
-    // sort node lists to ensure consistent preferred assignments
     List<String> allNodeList = new ArrayList<>(allNodesDeduped);
-    // We will not assign partition to instances with evacuation and wap-out tag.
+
     // TODO: Currently we have 2 groups of instances and compute preference list twice and merge.
     // Eventually we want to have exclusive groups of instance for different instance tag.
     List<String> liveEnabledAssignableNodeList = new ArrayList<>(
+        // We will not assign partitions to instances with EVACUATE InstanceOperation.
         DelayedRebalanceUtil.filterOutEvacuatingInstances(clusterData.getInstanceConfigMap(),
             liveEnabledNodes));
+    // sort node lists to ensure consistent preferred assignments
     Collections.sort(allNodeList);
     Collections.sort(liveEnabledAssignableNodeList);
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.api.config.StateTransitionThrottleConfig;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.constraint.MonitoredAbnormalResolver;
 import org.apache.helix.controller.rebalancer.util.DelayedRebalanceUtil;
@@ -56,7 +57,9 @@ import org.slf4j.LoggerFactory;
  */
 public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceControllerDataProvider> {
   private static final Logger LOG = LoggerFactory.getLogger(DelayedAutoRebalancer.class);
-   public static final Set<String> INSTANCE_OPERATION_TO_EXCLUDE_FROM_ASSIGNMENT = ImmutableSet.of("EVACUATE", "SWAP_IN");
+  public static ImmutableSet<String> INSTANCE_OPERATION_TO_EXCLUDE_FROM_ASSIGNMENT =
+      ImmutableSet.of(InstanceConstants.InstanceOperation.EVACUATE.name(),
+          InstanceConstants.InstanceOperation.SWAP_IN.name());
 
   @Override
   public IdealState computeNewIdealState(String resourceName,

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -201,8 +201,9 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
     // 1. Get all SWAP_OUT instances and corresponding SWAP_IN instance pairs in the cluster.
     Map<String, String> swapOutToSwapInInstancePairs =
         clusterData.getSwapOutToSwapInInstancePairs();
+    // 2. Get all enabled and live SWAP_IN instances in the cluster.
     Set<String> enabledLiveSwapInInstances = clusterData.getEnabledLiveSwapInInstanceNames();
-    // 2. For each SWAP_OUT instance in any of the preferenceLists, add the corresponding SWAP_IN instance to the end.
+    // 3. For each SWAP_OUT instance in any of the preferenceLists, add the corresponding SWAP_IN instance to the end.
     // Skipping this when there are not SWAP_IN instances ready(enabled and live) will reduce computation time when there is not an active
     // swap occurring.
     if (!clusterData.getEnabledLiveSwapInInstanceNames().isEmpty()) {
@@ -424,7 +425,7 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
         bestPossibleStateMap, preferenceList, combinedPreferenceList)) {
       for (int i = 0; i < combinedPreferenceList.size() - numReplicas; i++) {
         String instanceToDrop = combinedPreferenceList.get(combinedPreferenceList.size() - i - 1);
-        // We do not want to drop in a SWAP_IN node because if it is at the end of the preferenceList,
+        // We do not want to drop a SWAP_IN node if it is at the end of the preferenceList,
         // because partitions are actively being added on this node to prepare for SWAP completion.
         if (cache == null || !cache.getEnabledLiveSwapInInstanceNames().contains(instanceToDrop)) {
           bestPossibleStateMap.put(instanceToDrop, HelixDefinedState.DROPPED.name());

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
@@ -147,25 +147,16 @@ public class DelayedRebalanceUtil {
    * assignable. If there are duplicates with one node having no InstanceOperation and the other
    * having SWAP_OUT, the node with no InstanceOperation will be chosen. This signifies SWAP
    * completion, therefore making the node assignable.
-   * <p>
-   * Additionally, we never want to add a node that is not in the allowedInstances set if it is
-   * provided. allowedInstances should contain the filtered and deduped superset of nodes such as
-   * allInstances. If this filter method is called on a subset of allInstances, it should not ever
-   * keep an instance with a duplicate logical ID that was not previously returned when filtering
-   * the superset. This is important for cases where filtering allEnabledLiveInstances is filtered
-   * and the SWAP_OUT node is not enabled or live. We must prevent the SWAP_IN node from passing
-   * through the filter.
    *
    * @param clusterTopologyConfig the cluster topology configuration
    * @param instanceConfigMap     the map of instance name to corresponding InstanceConfig
    * @param instances             the set of instances to filter out duplicate logicalIDs for
-   * @param allowedInstances      the set of instances that are allowed to pass through the filter
    * @return the set of instances with duplicate logicalIDs filtered out, there will only be one
    * instance per logicalID
    */
   public static Set<String> filterOutInstancesWithDuplicateLogicalIds(
       ClusterTopologyConfig clusterTopologyConfig, Map<String, InstanceConfig> instanceConfigMap,
-      Set<String> instances, Set<String> allowedInstances) {
+      Set<String> instances) {
     Set<String> filteredNodes = new HashSet<>();
     Map<String, String> filteredInstancesByLogicalId = new HashMap<>();
 
@@ -176,11 +167,6 @@ public class DelayedRebalanceUtil {
       }
       String thisLogicalId =
           thisInstanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType());
-
-      // We do not want to allow the addition of nodes that are not in the allowedInstances set it is provided.
-      if (allowedInstances != null && !allowedInstances.contains(node)) {
-        return;
-      }
 
       if (filteredInstancesByLogicalId.containsKey(thisLogicalId)) {
         InstanceConfig filteredDuplicateInstanceConfig =

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
@@ -147,7 +147,8 @@ public class DelayedRebalanceUtil {
    * assignable. If there are duplicates with one node having no InstanceOperation and the other
    * having SWAP_OUT, the node with no InstanceOperation will be chosen. This signifies SWAP
    * completion, therefore making the node assignable.
-   *
+   * TODO: Eventually when we refactor DataProvider to have getAssignableInstances() and
+   * TODO: getAssignableEnabledLiveInstances() this will not need to be called in the rebalancer.
    * @param clusterTopologyConfig the cluster topology configuration
    * @param instanceConfigMap     the map of instance name to corresponding InstanceConfig
    * @param instances             the set of instances to filter out duplicate logicalIDs for
@@ -174,14 +175,12 @@ public class DelayedRebalanceUtil {
         if ((filteredDuplicateInstanceConfig.getInstanceOperation()
             .equals(InstanceConstants.InstanceOperation.SWAP_IN.name())
             && thisInstanceConfig.getInstanceOperation()
-            .equals(InstanceConstants.InstanceOperation.SWAP_OUT.name())) || (
-            filteredDuplicateInstanceConfig.getInstanceOperation()
-                .equals(InstanceConstants.InstanceOperation.SWAP_OUT.name())
-                && thisInstanceConfig.getInstanceOperation().isEmpty())) {
+            .equals(InstanceConstants.InstanceOperation.SWAP_OUT.name()))
+            || thisInstanceConfig.getInstanceOperation().isEmpty()) {
           // If the already filtered instance is SWAP_IN and this instance is in SWAP_OUT, then replace the filtered
-          // instance with this instance. If the already filtered instance is SWAP_OUT and this instance has
-          // no InstanceOperation, then replace the filtered instance with this instance. This is the case
-          // where the SWAP_IN node has been marked as complete.
+          // instance with this instance. If this instance has no InstanceOperation, then replace the filtered instance
+          // with this instance. This is the case where the SWAP_IN node has been marked as complete or SWAP_IN exists and
+          // SWAP_OUT does not. There can never be a case where both have no InstanceOperation set.
           filteredNodes.remove(filteredInstancesByLogicalId.get(thisLogicalId));
           filteredNodes.add(node);
           filteredInstancesByLogicalId.put(thisLogicalId, node);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
@@ -172,7 +172,7 @@ class GlobalRebalanceRunner implements AutoCloseable {
           // with both the SWAP_OUT and SWAP_IN node.
           DelayedRebalanceUtil.filterOutInstancesWithDuplicateLogicalIds(
               ClusterTopologyConfig.createFromClusterConfig(clusterData.getClusterConfig()),
-              clusterData.getInstanceConfigMap(), clusterData.getAllInstances(), null),
+              clusterData.getInstanceConfigMap(), clusterData.getAllInstances()),
               clusterChanges, currentBaseline);
     } catch (Exception ex) {
       throw new HelixRebalanceException("Failed to generate cluster model for global rebalance.",

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
@@ -30,10 +30,12 @@ import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.controller.changedetector.ResourceChangeDetector;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.rebalancer.util.DelayedRebalanceUtil;
 import org.apache.helix.controller.rebalancer.util.WagedRebalanceUtil;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModelProvider;
 import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.ClusterTopologyConfig;
 import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.monitoring.metrics.MetricCollector;
@@ -158,13 +160,19 @@ class GlobalRebalanceRunner implements AutoCloseable {
     // Build the cluster model for rebalance calculation.
     // Note, for a Baseline calculation,
     // 1. Ignore node status (disable/offline).
+    // 2. Dedupe and select correct node if there is more than one with the same logical id.
+    // We should be calculating a new baseline only after a swap operation is complete. Adding,
+    // this ensures that adding the SWAP_IN node to the cluster does not cause new baseline to be calculated
+    // with the SWAP_IN node.
     // 2. Use the previous Baseline as the only parameter about the previous assignment.
     Map<String, ResourceAssignment> currentBaseline =
         _assignmentManager.getBaselineAssignment(_assignmentMetadataStore, currentStateOutput, resourceMap.keySet());
     ClusterModel clusterModel;
     try {
-      clusterModel =
-          ClusterModelProvider.generateClusterModelForBaseline(clusterData, resourceMap, clusterData.getAllInstances(),
+      clusterModel = ClusterModelProvider.generateClusterModelForBaseline(clusterData, resourceMap,
+          DelayedRebalanceUtil.filterOutInstancesWithDuplicateLogicalIds(
+              ClusterTopologyConfig.createFromClusterConfig(clusterData.getClusterConfig()),
+              clusterData.getInstanceConfigMap(), clusterData.getAllInstances(), null),
               clusterChanges, currentBaseline);
     } catch (Exception ex) {
       throw new HelixRebalanceException("Failed to generate cluster model for global rebalance.",

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
@@ -160,16 +160,16 @@ class GlobalRebalanceRunner implements AutoCloseable {
     // Build the cluster model for rebalance calculation.
     // Note, for a Baseline calculation,
     // 1. Ignore node status (disable/offline).
-    // 2. Dedupe and select correct node if there is more than one with the same logical id.
-    // We should be calculating a new baseline only after a swap operation is complete. Adding,
-    // this ensures that adding the SWAP_IN node to the cluster does not cause new baseline to be calculated
-    // with the SWAP_IN node.
     // 2. Use the previous Baseline as the only parameter about the previous assignment.
     Map<String, ResourceAssignment> currentBaseline =
         _assignmentManager.getBaselineAssignment(_assignmentMetadataStore, currentStateOutput, resourceMap.keySet());
     ClusterModel clusterModel;
     try {
       clusterModel = ClusterModelProvider.generateClusterModelForBaseline(clusterData, resourceMap,
+          // Dedupe and select correct node if there is more than one with the same logical id.
+          // We should be calculating a new baseline only after a swap operation is complete and the SWAP_IN node is selected
+          // by deduping. This ensures that adding the SWAP_IN node to the cluster does not cause new baseline to be calculated
+          // with both the SWAP_OUT and SWAP_IN node.
           DelayedRebalanceUtil.filterOutInstancesWithDuplicateLogicalIds(
               ClusterTopologyConfig.createFromClusterConfig(clusterData.getClusterConfig()),
               clusterData.getInstanceConfigMap(), clusterData.getAllInstances(), null),

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -373,8 +373,9 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
         // 1. Get all SWAP_OUT instances and corresponding SWAP_IN instance pairs in the cluster.
         Map<String, String> swapOutToSwapInInstancePairs =
             clusterData.getSwapOutToSwapInInstancePairs();
+        // 2. Get all enabled and live SWAP_IN instances in the cluster.
         Set<String> enabledLiveSwapInInstances = clusterData.getEnabledLiveSwapInInstanceNames();
-        // 2. For each SWAP_OUT instance in any of the preferenceLists, add the corresponding SWAP_IN instance to the end.
+        // 3. For each SWAP_OUT instance in any of the preferenceLists, add the corresponding SWAP_IN instance to the end.
         // Skipping this when there are not SWAP_IN instances ready(enabled and live) will reduce computation time when there is not an active
         // swap occurring.
         if (!clusterData.getEnabledLiveSwapInInstanceNames().isEmpty()) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -47,8 +47,8 @@ import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModelProvider;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ClusterTopologyConfig;
 import org.apache.helix.model.IdealState;
-import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceAssignment;
@@ -302,8 +302,18 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
       ResourceControllerDataProvider clusterData, Map<String, Resource> resourceMap,
       final CurrentStateOutput currentStateOutput, RebalanceAlgorithm algorithm)
       throws HelixRebalanceException {
-    Set<String> activeNodes = DelayedRebalanceUtil
-        .getActiveNodes(clusterData.getAllInstances(), clusterData.getEnabledLiveInstances(),
+
+    Set<String> allNodesDeduped = DelayedRebalanceUtil.filterOutInstancesWithDuplicateLogicalIds(
+        ClusterTopologyConfig.createFromClusterConfig(clusterData.getClusterConfig()),
+        clusterData.getInstanceConfigMap(), clusterData.getAllInstances(), null);
+    Set<String> liveEnabledNodesDeduped =
+        DelayedRebalanceUtil.filterOutInstancesWithDuplicateLogicalIds(
+            ClusterTopologyConfig.createFromClusterConfig(clusterData.getClusterConfig()),
+            clusterData.getInstanceConfigMap(), clusterData.getEnabledLiveInstances(),
+            allNodesDeduped);
+
+    Set<String> activeNodes =
+        DelayedRebalanceUtil.getActiveNodes(allNodesDeduped, liveEnabledNodesDeduped,
             clusterData.getInstanceOfflineTimeMap(), clusterData.getLiveInstances().keySet(),
             clusterData.getInstanceConfigMap(), clusterData.getClusterConfig());
 
@@ -359,6 +369,19 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
         // Sort the preference list according to state priority.
         newIdealState.setPreferenceLists(
             getPreferenceLists(assignments.get(resourceName), statePriorityMap));
+
+        // 1. Get all SWAP_OUT instances and corresponding SWAP_IN instance pairs in the cluster.
+        Map<String, String> swapOutToSwapInInstancePairs =
+            clusterData.getSwapOutToSwapInInstancePairs();
+        Set<String> enabledLiveSwapInInstances = clusterData.getEnabledLiveSwapInInstanceNames();
+        // 2. For each SWAP_OUT instance in any of the preferenceLists, add the corresponding SWAP_IN instance to the end.
+        // Skipping this when there are not SWAP_IN instances ready(enabled and live) will reduce computation time when there is not an active
+        // swap occurring.
+        if (!clusterData.getEnabledLiveSwapInInstanceNames().isEmpty()) {
+          DelayedRebalanceUtil.addSwapInInstanceToPreferenceListsIfSwapOutInstanceExists(
+              newIdealState.getRecord(), swapOutToSwapInInstancePairs, enabledLiveSwapInInstances);
+        }
+
         // Note the state mapping in the new assignment won't directly propagate to the map fields.
         // The rebalancer will calculate for the final state mapping considering the current states.
         finalIdealStateMap.put(resourceName, newIdealState);
@@ -398,7 +421,16 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
       RebalanceAlgorithm algorithm) throws HelixRebalanceException {
     // the "real" live nodes at the time
     // TODO: this is a hacky way to filter our on operation instance. We should consider redesign `getEnabledLiveInstances()`.
-    final Set<String> enabledLiveInstances = filterOutOnOperationInstances(clusterData.getInstanceConfigMap(), clusterData.getEnabledLiveInstances());
+    final Set<String> allNodes = DelayedRebalanceUtil.filterOutInstancesWithDuplicateLogicalIds(
+        ClusterTopologyConfig.createFromClusterConfig(clusterData.getClusterConfig()),
+        clusterData.getInstanceConfigMap(), clusterData.getAllInstances(), null);
+    final Set<String> enabledLiveInstances =
+        DelayedRebalanceUtil.filterOutEvacuatingInstances(clusterData.getInstanceConfigMap(),
+            DelayedRebalanceUtil.filterOutInstancesWithDuplicateLogicalIds(
+                ClusterTopologyConfig.createFromClusterConfig(clusterData.getClusterConfig()),
+                clusterData.getInstanceConfigMap(), clusterData.getEnabledLiveInstances(),
+                allNodes));
+
     if (activeNodes.equals(enabledLiveInstances) || !requireRebalanceOverwrite(clusterData, currentResourceAssignment)) {
       // no need for additional process, return the current resource assignment
       return currentResourceAssignment;
@@ -425,14 +457,6 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     } finally {
       _rebalanceOverwriteLatency.endMeasuringLatency();
     }
-  }
-
-  private static Set<String> filterOutOnOperationInstances(Map<String, InstanceConfig> instanceConfigMap,
-      Set<String> nodes) {
-    return nodes.stream()
-        .filter(
-            instance -> !DelayedAutoRebalancer.INSTANCE_OPERATION_TO_EXCLUDE_FROM_ASSIGNMENT.contains(instanceConfigMap.get(instance).getInstanceOperation()))
-        .collect(Collectors.toSet());
   }
 
   /**
@@ -619,8 +643,17 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     bestPossibleAssignment.values().parallelStream().forEach((resourceAssignment -> {
       String resourceName = resourceAssignment.getResourceName();
       IdealState currentIdealState = clusterData.getIdealState(resourceName);
+
+      Set<String> allNodesDeduped = DelayedRebalanceUtil.filterOutInstancesWithDuplicateLogicalIds(
+          ClusterTopologyConfig.createFromClusterConfig(clusterData.getClusterConfig()),
+          clusterData.getInstanceConfigMap(), clusterData.getAllInstances(), null);
       Set<String> enabledLiveInstances =
-          filterOutOnOperationInstances(clusterData.getInstanceConfigMap(), clusterData.getEnabledLiveInstances());
+          DelayedRebalanceUtil.filterOutEvacuatingInstances(clusterData.getInstanceConfigMap(),
+              DelayedRebalanceUtil.filterOutInstancesWithDuplicateLogicalIds(
+                  ClusterTopologyConfig.createFromClusterConfig(clusterData.getClusterConfig()),
+                  clusterData.getInstanceConfigMap(), clusterData.getEnabledLiveInstances(),
+                  allNodesDeduped));
+
       int numReplica = currentIdealState.getReplicaCount(enabledLiveInstances.size());
       int minActiveReplica = DelayedRebalanceUtil.getMinActiveReplica(ResourceConfig
           .mergeIdealStateWithResourceConfig(clusterData.getResourceConfig(resourceName),

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -193,7 +193,7 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
           .containsKey(replica.getResourceName());
       _isInBaselineAssignment =
           clusterModel.getContext().getBaselineAssignment().containsKey(replica.getResourceName());
-      _replicaHash = Objects.hash(replica.toString(), clusterModel.getAssignableNodes().keySet());
+      _replicaHash = Objects.hash(replica.toString(), clusterModel.getAssignableLogicalIds());
       computeScore(overallClusterRemainingCapacityMap);
     }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -153,7 +153,7 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
             int idleScore1 = busyInstances.contains(instanceName1) ? 0 : 1;
             int idleScore2 = busyInstances.contains(instanceName2) ? 0 : 1;
             return idleScore1 != idleScore2 ? (idleScore1 - idleScore2)
-                : -instanceName1.compareTo(instanceName2);
+                : -nodeEntry1.getKey().compareTo(nodeEntry2.getKey());
           } else {
             return scoreCompareResult;
           }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
@@ -77,8 +77,8 @@ public class AssignableNode implements Comparable<AssignableNode> {
   AssignableNode(ClusterConfig clusterConfig, ClusterTopologyConfig clusterTopologyConfig,
       InstanceConfig instanceConfig, String instanceName) {
     _instanceName = instanceName;
-    _logicaId =
-        clusterTopologyConfig != null ? instanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType())
+    _logicaId = clusterTopologyConfig != null ? instanceConfig.getLogicalId(
+        clusterTopologyConfig.getEndNodeType())
             : instanceName;
     Map<String, Integer> instanceCapacity = fetchInstanceCapacity(clusterConfig, instanceConfig);
     _faultZone = computeFaultZone(clusterConfig, instanceConfig);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
@@ -34,6 +34,7 @@ import org.apache.helix.HelixException;
 import org.apache.helix.controller.rebalancer.topology.Topology;
 import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ClusterTopologyConfig;
 import org.apache.helix.model.InstanceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +49,7 @@ public class AssignableNode implements Comparable<AssignableNode> {
 
   // Immutable Instance Properties
   private final String _instanceName;
+  private final String _logicaId;
   private final String _faultZone;
   // maximum number of the partitions that can be assigned to the instance.
   private final int _maxPartition;
@@ -72,8 +74,12 @@ public class AssignableNode implements Comparable<AssignableNode> {
    * ResourceConfig could
    * subject to change. If the assumption is no longer true, this function should become private.
    */
-  AssignableNode(ClusterConfig clusterConfig, InstanceConfig instanceConfig, String instanceName) {
+  AssignableNode(ClusterConfig clusterConfig, ClusterTopologyConfig clusterTopologyConfig,
+      InstanceConfig instanceConfig, String instanceName) {
     _instanceName = instanceName;
+    _logicaId =
+        clusterConfig != null ? instanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType())
+            : instanceName;
     Map<String, Integer> instanceCapacity = fetchInstanceCapacity(clusterConfig, instanceConfig);
     _faultZone = computeFaultZone(clusterConfig, instanceConfig);
     _instanceTags = ImmutableSet.copyOf(instanceConfig.getTags());
@@ -84,6 +90,10 @@ public class AssignableNode implements Comparable<AssignableNode> {
     _remainingTopStateCapacity = new HashMap<>(instanceCapacity);
     _maxPartition = clusterConfig.getMaxPartitionsPerInstance();
     _currentAssignedReplicaMap = new HashMap<>();
+  }
+
+  AssignableNode(ClusterConfig clusterConfig, InstanceConfig instanceConfig, String instanceName) {
+    this(clusterConfig, null, instanceConfig, instanceName);
   }
 
   /**
@@ -272,6 +282,10 @@ public class AssignableNode implements Comparable<AssignableNode> {
     return _instanceName;
   }
 
+  public String getLogicalId() {
+    return _logicaId;
+  }
+
   public Set<String> getInstanceTags() {
     return _instanceTags;
   }
@@ -368,7 +382,7 @@ public class AssignableNode implements Comparable<AssignableNode> {
 
   @Override
   public int compareTo(AssignableNode o) {
-    return _instanceName.compareTo(o.getInstanceName());
+    return _logicaId.compareTo(o.getLogicalId());
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
@@ -78,7 +78,7 @@ public class AssignableNode implements Comparable<AssignableNode> {
       InstanceConfig instanceConfig, String instanceName) {
     _instanceName = instanceName;
     _logicaId =
-        clusterConfig != null ? instanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType())
+        clusterTopologyConfig != null ? instanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType())
             : instanceName;
     Map<String, Integer> instanceCapacity = fetchInstanceCapacity(clusterConfig, instanceConfig);
     _faultZone = computeFaultZone(clusterConfig, instanceConfig);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModel.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModel.java
@@ -37,6 +37,7 @@ public class ClusterModel {
   // Note that the identical replicas are deduped in the index.
   private final Map<String, Map<String, AssignableReplica>> _assignableReplicaIndex;
   private final Map<String, AssignableNode> _assignableNodeMap;
+  private final Set<String> _assignableNodeLogicalIds;
 
   /**
    * @param clusterContext         The initialized cluster context.
@@ -60,6 +61,9 @@ public class ClusterModel {
 
     _assignableNodeMap = assignableNodes.parallelStream()
         .collect(Collectors.toMap(AssignableNode::getInstanceName, node -> node));
+    _assignableNodeLogicalIds =
+        assignableNodes.parallelStream().map(AssignableNode::getLogicalId)
+            .collect(Collectors.toSet());
   }
 
   public ClusterContext getContext() {
@@ -68,6 +72,10 @@ public class ClusterModel {
 
   public Map<String, AssignableNode> getAssignableNodes() {
     return _assignableNodeMap;
+  }
+
+  public Set<String> getAssignableLogicalIds() {
+    return _assignableNodeLogicalIds;
   }
 
   public Map<String, Set<AssignableReplica>> getAssignableReplicaMap() {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -34,6 +34,7 @@ import org.apache.helix.HelixException;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.util.DelayedRebalanceUtil;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ClusterTopologyConfig;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Partition;
@@ -530,9 +531,12 @@ public class ClusterModelProvider {
    */
   private static Set<AssignableNode> getAllAssignableNodes(ClusterConfig clusterConfig,
       Map<String, InstanceConfig> instanceConfigMap, Set<String> activeInstances) {
+    ClusterTopologyConfig clusterTopologyConfig =
+        ClusterTopologyConfig.createFromClusterConfig(clusterConfig);
     return activeInstances.parallelStream()
         .filter(instanceConfigMap::containsKey).map(
-            instanceName -> new AssignableNode(clusterConfig, instanceConfigMap.get(instanceName),
+            instanceName -> new AssignableNode(clusterConfig, clusterTopologyConfig,
+                instanceConfigMap.get(instanceName),
                 instanceName)).collect(Collectors.toSet());
   }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -588,7 +588,7 @@ public class ZKHelixAdmin implements HelixAdmin {
    * @param swapInInstanceName  The instance that is being swapped in
    * @return True if the swap is ready to be completed, false otherwise.
    */
-  private boolean canSwapBeCompleted(String clusterName, String swapOutInstanceName,
+  private boolean canCompleteSwap(String clusterName, String swapOutInstanceName,
       String swapInInstanceName) {
     BaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_zkClient);
     HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, baseAccessor);
@@ -718,7 +718,7 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   @Override
-  public boolean canSwapBeCompleted(String clusterName, String instanceName) {
+  public boolean canCompleteSwap(String clusterName, String instanceName) {
     InstanceConfig instanceConfig = getInstanceConfig(clusterName, instanceName);
     if (instanceConfig == null) {
       logger.warn(
@@ -741,7 +741,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     // Check if the swap is ready to be completed.
-    return canSwapBeCompleted(clusterName, swapOutInstanceConfig.getInstanceName(),
+    return canCompleteSwap(clusterName, swapOutInstanceConfig.getInstanceName(),
         swapInInstanceConfig.getInstanceName());
   }
 
@@ -769,7 +769,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     // Check if the swap is ready to be completed. If not, return false.
-    if (!canSwapBeCompleted(clusterName, swapOutInstanceConfig.getInstanceName(),
+    if (!canCompleteSwap(clusterName, swapOutInstanceConfig.getInstanceName(),
         swapInInstanceConfig.getInstanceName())) {
       return false;
     }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -524,7 +524,7 @@ public class ZKHelixAdmin implements HelixAdmin {
    * Check to see if swapping between two instances is ready to be completed. Checks: 1. Both
    * instances must be alive. 2. Both instances must only have one session and not be carrying over
    * from a previous session. 3. Both instances must have no pending messages. 4. Both instances
-   * cannot have partitions in the ERROR state 4. SwapIn instance must have correct state for all
+   * cannot have partitions in the ERROR state 5. SwapIn instance must have correct state for all
    * partitions that are currently assigned to the SwapOut instance.
    * TODO: We may want to make this a public API in the future.
    *
@@ -533,7 +533,7 @@ public class ZKHelixAdmin implements HelixAdmin {
    * @param swapInInstanceName  The instance that is being swapped in
    * @return True if the swap is ready to be completed, false otherwise.
    */
-  private boolean isSwapReadyToComplete(String clusterName, String swapOutInstanceName,
+  private boolean canSwapBeCompleted(String clusterName, String swapOutInstanceName,
       String swapInInstanceName) {
     BaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_zkClient);
     HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, baseAccessor);
@@ -662,7 +662,7 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   @Override
-  public boolean isSwapReadyToComplete(String clusterName, String instanceName) {
+  public boolean canSwapBeCompleted(String clusterName, String instanceName) {
     InstanceConfig instanceConfig = getInstanceConfig(clusterName, instanceName);
     if (instanceConfig == null) {
       logger.warn(
@@ -685,12 +685,12 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     // Check if the swap is ready to be completed.
-    return isSwapReadyToComplete(clusterName, swapOutInstanceConfig.getInstanceName(),
+    return canSwapBeCompleted(clusterName, swapOutInstanceConfig.getInstanceName(),
         swapInInstanceConfig.getInstanceName());
   }
 
   @Override
-  public boolean completeSwapIfReady(String clusterName, String instanceName) {
+  public boolean completeSwapIfPossible(String clusterName, String instanceName) {
     InstanceConfig instanceConfig = getInstanceConfig(clusterName, instanceName);
     if (instanceConfig == null) {
       logger.warn(
@@ -713,7 +713,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     // Check if the swap is ready to be completed. If not, return false.
-    if (!isSwapReadyToComplete(clusterName, swapOutInstanceConfig.getInstanceName(),
+    if (!canSwapBeCompleted(clusterName, swapOutInstanceConfig.getInstanceName(),
         swapInInstanceConfig.getInstanceName())) {
       return false;
     }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -261,8 +261,8 @@ public class ZKHelixAdmin implements HelixAdmin {
                 + instanceConfig.getInstanceOperation());
       }
     } else if (!instanceConfig.getInstanceOperation().isEmpty()) {
-      // If there are no instances with the same logicalId, we can only add this instance if InstanceOperation is unset.
-      // because it is a new instance.
+      // If there are no instances with the same logicalId, we can only add this instance if InstanceOperation
+      // is unset because it is a new instance.
       throw new HelixException(
           "There is no instance with logicalId: " + toAddInstanceLogicalId + " in cluster: "
               + clusterName + "; therefore, " + nodeId
@@ -466,21 +466,6 @@ public class ZKHelixAdmin implements HelixAdmin {
           + "creating the InstanceConfig).");
     }
 
-    // Swap will not happen unless both instance are active
-
-    // Logic for picking active swapping instance
-    // SWAP_OUT -> null keep serving the old instance
-    // SWAP_OUT -> deactivated serve the new instance
-    // SWAP_IN -> null keep serving the old instance
-    // SWAP_IN -> deactivated serve the old instance
-
-    // Should not be able to change instance information from SWAP_IN to anything else.
-    // Should not be able to change instance information from SWAP_OUT to anything else.
-    // This should be changed once a SWAP is completed or aborted.
-
-    // active node is SWAP_OUT if it has SWAP_OUT operation and SWAP_IN operation is not set
-    // active node is SWAP_IN if it has SWAP_IN operation
-
     if (!baseAccessor.exists(path, 0)) {
       throw new HelixException(
           "Cluster " + clusterName + ", instance: " + instanceName + ", instance config does not exist");
@@ -515,7 +500,7 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   /**
-   * Find the instance that this passed instance is swapping with. If the passed instance has
+   * Find the instance that the passed instance is swapping with. If the passed instance has
    * SWAP_OUT instanceOperation, then find the corresponding instance that has SWAP_IN
    * instanceOperation. If the passed instance has SWAP_IN instanceOperation, then find the
    * corresponding instance that has SWAP_OUT instanceOperation.

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -446,6 +446,21 @@ public class ZKHelixAdmin implements HelixAdmin {
           + " This should be set when creating the InstanceConfig.");
     }
 
+    // Swap will not happen unless both instance are active
+
+    // Logic for picking active swapping instance
+    // SWAP_OUT -> null keep serving the old instance
+    // SWAP_OUT -> deactivated serve the new instance
+    // SWAP_IN -> null keep serving the old instance
+    // SWAP_IN -> deactivated serve the old instance
+
+    // Should not be able to change instance information from SWAP_IN to anything else.
+    // Should not be able to change instance information from SWAP_OUT to anything else.
+    // This should be changed once a SWAP is completed or aborted.
+
+    // active node is SWAP_OUT if it has SWAP_OUT operation and SWAP_IN operation is not set
+    // active node is SWAP_IN if it has SWAP_IN operation
+
     if (!baseAccessor.exists(path, 0)) {
       throw new HelixException(
           "Cluster " + clusterName + ", instance: " + instanceName + ", instance config does not exist");

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -702,6 +702,16 @@ public class InstanceConfig extends HelixProperty {
     return _record.getId();
   }
 
+  /**
+   * Get the logicalId of this instance. If it does not exist or is not set,
+   * return the instance name.
+   * @param logicalIdKey the key for the DOMAIN field containing the logicalId
+   * @return the logicalId of this instance
+   */
+  public String getLogicalId(String logicalIdKey) {
+    return getDomainAsMap().getOrDefault(logicalIdKey, getInstanceName());
+  }
+
   @Override
   public boolean isValid() {
     // HELIX-65: remove check for hostname/port existence

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -709,6 +709,8 @@ public class InstanceConfig extends HelixProperty {
    * @return the logicalId of this instance
    */
   public String getLogicalId(String logicalIdKey) {
+    // TODO: Consider caching DomainMap, parsing the DOMAIN string every time
+    // getLogicalId is called can become expensive if called too frequently.
     return getDomainAsMap().getOrDefault(logicalIdKey, getInstanceName());
   }
 

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -782,6 +782,7 @@ public class InstanceConfig extends HelixProperty {
     private int _weight = WEIGHT_NOT_SET;
     private List<String> _tags = new ArrayList<>();
     private boolean _instanceEnabled = HELIX_ENABLED_DEFAULT_VALUE;
+    private InstanceConstants.InstanceOperation _instanceOperation;
     private Map<String, String> _instanceInfoMap;
     private Map<String, Integer> _instanceCapacityMap;
 
@@ -827,6 +828,10 @@ public class InstanceConfig extends HelixProperty {
 
       if (_instanceEnabled != HELIX_ENABLED_DEFAULT_VALUE) {
         instanceConfig.setInstanceEnabled(_instanceEnabled);
+      }
+
+      if (_instanceOperation != null) {
+        instanceConfig.setInstanceOperation(_instanceOperation);
       }
 
       if (_instanceInfoMap != null) {
@@ -897,6 +902,17 @@ public class InstanceConfig extends HelixProperty {
      */
     public Builder setInstanceEnabled(boolean instanceEnabled) {
       _instanceEnabled = instanceEnabled;
+      return this;
+    }
+
+    /**
+     * Set the instance operation for this instance
+     *
+     * @param instanceOperation the instance operation.
+     * @return InstanceConfig.Builder
+     */
+    public Builder setInstanceOperation(InstanceConstants.InstanceOperation instanceOperation) {
+      _instanceOperation = instanceOperation;
       return this;
     }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -22,6 +22,7 @@ package org.apache.helix.controller.rebalancer.waged;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -738,7 +739,8 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     instances.add(offlineInstance);
     when(clusterData.getAllInstances()).thenReturn(instances);
     when(clusterData.getEnabledInstances()).thenReturn(instances);
-    when(clusterData.getEnabledLiveInstances()).thenReturn(new HashSet<>(Set.of(instance0, instance1, instance2)));
+    when(clusterData.getEnabledLiveInstances()).thenReturn(
+        new HashSet<>(Arrays.asList(instance0, instance1, instance2)));
     Map<String, Long> instanceOfflineTimeMap = new HashMap<>();
     instanceOfflineTimeMap.put(offlineInstance, System.currentTimeMillis() + Integer.MAX_VALUE);
     when(clusterData.getInstanceOfflineTimeMap()).thenReturn(instanceOfflineTimeMap);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -738,7 +738,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     instances.add(offlineInstance);
     when(clusterData.getAllInstances()).thenReturn(instances);
     when(clusterData.getEnabledInstances()).thenReturn(instances);
-    when(clusterData.getEnabledLiveInstances()).thenReturn(ImmutableSet.of(instance0, instance1, instance2));
+    when(clusterData.getEnabledLiveInstances()).thenReturn(new HashSet<>(Set.of(instance0, instance1, instance2)));
     Map<String, Long> instanceOfflineTimeMap = new HashMap<>();
     instanceOfflineTimeMap.put(offlineInstance, System.currentTimeMillis() + Integer.MAX_VALUE);
     when(clusterData.getInstanceOfflineTimeMap()).thenReturn(instanceOfflineTimeMap);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -908,7 +908,7 @@ public class TestInstanceOperation extends ZkTestBase {
   @Test(dependsOnMethods = "testNodeSwapAfterEMM")
   public void testNodeSwapWithSwapOutInstanceDisabled() throws Exception {
     System.out.println(
-        "START TestInstanceOperation.testNodeSwapWithSwapInstancesOutOffline() at " + new Date(
+        "START TestInstanceOperation.testNodeSwapWithSwapOutInstanceDisabled() at " + new Date(
             System.currentTimeMillis()));
 
     resetInstances();

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -405,6 +405,8 @@ public class TestInstanceOperation extends ZkTestBase {
       Assert.assertTrue(newPAssignedParticipants.containsAll(currentActiveInstances));
     }
     Assert.assertTrue(_admin.isReadyForPreparingJoiningCluster(CLUSTER_NAME, instanceToEvacuate));
+
+    _stateModelDelay = 3L;
   }
 
   @Test(dependsOnMethods = "testMarkEvacuationAfterEMM")
@@ -441,6 +443,9 @@ public class TestInstanceOperation extends ZkTestBase {
         return true;
       }, 30000);
     }
+
+    resetInstances();
+    dropTestDBs(ImmutableSet.of("TEST_DB3_DELAYED_CRUSHED", "TEST_DB4_DELAYED_WAGED"));
   }
 
   @Test(expectedExceptions = HelixException.class, dependsOnMethods = "testEvacuationWithOfflineInstancesInCluster")
@@ -450,7 +455,6 @@ public class TestInstanceOperation extends ZkTestBase {
             System.currentTimeMillis()));
 
     resetInstances();
-    dropTestDBs(ImmutableSet.of("TEST_DB3_DELAYED_CRUSHED", "TEST_DB4_DELAYED_WAGED"));
 
     // Set instance's InstanceOperation to SWAP_OUT
     String instanceToSwapOutName = _participants.get(0).getInstanceName();

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -586,6 +586,8 @@ public class TestInstanceOperation extends ZkTestBase {
     addParticipant(instanceToSwapInName, instanceToSwapOutInstanceConfig.getLogicalId(LOGICAL_ID),
         instanceToSwapOutInstanceConfig.getDomainAsMap().get(ZONE),
         InstanceConstants.InstanceOperation.SWAP_IN, true);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
   }
 
   @Test(dependsOnMethods = "testNodeSwapNoTopologySetup")

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -898,24 +898,28 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
       InstanceConfig instanceConfig = new InstanceConfig(instanceName);
       instanceConfig.setHostName(hostname);
       instanceConfig.setPort(port);
-      if (i == 40) {
-        instanceConfig.setDomain(String
-            .format("invaliddomain=%s,zone=%s,rack=%s,host=%s", "mygroup" + i % 2, "myzone" + i % 4,
-                "myrack" + i % 4, hostname));
-      } else if (i == 41) {
-        instanceConfig.setDomain("invaliddomain");
-      } else {
-        String domain = String
-            .format("group=%s,zone=%s,rack=%s,host=%s", "mygroup" + i % 2, "myzone" + i % 4,
-                "myrack" + i % 4, hostname);
-        instanceConfig.setDomain(domain);
-      }
+
+      String domain =
+          String.format("group=%s,zone=%s,rack=%s,host=%s", "mygroup" + i % 2, "myzone" + i % 4,
+              "myrack" + i % 4, hostname);
+      instanceConfig.setDomain(domain);
+
       LiveInstance liveInstance = new LiveInstance(instanceName);
       liveInstance.setSessionId(UUID.randomUUID().toString());
       liveInstance.setHelixVersion(UUID.randomUUID().toString());
       accessor.setProperty(keyBuilder.liveInstance(instanceName), liveInstance);
       admin.addInstance(clusterName, instanceConfig);
       admin.enableInstance(clusterName, instanceName, true);
+
+      if (i == 40) {
+        instanceConfig.setDomain(
+            String.format("invaliddomain=%s,zone=%s,rack=%s,host=%s", "mygroup" + i % 2,
+                "myzone" + i % 4, "myrack" + i % 4, hostname));
+        admin.setInstanceConfig(clusterName, instanceName, instanceConfig);
+      } else if (i == 41) {
+        instanceConfig.setDomain("invaliddomain");
+        admin.setInstanceConfig(clusterName, instanceName, instanceConfig);
+      }
     }
 
     ClusterTopology clusterTopology = admin.getClusterTopology(clusterName);

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -557,12 +557,12 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   @Override
-  public boolean isSwapReadyToComplete(String clusterName, String instancesNames) {
+  public boolean canSwapBeCompleted(String clusterName, String instancesNames) {
     return false;
   }
 
   @Override
-  public boolean completeSwapIfReady(String clusterName, String instanceName) {
+  public boolean completeSwapIfPossible(String clusterName, String instanceName) {
     return false;
   }
 

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -557,6 +557,16 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   @Override
+  public boolean isSwapReadyToComplete(String clusterName, String instancesNames) {
+    return false;
+  }
+
+  @Override
+  public boolean completeSwapIfReady(String clusterName, String instanceName) {
+    return false;
+  }
+
+  @Override
   public boolean isReadyForPreparingJoiningCluster(String clusterName, String instancesNames) {
     return false;
   }

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -557,7 +557,7 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   @Override
-  public boolean canSwapBeCompleted(String clusterName, String instancesNames) {
+  public boolean canCompleteSwap(String clusterName, String instancesNames) {
     return false;
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -86,7 +86,7 @@ public class AbstractResource {
     getInstance,
     getAllInstances,
     setInstanceOperation, // TODO: Name is just a place holder, may change in future
-    completeSwapIfReady,
+    completeSwapIfPossible,
     onDemandRebalance
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -86,6 +86,7 @@ public class AbstractResource {
     getInstance,
     getAllInstances,
     setInstanceOperation, // TODO: Name is just a place holder, may change in future
+    completeSwapIfReady,
     onDemandRebalance
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -86,6 +86,7 @@ public class AbstractResource {
     getInstance,
     getAllInstances,
     setInstanceOperation, // TODO: Name is just a place holder, may change in future
+    canCompleteSwap,
     completeSwapIfPossible,
     onDemandRebalance
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -427,57 +427,63 @@ public class PerInstanceAccessor extends AbstractHelixResource {
           }
           admin.resetPartition(clusterId, instanceName,
               node.get(PerInstanceProperties.resource.name()).textValue(),
-              (List<String>) OBJECT_MAPPER
-                  .readValue(node.get(PerInstanceProperties.partitions.name()).toString(),
-                    OBJECT_MAPPER.getTypeFactory()
-                        .constructCollectionType(List.class, String.class)));
-        break;
-      case setInstanceOperation:
-         admin.setInstanceOperation(clusterId, instanceName, state);
-         break;
+              (List<String>) OBJECT_MAPPER.readValue(
+                  node.get(PerInstanceProperties.partitions.name()).toString(),
+                  OBJECT_MAPPER.getTypeFactory()
+                      .constructCollectionType(List.class, String.class)));
+          break;
+        case setInstanceOperation:
+          admin.setInstanceOperation(clusterId, instanceName, state);
+          break;
+        case canCompleteSwap:
+          if (!admin.canCompleteSwap(clusterId, instanceName)) {
+            return badRequest("Swap is not ready to be completed!");
+          }
+          break;
         case completeSwapIfPossible:
           if (!admin.completeSwapIfPossible(clusterId, instanceName)) {
             return badRequest("Swap is not ready to be completed!");
           }
           break;
-      case addInstanceTag:
-        if (!validInstance(node, instanceName)) {
-          return badRequest("Instance names are not match!");
-        }
-        for (String tag : (List<String>) OBJECT_MAPPER
-            .readValue(node.get(PerInstanceProperties.instanceTags.name()).toString(),
-                OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, String.class))) {
-          admin.addInstanceTag(clusterId, instanceName, tag);
-        }
-        break;
-      case removeInstanceTag:
-        if (!validInstance(node, instanceName)) {
-          return badRequest("Instance names are not match!");
-        }
-        for (String tag : (List<String>) OBJECT_MAPPER
-            .readValue(node.get(PerInstanceProperties.instanceTags.name()).toString(),
-                OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, String.class))) {
-          admin.removeInstanceTag(clusterId, instanceName, tag);
-        }
-        break;
-      case enablePartitions:
-        admin.enablePartition(true, clusterId, instanceName,
-            node.get(PerInstanceProperties.resource.name()).textValue(),
-            (List<String>) OBJECT_MAPPER
-                .readValue(node.get(PerInstanceProperties.partitions.name()).toString(),
-                    OBJECT_MAPPER.getTypeFactory()
-                        .constructCollectionType(List.class, String.class)));
-        break;
-      case disablePartitions:
-        admin.enablePartition(false, clusterId, instanceName,
-            node.get(PerInstanceProperties.resource.name()).textValue(),
-            (List<String>) OBJECT_MAPPER
-                .readValue(node.get(PerInstanceProperties.partitions.name()).toString(),
-                    OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, String.class)));
-        break;
-      default:
-        LOG.error("Unsupported command :" + command);
-        return badRequest("Unsupported command :" + command);
+        case addInstanceTag:
+          if (!validInstance(node, instanceName)) {
+            return badRequest("Instance names are not match!");
+          }
+          for (String tag : (List<String>) OBJECT_MAPPER.readValue(
+              node.get(PerInstanceProperties.instanceTags.name()).toString(),
+              OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, String.class))) {
+            admin.addInstanceTag(clusterId, instanceName, tag);
+          }
+          break;
+        case removeInstanceTag:
+          if (!validInstance(node, instanceName)) {
+            return badRequest("Instance names are not match!");
+          }
+          for (String tag : (List<String>) OBJECT_MAPPER.readValue(
+              node.get(PerInstanceProperties.instanceTags.name()).toString(),
+              OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, String.class))) {
+            admin.removeInstanceTag(clusterId, instanceName, tag);
+          }
+          break;
+        case enablePartitions:
+          admin.enablePartition(true, clusterId, instanceName,
+              node.get(PerInstanceProperties.resource.name()).textValue(),
+              (List<String>) OBJECT_MAPPER.readValue(
+                  node.get(PerInstanceProperties.partitions.name()).toString(),
+                  OBJECT_MAPPER.getTypeFactory()
+                      .constructCollectionType(List.class, String.class)));
+          break;
+        case disablePartitions:
+          admin.enablePartition(false, clusterId, instanceName,
+              node.get(PerInstanceProperties.resource.name()).textValue(),
+              (List<String>) OBJECT_MAPPER.readValue(
+                  node.get(PerInstanceProperties.partitions.name()).toString(),
+                  OBJECT_MAPPER.getTypeFactory()
+                      .constructCollectionType(List.class, String.class)));
+          break;
+        default:
+          LOG.error("Unsupported command :" + command);
+          return badRequest("Unsupported command :" + command);
       }
     } catch (Exception e) {
       LOG.error("Failed in updating instance : " + instanceName, e);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -435,8 +435,8 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       case setInstanceOperation:
          admin.setInstanceOperation(clusterId, instanceName, state);
          break;
-        case completeSwapIfReady:
-          if (!admin.completeSwapIfReady(clusterId, instanceName)) {
+        case completeSwapIfPossible:
+          if (!admin.completeSwapIfPossible(clusterId, instanceName)) {
             return badRequest("Swap is not ready to be completed!");
           }
           break;

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -435,6 +435,11 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       case setInstanceOperation:
          admin.setInstanceOperation(clusterId, instanceName, state);
          break;
+        case completeSwapIfReady:
+          if (!admin.completeSwapIfReady(clusterId, instanceName)) {
+            return badRequest("Swap is not ready to be completed!");
+          }
+          break;
       case addInstanceTag:
         if (!validInstance(node, instanceName)) {
           return badRequest("Instance names are not match!");


### PR DESCRIPTION
### Issues

- [x]  HelixAdmin.setInstanceOperation and addInstance sanity checks for SWAP_IN & SWAP_OUT #2662 

     - Can only set instance to SWAP_OUT
     - Can only add instance with the same logicaId as another if the already existing has InstanceOperation set to SWAP_OUT and there is not more than 1 already.

- [x]  Create HelixAdmin.isSwapReadyToComplete and completeSwapIfReady(returns if swap finished)  #2662 

    - completeSwapIfFinished will check if the swap is ready to complete. If ready, mark the SWAP_OUT instance as `HELIX_ENABLED: false` and clear the `INSTANCE_OPERATION` for SWAP_IN node.
  
- [x] Change WAGED assignment tie breaker logic to use logicalId when present #2662 

     - May want to make this configurable, as it will lead to shuffling when this change is deployed

- [x]  Refactor DelayedAutoRebalancerUtil and DelayedAutoRebalancer.computeBestPossibleStateForPartition
 to filter out SWAP_IN node because we will add SWAP_IN node to the end of preference list in computeBestPossibleStateForPartition until the swap is complete #2662 
     - Adding it to the end of the preference list will ensure that the SWAP_IN node only carries secondary states
     - When SWAP_IN node has identical Current State to SWAP_OUT, isSwapFinished completeSwapIfFinished will return true

### Description

Adding Helix Admin APIs and updating existing setInstanceOperation and addInstance implementations to support Helix Node Swap.

- setInstanceOperation: Add sanity check to disallow setting the `INSTANCE_OPERATION` to `SWAP_IN`, as this should be set when we addInstance to cluster. We can't have a case where where there are two instances in the cluster with the same logicalId unless there is exactly 1 with `SWAP_OUT` and 1 with `SWAP_IN` `INSTANCE_OPERATION`.
- addInstance: We now check to ensure that there is not already an instance in the cluster with the same logicalId. We only allow adding an instance with the same logicalId if the existing instance has `SWAP_OUT` `INSTANCE_OPERATION` or the add instance is being added in the disable state.
- canSwapComplete: Checks if the swap of two instances is ready to mark completed. It takes either the `SWAP_OUT` or `SWAP_IN` instance as an argument. It does the following checks:
  1. Both instances must be alive.
  2. Both instances must only have one session and not be carrying over from a previous session.
  3. Both instances must have no pending messages.
  4. Both instances cannot have partitions in the ERROR state
  5. SwapIn instance must have correct state for all partitions that are currently assigned to the SwapOut instance.
- completeSwapPossible: Checks to see if the swap is ready to complete using isSwapReadyToComplete. If ready, it will clear the SwapIn node's `INSTANCE_OPERATION` and disable the SwapOut node.

Add ability for up to 2 nodes with the same logicalId to be added to the cluster at the same time when a SWAP is happening.
During all paritionAssignment for WAGED and DelayedAutoRebalancer, we select just one instance for each logicalId.

Cases:
- If only one instance with logicalId, it passes through the filter
- If two instances with logicalId, SWAP_OUT passes through the filter if the other node is SWAP_IN. If SWAP_IN node passes through the filter when the SWAP is marked complete by setting the InstanceOperation of the SWAP_IN node to null.

When SWAP_OUT nodes are the instances which pass through the filter and there are corresponding SWAP_IN nodes which are live and enabled, we add them to the end of all preference lists which contain the SWAP_OUT node following computeIdealState. This ensures that they are in secondTopState for all StateModels that can only have a single replica in the topState. For stateModels that allow multiple replicas of the topState, the SWAP_IN node could host topState replicas before the SWAP is completed.

Once the swap is complete and SWAP_IN node has InstanceOperation set to null, SWAP_IN node becomes assignable and WAGED and DelayedAutoRebalancer + CRUSHED will computePartitionAssignment and generate IdealState with SWAP_IN instance in same index of the preferenceList as the SWAP_OUT instance used to be in. This means that not only will SWAP_IN node have all the same partitions that the SWAP_OUT node had, but also the same states.

### Tests

- [x] testAddingNodeWithSwapOutInstanceOperation
- [x] testAddingNodeWithSwapOutNodeInstanceOperationUnset
- [x] testNodeSwapWithNoSwapOutNode
- [x] testNodeSwapSwapInNodeNoInstanceOperationEnabled
- [x] testNodeSwapSwapInNodeWithAlreadySwappingPair
- [x] testNodeSwapWrongFaultZone
- [x] testNodeSwapWrongCapacity
- [x] testNodeSwapNoTopologySetup
- [x] testNodeSwap
- [x] testNodeSwapSwapInNodeNoInstanceOperationDisabled
- [x] testNodeSwapCancelSwapWhenReadyToComplete
- [x] testNodeSwapAfterEMM
- [x] testNodeSwapWithSwapOutInstanceDisabled
- [x] testNodeSwapAddSwapInFirstEnabledBeforeSwapOutSet(
- [x] testNodeSwapAddSwapInFirstEnableBeforeSwapOutSet
- [x] testUnsetInstanceOperationOnSwapInWhenAlreadyUnsetOnSwapOut
- [x] testNodeSwapAddSwapInFirst

```
➜  helix git:(helix_node_swap_apis) ✗ mvn test -o -Dtest=TestInstanceOperation -pl=helix-core
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.helix:metrics-common:bundle:1.3.2-SNAPSHOT
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ org.apache.helix:helix:1.3.2-SNAPSHOT, /Users/zapinto/Documents/git2/zpinto/helix/pom.xml, line 678, column 17
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.helix:helix:pom:1.3.2-SNAPSHOT
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ line 678, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] 
[INFO] --------------------< org.apache.helix:helix-core >---------------------
[INFO] Building Apache Helix :: Core 1.3.2-SNAPSHOT
[INFO]   from pom.xml
[INFO] -------------------------------[ bundle ]-------------------------------
[INFO] 
[INFO] --- enforcer:1.4.1:enforce (enforce-maven-version) @ helix-core ---
[INFO] 
[INFO] --- enforcer:1.4.1:enforce (enforce-java-version) @ helix-core ---
[INFO] 
[INFO] --- enforcer:1.4.1:enforce (enforce-output-timestamp-property) @ helix-core ---
[INFO] 
[INFO] --- jacoco:0.8.6:prepare-agent (default) @ helix-core ---
[INFO] argLine set to -javaagent:/Users/zapinto/.m2/repository/org/jacoco/org.jacoco.agent/0.8.6/org.jacoco.agent-0.8.6-runtime.jar=destfile=/Users/zapinto/Documents/git2/zpinto/helix/helix-core/target/jacoco.exec
[INFO] 
[INFO] --- remote-resources:1.7.0:process (process-resource-bundles) @ helix-core ---
[INFO] Preparing remote bundle org.apache:apache-jar-resource-bundle:1.4
[INFO] Copying 3 resources from 1 bundle.
[INFO] 
[INFO] --- resources:3.2.0:resources (default-resources) @ helix-core ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Using 'UTF-8' encoding to copy filtered properties files.
[INFO] Copying 4 resources
[INFO] Copying 0 resource
[INFO] Copying 3 resources
[INFO] The encoding used to copy filtered properties files have not been set. This means that the same encoding will be used to copy filtered properties files as when copying other filtered resources. This might not be what you want! Run your build with --debug to see which files might be affected. Read more at https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html
[INFO] 
[INFO] --- compiler:3.10.1:compile (default-compile) @ helix-core ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- bundle:5.1.4:manifest (bundle-manifest) @ helix-core ---
[WARNING] Manifest org.apache.helix:helix-core:bundle:1.3.2-SNAPSHOT : Unused Import-Package instructions: [org.apache.logging.log4j*, org.apache.logging.slf4j*] 
[INFO] Writing manifest: /Users/zapinto/Documents/git2/zpinto/helix/helix-core/target/classes/META-INF/MANIFEST.MF
[INFO] 
[INFO] --- resources:3.2.0:testResources (default-testResources) @ helix-core ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Using 'UTF-8' encoding to copy filtered properties files.
[INFO] Copying 15 resources
[INFO] Copying 3 resources
[INFO] 
[INFO] --- compiler:3.10.1:testCompile (default-testCompile) @ helix-core ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 498 source files to /Users/zapinto/Documents/git2/zpinto/helix/helix-core/target/test-classes
[INFO] /Users/zapinto/Documents/git2/zpinto/helix/helix-core/src/test/java/org/apache/helix/integration/TestCarryOverBadCurState.java: Some input files use or override a deprecated API.
[INFO] /Users/zapinto/Documents/git2/zpinto/helix/helix-core/src/test/java/org/apache/helix/integration/TestCarryOverBadCurState.java: Recompile with -Xlint:deprecation for details.
[INFO] /Users/zapinto/Documents/git2/zpinto/helix/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java: Some input files use unchecked or unsafe operations.
[INFO] /Users/zapinto/Documents/git2/zpinto/helix/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- surefire:3.0.0-M3:test (default-test) @ helix-core ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.helix.integration.rebalancer.TestInstanceOperation
Start zookeeper at localhost:2183 in thread main

...

START TestInstanceOperation.testAddingNodeWithSwapOutInstanceOperation() at Wed Nov 01 16:07:33 PDT 2023
START TestInstanceOperation.testAddingNodeWithSwapOutNodeInstanceOperationUnset() at Wed Nov 01 16:07:35 PDT 2023
START TestInstanceOperation.testNodeSwapWithNoSwapOutNode() at Wed Nov 01 16:07:37 PDT 2023
START TestInstanceOperation.testNodeSwapSwapInNodeNoInstanceOperationEnabled() at Wed Nov 01 16:07:39 PDT 2023
START TestInstanceOperation.testNodeSwapSwapInNodeWithAlreadySwappingPair() at Wed Nov 01 16:07:43 PDT 2023
START TestInstanceOperation.testNodeSwapNoTopologySetup() at Wed Nov 01 16:07:47 PDT 2023
START TestInstanceOperation.testNodeSwapWrongFaultZone() at Wed Nov 01 16:07:49 PDT 2023
START TestInstanceOperation.testNodeSwapWrongCapacity() at Wed Nov 01 16:07:55 PDT 2023
START TestInstanceOperation.testNodeSwap() at Wed Nov 01 16:07:57 PDT 2023
START TestInstanceOperation.testNodeSwapSwapInNodeNoInstanceOperationDisabled() at Wed Nov 01 16:08:05 PDT 2023
START TestInstanceOperation.testNodeSwapCancelSwapWhenReadyToComplete() at Wed Nov 01 16:08:15 PDT 2023
START TestInstanceOperation.testNodeSwapAfterEMM() at Wed Nov 01 16:08:26 PDT 2023
START TestInstanceOperation.testNodeSwapWithSwapOutInstanceDisabled() at Wed Nov 01 16:08:36 PDT 2023
START TestInstanceOperation.testNodeSwapAddSwapInFirstEnabledBeforeSwapOutSet() at Wed Nov 01 16:08:47 PDT 2023
START TestInstanceOperation.testNodeSwapAddSwapInFirstEnableBeforeSwapOutSet() at Wed Nov 01 16:08:50 PDT 2023
START TestInstanceOperation.testUnsetInstanceOperationOnSwapInWhenAlreadyUnsetOnSwapOut() at Wed Nov 01 16:08:55 PDT 2023
START TestInstanceOperation.testNodeSwapAddSwapInFirst() at Wed Nov 01 16:08:59 PDT 2023
AfterClass: TestInstanceOperation called.
Shut down zookeeper at port 2183 in thread main
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 238.321 s - in org.apache.helix.integration.rebalancer.TestInstanceOperation
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/zapinto/Documents/git2/zpinto/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 947 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:36 min
[INFO] Finished at: 2023-10-30T12:32:08-04:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- We change the compareTo method in AssignableNode to use logicalId to make sure partitionAssignment will be the same after switching to SWAP_IN node. This is only used for tie breaking, so impact should not be large on already existing WAGED cluster assignment; however, it can cause some replica shuffling.

### Documentation (Optional)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
