### PR TITLE
helix-rest swapApis return result in json instead of by status code

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -436,15 +436,11 @@ public class PerInstanceAccessor extends AbstractHelixResource {
           admin.setInstanceOperation(clusterId, instanceName, state);
           break;
         case canCompleteSwap:
-          if (!admin.canCompleteSwap(clusterId, instanceName)) {
-            return badRequest("Swap is not ready to be completed!");
-          }
-          break;
+          return OK(OBJECT_MAPPER.writeValueAsString(
+              Map.of("successful", admin.canCompleteSwap(clusterId, instanceName))));
         case completeSwapIfPossible:
-          if (!admin.completeSwapIfPossible(clusterId, instanceName)) {
-            return badRequest("Swap is not ready to be completed!");
-          }
-          break;
+          return OK(OBJECT_MAPPER.writeValueAsString(
+              Map.of("successful", admin.completeSwapIfPossible(clusterId, instanceName))));
         case addInstanceTag:
           if (!validInstance(node, instanceName)) {
             return badRequest("Instance names are not match!");

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -501,6 +501,26 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME);
     Assert.assertEquals(
         instanceConfig.getInstanceOperation(), "");
+
+    // test canCompleteSwap
+    Response canCompleteSwapResponse =
+        new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=canCompleteSwap").format(
+            CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
+    Assert.assertEquals(canCompleteSwapResponse.getStatus(), Response.Status.OK.getStatusCode());
+    Map<String, Object> responseMap =
+        OBJECT_MAPPER.readValue(canCompleteSwapResponse.readEntity(String.class), Map.class);
+    Assert.assertFalse((boolean) responseMap.get("successful"));
+
+    // test completeSwapIfPossible
+    Response completeSwapIfPossibleResponse = new JerseyUriRequestBuilder(
+        "clusters/{}/instances/{}?command=completeSwapIfPossible").format(CLUSTER_NAME,
+        INSTANCE_NAME).post(this, entity);
+    Assert.assertEquals(completeSwapIfPossibleResponse.getStatus(),
+        Response.Status.OK.getStatusCode());
+    responseMap =
+        OBJECT_MAPPER.readValue(completeSwapIfPossibleResponse.readEntity(String.class), Map.class);
+    Assert.assertFalse((boolean) responseMap.get("successful"));
+
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 


### PR DESCRIPTION
### Issues
NA

### Description
Change canCompleteSwap and completeSwapIfPossible to return json with kv pair for result of check or attempt to complete swap.

### Tests

- [x] Add to updateInstance test

### Changes that Break Backward Compatibility (Optional)

NA

### Documentation (Optional)

NA

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
