### PR TITLE
Add NPR guard when reading instance config - Race when reading config while adding/removing instance

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
@@ -132,9 +132,10 @@ public class DelayedRebalanceUtil {
 
   public static Set<String> filterOutEvacuatingInstances(Map<String, InstanceConfig> instanceConfigMap,
       Set<String> nodes) {
-    return  nodes.stream()
-        .filter(instance -> !instanceConfigMap.get(instance).getInstanceOperation().equals(
-            InstanceConstants.InstanceOperation.EVACUATE.name()))
+    return nodes.stream()
+        .filter(instance -> (instanceConfigMap.get(instance) != null && !instanceConfigMap.get(instance)
+            .getInstanceOperation()
+            .equals(InstanceConstants.InstanceOperation.EVACUATE.name())))
         .collect(Collectors.toSet());
   }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -410,15 +410,21 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   @Override
   public boolean isEvacuateFinished(String clusterName, String instanceName) {
-    return !instanceHasCurrentSateOrMessage(clusterName, instanceName) && (getInstanceConfig(clusterName,
-        instanceName).getInstanceOperation().equals(InstanceConstants.InstanceOperation.EVACUATE.name()));
+    if (!instanceHasCurrentSateOrMessage(clusterName, instanceName)) {
+      InstanceConfig config = getInstanceConfig(clusterName, instanceName);
+      return config != null && config.getInstanceOperation().equals(InstanceConstants.InstanceOperation.EVACUATE.name());
+    }
+    return false;
   }
 
   @Override
   public boolean isReadyForPreparingJoiningCluster(String clusterName, String instanceName) {
-    return !instanceHasCurrentSateOrMessage(clusterName, instanceName)
-        && DelayedAutoRebalancer.INSTANCE_OPERATION_TO_EXCLUDE_FROM_ASSIGNMENT.contains(
-        getInstanceConfig(clusterName, instanceName).getInstanceOperation());
+    if (!instanceHasCurrentSateOrMessage(clusterName, instanceName)) {
+      InstanceConfig config = getInstanceConfig(clusterName, instanceName);
+      return config != null && DelayedAutoRebalancer.INSTANCE_OPERATION_TO_EXCLUDE_FROM_ASSIGNMENT.contains(
+          config.getInstanceOperation());
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2670 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

When adding/removing instance from a cluster, it is possible that at a point of time, instance config is gone but the INSTANCE ZNode is still there. This would cause config map in helix controller cache to have instance mapped to null config.
We need to add NPR guard in pipeline to prevent transient pipeline failure.

The failure is not a blocking error causing further pipeline failure but we would like to avoid noise in log.

This change add null check before access instance config. 

### Tests

- [X] The following tests are written for this issue:

NA

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
