### PR TITLE
Enable computation of evenness score based on a preferred scoring key [Testing Purporses]

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/MaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/MaxCapacityUsageInstanceConstraint.java
@@ -22,6 +22,8 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The constraint evaluates the score by checking the max used capacity key out of all the capacity
@@ -31,13 +33,17 @@ import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
  * It is a greedy approach since it evaluates only on the most used capacity key.
  */
 class MaxCapacityUsageInstanceConstraint extends UsageSoftConstraint {
+  private static final Logger LOG = LoggerFactory.getLogger(MaxCapacityUsageInstanceConstraint.class.getName());
 
   @Override
   protected double getAssignmentScore(AssignableNode node, AssignableReplica replica,
       ClusterContext clusterContext) {
     float estimatedMaxUtilization = clusterContext.getEstimatedMaxUtilization();
     float projectedHighestUtilization =
-        node.getGeneralProjectedHighestUtilization(replica.getCapacity());
-    return computeUtilizationScore(estimatedMaxUtilization, projectedHighestUtilization);
+            node.getGeneralProjectedHighestUtilization(replica.getCapacity(), clusterContext.getPreferredScoringKey());
+    double utilizationScore = computeUtilizationScore(estimatedMaxUtilization, projectedHighestUtilization);
+    LOG.info("[DEPEND-29018] clusterName: {}, node: {}, replica partition: {}, estimatedMaxUtilization: {}, projectedHighestUtilization: {}, utilizationScore: {}, preferredScoringKey: {}",
+            clusterContext.getClusterName(), node.getInstanceName(), replica.getPartitionName(),estimatedMaxUtilization, projectedHighestUtilization, utilizationScore, clusterContext.getPreferredScoringKey());
+    return utilizationScore;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/TopStateMaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/TopStateMaxCapacityUsageInstanceConstraint.java
@@ -22,6 +22,8 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -31,6 +33,7 @@ import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
  * It is a greedy approach since it evaluates only on the most used capacity key.
  */
 class TopStateMaxCapacityUsageInstanceConstraint extends UsageSoftConstraint {
+  private static final Logger LOG = LoggerFactory.getLogger(TopStateMaxCapacityUsageInstanceConstraint.class.getName());
   @Override
   protected double getAssignmentScore(AssignableNode node, AssignableReplica replica,
       ClusterContext clusterContext) {
@@ -41,7 +44,10 @@ class TopStateMaxCapacityUsageInstanceConstraint extends UsageSoftConstraint {
     }
     float estimatedTopStateMaxUtilization = clusterContext.getEstimatedTopStateMaxUtilization();
     float projectedHighestUtilization =
-        node.getTopStateProjectedHighestUtilization(replica.getCapacity());
-    return computeUtilizationScore(estimatedTopStateMaxUtilization, projectedHighestUtilization);
+            node.getTopStateProjectedHighestUtilization(replica.getCapacity(), clusterContext.getPreferredScoringKey());
+    double utilizationScore = computeUtilizationScore(estimatedTopStateMaxUtilization, projectedHighestUtilization);
+    LOG.info("[DEPEND-29018] clusterName: {}, node: {}, replica partition: {}, estimatedTopStateMaxUtilization: {}, projectedHighestUtilization: {}, utilizationScore: {}, preferredScoringKey: {}",
+            clusterContext.getClusterName(), node.getInstanceName(), replica.getPartitionName(), estimatedTopStateMaxUtilization, projectedHighestUtilization, utilizationScore, clusterContext.getPreferredScoringKey());
+    return utilizationScore;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -235,7 +235,7 @@ public class ClusterModelProvider {
     // Construct and initialize cluster context.
     ClusterContext context = new ClusterContext(
         replicaMap.values().stream().flatMap(Set::stream).collect(Collectors.toSet()),
-        assignableNodes, idealAssignment, currentAssignment);
+        assignableNodes, idealAssignment, currentAssignment, dataProvider.getClusterConfig());
     // Initial the cluster context with the allocated assignments.
     context.setAssignmentForFaultZoneMap(mapAssignmentToFaultZone(assignableNodes));
 

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -154,7 +154,10 @@ public class ClusterConfig extends HelixProperty {
     HELIX_DISABLED_TYPE,
 
     // The last time when the on-demand rebalance is triggered.
-    LAST_ON_DEMAND_REBALANCE_TIMESTAMP
+    LAST_ON_DEMAND_REBALANCE_TIMESTAMP,
+
+    //Preferred scoring key used in evenness score computation
+    PREFERRED_SCORING_KEY
   }
 
   public enum GlobalRebalancePreferenceKey {
@@ -1197,5 +1200,24 @@ public class ClusterConfig extends HelixProperty {
   public void setLastOnDemandRebalanceTimestamp(long rebalanceTimestamp) {
     _record.setLongField(ClusterConfigProperty.LAST_ON_DEMAND_REBALANCE_TIMESTAMP.name(),
         rebalanceTimestamp);
+  }
+
+  /**
+   * Get preferred scoring key if set.
+   *
+   * @return PreferredScoringKey that is used in computation of evenness score
+   */
+  public String getPreferredScoringKey() {
+    return _record.getSimpleField(ClusterConfigProperty.PREFERRED_SCORING_KEY.name());
+  }
+
+  /**
+   * Set preferred scoring key for cluster.
+   *
+   * @param preferredScoringKey value used in evenness score computation
+   */
+  public void setPreferredScoringKey(String preferredScoringKey) {
+    _record.setSimpleField(ClusterConfigProperty.PREFERRED_SCORING_KEY.name(),
+            preferredScoringKey);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestMaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestMaxCapacityUsageInstanceConstraint.java
@@ -29,6 +29,8 @@ import org.testng.annotations.Test;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 
 public class TestMaxCapacityUsageInstanceConstraint {
   private AssignableReplica _testReplica;
@@ -45,13 +47,27 @@ public class TestMaxCapacityUsageInstanceConstraint {
 
   @Test
   public void testGetNormalizedScore() {
-    when(_testNode.getGeneralProjectedHighestUtilization(anyMap())).thenReturn(0.8f);
+    when(_testNode.getGeneralProjectedHighestUtilization(anyMap(), any())).thenReturn(0.8f);
     when(_clusterContext.getEstimatedMaxUtilization()).thenReturn(1f);
     double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
     // Convert to float so as to compare with equal.
     Assert.assertEquals((float) score,0.8f);
     double normalizedScore =
         _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertTrue(normalizedScore > 0.99);
+  }
+
+  @Test
+  public void testGetNormalizedScoreWithPreferredScoringKey() {
+    String preferredScoringkey = "CU";
+    when(_testNode.getGeneralProjectedHighestUtilization(anyMap(), eq(preferredScoringkey))).thenReturn(0.5f);
+    when(_clusterContext.getPreferredScoringKey()).thenReturn(preferredScoringkey);
+    when(_clusterContext.getEstimatedMaxUtilization()).thenReturn(1f);
+    double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    // Convert to float so as to compare with equal.
+    Assert.assertEquals((float) score,0.5f);
+    double normalizedScore =
+            _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
     Assert.assertTrue(normalizedScore > 0.99);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestTopStateMaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestTopStateMaxCapacityUsageInstanceConstraint.java
@@ -26,6 +26,8 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -47,13 +49,29 @@ public class TestTopStateMaxCapacityUsageInstanceConstraint {
   @Test
   public void testGetNormalizedScore() {
     when(_testReplica.isReplicaTopState()).thenReturn(true);
-    when(_testNode.getTopStateProjectedHighestUtilization(anyMap())).thenReturn(0.8f);
+    when(_testNode.getTopStateProjectedHighestUtilization(anyMap(), any())).thenReturn(0.8f);
     when(_clusterContext.getEstimatedTopStateMaxUtilization()).thenReturn(1f);
     double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
     // Convert to float so as to compare with equal.
     Assert.assertEquals((float) score, 0.8f);
     double normalizedScore =
         _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertTrue(normalizedScore > 0.99);
+  }
+
+
+  @Test
+  public void testGetNormalizedScoreWithPreferredScoringKey() {
+    String preferredScoringkey = "CU";
+    when(_testReplica.isReplicaTopState()).thenReturn(true);
+    when(_testNode.getTopStateProjectedHighestUtilization(anyMap(), eq(preferredScoringkey))).thenReturn(0.5f);
+    when(_clusterContext.getPreferredScoringKey()).thenReturn(preferredScoringkey);
+    when(_clusterContext.getEstimatedTopStateMaxUtilization()).thenReturn(1f);
+    double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    // Convert to float so as to compare with equal.
+    Assert.assertEquals((float) score,0.5f);
+    double normalizedScore =
+            _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
     Assert.assertTrue(normalizedScore > 0.99);
   }
 }


### PR DESCRIPTION
Note : This PR is used for testing purposes, won't be merged.

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description: 
        #2674 


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently, WAGED consider many capacity categories/dimensions such as CPU, Disk, etc for the placement decision evenness scores. In some use case, only one dimension is relevant because the clusters are provisioned based on that category. And, if evenness scores are not based on that then it introduces more shuffle/movements.

So, we would like to provide a way for users to specify a prioritized evennessScoringKey that will help computing scores based on that category only.


### Tests

- [x] The following tests are written for this issue:

1. TestClusterContext 

- testEstimateMaxUtilization

2. TestMaxCapacityUsageInstanceConstraint

- testGetNormalizedScoreWithPreferredScoringKey

3. TestTopStateMaxCapacityUsageInstanceConstraint

- testGetNormalizedScoreWithPreferredScoringKey

```
[INFO] Reactor Summary for Apache Helix 1.3.2-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  2.365 s]
[INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  3.243 s]
[INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [  2.169 s]
[INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [  6.354 s]
[INFO] Apache Helix :: Helix Common ....................... SUCCESS [  2.425 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [ 41.671 s]
[INFO] Apache Helix :: Admin Webapp ....................... SUCCESS [  5.571 s]
[INFO] Apache Helix :: Restful Interface .................. SUCCESS [ 10.913 s]
[INFO] Apache Helix :: Distributed Lock ................... SUCCESS [  2.080 s]
[INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  3.155 s]
[INFO] Apache Helix :: Front End .......................... SUCCESS [05:15 min]
[INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.051 s]
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  2.146 s]
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  2.399 s]
[INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  1.894 s]
[INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  1.934 s]
[INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  1.964 s]
[INFO] Apache Helix :: View Aggregator .................... SUCCESS [  4.175 s]
[INFO] Apache Helix :: Meta Client ........................ SUCCESS [  3.506 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  06:54 min
[INFO] Finished at: 2023-11-16T11:48:16-08:00
[INFO] ------------------------------------------------------------------------
```

**mvn test -o -Dtest=TestClusterContext -pl=helix-core**

```

[INFO] Results:
[INFO] 
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/csudhars/Documents/GitHub/csudharsanan_helix/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 947 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```
**mvn test -o -Dtest=TestMaxCapacityUsageInstanceConstraint -pl=helix-core**   

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.534 s - in org.apache.helix.controller.rebalancer.waged.constraints.TestMaxCapacityUsageInstanceConstraint
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/csudhars/Documents/GitHub/csudharsanan_helix/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 947 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

 **mvn test -o -Dtest=TestTopStateMaxCapacityUsageInstanceConstraint -pl=helix-core**

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.218 s - in org.apache.helix.controller.rebalancer.waged.constraints.TestTopStateMaxCapacityUsageInstanceConstraint
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/csudhars/Documents/GitHub/csudharsanan_helix/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 947 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.500 s
[INFO] Finished at: 2023-11-16T12:44:49-08:00
[INFO] ------------------------------------------------------------------------
```


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
