### PR TITLE
Fix helix-lock regression

### DIFF
--- a/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/LockInfo.java
@@ -168,7 +168,7 @@ public class LockInfo {
 
   /**
    * Get the value for PRIORITY attribute of the lock
-   * @return the priority of the lock, -1 if there is no priority set
+   * @return the priority of the lock, 0 if there is no priority set
    */
   public Integer getPriority() {
     return _record
@@ -204,7 +204,7 @@ public class LockInfo {
 
   /**
    * Get the value for REQUESTOR_PRIORITY attribute of the lock
-   * @return the requestor priority of the lock, -1 if there is no requestor priority set
+   * @return the requestor priority of the lock, 0 if there is no requestor priority set
    */
   public int getRequestorPriority() {
     return _record.getIntField(LockInfoAttribute.REQUESTOR_PRIORITY.name(),

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/LockConstants.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/LockConstants.java
@@ -27,7 +27,7 @@ public class LockConstants {
   public static final String DEFAULT_USER_ID = "NONE";
   public static final String DEFAULT_MESSAGE_TEXT = "NONE";
   public static final long DEFAULT_TIMEOUT_LONG = -1;
-  public static final int DEFAULT_PRIORITY_INT = -1;
+  public static final int DEFAULT_PRIORITY_INT = 0;
   public static final long DEFAULT_WAITING_TIMEOUT_LONG = -1;
   public static final long DEFAULT_CLEANUP_TIMEOUT_LONG = -1;
   public static final long DEFAULT_REQUESTING_TIMESTAMP_LONG = -1;

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
@@ -55,6 +55,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
   private final long _cleanupTimeout;
   private final int _priority;
   private final boolean _isForceful;
+  private final boolean _canUnlockNotOwnedLock;
   private final LockListener _lockListener;
   private final BaseDataAccessor<ZNRecord> _baseDataAccessor;
   private LockConstants.LockStatus _lockStatus;
@@ -72,7 +73,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
   public ZKDistributedNonblockingLock(LockScope scope, String zkAddress, Long leaseTimeout,
       String lockMsg, String userId) {
     this(scope.getPath(), leaseTimeout, lockMsg, userId, 0, Integer.MAX_VALUE, 0, false, null,
-        new ZkBaseDataAccessor<ZNRecord>(zkAddress));
+        new ZkBaseDataAccessor<ZNRecord>(zkAddress), true);
   }
 
   /**
@@ -105,7 +106,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
       String lockMsg, String userId, int priority, long waitingTimeout, long cleanupTimeout,
       boolean isForceful, LockListener lockListener) {
     this(scope.getPath(), leaseTimeout, lockMsg, userId, priority, waitingTimeout, cleanupTimeout,
-        isForceful, lockListener, new ZkBaseDataAccessor<ZNRecord>(zkAddress));
+        isForceful, lockListener, new ZkBaseDataAccessor<ZNRecord>(zkAddress), true);
   }
 
   /**
@@ -123,10 +124,12 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
    *                   lock encountered an exception during preempting lower priority lock
    * @param lockListener the listener associated to the lock
    * @param baseDataAccessor baseDataAccessor instance to do I/O against ZK with
+   * @param canUnlockNotOwnedLock whether non-owners can unlock the lock
    */
   private ZKDistributedNonblockingLock(String lockPath, Long leaseTimeout, String lockMsg,
       String userId, int priority, long waitingTimeout, long cleanupTimeout, boolean isForceful,
-      LockListener lockListener, BaseDataAccessor<ZNRecord> baseDataAccessor) {
+      LockListener lockListener, BaseDataAccessor<ZNRecord> baseDataAccessor,
+      boolean canUnlockNotOwnedLock) {
     _lockPath = lockPath;
     if (leaseTimeout < 0 || waitingTimeout < 0 || cleanupTimeout < 0) {
       throw new IllegalArgumentException("Timeout cannot be negative.");
@@ -143,6 +146,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
     _cleanupTimeout = cleanupTimeout;
     _lockListener = lockListener;
     _isForceful = isForceful;
+    _canUnlockNotOwnedLock = canUnlockNotOwnedLock;
     validateInput();
   }
 
@@ -313,8 +317,9 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
       }
 
       LockInfo unlockOrLockRequestLockInfo = new LockInfo(_record);
-      // Any unlock request from non-lock owners is blocked.
-      if (unlockOrLockRequestLockInfo.getOwner().equals(LockConstants.DEFAULT_USER_ID)) {
+      // Any unlock request from non-lock owners is blocked if canUnlockNotOwnedLock is false.
+      if (!_canUnlockNotOwnedLock && unlockOrLockRequestLockInfo.getOwner()
+          .equals(LockConstants.DEFAULT_USER_ID)) {
         LOG.error("User {} is not the lock owner and cannot release lock at Lock path {}.", _userId,
             _lockPath);
         throw new HelixException(
@@ -466,6 +471,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
     private long _cleanupTimeout;
     private boolean _isForceful;
     private LockListener _lockListener;
+    private boolean _canUnlockNotOwnedLock = true; // default to unlock not owned lock
 
     public Builder() {
     }
@@ -515,6 +521,11 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
       return this;
     }
 
+    public Builder setCanUnlockNotOwnedLock(boolean canUnlockNotOwnedLock) {
+      _canUnlockNotOwnedLock = canUnlockNotOwnedLock;
+      return this;
+    }
+
     public ZKDistributedNonblockingLock build() {
       // Resolve which way we want to create BaseDataAccessor instance
       BaseDataAccessor<ZNRecord> baseDataAccessor;
@@ -532,7 +543,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
       // Return a ZKDistributedNonblockingLock instance
       return new ZKDistributedNonblockingLock(_lockScope.getPath(), _timeout, _lockMsg, _userId,
           _priority, _waitingTimeout, _cleanupTimeout, _isForceful, _lockListener,
-          baseDataAccessor);
+          baseDataAccessor, _canUnlockNotOwnedLock);
     }
   }
 

--- a/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
+++ b/helix-lock/src/main/java/org/apache/helix/lock/helix/ZKDistributedNonblockingLock.java
@@ -313,11 +313,17 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
       }
 
       LockInfo unlockOrLockRequestLockInfo = new LockInfo(_record);
-      int unlockOrLockRequestPriority = unlockOrLockRequestLockInfo.getPriority();
-      // higher priority lock request will try to  preempt current lock owner. And any unlock request
-      // from non-lock owners will always be blocked because the default priority of unlock request
-      // is 0. And it would always be less than or equal to the priority value of the current lock.
-      if (!isCurrentOwner(curLockInfo) && unlockOrLockRequestPriority > curLockInfo.getPriority()) {
+      // Any unlock request from non-lock owners is blocked.
+      if (unlockOrLockRequestLockInfo.getOwner().equals(LockConstants.DEFAULT_USER_ID)) {
+        LOG.error("User {} is not the lock owner and cannot release lock at Lock path {}.", _userId,
+            _lockPath);
+        throw new HelixException(
+            String.format("User %s is not the lock owner and cannot release lock at Lock path %s.",
+                _userId, _lockPath));
+      }
+
+      // higher priority lock request will try to  preempt current lock owner.
+      if (!isCurrentOwner(curLockInfo) && _priority > curLockInfo.getPriority()) {
         // if requestor field is empty, fill the field with requestor's id
         if (curLockInfo.getRequestorId().equals(LockConstants.DEFAULT_USER_ID)) {
           _pendingTimeout =
@@ -325,7 +331,7 @@ public class ZKDistributedNonblockingLock implements DistributedLock, IZkDataLis
                   : _waitingTimeout;
         } // If the requestor field is not empty, and the coming lock request has an even higher
         // priority. The new request will replace current requestor field of the lock
-        else if (unlockOrLockRequestPriority > curLockInfo.getRequestorPriority()) {
+        else if (_priority > curLockInfo.getRequestorPriority()) {
           long remainingCleanupTime =
               curLockInfo.getCleanupTimeout() - (System.currentTimeMillis() - curLockInfo
                   .getRequestingTimestamp());

--- a/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLock.java
+++ b/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLock.java
@@ -172,8 +172,9 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
     Assert.assertFalse(_lock.isCurrentOwner());
     // Since _lock with _userId is not the locker owner anymore, its unlock() should fail.
     Assert.assertFalse(_lock.unlock());
+    // trylock will return false since both users have default priority of 0
+    Assert.assertFalse(_lock.tryLock());
   }
-
 
   @Test
   public void testSimultaneousAcquire() {

--- a/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLock.java
+++ b/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLock.java
@@ -166,7 +166,6 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
     fakeRecord.setSimpleField(LockInfo.LockInfoAttribute.OWNER.name(), fakeUserID);
     fakeRecord
         .setSimpleField(LockInfo.LockInfoAttribute.TIMEOUT.name(), String.valueOf(Long.MAX_VALUE));
-    fakeRecord.setIntField(LockInfo.LockInfoAttribute.PRIORITY.name(), 0);
     _gZkClient.create(_lockPath, fakeRecord, CreateMode.PERSISTENT);
 
     ZKDistributedNonblockingLock.Builder lockBuilder = new ZKDistributedNonblockingLock.Builder();

--- a/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLock.java
+++ b/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLock.java
@@ -142,7 +142,7 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
   }
 
   @Test
-  public void testOtherClientsAcquireLockFromExistingLockExpired() {
+  public void testNonLockOwnerUnlockPriorityLock() {
     // Fake condition when the lock owner is not current user
     String fakeUserID = UUID.randomUUID().toString();
     ZNRecord fakeRecord = new ZNRecord(fakeUserID);
@@ -157,6 +157,23 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
     // Since _lock with _userId is not the locker owner anymore, its unlock() should fail.
     Assert.assertFalse(_lock.unlock());
   }
+
+  @Test
+  public void testNonLockOwnerUnlockNoPriorityLock() {
+    // Fake condition when the lock owner is not current user
+    String fakeUserID = UUID.randomUUID().toString();
+    ZNRecord fakeRecord = new ZNRecord(fakeUserID);
+    fakeRecord.setSimpleField(LockInfo.LockInfoAttribute.OWNER.name(), fakeUserID);
+    fakeRecord
+        .setSimpleField(LockInfo.LockInfoAttribute.TIMEOUT.name(), String.valueOf(Long.MAX_VALUE));
+    _gZkClient.create(_lockPath, fakeRecord, CreateMode.PERSISTENT);
+
+    // Verify the current user is not a lock owner
+    Assert.assertFalse(_lock.isCurrentOwner());
+    // Since _lock with _userId is not the locker owner anymore, its unlock() should fail.
+    Assert.assertFalse(_lock.unlock());
+  }
+
 
   @Test
   public void testSimultaneousAcquire() {

--- a/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLock.java
+++ b/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLock.java
@@ -142,23 +142,6 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
   }
 
   @Test
-  public void testNonLockOwnerUnlockPriorityLock() {
-    // Fake condition when the lock owner is not current user
-    String fakeUserID = UUID.randomUUID().toString();
-    ZNRecord fakeRecord = new ZNRecord(fakeUserID);
-    fakeRecord.setSimpleField(LockInfo.LockInfoAttribute.OWNER.name(), fakeUserID);
-    fakeRecord
-        .setSimpleField(LockInfo.LockInfoAttribute.TIMEOUT.name(), String.valueOf(Long.MAX_VALUE));
-    fakeRecord.setIntField(LockInfo.LockInfoAttribute.PRIORITY.name(), 0);
-    _gZkClient.create(_lockPath, fakeRecord, CreateMode.PERSISTENT);
-
-    // Verify the current user is not a lock owner
-    Assert.assertFalse(_lock.isCurrentOwner());
-    // Since _lock with _userId is not the locker owner anymore, its unlock() should fail.
-    Assert.assertFalse(_lock.unlock());
-  }
-
-  @Test
   public void testNonLockOwnerUnlockNoPriorityLock() {
     // Fake condition when the lock owner is not current user
     String fakeUserID = UUID.randomUUID().toString();
@@ -170,10 +153,9 @@ public class TestZKHelixNonblockingLock extends ZkTestBase {
 
     // Verify the current user is not a lock owner
     Assert.assertFalse(_lock.isCurrentOwner());
-    // Since _lock with _userId is not the locker owner anymore, its unlock() should fail.
-    Assert.assertFalse(_lock.unlock());
-    // trylock will return false since both users have default priority of 0
+    // trylock and unlock will return false since both users have default priority of 0
     Assert.assertFalse(_lock.tryLock());
+    Assert.assertFalse(_lock.unlock());
   }
 
   @Test

--- a/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLockWithPriority.java
+++ b/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLockWithPriority.java
@@ -82,6 +82,45 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
   }
 
   @Test
+  public void testNonLockOwnerUnlock() throws Exception {
+    ZKDistributedNonblockingLock.Builder lockBuilder = new ZKDistributedNonblockingLock.Builder();
+    lockBuilder.setLockScope(_participantScope).setZkAddress(ZK_ADDR).setTimeout(3600000L)
+        .setLockMsg("higher priority lock").setUserId("user1").setPriority(0)
+        .setWaitingTimeout(30000).setCleanupTimeout(10000).setIsForceful(false)
+        .setLockListener(createLockListener());
+    ZKDistributedNonblockingLock lock = lockBuilder.build();
+
+    Thread t = new Thread() {
+      @Override
+      public void run() {
+        lock.tryLock();
+      }
+    };
+
+    t.start();
+    t.join();
+    Assert.assertTrue(lock.isCurrentOwner());
+
+    lockBuilder.setUserId("user2").setPriority(5);
+    ZKDistributedNonblockingLock lock2 = lockBuilder.build();
+    // unlock should fail because even if user2 has higher priority, user2 can't unlock a lock
+    // which is owned by user1. If user2 wants to grab the lock, it should do tryLock().
+    Assert.assertFalse(lock2.unlock());
+    t = new Thread() {
+      @Override
+      public void run() {
+        lock2.tryLock();
+      }
+    };
+    t.start();
+    t.join();
+    Assert.assertTrue(lock2.isCurrentOwner());
+    lock2.unlock();
+    lock2.close();
+    lock.close();
+  }
+
+  @Test
   public void testLowerPriorityRequestRejected() throws Exception {
     ZKDistributedNonblockingLock lock = createLockWithConfig();
     ZKDistributedNonblockingLock.Builder lockBuilder = new ZKDistributedNonblockingLock.Builder();

--- a/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLockWithPriority.java
+++ b/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLockWithPriority.java
@@ -82,7 +82,7 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
   }
 
   @Test
-  public void testNonLockOwnerUnlock() throws Exception {
+  public void testNonLockOwnerUnlockFail() throws Exception {
     ZKDistributedNonblockingLock.Builder lockBuilder = new ZKDistributedNonblockingLock.Builder();
     lockBuilder.setLockScope(_participantScope).setZkAddress(ZK_ADDR).setTimeout(3600000L)
         .setLockMsg("higher priority lock").setUserId("user1").setPriority(0)
@@ -101,10 +101,10 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
     t.join();
     Assert.assertTrue(lock.isCurrentOwner());
 
-    lockBuilder.setUserId("user2").setPriority(5);
+    lockBuilder.setUserId("user2").setPriority(5).setCanUnlockNotOwnedLock(false);
     ZKDistributedNonblockingLock lock2 = lockBuilder.build();
-    // unlock should fail because even if user2 has higher priority, user2 can't unlock a lock
-    // which is owned by user1. If user2 wants to grab the lock, it should do tryLock().
+    // unlock should fail because even if user2 has higher priority because user2 set can unlock
+    // not owned lock to false.
     Assert.assertFalse(lock2.unlock());
     t = new Thread() {
       @Override
@@ -118,6 +118,40 @@ public class TestZKHelixNonblockingLockWithPriority extends ZkTestBase {
     lock2.unlock();
     lock2.close();
     lock.close();
+  }
+
+  @Test
+  public void testNonLockOwnerUnlockSuccess() throws Exception {
+    ZKLockConfig.Builder builder = new ZKLockConfig.Builder();
+    builder.setLockScope(_participantScope).setZkAdress(ZK_ADDR).setLeaseTimeout(3600000L)
+        .setLockMsg("original lock").setUserId("original_lock").setPriority(0)
+        .setWaitingTimeout(1000).setCleanupTimeout(25000).setIsForceful(false)
+        .setLockListener(_lockListener);
+    ZKLockConfig zkLockConfig = builder.build();
+    ZKDistributedNonblockingLock lock = new ZKDistributedNonblockingLock(zkLockConfig);
+    Thread t = new Thread() {
+      @Override
+      public void run() {
+        lock.tryLock();
+      }
+    };
+    t.start();
+    t.join();
+    Assert.assertTrue(lock.isCurrentOwner());
+
+    ZKDistributedNonblockingLock.Builder lockBuilder = new ZKDistributedNonblockingLock.Builder();
+    lockBuilder.setLockScope(_participantScope).setZkAddress(ZK_ADDR).setTimeout(3600000L)
+        .setLockMsg("higher priority lock").setUserId("user2").setPriority(5)
+        .setWaitingTimeout(30000).setCleanupTimeout(10000).setIsForceful(false)
+        .setLockListener(createLockListener());
+    ZKDistributedNonblockingLock higherLock = lockBuilder.build();
+    // unlock should pass because higherLock has higher priority and canUnlockNotOwnedLock
+    // is true by default
+    Assert.assertTrue(higherLock.unlock());
+    Assert.assertFalse(higherLock.isCurrentOwner());
+    lock.unlock();
+    lock.close();
+    higherLock.close();
   }
 
   @Test

--- a/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLockWithPriority.java
+++ b/helix-lock/src/test/java/org/apache/helix/lock/helix/TestZKHelixNonblockingLockWithPriority.java
@@ -23,15 +23,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.helix.HelixException;
 import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
-import org.apache.helix.lock.LockInfo;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.zookeeper.CreateMode;
 import org.testng.Assert;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeClass;


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
- This PR mainly addresses the recent behavior regression of helix-lock

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
- The incompatibility between old and new helix-lock versions was caused by the last update to helix-lock in Dec 2020, the update is in https://github.com/apache/helix/pull/1564 which added priority and notification support to Helix locks.
#### There are two separate regressions in this PR
1. When a lock request is made from the new helix-lock version to a lock path currently locked by the old helix-lock version, what happens is:
* The lock request sees current lock priority is -1 (due to the priority field not present in lock ZNode), which is lower than the priority 0 of the lock being requested. Thus it will try to preempt the current lock owner by writing its own user id, priority and waiting timeout to the requestor fields in the lock ZNode. The lock request pending timeout is set to -1 since the current lock cleanup timeout is -1 (due to the cleanup timeout field not present in lock ZNode). Lock status of the lock request now becomes PENDING.
* The lock request waits on a CountDownLatch for the pending timeout which is -1, therefore the wait immediately returns.
The current lock owner won’t clean up itself and release the lock since it’s using the old helix-lock version which doesn’t react to lock requests with higher priority.
* Since the lock status of the lock request is still PENDING and the lock request by default is not forceful, an exception is thrown saying “Cleanup has not been finished by lock owner”, which breaks clients' workflow.
2. The non-lock owners is able to `unlock()` a lock if its priority is larger than the priority recorded in the lock. This should be avoided as well. If the non-lock owners want to acquire a lock, it should only call `tryLock()`. 

#### To resolve the two issue discussed above
1. Change the default value of priority from -1 to 0. In this way, a lock request made from new helix-lock version with default priority won't be able to acquire the lock holding by the old helix-lock.
2. Throws exception when `update()` handles a unlock request but the requestor is not the current owner of the lock.


(Write a concise description including what, why, how)

### Tests
`mvn test -Dtest=TestZKHelixNonblockingLock,TestZKHelixNonblockingLockWithPriority -pl helix-lock`
- [X] The following tests are written for this issue:
```
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 54.524 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-lock ---
[INFO] Loading execution data file /Users/xiaxgao/IdeaProjects/helix_ps/helix-lock/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Distributed Lock' with 13 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  57.140 s
[INFO] Finished at: 2024-01-29T17:59:36-08:00
[INFO] ------------------------------------------------------------------------
```

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
