### PR TITLE
Fix flaky test org.apache.helix.rest.server.TestInstancesAccessor #2644

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -159,8 +159,12 @@ public class TestInstancesAccessor extends AbstractTestClass {
 
     Set<String> instances = OBJECT_MAPPER.readValue(instancesStr,
         OBJECT_MAPPER.getTypeFactory().constructCollectionType(Set.class, String.class));
-    Assert.assertEquals(instances, _instancesMap.get(CLUSTER_NAME), "Instances from response: "
-        + instances + " vs instances actually: " + _instancesMap.get(CLUSTER_NAME));
+    Assert.assertEquals(instances.size(), _instancesMap.get(CLUSTER_NAME).size(), "Different amount of elements in "
+        + "the sets: " + instances.size() + " vs: " + _instancesMap.get(CLUSTER_NAME).size());
+    Assert.assertTrue(instances.containsAll(_instancesMap.get(CLUSTER_NAME)), "instances set does not contain all "
+        + "elements of _instanceMap");
+    Assert.assertTrue(_instancesMap.get(CLUSTER_NAME).containsAll(instances), "_instanceMap set does not contain all "
+        + "elements of instances");
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #2644

### Description

This fix changes the assertion of the tests. Sets return the elements in a non-deterministic order, which means that this assertion is not correct, because it checks whether the collections contain the same elements in the same order. This leads to a flaky test. To fix this problem, the assertion has been rewritten to check if the collections contain the same amount of elements as well as booth collections contain all values of the other collection.

This problem was found by the NonDex Engine – to reproduce run
```shell
mvn -pl helix-rest edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.helix.rest.server.TestInstancesAccessor
``` 

### Tests

There have been no tests added, one test condition was changed.

- The following is the result of the "mvn test" command on the appropriate module:

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:54 min
[INFO] Finished at: 2023-10-04T23:01:45-05:00
[INFO] ------------------------------------------------------------------------

