### PR TITLE
[apache/helix] -- Updated Java 9 functions with Java-8 complaint functions

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
@@ -28,6 +28,7 @@ import java.util.TreeMap;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.api.config.HelixConfigProperty;
 import org.apache.helix.api.config.RebalanceConfig;
@@ -448,7 +449,7 @@ public class ResourceConfig extends HelixProperty {
             String.format("Capacity Data contains a negative value:%s", capacities.toString()));
       }
       newCapacityRecord.put(partition, _objectMapper.writeValueAsString(capacities));
-      newDeserializedPartitionCapacityMap.put(partition, Map.copyOf(capacities));
+      newDeserializedPartitionCapacityMap.put(partition, ImmutableMap.copyOf(capacities));
     }
 
     _record.setMapField(ResourceConfigProperty.PARTITION_CAPACITY_MAP.name(), newCapacityRecord);

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClientCache.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClientCache.java
@@ -19,6 +19,7 @@ package org.apache.helix.metaclient.impl.zk;
  * under the License.
  */
 
+import com.google.common.collect.ImmutableList;
 import org.apache.helix.metaclient.api.ChildChangeListener;
 import org.apache.helix.metaclient.api.MetaClientCacheInterface;
 import org.apache.helix.metaclient.exception.MetaClientException;
@@ -118,7 +119,7 @@ public class ZkMetaClientCache<T> extends ZkMetaClient<T> implements MetaClientC
                 LOG.debug("Children not found in cache for key: {}. This could be because the cache is still being populated.", key);
                 return null;
             }
-            return List.copyOf(node.getChildren().keySet());
+            return ImmutableList.copyOf(node.getChildren().keySet());
         }
         return super.getDirectChildrenKeys(key);
     }


### PR DESCRIPTION
### Issues
- [x] My PR addresses the following Helix issues and references them in the PR description:
   Updated codebase to be build with JDK-8.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
We will releasing the Open source Helix on Java 11, but we are updating the codebase to be build compatible with Java-8, so that we can internally release it on Java-8.

### Tests
- [x] The following tests are written for this issue:
```console
[INFO] --- bundle:5.1.4:install (default-install) @ meta-client ---
[INFO] Installing org/apache/helix/meta-client/1.3.2-SNAPSHOT/meta-client-1.3.2-SNAPSHOT.jar
[INFO] Writing OBR metadata
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Helix 1.3.2-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  0.933 s]
[INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  1.184 s]
[INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [  0.604 s]
[INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [  1.471 s]
[INFO] Apache Helix :: Helix Common ....................... SUCCESS [  0.550 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [  8.389 s]
[INFO] Apache Helix :: Admin Webapp ....................... SUCCESS [  0.966 s]
[INFO] Apache Helix :: Restful Interface .................. SUCCESS [  1.983 s]
[INFO] Apache Helix :: Distributed Lock ................... SUCCESS [  0.401 s]
[INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  0.569 s]
[INFO] Apache Helix :: Front End .......................... SUCCESS [01:07 min]
[INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.012 s]
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  0.474 s]
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  0.499 s]
[INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  0.368 s]
[INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  0.394 s]
[INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  0.368 s]
[INFO] Apache Helix :: View Aggregator .................... SUCCESS [  0.686 s]
[INFO] Apache Helix :: Meta Client ........................ SUCCESS [  0.588 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:28 min
[INFO] Finished at: 2023-11-03T16:31:40-07:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
