### PR TITLE
Fix flaky test org.apache.helix.rest.server.TestResourceAccessor (#2643)

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAccessor.java
@@ -75,8 +75,10 @@ public class TestResourceAccessor extends AbstractTestClass {
 
     Set<String> resources = OBJECT_MAPPER.readValue(idealStates,
         OBJECT_MAPPER.getTypeFactory().constructCollectionType(Set.class, String.class));
-    Assert.assertEquals(resources, _resourcesMap.get("TestCluster_0"), "Resources from response: "
-        + resources + " vs clusters actually: " + _resourcesMap.get("TestCluster_0"));
+    Assert.assertTrue(resources.size() == _resourcesMap.get("TestCluster_0").size()
+        && resources.containsAll(_resourcesMap.get("TestCluster_0"))
+        && _resourcesMap.get("TestCluster_0").containsAll(resources),
+        "Sets are not equal. Resources from response: " + resources + " vs clusters actually: " + _resourcesMap.get("TestCluster_0"));
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #2643

### Description

This fix changes the flaky assertions of the tests in the class org.apache.helix.rest.server.TestResourceAccessor. 
Sets return the elements in a non-deterministic order which means that this assertion is not correct, because it checks whether the collections contain the same elements in the same order. (This was changed in the [library](https://github.com/testng-team/testng/issues/2643).)This leads to a flaky test. To fix this problem, the assertion has been rewritten to check if the collections contain the same amount of elements as well as both collections contain all values of the other collection.

The flaky test has been found by using the [NonDex](https://mvnrepository.com/artifact/edu.illinois/nondex-maven-plugin) tool – to reproduce run
```shell
mvn -pl helix-rest edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.helix.rest.server.TestResourceAccessor
``` 

### Tests

There have been no tests added, one test condition was changed. 

- The following is the result of the "mvn test" command on the appropriate module:

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:54 min
[INFO] Finished at: 2023-10-04T22:44:58-05:00
