### PR TITLE
Fix flaky tests org.apache.helix.rest.metadatastore.TestZkMetadataStoreDirectory (#2645)

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java
@@ -21,6 +21,7 @@ package org.apache.helix.rest.metadatastore;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -31,7 +32,6 @@ import java.util.Set;
 
 import org.apache.helix.TestHelper;
 import org.apache.helix.msdcommon.constant.MetadataStoreRoutingConstants;
-import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.rest.server.AbstractTestClass;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
@@ -136,7 +136,7 @@ public class TestZkMetadataStoreDirectory extends AbstractTestClass {
     realms.add(TEST_REALM_2);
 
     for (String namespace : _routingZkAddrMap.keySet()) {
-      Assert.assertEquals(_metadataStoreDirectory.getAllMetadataStoreRealms(namespace), realms);
+      assertCollectionsContainSameElementsIgnoringOrder(_metadataStoreDirectory.getAllMetadataStoreRealms(namespace), realms);
     }
   }
 
@@ -147,7 +147,7 @@ public class TestZkMetadataStoreDirectory extends AbstractTestClass {
     allShardingKeys.addAll(TEST_SHARDING_KEYS_2);
 
     for (String namespace : _routingZkAddrMap.keySet()) {
-      Assert.assertEquals(_metadataStoreDirectory.getAllShardingKeys(namespace), allShardingKeys);
+      assertCollectionsContainSameElementsIgnoringOrder(_metadataStoreDirectory.getAllShardingKeys(namespace),allShardingKeys);
     }
   }
 
@@ -374,5 +374,11 @@ public class TestZkMetadataStoreDirectory extends AbstractTestClass {
       }
       return true;
     }, TestHelper.WAIT_DURATION), "Routing data path should be deleted after the tests.");
+  }
+  private void assertCollectionsContainSameElementsIgnoringOrder(Collection<String> collection1,
+   Collection<String> collection2) {
+     Assert.assertEquals(collection2.size(), collection1.size());
+     Assert.assertTrue(collection2.containsAll(collection1));
+     Assert.assertTrue(collection1.containsAll(collection2));
   }
 }


### PR DESCRIPTION
## Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #2645

## Description

Sets return the elements in a non-deterministic order, which means that this assertion is not correct, because it checks whether the collections contain the same elements in the same order. This leads to a flack test. To fix this problem, the assertion has been rewritten to check if the collections contain the same amount of elements as well as booth collections contain all values of the other collection.

Tests that cause problems: 
<!--https://github.com/hofi1/helix/blob/6241bcbf5f9fab1726c87c20b5e948daa95b7bbf/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java#L133-L141-->

https://github.com/apache/helix/blob/5f1a3f716ec71178f2f1f98c2ef48c62d6285df5/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java#L133-L141

and 
https://github.com/apache/helix/blob/5f1a3f716ec71178f2f1f98c2ef48c62d6285df5/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java#L144-L152

This problem was found by the [NonDex](https://github.com/TestingResearchIllinois/NonDex) Engine – to reproduce run
```shell
mvn -pl helix-rest edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.helix.rest.metadatastore.TestZkMetadataStoreDirectory
``` 

## Solution
Replace the assertions with a custom matcher, which checks if the sets contain the same elements without taking care of the order of the elements returned by the set. 

Custom Matcher:
<!--https://github.com/hofi1/helix/blob/9cd4181fe361ee2015e3e8fd507e158a2eb78991/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java#L378-L383-->

https://github.com/apache/helix/blob/9cd4181fe361ee2015e3e8fd507e158a2eb78991/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/TestZkMetadataStoreDirectory.java#L378-L383

## Tests

No test have been written – one existing test has been updated.

- The following is the result of the "mvn test" command on the appropriate module:

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:51 min
[INFO] Finished at: 2023-10-04T23:16:04-05:00
[INFO] ------------------------------------------------------------------------
