### PR TITLE
Add key and certfile to request options for helix-front calls to helix-rest

### DIFF
--- a/helix-front/server/controllers/d.ts
+++ b/helix-front/server/controllers/d.ts
@@ -17,6 +17,8 @@ interface HelixSession {
 type AgentOptions = {
   rejectUnauthorized: boolean;
   ca?: string;
+  key?: Buffer;
+  cert?: Buffer;
 };
 
 export type HelixRequestOptions = {

--- a/helix-front/server/controllers/helix.ts
+++ b/helix-front/server/controllers/helix.ts
@@ -59,6 +59,12 @@ export class HelixCtrl {
           encoding: 'utf-8',
         });
       }
+      if (SSL.keyfile) {
+        options.agentOptions.key = readFileSync(SSL.keyfile);
+      }
+      if (SSL.certfile) {
+        options.agentOptions.cert = readFileSync(SSL.certfile);
+      }
 
       if (IDENTITY_TOKEN_SOURCE) {
         options.headers['Identity-Token'] =


### PR DESCRIPTION
### Issues
HTTPS helix-rest endpoints not working for helix-front

### Description

Was not able to get HTTPS requests to helix-rest to work without also passing the cert and key in the request options. 

### Tests

Deployed locally
```
cd pathToRepo/helix-front
yarn build
yarn start
```

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)

