### PR TITLE
fix flaky test assertions in org.apache.helix.rest.server.TestPerInstanceAccessor#testGetAllMessages

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -325,8 +325,11 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
 
     Set<String> instances = OBJECT_MAPPER.readValue(instancesStr,
         OBJECT_MAPPER.getTypeFactory().constructCollectionType(Set.class, String.class));
-    Assert.assertEquals(instances, _instancesMap.get(CLUSTER_NAME), "Instances from response: "
-        + instances + " vs instances actually: " + _instancesMap.get(CLUSTER_NAME));
+    String errorMessage = "Instances from response: "+ instances + " vs instances actually: "
+        + _instancesMap.get(CLUSTER_NAME);
+    Assert.assertEquals(instances.size(), _instancesMap.get(CLUSTER_NAME).size(), errorMessage);
+    Assert.assertTrue(instances.containsAll(_instancesMap.get(CLUSTER_NAME)), errorMessage);
+    Assert.assertTrue(_instancesMap.get(CLUSTER_NAME).containsAll(instances), errorMessage);
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes apache#2667

### Description

This fix changes the flaky assertions of the tests in the class org.apache.helix.rest.server.TestPerInstanceAccessor#testGetAllMessages. 
Sets return the elements in a non-deterministic order, which means that this assertion is not correct, because it checks whether the collections contain the same elements in the same order (this was changed in the [library](https://github.com/testng-team/testng/issues/2643)). This leads to a flaky test. 

https://github.com/apache/helix/blob/bd1d28c52126c27bbc3a3c156a18bee13f8079c4/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java#L329-L330

To fix this problem, the assertion has been rewritten to check if the collections contain the same amount of elements as well as both collections contain all values of the other collection.

https://github.com/apache/helix/blob/e0b1834240542994e00ec512ddc6f844f1deea43/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java#L328-L332

The flaky test has been found by using the [NonDex](https://mvnrepository.com/artifact/edu.illinois/nondex-maven-plugin) tool – to reproduce run

```shell
mvn -pl helix-rest edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.helix.rest.server.TestPerInstanceAccessor -DnondexSeed=933178
``` 

### Tests

No test have been written – one existing test has been updated.

- The following is the result of the "mvn test" command on the appropriate module:
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:23 min
[INFO] Finished at: 2023-10-17T22:47:43-05:00
[INFO] ------------------------------------------------------------------------
