### PR TITLE
Expose Evacuate Finished API in Helix-Rest

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -88,7 +88,8 @@ public class AbstractResource {
     setInstanceOperation, // TODO: Name is just a place holder, may change in future
     canCompleteSwap,
     completeSwapIfPossible,
-    onDemandRebalance
+    onDemandRebalance,
+    isEvacuateFinished
   }
 
   @Context

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -477,6 +477,16 @@ public class PerInstanceAccessor extends AbstractHelixResource {
                   OBJECT_MAPPER.getTypeFactory()
                       .constructCollectionType(List.class, String.class)));
           break;
+        case isEvacuateFinished:
+          boolean evacuateFinished;
+          try {
+            evacuateFinished = admin.isEvacuateFinished(clusterId, instanceName);
+          } catch (HelixException e) {
+            LOG.error(String.format("Encountered error when checking if evacuation finished for cluster: "
+                + "{}, instance: {}", clusterId, instanceName), e);
+            return serverError(e);
+          }
+          return OK(OBJECT_MAPPER.writeValueAsString(Map.of("successful", evacuateFinished)));
         default:
           LOG.error("Unsupported command :" + command);
           return badRequest("Unsupported command :" + command);


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

isEvacuateFinished API not available in helix-rest

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Expose isEvacuateFinished API in helix-rest. setInstanceOperation is already exposed.

One key thing to note is the way we return the true/false value. Should we always return a 200 response code if we do not encounter an error? If so, then how do we represent the true/false value? Do we want to send it as json {"isEvacuateFinished": "true"} or just as a raw "true" / "false" string? Ideally we should decide on 1 way of returning true/false's and stick to that


### Tests

- [ ] The following tests are written for this issue:

Added tests to updateInstance method in testPerInstanceAccessor.java

- The following is the result of the "mvn test" command on the appropriate module:

$  mvn test -o -Dtest=TestPerInstanceAccessor -pl=helix-rest
```
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 52.578 s - in org.apache.helix.rest.server.TestPerInstanceAccessor
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /Users/gspencer/Desktop/git-repos/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 92 classes
[WARNING] Classes in bundle 'Apache Helix :: Restful Interface' do not match with execution data. For report generation the same class files must be used as at runtime.
[WARNING] Execution data for class org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor does not match.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  57.262 s
[INFO] Finished at: 2023-11-06T16:13:53-08:00
[INFO] ------------------------------------------------------------------------

```



### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
