### PR TITLE
[apache/helix] -- Enabled specification of prioritized capacity key for evenness scoring calculation

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/MaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/MaxCapacityUsageInstanceConstraint.java
@@ -37,7 +37,7 @@ class MaxCapacityUsageInstanceConstraint extends UsageSoftConstraint {
       ClusterContext clusterContext) {
     float estimatedMaxUtilization = clusterContext.getEstimatedMaxUtilization();
     float projectedHighestUtilization =
-        node.getGeneralProjectedHighestUtilization(replica.getCapacity());
+        node.getGeneralProjectedHighestUtilization(replica.getCapacity(), replica.getEvennessScoringCapacityKey());
     return computeUtilizationScore(estimatedMaxUtilization, projectedHighestUtilization);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/TopStateMaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/TopStateMaxCapacityUsageInstanceConstraint.java
@@ -41,7 +41,7 @@ class TopStateMaxCapacityUsageInstanceConstraint extends UsageSoftConstraint {
     }
     float estimatedTopStateMaxUtilization = clusterContext.getEstimatedTopStateMaxUtilization();
     float projectedHighestUtilization =
-        node.getTopStateProjectedHighestUtilization(replica.getCapacity());
+        node.getTopStateProjectedHighestUtilization(replica.getCapacity(), replica.getEvennessScoringCapacityKey());
     return computeUtilizationScore(estimatedTopStateMaxUtilization, projectedHighestUtilization);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
@@ -239,7 +239,27 @@ public class AssignableNode implements Comparable<AssignableNode> {
    * @return The highest utilization number of the node among all the capacity category.
    */
   public float getGeneralProjectedHighestUtilization(Map<String, Integer> newUsage) {
-    return getProjectedHighestUtilization(newUsage, _remainingCapacity);
+    return getProjectedHighestUtilization(newUsage, _remainingCapacity, null);
+  }
+
+  /**
+   * Return the most concerning capacity utilization number for evenly partition assignment.
+   * The method dynamically calculates the projected highest utilization number among all the
+   * capacity categories assuming the new capacity usage is added to the node.
+   *
+   * If the prioritizedCapacityKey is specified then utilization number is computed based op the
+   * specified capacity category (key) only.
+   *
+   * For example, if the current node usage is {CPU: 0.9, MEM: 0.4, DISK: 0.6}, prioritizedCapacityKey: CPU
+   * Then this call shall return 0.9.
+   *
+   * @param newUsage the proposed new additional capacity usage.
+   * @param prioritizedCapacityKey if provided, the capacity utilization will be calculated based on
+   *                               the supplied key only, else across all capacity categories.
+   * @return The highest utilization number of the node among the specified capacity category.
+   */
+  public float getGeneralProjectedHighestUtilization(Map<String, Integer> newUsage, String prioritizedCapacityKey) {
+    return getProjectedHighestUtilization(newUsage, _remainingCapacity, prioritizedCapacityKey);
   }
 
   /**
@@ -253,13 +273,39 @@ public class AssignableNode implements Comparable<AssignableNode> {
    * @return The highest utilization number of the node among all the capacity category.
    */
   public float getTopStateProjectedHighestUtilization(Map<String, Integer> newUsage) {
-    return getProjectedHighestUtilization(newUsage, _remainingTopStateCapacity);
+    return getProjectedHighestUtilization(newUsage, _remainingTopStateCapacity, null);
+  }
+
+  /**
+   * Return the most concerning capacity utilization number for evenly partition assignment.
+   * The method dynamically calculates the projected highest utilization number among all the
+   * capacity categories assuming the new capacity usage is added to the node.
+   *
+   * If the prioritizedCapacityKey is specified then utilization number is computed based op the
+   * specified capacity category (key) only.
+   *
+   * For example, if the current node usage is {CPU: 0.9, MEM: 0.4, DISK: 0.6}, prioritizedCapacityKey: CPU
+   * Then this call shall return 0.9.
+   *
+   * This function returns projected highest utilization for only top state partitions.
+   * @param newUsage the proposed new additional capacity usage.
+   * @param prioritizedCapacityKey if provided, the capacity utilization will be calculated based on
+   *                               the supplied key only, else across all capacity categories.
+   * @return The highest utilization number of the node among all the capacity category.
+   */
+  public float getTopStateProjectedHighestUtilization(Map<String, Integer> newUsage, String prioritizedCapacityKey) {
+    return getProjectedHighestUtilization(newUsage, _remainingTopStateCapacity, prioritizedCapacityKey);
   }
 
   private float getProjectedHighestUtilization(Map<String, Integer> newUsage,
-      Map<String, Integer> remainingCapacity) {
+      Map<String, Integer> remainingCapacity, String prioritizedCapacityKey) {
+    Set<String> capacityKeySet = _maxAllowedCapacity.keySet();
+    if (prioritizedCapacityKey != null && capacityKeySet.contains(prioritizedCapacityKey)) {
+      capacityKeySet = ImmutableSet.of(prioritizedCapacityKey);
+    }
+
     float highestCapacityUtilization = 0;
-    for (String capacityKey : _maxAllowedCapacity.keySet()) {
+    for (String capacityKey : capacityKeySet) {
       float capacityValue = _maxAllowedCapacity.get(capacityKey);
       float utilization = (capacityValue - remainingCapacity.get(capacityKey) + newUsage
           .getOrDefault(capacityKey, 0)) / capacityValue;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableReplica.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableReplica.java
@@ -50,6 +50,7 @@ public class AssignableReplica implements Comparable<AssignableReplica> {
   private final int _statePriority;
   // The state of the replica
   private final String _replicaState;
+  private final String _evennessScoringCapacityKey;
 
   /**
    * @param clusterConfig  The cluster config.
@@ -68,6 +69,7 @@ public class AssignableReplica implements Comparable<AssignableReplica> {
     _resourceInstanceGroupTag = resourceConfig.getInstanceGroupTag();
     _resourceMaxPartitionsPerInstance = resourceConfig.getMaxPartitionsPerInstance();
     _replicaKey = generateReplicaKey(_resourceName, _partitionName,_replicaState);
+    _evennessScoringCapacityKey = resourceConfig.getEvennessScoringCapacityKey();
   }
 
   public Map<String, Integer> getCapacity() {
@@ -104,6 +106,10 @@ public class AssignableReplica implements Comparable<AssignableReplica> {
 
   public int getResourceMaxPartitionsPerInstance() {
     return _resourceMaxPartitionsPerInstance;
+  }
+
+  public String getEvennessScoringCapacityKey() {
+    return _evennessScoringCapacityKey;
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
@@ -58,7 +58,8 @@ public class ResourceConfig extends HelixProperty {
     GROUP_ROUTING_ENABLED,
     EXTERNAL_VIEW_DISABLED,
     DELAY_REBALANCE_ENABLED,
-    PARTITION_CAPACITY_MAP
+    PARTITION_CAPACITY_MAP,
+    EVENNESS_SCORING_CAPACITY_KEY
   }
 
   public enum ResourceConfigConstants {
@@ -109,7 +110,7 @@ public class ResourceConfig extends HelixProperty {
     this(resourceId, monitorDisabled, numPartitions, stateModelDefRef, stateModelFactoryName,
         numReplica, minActiveReplica, maxPartitionsPerInstance, instanceGroupTag, helixEnabled,
         resourceGroupName, resourceType, groupRoutingEnabled, externalViewDisabled, rebalanceConfig,
-        stateTransitionTimeoutConfig, listFields, mapFields, p2pMessageEnabled, null);
+        stateTransitionTimeoutConfig, listFields, mapFields, p2pMessageEnabled, null, null);
   }
 
   private ResourceConfig(String resourceId, Boolean monitorDisabled, int numPartitions,
@@ -119,7 +120,8 @@ public class ResourceConfig extends HelixProperty {
         Boolean groupRoutingEnabled, Boolean externalViewDisabled,
         RebalanceConfig rebalanceConfig, StateTransitionTimeoutConfig stateTransitionTimeoutConfig,
         Map<String, List<String>> listFields, Map<String, Map<String, String>> mapFields,
-        Boolean p2pMessageEnabled, Map<String, Map<String, Integer>> partitionCapacityMap) {
+        Boolean p2pMessageEnabled, Map<String, Map<String, Integer>> partitionCapacityMap,
+        String evennessScoringCapacityKey) {
     super(resourceId);
 
     if (monitorDisabled != null) {
@@ -204,6 +206,10 @@ public class ResourceConfig extends HelixProperty {
         throw new IllegalArgumentException(
             "Failed to set partition capacity. Invalid capacity configuration.");
       }
+    }
+
+    if (evennessScoringCapacityKey != null) {
+      putSimpleConfig(ResourceConfigProperty.EVENNESS_SCORING_CAPACITY_KEY.name(), evennessScoringCapacityKey);
     }
   }
 
@@ -457,6 +463,15 @@ public class ResourceConfig extends HelixProperty {
   }
 
   /**
+   * Get the evenness scoring capacity key for the resource, if set.
+   *
+   * @return the evenness scoring capacity key
+   */
+  public String getEvennessScoringCapacityKey() {
+    return _record.getSimpleField(ResourceConfigProperty.EVENNESS_SCORING_CAPACITY_KEY.name());
+  }
+
+  /**
    * Put a set of simple configs.
    *
    * @param configsMap
@@ -583,6 +598,7 @@ public class ResourceConfig extends HelixProperty {
     private Map<String, List<String>> _preferenceLists;
     private Map<String, Map<String, String>> _mapFields;
     private Map<String, Map<String, Integer>> _partitionCapacityMap;
+    private String _evennessScoringCapacityKey;
 
     public Builder(String resourceId) {
       _resourceId = resourceId;
@@ -788,6 +804,15 @@ public class ResourceConfig extends HelixProperty {
       return _partitionCapacityMap.get(partition);
     }
 
+    public Builder setEvennessScoringCapacityKey(String evennessScoringCapacityKey) {
+      _evennessScoringCapacityKey = evennessScoringCapacityKey;
+      return this;
+    }
+
+    public String getEvennessScoringCapacityKey() {
+      return _evennessScoringCapacityKey;
+    }
+
     public Builder setMapField(String key, Map<String, String> fields) {
       if (_mapFields == null) {
         _mapFields = new TreeMap<>();
@@ -855,7 +880,7 @@ public class ResourceConfig extends HelixProperty {
           _stateModelFactoryName, _numReplica, _minActiveReplica, _maxPartitionsPerInstance,
           _instanceGroupTag, _helixEnabled, _resourceGroupName, _resourceType, _groupRoutingEnabled,
           _externalViewDisabled, _rebalanceConfig, _stateTransitionTimeoutConfig, _preferenceLists,
-          _mapFields, _p2pMessageEnabled, _partitionCapacityMap);
+          _mapFields, _p2pMessageEnabled, _partitionCapacityMap, _evennessScoringCapacityKey);
     }
   }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestMaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestMaxCapacityUsageInstanceConstraint.java
@@ -26,6 +26,9 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -45,11 +48,25 @@ public class TestMaxCapacityUsageInstanceConstraint {
 
   @Test
   public void testGetNormalizedScore() {
-    when(_testNode.getGeneralProjectedHighestUtilization(anyMap())).thenReturn(0.8f);
+    when(_testNode.getGeneralProjectedHighestUtilization(anyMap(), any())).thenReturn(0.8f);
     when(_clusterContext.getEstimatedMaxUtilization()).thenReturn(1f);
     double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
     // Convert to float so as to compare with equal.
     Assert.assertEquals((float) score,0.8f);
+    double normalizedScore =
+        _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertTrue(normalizedScore > 0.99);
+  }
+
+  @Test
+  public void testGetNormalizedScoreWithPrioritizedKey() {
+    String prioritizedCapacityKey = "CU";
+    when(_testNode.getGeneralProjectedHighestUtilization(anyMap(), eq(prioritizedCapacityKey))).thenReturn(0.5f);
+    when(_testReplica.getEvennessScoringCapacityKey()).thenReturn(prioritizedCapacityKey);
+    when(_clusterContext.getEstimatedMaxUtilization()).thenReturn(1f);
+    double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    // Convert to float so as to compare with equal.
+    Assert.assertEquals((float) score,0.5f);
     double normalizedScore =
         _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
     Assert.assertTrue(normalizedScore > 0.99);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestTopStateMaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestTopStateMaxCapacityUsageInstanceConstraint.java
@@ -26,6 +26,8 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -47,11 +49,26 @@ public class TestTopStateMaxCapacityUsageInstanceConstraint {
   @Test
   public void testGetNormalizedScore() {
     when(_testReplica.isReplicaTopState()).thenReturn(true);
-    when(_testNode.getTopStateProjectedHighestUtilization(anyMap())).thenReturn(0.8f);
+    when(_testNode.getTopStateProjectedHighestUtilization(anyMap(), any())).thenReturn(0.8f);
     when(_clusterContext.getEstimatedTopStateMaxUtilization()).thenReturn(1f);
     double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
     // Convert to float so as to compare with equal.
     Assert.assertEquals((float) score, 0.8f);
+    double normalizedScore =
+        _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertTrue(normalizedScore > 0.99);
+  }
+
+  @Test
+  public void testGetNormalizedScoreWithPrioritizedKey() {
+    String prioritizedCapacityKey = "CU";
+    when(_testReplica.isReplicaTopState()).thenReturn(true);
+    when(_testNode.getTopStateProjectedHighestUtilization(anyMap(), eq(prioritizedCapacityKey))).thenReturn(0.5f);
+    when(_testReplica.getEvennessScoringCapacityKey()).thenReturn(prioritizedCapacityKey);
+    when(_clusterContext.getEstimatedTopStateMaxUtilization()).thenReturn(1f);
+    double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    // Convert to float so as to compare with equal.
+    Assert.assertEquals((float) score,0.5f);
     double normalizedScore =
         _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
     Assert.assertTrue(normalizedScore > 0.99);


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR description:
#2674

### Description
Currently, WAGED consider many capacity categories/dimensions such as CPU, Disk, etc for the placement decision evenness scores. In some use case, only one dimension is relevant because the clusters are provisioned based on that category. And, if evenness scores are not based on that then it introduces more shuffle/movements.

So, we would like to provide a way for users to specify a prioritized evennessScoringKey that will help computing scores based on that category only.

### Tests

- [x] The following tests are written for this issue:
* TestMaxCapacityUsageInstanceConstraint
  * testGetNormalizedScoreWithPrioritizedKey

*  TestTopStateMaxCapacityUsageInstanceConstraint
  * testGetNormalizedScoreWithPrioritizedKey

- The following is the result of the "mvn test" command on the appropriate module:

```console
mvn test -o "-Dtest=Test*Constraint"  -pl=helix-core 

[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.742 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 947 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  27.529 s
[INFO] Finished at: 2023-10-19T07:50:37-07:00
[INFO] ------------------------------------------------------------------------

```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
