### PR TITLE
Fix WAGED to only use logicalId when computing baseline and centralize picking assignable instances in the cache

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeDetector.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeDetector.java
@@ -119,7 +119,7 @@ public class ResourceChangeDetector implements ChangeDetector {
     case RESOURCE_CONFIG:
       return snapshot.getResourceConfigMap();
     case LIVE_INSTANCE:
-      return snapshot.getLiveInstances();
+      return snapshot.getAssignableLiveInstances();
     case CLUSTER_CONFIG:
       ClusterConfig config = snapshot.getClusterConfig();
       if (config == null) {

--- a/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeDetector.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeDetector.java
@@ -113,7 +113,7 @@ public class ResourceChangeDetector implements ChangeDetector {
       HelixConstants.ChangeType changeType, ResourceChangeSnapshot snapshot) {
     switch (changeType) {
     case INSTANCE_CONFIG:
-      return snapshot.getInstanceConfigMap();
+      return snapshot.getAssignableInstanceConfigMap();
     case IDEAL_STATE:
       return snapshot.getIdealStateMap();
     case RESOURCE_CONFIG:

--- a/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeSnapshot.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeSnapshot.java
@@ -54,7 +54,8 @@ class ResourceChangeSnapshot {
   private Map<String, InstanceConfig> _assignableInstanceConfigMap;
   private Map<String, IdealState> _idealStateMap;
   private Map<String, ResourceConfig> _resourceConfigMap;
-  private Map<String, LiveInstance> _liveInstances;
+  private Map<String, LiveInstance> _allLiveInstances;
+  private Map<String, LiveInstance> _assignableLiveInstances;
   private ClusterConfig _clusterConfig;
 
   /**
@@ -66,7 +67,8 @@ class ResourceChangeSnapshot {
     _assignableInstanceConfigMap = new HashMap<>();
     _idealStateMap = new HashMap<>();
     _resourceConfigMap = new HashMap<>();
-    _liveInstances = new HashMap<>();
+    _allLiveInstances = new HashMap<>();
+    _assignableLiveInstances = new HashMap<>();
     _clusterConfig = null;
   }
 
@@ -105,7 +107,8 @@ class ResourceChangeSnapshot {
     _clusterConfig = ignoreNonTopologyChange ?
         ClusterConfigTrimmer.getInstance().trimProperty(dataProvider.getClusterConfig()) :
         dataProvider.getClusterConfig();
-    _liveInstances = new HashMap<>(dataProvider.getAssignableLiveInstances());
+    _allLiveInstances = new HashMap<>(dataProvider.getLiveInstances());
+    _assignableLiveInstances = new HashMap<>(dataProvider.getAssignableLiveInstances());
   }
 
   /**
@@ -118,7 +121,8 @@ class ResourceChangeSnapshot {
     _assignableInstanceConfigMap = new HashMap<>(snapshot._assignableInstanceConfigMap);
     _idealStateMap = new HashMap<>(snapshot._idealStateMap);
     _resourceConfigMap = new HashMap<>(snapshot._resourceConfigMap);
-    _liveInstances = new HashMap<>(snapshot._liveInstances);
+    _allLiveInstances = new HashMap<>(snapshot._allLiveInstances);
+    _assignableLiveInstances = new HashMap<>(snapshot._assignableLiveInstances);
     _clusterConfig = snapshot._clusterConfig;
   }
 
@@ -143,7 +147,11 @@ class ResourceChangeSnapshot {
   }
 
   Map<String, LiveInstance> getLiveInstances() {
-    return _liveInstances;
+    return _allLiveInstances;
+  }
+
+  Map<String, LiveInstance> getAssignableLiveInstances() {
+    return _assignableLiveInstances;
   }
 
   ClusterConfig getClusterConfig() {

--- a/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeSnapshot.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/changedetector/ResourceChangeSnapshot.java
@@ -82,10 +82,10 @@ class ResourceChangeSnapshot {
     _changedTypes = new HashSet<>(dataProvider.getRefreshedChangeTypes());
 
     _instanceConfigMap = ignoreNonTopologyChange ?
-        dataProvider.getInstanceConfigMap().entrySet().parallelStream().collect(Collectors
+        dataProvider.getAssignableInstanceConfigMap().entrySet().parallelStream().collect(Collectors
             .toMap(e -> e.getKey(),
                 e -> InstanceConfigTrimmer.getInstance().trimProperty(e.getValue()))) :
-        new HashMap<>(dataProvider.getInstanceConfigMap());
+        new HashMap<>(dataProvider.getAssignableInstanceConfigMap());
     _idealStateMap = ignoreNonTopologyChange ?
         dataProvider.getIdealStates().entrySet().parallelStream().collect(Collectors
             .toMap(e -> e.getKey(),
@@ -99,7 +99,7 @@ class ResourceChangeSnapshot {
     _clusterConfig = ignoreNonTopologyChange ?
         ClusterConfigTrimmer.getInstance().trimProperty(dataProvider.getClusterConfig()) :
         dataProvider.getClusterConfig();
-    _liveInstances = new HashMap<>(dataProvider.getLiveInstances());
+    _liveInstances = new HashMap<>(dataProvider.getAssignableLiveInstances());
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -103,7 +103,9 @@ public class BaseControllerDataProvider implements ControlContextProvider {
   // Property caches
   private final PropertyCache<ResourceConfig> _resourceConfigCache;
   private final PropertyCache<InstanceConfig> _instanceConfigCache;
+  private final Map<String, InstanceConfig> _assignableInstanceConfigMap = new HashMap<>();
   private final PropertyCache<LiveInstance> _liveInstanceCache;
+  private final Map<String, LiveInstance> _assignableLiveInstancesMap = new HashMap<>();
   private final PropertyCache<IdealState> _idealStateCache;
   private final PropertyCache<ClusterConstraints> _clusterConstraintsCache;
   private final PropertyCache<StateModelDefinition> _stateModelDefinitionCache;
@@ -118,6 +120,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
   private Map<String, Map<String, String>> _idealStateRuleMap;
   private final Map<String, Map<String, Set<String>>> _disabledInstanceForPartitionMap = new HashMap<>();
   private final Set<String> _disabledInstanceSet = new HashSet<>();
+  private final Set<String> _assignableDisabledInstanceSet = new HashSet<>();
   private final Map<String, String> _swapOutInstanceNameToSwapInInstanceName = new HashMap<>();
   private final Set<String> _enabledLiveSwapInInstanceNames = new HashSet<>();
   private final Map<String, MonitoredAbnormalResolver> _abnormalStateResolverMap = new HashMap<>();
@@ -335,6 +338,107 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     }
   }
 
+  /**
+   * Refreshes the assignable instances and SWAP related caches. This should be called after
+   * liveInstance and instanceConfig caches are refreshed. To determine what instances are
+   * assignable and live, it takes a combination of both the all instanceConfigs and liveInstances.
+   *
+   * @param instanceConfigMap InstanceConfig map from instanceConfig cache
+   * @param liveInstancesMap  LiveInstance map from liveInstance cache
+   * @param clusterConfig     ClusterConfig from clusterConfig cache
+   */
+  private void updateInstanceSets(Map<String, InstanceConfig> instanceConfigMap,
+      Map<String, LiveInstance> liveInstancesMap, ClusterConfig clusterConfig) {
+
+    if (clusterConfig == null) {
+      logger.warn("Skip refreshing swapping instances because clusterConfig is null.");
+      return;
+    }
+
+    ClusterTopologyConfig clusterTopologyConfig =
+        ClusterTopologyConfig.createFromClusterConfig(clusterConfig);
+
+    // Clear all caches
+    _assignableInstanceConfigMap.clear();
+    _assignableLiveInstancesMap.clear();
+    _swapOutInstanceNameToSwapInInstanceName.clear();
+    _enabledLiveSwapInInstanceNames.clear();
+
+    Map<String, String> filteredInstancesByLogicalId = new HashMap<>();
+    Map<String, String> swapOutLogicalIdsByInstanceName = new HashMap<>();
+    Map<String, String> swapInInstancesByLogicalId = new HashMap<>();
+
+    for (Map.Entry<String, InstanceConfig> entry : instanceConfigMap.entrySet()) {
+      String node = entry.getKey();
+      InstanceConfig currentInstanceConfig = entry.getValue();
+
+      if (currentInstanceConfig == null) {
+        continue;
+      }
+
+      String currentInstanceLogicalId =
+          currentInstanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType());
+
+      // Filter out instances with duplicate logical IDs. If there are duplicates, the instance with
+      // InstanceOperation SWAP_OUT will be chosen over the instance with SWAP_IN. SWAP_IN is not
+      // assignable. If there are duplicates with one node having no InstanceOperation and the other
+      // having SWAP_OUT, the node with no InstanceOperation will be chosen. This signifies SWAP
+      // completion, therefore making the node assignable.
+      if (filteredInstancesByLogicalId.containsKey(currentInstanceLogicalId)) {
+        String filteredNode = filteredInstancesByLogicalId.get(currentInstanceLogicalId);
+        InstanceConfig filteredDuplicateInstanceConfig = instanceConfigMap.get(filteredNode);
+
+        if ((filteredDuplicateInstanceConfig.getInstanceOperation()
+            .equals(InstanceConstants.InstanceOperation.SWAP_IN.name())
+            && currentInstanceConfig.getInstanceOperation()
+            .equals(InstanceConstants.InstanceOperation.SWAP_OUT.name()))
+            || currentInstanceConfig.getInstanceOperation().isEmpty()) {
+          // If the already filtered instance is SWAP_IN and this instance is in SWAP_OUT, then replace the filtered
+          // instance with this instance. If this instance has no InstanceOperation, then replace the filtered instance
+          // with this instance. This is the case where the SWAP_IN node has been marked as complete or SWAP_IN exists and
+          // SWAP_OUT does not. There can never be a case where both have no InstanceOperation set.
+          _assignableInstanceConfigMap.remove(filteredNode);
+          _assignableInstanceConfigMap.put(node, currentInstanceConfig);
+          filteredInstancesByLogicalId.put(currentInstanceLogicalId, node);
+        }
+      } else {
+        _assignableInstanceConfigMap.put(node, currentInstanceConfig);
+        filteredInstancesByLogicalId.put(currentInstanceLogicalId, node);
+      }
+
+      if (currentInstanceConfig.getInstanceOperation()
+          .equals(InstanceConstants.InstanceOperation.SWAP_OUT.name())) {
+        swapOutLogicalIdsByInstanceName.put(currentInstanceConfig.getInstanceName(),
+            currentInstanceLogicalId);
+      }
+
+      if (currentInstanceConfig.getInstanceOperation()
+          .equals(InstanceConstants.InstanceOperation.SWAP_IN.name())) {
+        swapInInstancesByLogicalId.put(
+            currentInstanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType()),
+            currentInstanceConfig.getInstanceName());
+      }
+    }
+
+    liveInstancesMap.forEach((instanceName, liveInstance) -> {
+      if (_assignableInstanceConfigMap.containsKey(instanceName)) {
+        _assignableLiveInstancesMap.put(instanceName, liveInstance);
+      }
+    });
+
+    swapOutLogicalIdsByInstanceName.forEach((swapOutInstanceName, value) -> {
+      String swapInInstanceName = swapInInstancesByLogicalId.get(value);
+      if (swapInInstanceName != null) {
+        _swapOutInstanceNameToSwapInInstanceName.put(swapOutInstanceName, swapInInstanceName);
+        if (liveInstancesMap.containsKey(swapInInstanceName)
+            && InstanceValidationUtil.isInstanceEnabled(instanceConfigMap.get(swapInInstanceName),
+            clusterConfig)) {
+          _enabledLiveSwapInInstanceNames.add(swapInInstanceName);
+        }
+      }
+    });
+  }
+
   private void refreshResourceConfig(final HelixDataAccessor accessor,
       Set<HelixConstants.ChangeType> refreshedType) {
     if (_propertyDataChangedMap.get(HelixConstants.ChangeType.RESOURCE_CONFIG).getAndSet(false)) {
@@ -373,7 +477,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
       timeOutWindow = clusterConfig.getOfflineNodeTimeOutForMaintenanceMode();
     }
     if (timeOutWindow >= 0 && isMaintenanceModeEnabled) {
-      for (String instance : _liveInstanceCache.getPropertyMap().keySet()) {
+      for (String instance : _assignableLiveInstancesMap.keySet()) {
         // 1. Check timed-out cache and don't do repeated work;
         // 2. Check for nodes that didn't exist in the last iteration, because it has been checked;
         // 3. For all other nodes, check if it's timed-out.
@@ -386,9 +490,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
       }
     }
     if (isMaintenanceModeEnabled) {
-      _liveInstanceExcludeTimedOutForMaintenance =
-          _liveInstanceCache.getPropertyMap().entrySet().stream()
-              .filter(e -> !_timedOutInstanceDuringMaintenance.contains(e.getKey()))
+      _liveInstanceExcludeTimedOutForMaintenance = _assignableLiveInstancesMap.entrySet().stream()
+          .filter(e -> !_timedOutInstanceDuringMaintenance.contains(e.getKey()))
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
   }
@@ -421,6 +524,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     refreshIdealState(accessor, refreshedTypes);
     refreshLiveInstances(accessor, refreshedTypes);
     refreshInstanceConfigs(accessor, refreshedTypes);
+    updateInstanceSets(_instanceConfigCache.getPropertyMap(), _liveInstanceCache.getPropertyMap(),
+        _clusterConfig);
     refreshResourceConfig(accessor, refreshedTypes);
     _stateModelDefinitionCache.refresh(accessor);
     _clusterConstraintsCache.refresh(accessor);
@@ -431,6 +536,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     updateOfflineInstanceHistory(accessor);
 
     // Refresh derived data
+    // Must use _liveInstanceCache instead of _assignableLiveInstancesMap because we need to
+    // know about the messages and current state of all instances including the SWAP_IN ones.
     _instanceMessagesCache.refresh(accessor, _liveInstanceCache.getPropertyMap());
     _currentStateCache.refresh(accessor, _liveInstanceCache.getPropertyMap());
 
@@ -440,8 +547,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
         _currentStateCache.getParticipantStatesMap());
 
     updateIdealRuleMap(getClusterConfig());
-    updateDisabledInstances(getInstanceConfigMap().values(), getClusterConfig());
-    updateSwappingInstances(getInstanceConfigMap().values(), getEnabledLiveInstances(),
+    updateDisabledInstances(getInstanceConfigMap().values(),
+        getAssignableInstanceConfigMap().values(),
         getClusterConfig());
 
     return refreshedTypes;
@@ -453,9 +560,9 @@ public class BaseControllerDataProvider implements ControlContextProvider {
           "# of StateModelDefinition read from zk: " + getStateModelDefMap().size());
       LogUtil.logDebug(logger, getClusterEventId(),
           "# of ConstraintMap read from zk: " + getConstraintMap().size());
-      LogUtil
-          .logDebug(logger, getClusterEventId(), "LiveInstances: " + getLiveInstances().keySet());
-      for (LiveInstance instance : getLiveInstances().values()) {
+      LogUtil.logDebug(logger, getClusterEventId(),
+          "LiveInstances: " + getAssignableLiveInstances().keySet());
+      for (LiveInstance instance : getAssignableLiveInstances().values()) {
         LogUtil.logDebug(logger, getClusterEventId(),
             "live instance: " + instance.getInstanceName() + " " + instance.getEphemeralOwner());
       }
@@ -463,7 +570,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
       LogUtil.logDebug(logger, getClusterEventId(),
           "ResourceConfigs: " + getResourceConfigMap().keySet());
       LogUtil.logDebug(logger, getClusterEventId(),
-          "InstanceConfigs: " + getInstanceConfigMap().keySet());
+          "InstanceConfigs: " + getAssignableInstanceConfigMap().keySet());
       LogUtil.logDebug(logger, getClusterEventId(), "ClusterConfigs: " + getClusterConfig());
     }
   }
@@ -476,8 +583,10 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     _clusterConfig = clusterConfig;
     refreshAbnormalStateResolverMap(_clusterConfig);
     updateIdealRuleMap(_clusterConfig);
-    updateDisabledInstances(getInstanceConfigMap().values(), _clusterConfig);
-    updateSwappingInstances(getInstanceConfigMap().values(), getEnabledLiveInstances(),
+    updateInstanceSets(_instanceConfigCache.getPropertyMap(), _liveInstanceCache.getPropertyMap(),
+        _clusterConfig);
+    updateDisabledInstances(getInstanceConfigMap().values(),
+        getAssignableInstanceConfigMap().values(),
         _clusterConfig);
   }
 
@@ -527,23 +636,57 @@ public class BaseControllerDataProvider implements ControlContextProvider {
   }
 
   /**
-   * Returns the LiveInstances for each of the instances that are currently up and running,
+   * Returns the assignable LiveInstances for each of the instances that are currently up and running,
    * excluding the instances that are considered offline during maintenance mode. Instances
    * are timed-out if they have been offline for a while before going live during maintenance mode.
+   * @return A map of LiveInstances to their instance names
    */
-  public Map<String, LiveInstance> getLiveInstances() {
+  public Map<String, LiveInstance> getAssignableLiveInstances() {
     if (isMaintenanceModeEnabled()) {
       return _liveInstanceExcludeTimedOutForMaintenance;
     }
 
+    return Collections.unmodifiableMap(_assignableLiveInstancesMap);
+  }
+
+  /**
+   * Returns the LiveInstances for each of the instances that are currently up and running,
+   * excluding the instances that are considered offline during maintenance mode. Instances are
+   * timed-out if they have been offline for a while before going live during maintenance mode.
+   *
+   * @return A map of LiveInstances to their instance names
+   */
+  public Map<String, LiveInstance> getLiveInstances() {
     return _liveInstanceCache.getPropertyMap();
   }
 
   /**
+   * Return the set of all assignable instances names.
+   *
+   * @return A new set contains instance name
+   */
+  public Set<String> getAssignableInstances() {
+    return _assignableInstanceConfigMap.keySet();
+  }
+
+  /**
    * Return the set of all instances names.
+   * @return A new set contains instance name
    */
   public Set<String> getAllInstances() {
     return _instanceConfigCache.getPropertyMap().keySet();
+  }
+
+  /**
+   * Return all the live nodes that are enabled and assignable
+   *
+   * @return A new set contains live instance name and that are marked enabled
+   */
+  public Set<String> getAssignableEnabledLiveInstances() {
+    Set<String> enabledLiveInstances = new HashSet<>(getAssignableLiveInstances().keySet());
+    enabledLiveInstances.removeAll(getDisabledInstances());
+
+    return enabledLiveInstances;
   }
 
   /**
@@ -552,20 +695,48 @@ public class BaseControllerDataProvider implements ControlContextProvider {
    */
   public Set<String> getEnabledLiveInstances() {
     Set<String> enabledLiveInstances = new HashSet<>(getLiveInstances().keySet());
-    enabledLiveInstances.removeAll(getDisabledInstances());
+    enabledLiveInstances.removeAll(getAssignableDisabledInstances());
 
     return enabledLiveInstances;
   }
 
   /**
-   * Return all nodes that are enabled.
-   * @return
+   * Return all nodes that are enabled and assignable.
+   *
+   * @return A new set contains instance name and that are marked enabled
    */
-  public Set<String> getEnabledInstances() {
-    Set<String> enabledNodes = new HashSet<>(getAllInstances());
+  public Set<String> getAssignableEnabledInstances() {
+    Set<String> enabledNodes = new HashSet<>(getAssignableInstances());
     enabledNodes.removeAll(getDisabledInstances());
 
     return enabledNodes;
+  }
+
+  /**
+   * Return all nodes that are enabled.
+   * @return A new set contains instance name and that are marked enabled
+   */
+  public Set<String> getEnabledInstances() {
+    Set<String> enabledNodes = new HashSet<>(getAllInstances());
+    enabledNodes.removeAll(getAssignableDisabledInstances());
+
+    return enabledNodes;
+  }
+
+  /**
+   * Return all the live nodes that are enabled and assignable and tagged with given instanceTag.
+   *
+   * @param instanceTag The instance group tag.
+   * @return A new set contains live instance name and that are marked enabled and have the
+   * specified tag.
+   */
+  public Set<String> getAssignableEnabledLiveInstancesWithTag(String instanceTag) {
+    Set<String> enabledLiveInstancesWithTag = new HashSet<>(getAssignableLiveInstances().keySet());
+    Set<String> instancesWithTag = getAssignableInstancesWithTag(instanceTag);
+    enabledLiveInstancesWithTag.retainAll(instancesWithTag);
+    enabledLiveInstancesWithTag.removeAll(getDisabledInstances());
+
+    return enabledLiveInstancesWithTag;
   }
 
   /**
@@ -576,11 +747,28 @@ public class BaseControllerDataProvider implements ControlContextProvider {
    */
   public Set<String> getEnabledLiveInstancesWithTag(String instanceTag) {
     Set<String> enabledLiveInstancesWithTag = new HashSet<>(getLiveInstances().keySet());
-    Set<String> instancesWithTag = getInstancesWithTag(instanceTag);
+    Set<String> instancesWithTag = getAssignableInstancesWithTag(instanceTag);
     enabledLiveInstancesWithTag.retainAll(instancesWithTag);
     enabledLiveInstancesWithTag.removeAll(getDisabledInstances());
 
     return enabledLiveInstancesWithTag;
+  }
+
+  /**
+   * Return all the nodes that are assignable and tagged with given instance tag.
+   *
+   * @param instanceTag The instance group tag.
+   */
+  public Set<String> getAssignableInstancesWithTag(String instanceTag) {
+    Set<String> taggedInstances = new HashSet<>();
+    for (String instance : _assignableInstanceConfigMap.keySet()) {
+      InstanceConfig instanceConfig = _instanceConfigCache.getPropertyByName(instance);
+      if (instanceConfig != null && instanceConfig.containsTag(instanceTag)) {
+        taggedInstances.add(instance);
+      }
+    }
+
+    return taggedInstances;
   }
 
   /**
@@ -589,7 +777,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
    */
   public Set<String> getInstancesWithTag(String instanceTag) {
     Set<String> taggedInstances = new HashSet<>();
-    for (String instance : _instanceConfigCache.getPropertyMap().keySet()) {
+    for (String instance : _assignableInstanceConfigMap.keySet()) {
       InstanceConfig instanceConfig = _instanceConfigCache.getPropertyByName(instance);
       if (instanceConfig != null && instanceConfig.containsTag(instanceTag)) {
         taggedInstances.add(instance);
@@ -623,6 +811,15 @@ public class BaseControllerDataProvider implements ControlContextProvider {
    */
   public Set<String> getDisabledInstances() {
     return Collections.unmodifiableSet(_disabledInstanceSet);
+  }
+
+  /**
+   * This method allows one to fetch the set of nodes that are disabled
+   *
+   * @return
+   */
+  public Set<String> getAssignableDisabledInstances() {
+    return Collections.unmodifiableSet(_assignableDisabledInstanceSet);
   }
 
   /**
@@ -762,8 +959,17 @@ public class BaseControllerDataProvider implements ControlContextProvider {
   }
 
   /**
-   * Returns the instance config map
-   * @return
+   * Returns the instance config map for all assignable instances.
+   *
+   * @return a map of instance name to instance config
+   */
+  public Map<String, InstanceConfig> getAssignableInstanceConfigMap() {
+    return Collections.unmodifiableMap(_assignableInstanceConfigMap);
+  }
+
+  /**
+   * Returns the instance config map for all assignable instances.
+   * @return a map of instance name to instance config
    */
   public Map<String, InstanceConfig> getInstanceConfigMap() {
     return _instanceConfigCache.getPropertyMap();
@@ -775,8 +981,10 @@ public class BaseControllerDataProvider implements ControlContextProvider {
    */
   public void setInstanceConfigMap(Map<String, InstanceConfig> instanceConfigMap) {
     _instanceConfigCache.setPropertyMap(instanceConfigMap);
-    updateDisabledInstances(instanceConfigMap.values(), getClusterConfig());
-    updateSwappingInstances(instanceConfigMap.values(), getEnabledLiveInstances(),
+    updateInstanceSets(_instanceConfigCache.getPropertyMap(), _liveInstanceCache.getPropertyMap(),
+        getClusterConfig());
+    updateDisabledInstances(getInstanceConfigMap().values(),
+        getAssignableInstanceConfigMap().values(),
         getClusterConfig());
   }
 
@@ -866,15 +1074,19 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     _updateInstanceOfflineTime = false;
   }
 
-  private void updateDisabledInstances(Collection<InstanceConfig> instanceConfigs,
-      ClusterConfig clusterConfig) {
+  private void updateDisabledInstances(Collection<InstanceConfig> allInstanceConfigs,
+      Collection<InstanceConfig> assignableInstanceConfigs, ClusterConfig clusterConfig) {
     // Move the calculating disabled instances to refresh
     _disabledInstanceForPartitionMap.clear();
     _disabledInstanceSet.clear();
-    for (InstanceConfig config : instanceConfigs) {
+    for (InstanceConfig config : allInstanceConfigs) {
       Map<String, List<String>> disabledPartitionMap = config.getDisabledPartitionsMap();
       if (!InstanceValidationUtil.isInstanceEnabled(config, clusterConfig)) {
         _disabledInstanceSet.add(config.getInstanceName());
+        // TODO: Make sure this contains works
+        if (assignableInstanceConfigs.contains(config)) {
+          _assignableDisabledInstanceSet.add(config.getInstanceName());
+        }
       }
       for (String resource : disabledPartitionMap.keySet()) {
         _disabledInstanceForPartitionMap.putIfAbsent(resource, new HashMap<>());
@@ -884,49 +1096,6 @@ public class BaseControllerDataProvider implements ControlContextProvider {
         }
       }
     }
-  }
-
-  private void updateSwappingInstances(Collection<InstanceConfig> instanceConfigs,
-      Set<String> liveEnabledInstances, ClusterConfig clusterConfig) {
-    _swapOutInstanceNameToSwapInInstanceName.clear();
-    _enabledLiveSwapInInstanceNames.clear();
-
-    if (clusterConfig == null) {
-      logger.warn("Skip refreshing swapping instances because clusterConfig is null.");
-      return;
-    }
-
-    ClusterTopologyConfig clusterTopologyConfig =
-        ClusterTopologyConfig.createFromClusterConfig(clusterConfig);
-
-    Map<String, String> swapOutLogicalIdsByInstanceName = new HashMap<>();
-    Map<String, String> swapInInstancesByLogicalId = new HashMap<>();
-    instanceConfigs.forEach(instanceConfig -> {
-      if (instanceConfig == null) {
-        return;
-      }
-      if (instanceConfig.getInstanceOperation()
-          .equals(InstanceConstants.InstanceOperation.SWAP_OUT.name())) {
-        swapOutLogicalIdsByInstanceName.put(instanceConfig.getInstanceName(),
-            instanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType()));
-      }
-      if (instanceConfig.getInstanceOperation()
-          .equals(InstanceConstants.InstanceOperation.SWAP_IN.name())) {
-        swapInInstancesByLogicalId.put(
-            instanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType()),
-            instanceConfig.getInstanceName());
-      }
-    });
-
-    swapOutLogicalIdsByInstanceName.forEach((swapOutInstanceName, value) -> {
-      String swapInInstanceName = swapInInstancesByLogicalId.get(value);
-      if (swapInInstanceName != null) {
-        _swapOutInstanceNameToSwapInInstanceName.put(swapOutInstanceName, swapInInstanceName);
-        if (liveEnabledInstances.contains(swapInInstanceName)) {
-          _enabledLiveSwapInInstanceNames.add(swapInInstanceName);
-        }
-      }
-    });
   }
 
   /*
@@ -1101,10 +1270,16 @@ public class BaseControllerDataProvider implements ControlContextProvider {
 
   protected StringBuilder genCacheContentStringBuilder() {
     StringBuilder sb = new StringBuilder();
-    sb.append(String.format("liveInstaceMap: %s", _liveInstanceCache.getPropertyMap())).append("\n");
+    sb.append(String.format("liveInstaceMap: %s", _liveInstanceCache.getPropertyMap()))
+        .append("\n");
+    sb.append(String.format("assignableLiveInstaceMap: %s", _assignableLiveInstancesMap))
+        .append("\n");
     sb.append(String.format("idealStateMap: %s", _idealStateCache.getPropertyMap())).append("\n");
     sb.append(String.format("stateModelDefMap: %s",  _stateModelDefinitionCache.getPropertyMap())).append("\n");
-    sb.append(String.format("instanceConfigMap: %s", _instanceConfigCache.getPropertyMap())).append("\n");
+    sb.append(String.format("instanceConfigMap: %s", _instanceConfigCache.getPropertyMap()))
+        .append("\n");
+    sb.append(String.format("assignableInstanceConfigMap: %s", _assignableInstanceConfigMap))
+        .append("\n");
     sb.append(String.format("resourceConfigMap: %s", _resourceConfigCache.getPropertyMap())).append("\n");
     sb.append(String.format("messageCache: %s", _instanceMessagesCache)).append("\n");
     sb.append(String.format("currentStateCache: %s", _currentStateCache)).append("\n");

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -842,6 +842,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
 
   public synchronized void setLiveInstances(List<LiveInstance> liveInstances) {
     _liveInstanceCache.setPropertyMap(HelixProperty.convertListToMap(liveInstances));
+    updateInstanceSets(_instanceConfigCache.getPropertyMap(), _liveInstanceCache.getPropertyMap(),
+        _clusterConfig);
     _updateInstanceOfflineTime = true;
   }
 
@@ -1083,7 +1085,6 @@ public class BaseControllerDataProvider implements ControlContextProvider {
       Map<String, List<String>> disabledPartitionMap = config.getDisabledPartitionsMap();
       if (!InstanceValidationUtil.isInstanceEnabled(config, clusterConfig)) {
         _disabledInstanceSet.add(config.getInstanceName());
-        // TODO: Make sure this contains works
         if (assignableInstanceConfigs.contains(config)) {
           _assignableDisabledInstanceSet.add(config.getInstanceName());
         }

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/WorkflowControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/WorkflowControllerDataProvider.java
@@ -26,7 +26,6 @@ import java.util.Set;
 
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixDataAccessor;
-import org.apache.helix.common.caches.TaskCurrentStateCache;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.common.caches.AbstractDataCache;
@@ -164,7 +163,7 @@ public class WorkflowControllerDataProvider extends BaseControllerDataProvider {
    */
   public void resetActiveTaskCount(CurrentStateOutput currentStateOutput) {
     // init participant map
-    for (String liveInstance : getLiveInstances().keySet()) {
+    for (String liveInstance : getAssignableLiveInstances().keySet()) {
       _participantActiveTaskCount.put(liveInstance, 0);
     }
     // Active task == init and running tasks

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
@@ -400,7 +400,7 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
    * @param disabledInstancesForPartition Set of disabled instances for the partition
    * @param bestPossibleStateMap Output map of <instance: state> for the partition
    */
-  public static void assignStatesToInstances(final List<String> preferenceList,
+  public void assignStatesToInstances(final List<String> preferenceList,
       final StateModelDefinition stateModelDef, final Map<String, String> currentStateMap,
       final Set<String> liveInstances, final Set<String> disabledInstancesForPartition,
       Map<String, String> bestPossibleStateMap) {
@@ -485,7 +485,7 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
    * @return The alternative instance, or the original proposed instance if adjustment is not
    * necessary.
    */
-  private static String adjustInstanceIfNecessary(String requestedState, String proposedInstance,
+  private String adjustInstanceIfNecessary(String requestedState, String proposedInstance,
       String currentState, StateModelDefinition stateModelDef, Set<String> assignedInstances,
       int remainCandidateCount, int remainRequestCount,
       Iterator<String> currentStatePrioritizedInstanceIter) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
@@ -102,9 +102,10 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
       Set<String> disabledInstancesForPartition =
           cache.getDisabledInstancesForPartition(resource.getResourceName(), partition.toString());
       List<String> preferenceList = getPreferenceList(partition, idealState,
-          Collections.unmodifiableSet(cache.getLiveInstances().keySet()));
+          Collections.unmodifiableSet(cache.getAssignableLiveInstances().keySet()));
       Map<String, String> bestStateForPartition =
-          computeBestPossibleStateForPartition(cache.getLiveInstances().keySet(), stateModelDef,
+          computeBestPossibleStateForPartition(cache.getAssignableLiveInstances().keySet(),
+              stateModelDef,
               preferenceList, currentStateOutput, disabledInstancesForPartition, idealState,
               cache.getClusterConfig(), partition,
               cache.getAbnormalStateResolver(stateModelDefName), cache);
@@ -392,8 +393,14 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
    * transition to the top-state, which could minimize the impact to the application's availability.
    * To achieve that, we sort the preferenceList based on CurrentState, by treating top-state and
    * second-states with same priority and rely on the fact that Collections.sort() is stable.
+   * @param preferenceList List of instances the replica will be placed on
+   * @param stateModelDef State model definition
+   * @param currentStateMap Current state of each replica <instance: state>
+   * @param liveInstances Set of live instances
+   * @param disabledInstancesForPartition Set of disabled instances for the partition
+   * @param bestPossibleStateMap Output map of <instance: state> for the partition
    */
-  private void assignStatesToInstances(final List<String> preferenceList,
+  public static void assignStatesToInstances(final List<String> preferenceList,
       final StateModelDefinition stateModelDef, final Map<String, String> currentStateMap,
       final Set<String> liveInstances, final Set<String> disabledInstancesForPartition,
       Map<String, String> bestPossibleStateMap) {
@@ -478,7 +485,7 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
    * @return The alternative instance, or the original proposed instance if adjustment is not
    * necessary.
    */
-  private String adjustInstanceIfNecessary(String requestedState, String proposedInstance,
+  private static String adjustInstanceIfNecessary(String requestedState, String proposedInstance,
       String currentState, StateModelDefinition stateModelDef, Set<String> assignedInstances,
       int remainCandidateCount, int remainRequestCount,
       Iterator<String> currentStatePrioritizedInstanceIter) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
@@ -400,7 +400,7 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
    * @param disabledInstancesForPartition Set of disabled instances for the partition
    * @param bestPossibleStateMap Output map of <instance: state> for the partition
    */
-  public void assignStatesToInstances(final List<String> preferenceList,
+  private void assignStatesToInstances(final List<String> preferenceList,
       final StateModelDefinition stateModelDef, final Map<String, String> currentStateMap,
       final Set<String> liveInstances, final Set<String> disabledInstancesForPartition,
       Map<String, String> bestPossibleStateMap) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
@@ -72,13 +72,13 @@ public class AutoRebalancer extends AbstractRebalancer<ResourceControllerDataPro
       LOG.error("State Model Definition null for resource: " + resourceName);
       throw new HelixException("State Model Definition null for resource: " + resourceName);
     }
-    Map<String, LiveInstance> liveInstance = clusterData.getLiveInstances();
+    Map<String, LiveInstance> liveInstance = clusterData.getAssignableLiveInstances();
     int replicas = currentIdealState.getReplicaCount(liveInstance.size());
 
     LinkedHashMap<String, Integer> stateCountMap = stateModelDef
         .getStateCountMap(liveInstance.size(), replicas);
     List<String> liveNodes = new ArrayList<>(liveInstance.keySet());
-    List<String> allNodes = new ArrayList<>(clusterData.getAllInstances());
+    List<String> allNodes = new ArrayList<>(clusterData.getAssignableInstances());
     allNodes.removeAll(clusterData.getDisabledInstances());
     liveNodes.retainAll(allNodes);
 
@@ -90,7 +90,7 @@ public class AutoRebalancer extends AbstractRebalancer<ResourceControllerDataPro
     Set<String> taggedLiveNodes = new HashSet<String>();
     if (currentIdealState.getInstanceGroupTag() != null) {
       for (String instanceName : allNodes) {
-        if (clusterData.getInstanceConfigMap().get(instanceName)
+        if (clusterData.getAssignableInstanceConfigMap().get(instanceName)
             .containsTag(currentIdealState.getInstanceGroupTag())) {
           taggedNodes.add(instanceName);
           if (liveInstance.containsKey(instanceName)) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AutoRebalancer.java
@@ -72,15 +72,15 @@ public class AutoRebalancer extends AbstractRebalancer<ResourceControllerDataPro
       LOG.error("State Model Definition null for resource: " + resourceName);
       throw new HelixException("State Model Definition null for resource: " + resourceName);
     }
-    Map<String, LiveInstance> liveInstance = clusterData.getAssignableLiveInstances();
-    int replicas = currentIdealState.getReplicaCount(liveInstance.size());
+    Map<String, LiveInstance> assignableLiveInstance = clusterData.getAssignableLiveInstances();
+    int replicas = currentIdealState.getReplicaCount(assignableLiveInstance.size());
 
     LinkedHashMap<String, Integer> stateCountMap = stateModelDef
-        .getStateCountMap(liveInstance.size(), replicas);
-    List<String> liveNodes = new ArrayList<>(liveInstance.keySet());
-    List<String> allNodes = new ArrayList<>(clusterData.getAssignableInstances());
-    allNodes.removeAll(clusterData.getDisabledInstances());
-    liveNodes.retainAll(allNodes);
+        .getStateCountMap(assignableLiveInstance.size(), replicas);
+    List<String> assignableLiveNodes = new ArrayList<>(assignableLiveInstance.keySet());
+    List<String> assignableNodes = new ArrayList<>(clusterData.getAssignableInstances());
+    assignableNodes.removeAll(clusterData.getDisabledInstances());
+    assignableLiveNodes.retainAll(assignableNodes);
 
     Map<String, Map<String, String>> currentMapping =
         currentMapping(currentStateOutput, resourceName, partitions, stateCountMap);
@@ -89,11 +89,11 @@ public class AutoRebalancer extends AbstractRebalancer<ResourceControllerDataPro
     Set<String> taggedNodes = new HashSet<String>();
     Set<String> taggedLiveNodes = new HashSet<String>();
     if (currentIdealState.getInstanceGroupTag() != null) {
-      for (String instanceName : allNodes) {
+      for (String instanceName : assignableNodes) {
         if (clusterData.getAssignableInstanceConfigMap().get(instanceName)
             .containsTag(currentIdealState.getInstanceGroupTag())) {
           taggedNodes.add(instanceName);
-          if (liveInstance.containsKey(instanceName)) {
+          if (assignableLiveInstance.containsKey(instanceName)) {
             taggedLiveNodes.add(instanceName);
           }
         }
@@ -114,25 +114,25 @@ public class AutoRebalancer extends AbstractRebalancer<ResourceControllerDataPro
         LOG.warn("Resource " + resourceName + " has tag " + currentIdealState.getInstanceGroupTag()
             + " but no live participants have this tag");
       }
-      allNodes = new ArrayList<>(taggedNodes);
-      liveNodes = new ArrayList<>(taggedLiveNodes);
+      assignableNodes = new ArrayList<>(taggedNodes);
+      assignableLiveNodes = new ArrayList<>(taggedLiveNodes);
     }
 
     // sort node lists to ensure consistent preferred assignments
-    Collections.sort(allNodes);
-    Collections.sort(liveNodes);
+    Collections.sort(assignableNodes);
+    Collections.sort(assignableLiveNodes);
 
     int maxPartition = currentIdealState.getMaxPartitionsPerInstance();
     _rebalanceStrategy =
         getRebalanceStrategy(currentIdealState.getRebalanceStrategy(), partitions, resourceName,
             stateCountMap, maxPartition);
     ZNRecord newMapping = _rebalanceStrategy
-        .computePartitionAssignment(allNodes, liveNodes, currentMapping, clusterData);
+        .computePartitionAssignment(assignableNodes, assignableLiveNodes, currentMapping, clusterData);
 
     LOG.debug("currentMapping: {}", currentMapping);
     LOG.debug("stateCountMap: {}", stateCountMap);
-    LOG.debug("liveNodes: {}", liveNodes);
-    LOG.debug("allNodes: {}", allNodes);
+    LOG.debug("assignableLiveNodes: {}", assignableLiveNodes);
+    LOG.debug("assignableNodes: {}", assignableNodes);
     LOG.debug("maxPartition: {}", maxPartition);
     LOG.debug("newMapping: {}", newMapping);
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
@@ -127,7 +127,7 @@ public class CustomRebalancer extends AbstractRebalancer<ResourceControllerDataP
       return instanceStateMap;
     }
 
-    Map<String, LiveInstance> liveInstancesMap = cache.getLiveInstances();
+    Map<String, LiveInstance> liveInstancesMap = cache.getAssignableLiveInstances();
     for (String instance : idealStateMap.keySet()) {
       boolean notInErrorState = currentStateMap != null
           && !HelixDefinedState.ERROR.toString().equals(currentStateMap.get(instance));

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
@@ -127,7 +127,7 @@ public class CustomRebalancer extends AbstractRebalancer<ResourceControllerDataP
       return instanceStateMap;
     }
 
-    Map<String, LiveInstance> liveInstancesMap = cache.getAssignableLiveInstances();
+    Map<String, LiveInstance> assignableLiveInstancesMap = cache.getAssignableLiveInstances();
     for (String instance : idealStateMap.keySet()) {
       boolean notInErrorState = currentStateMap != null
           && !HelixDefinedState.ERROR.toString().equals(currentStateMap.get(instance));
@@ -135,7 +135,7 @@ public class CustomRebalancer extends AbstractRebalancer<ResourceControllerDataP
 
       // Note: if instance is not live, the mapping for that instance will not show up in
       // BestPossibleMapping (and ExternalView)
-      if (liveInstancesMap.containsKey(instance) && notInErrorState) {
+      if (assignableLiveInstancesMap.containsKey(instance) && notInErrorState) {
         if (enabled) {
           instanceStateMap.put(instance, idealStateMap.get(instance));
         } else {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -40,7 +40,6 @@ import org.apache.helix.controller.rebalancer.util.DelayedRebalanceUtil;
 import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.ClusterConfig;
-import org.apache.helix.model.ClusterTopologyConfig;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
@@ -100,8 +99,8 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
 
     String instanceTag = currentIdealState.getInstanceGroupTag();
     if (instanceTag != null) {
-      liveEnabledNodes = clusterData.getEnabledLiveInstancesWithTag(instanceTag);
-      allNodes = clusterData.getInstancesWithTag(instanceTag);
+      liveEnabledNodes = clusterData.getAssignableEnabledLiveInstancesWithTag(instanceTag);
+      allNodes = clusterData.getAssignableInstancesWithTag(instanceTag);
 
       if (LOG.isInfoEnabled()) {
         LOG.info(String.format(
@@ -110,36 +109,31 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
             currentIdealState.getInstanceGroupTag(), resourceName, allNodes, liveEnabledNodes));
       }
     } else {
-      liveEnabledNodes = clusterData.getEnabledLiveInstances();
-      allNodes = clusterData.getAllInstances();
+      liveEnabledNodes = clusterData.getAssignableEnabledLiveInstances();
+      allNodes = clusterData.getAssignableInstances();
     }
 
-    Set<String> allNodesDeduped = DelayedRebalanceUtil.filterOutInstancesWithDuplicateLogicalIds(
-        ClusterTopologyConfig.createFromClusterConfig(clusterConfig),
-        clusterData.getInstanceConfigMap(), allNodes);
-    // Remove the non-selected instances with duplicate logicalIds from liveEnabledNodes
-    // This ensures the same duplicate instance is kept in both allNodesDeduped and liveEnabledNodes
-    liveEnabledNodes.retainAll(allNodesDeduped);
-
     long delay = DelayedRebalanceUtil.getRebalanceDelay(currentIdealState, clusterConfig);
-    Set<String> activeNodes = DelayedRebalanceUtil
-        .getActiveNodes(allNodesDeduped, currentIdealState, liveEnabledNodes,
-            clusterData.getInstanceOfflineTimeMap(), clusterData.getLiveInstances().keySet(),
-            clusterData.getInstanceConfigMap(), delay, clusterConfig);
+    Set<String> activeNodes =
+        DelayedRebalanceUtil.getActiveNodes(allNodes, currentIdealState, liveEnabledNodes,
+            clusterData.getInstanceOfflineTimeMap(),
+            clusterData.getAssignableLiveInstances().keySet(),
+            clusterData.getAssignableInstanceConfigMap(), delay, clusterConfig);
     if (delayRebalanceEnabled) {
       Set<String> offlineOrDisabledInstances = new HashSet<>(activeNodes);
       offlineOrDisabledInstances.removeAll(liveEnabledNodes);
       DelayedRebalanceUtil.setRebalanceScheduler(currentIdealState.getResourceName(), true,
           offlineOrDisabledInstances, clusterData.getInstanceOfflineTimeMap(),
-          clusterData.getLiveInstances().keySet(), clusterData.getInstanceConfigMap(), delay,
+          clusterData.getAssignableLiveInstances().keySet(),
+          clusterData.getAssignableInstanceConfigMap(), delay,
           clusterConfig, _manager);
     }
 
-    if (allNodesDeduped.isEmpty() || activeNodes.isEmpty()) {
+    if (allNodes.isEmpty() || activeNodes.isEmpty()) {
       LOG.error(String.format(
           "No instances or active instances available for resource %s, "
-              + "allInstances: %s, liveInstances: %s, activeInstances: %s",
-          resourceName, allNodesDeduped, liveEnabledNodes, activeNodes));
+              + "allInstances: %s, liveInstances: %s, activeInstances: %s", resourceName, allNodes,
+          liveEnabledNodes, activeNodes));
       return generateNewIdealState(resourceName, currentIdealState,
           emptyMapping(currentIdealState));
     }
@@ -165,13 +159,14 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
         getRebalanceStrategy(currentIdealState.getRebalanceStrategy(), allPartitions, resourceName,
             stateCountMap, maxPartition);
 
-    List<String> allNodeList = new ArrayList<>(allNodesDeduped);
+    List<String> allNodeList = new ArrayList<>(allNodes);
 
     // TODO: Currently we have 2 groups of instances and compute preference list twice and merge.
     // Eventually we want to have exclusive groups of instance for different instance tag.
     List<String> liveEnabledAssignableNodeList = new ArrayList<>(
         // We will not assign partitions to instances with EVACUATE InstanceOperation.
-        DelayedRebalanceUtil.filterOutEvacuatingInstances(clusterData.getInstanceConfigMap(),
+        DelayedRebalanceUtil.filterOutEvacuatingInstances(
+            clusterData.getAssignableInstanceConfigMap(),
             liveEnabledNodes));
     // sort node lists to ensure consistent preferred assignments
     Collections.sort(allNodeList);
@@ -199,24 +194,11 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
 
     finalMapping.getListFields().putAll(userDefinedPreferenceList);
 
-    // 1. Get all SWAP_OUT instances and corresponding SWAP_IN instance pairs in the cluster.
-    Map<String, String> swapOutToSwapInInstancePairs =
-        clusterData.getSwapOutToSwapInInstancePairs();
-    // 2. Get all enabled and live SWAP_IN instances in the cluster.
-    Set<String> enabledLiveSwapInInstances = clusterData.getEnabledLiveSwapInInstanceNames();
-    // 3. For each SWAP_OUT instance in any of the preferenceLists, add the corresponding SWAP_IN instance to the end.
-    // Skipping this when there are not SWAP_IN instances ready(enabled and live) will reduce computation time when there is not an active
-    // swap occurring.
-    if (!clusterData.getEnabledLiveSwapInInstanceNames().isEmpty()) {
-      DelayedRebalanceUtil.addSwapInInstanceToPreferenceListsIfSwapOutInstanceExists(finalMapping,
-          swapOutToSwapInInstancePairs, enabledLiveSwapInInstances);
-    }
-
     LOG.debug("currentMapping: {}", currentMapping);
     LOG.debug("stateCountMap: {}", stateCountMap);
     LOG.debug("liveEnabledNodes: {}", liveEnabledNodes);
     LOG.debug("activeNodes: {}", activeNodes);
-    LOG.debug("allNodes: {}", allNodesDeduped);
+    LOG.debug("allNodes: {}", allNodes);
     LOG.debug("maxPartition: {}", maxPartition);
     LOG.debug("newIdealMapping: {}", newIdealMapping);
     LOG.debug("finalMapping: {}", finalMapping);
@@ -274,14 +256,15 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
       LOG.debug("Processing resource:" + resource.getResourceName());
     }
 
-    Set<String> allNodes = cache.getEnabledInstances();
-    Set<String> liveNodes = cache.getLiveInstances().keySet();
+    Set<String> allNodes = cache.getAssignableEnabledInstances();
+    Set<String> liveNodes = cache.getAssignableLiveInstances().keySet();
 
     ClusterConfig clusterConfig = cache.getClusterConfig();
     long delayTime = DelayedRebalanceUtil.getRebalanceDelay(idealState, clusterConfig);
     Set<String> activeNodes = DelayedRebalanceUtil
         .getActiveNodes(allNodes, idealState, liveNodes, cache.getInstanceOfflineTimeMap(),
-            cache.getLiveInstances().keySet(), cache.getInstanceConfigMap(), delayTime,
+            cache.getAssignableLiveInstances().keySet(), cache.getAssignableInstanceConfigMap(),
+            delayTime,
             clusterConfig);
 
     String stateModelDefName = idealState.getStateModelDefRef();

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/AbstractEvenDistributionRebalanceStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/AbstractEvenDistributionRebalanceStrategy.java
@@ -87,7 +87,7 @@ public abstract class AbstractEvenDistributionRebalanceStrategy
       final List<String> liveNodes, final Map<String, Map<String, String>> currentMapping,
       ResourceControllerDataProvider clusterData) {
     // validate the instance configs
-    Map<String, InstanceConfig> instanceConfigMap = clusterData.getInstanceConfigMap();
+    Map<String, InstanceConfig> instanceConfigMap = clusterData.getAssignableInstanceConfigMap();
     if (instanceConfigMap == null || !instanceConfigMap.keySet().containsAll(allNodes)) {
       throw new HelixException(String.format("Config for instances %s is not found!",
               allNodes.removeAll(instanceConfigMap.keySet())));
@@ -116,7 +116,8 @@ public abstract class AbstractEvenDistributionRebalanceStrategy
     if (!origPartitionMap.isEmpty()) {
       Map<String, List<Node>> finalPartitionMap = null;
       Topology allNodeTopo =
-              new Topology(allNodes, allNodes, clusterData.getInstanceConfigMap(), clusterData.getClusterConfig());
+          new Topology(allNodes, allNodes, clusterData.getAssignableInstanceConfigMap(),
+              clusterData.getClusterConfig());
       // Transform current assignment to instance->partitions map, and get total partitions
       Map<Node, List<String>> nodeToPartitionMap =
           convertPartitionMap(origPartitionMap, allNodeTopo);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/ConstraintRebalanceStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/ConstraintRebalanceStrategy.java
@@ -154,7 +154,7 @@ public class ConstraintRebalanceStrategy extends AbstractEvenDistributionRebalan
     // Since instance weight will be replaced by constraint evaluation, record it in advance to avoid
     // overwriting.
     Map<String, Integer> instanceWeightRecords = new HashMap<>();
-    for (InstanceConfig instanceConfig : clusterData.getInstanceConfigMap().values()) {
+    for (InstanceConfig instanceConfig : clusterData.getAssignableInstanceConfigMap().values()) {
       if (instanceConfig.getWeight() != InstanceConfig.WEIGHT_NOT_SET) {
         instanceWeightRecords.put(instanceConfig.getInstanceName(), instanceConfig.getWeight());
       }
@@ -163,7 +163,7 @@ public class ConstraintRebalanceStrategy extends AbstractEvenDistributionRebalan
     List<String> candidates = new ArrayList<>(allNodes);
     // Only calculate for configured nodes.
     // Remove all non-configured nodes.
-    candidates.retainAll(clusterData.getAllInstances());
+    candidates.retainAll(clusterData.getAssignableInstances());
 
     // For generating the IdealState ZNRecord
     Map<String, List<String>> preferenceList = new HashMap<>();
@@ -207,7 +207,7 @@ public class ConstraintRebalanceStrategy extends AbstractEvenDistributionRebalan
 
     // recover the original weight
     for (String instanceName : instanceWeightRecords.keySet()) {
-      clusterData.getInstanceConfigMap().get(instanceName)
+      clusterData.getAssignableInstanceConfigMap().get(instanceName)
           .setWeight(instanceWeightRecords.get(instanceName));
     }
 
@@ -297,7 +297,7 @@ public class ConstraintRebalanceStrategy extends AbstractEvenDistributionRebalan
     }
     // Limit the weight to be at least MIN_INSTANCE_WEIGHT
     for (int i = 0; i < instancePriority.length; i++) {
-      clusterData.getInstanceConfigMap().get(qualifiedNodes.get(i))
+      clusterData.getAssignableInstanceConfigMap().get(qualifiedNodes.get(i))
           .setWeight(instancePriority[i] - baseline + MIN_INSTANCE_WEIGHT);
     }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/CrushRebalanceStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/CrushRebalanceStrategy.java
@@ -75,7 +75,7 @@ public class CrushRebalanceStrategy implements RebalanceStrategy<ResourceControl
   public ZNRecord computePartitionAssignment(final List<String> allNodes,
       final List<String> liveNodes, final Map<String, Map<String, String>> currentMapping,
       ResourceControllerDataProvider clusterData) throws HelixException {
-    Map<String, InstanceConfig> instanceConfigMap = clusterData.getInstanceConfigMap();
+    Map<String, InstanceConfig> instanceConfigMap = clusterData.getAssignableInstanceConfigMap();
     _clusterTopo =
         new Topology(allNodes, liveNodes, instanceConfigMap, clusterData.getClusterConfig());
     Node topNode = _clusterTopo.getRootNode();

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/MultiRoundCrushRebalanceStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/MultiRoundCrushRebalanceStrategy.java
@@ -82,7 +82,7 @@ public class MultiRoundCrushRebalanceStrategy implements RebalanceStrategy<Resou
   public ZNRecord computePartitionAssignment(final List<String> allNodes,
       final List<String> liveNodes, final Map<String, Map<String, String>> currentMapping,
       ResourceControllerDataProvider clusterData) throws HelixException {
-    Map<String, InstanceConfig> instanceConfigMap = clusterData.getInstanceConfigMap();
+    Map<String, InstanceConfig> instanceConfigMap = clusterData.getAssignableInstanceConfigMap();
     _clusterTopo =
         new Topology(allNodes, liveNodes, instanceConfigMap, clusterData.getClusterConfig());
     Node root = _clusterTopo.getRootNode();

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
@@ -343,8 +343,8 @@ public class DelayedRebalanceUtil {
 
       // keep all current assignment and add to allocated replicas
       resourceAssignment.getMappedPartitions().forEach(partition ->
-          resourceAssignment.getReplicaMap(partition).forEach((instance, state) ->
-              allocatedReplicas.computeIfAbsent(instance, key -> new HashSet<>())
+          resourceAssignment.getReplicaMap(partition).forEach((logicalId, state) ->
+              allocatedReplicas.computeIfAbsent(logicalId, key -> new HashSet<>())
                   .add(new AssignableReplica(clusterData.getClusterConfig(), mergedResourceConfig,
                       partition.getPartitionName(), state, statePriorityMap.get(state)))));
       // only proceed for resource requiring delayed rebalance overwrites

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
@@ -142,92 +142,6 @@ public class DelayedRebalanceUtil {
   }
 
   /**
-   * Filter out instances with duplicate logical IDs. If there are duplicates, the instance with
-   * InstanceOperation SWAP_OUT will be chosen over the instance with SWAP_IN. SWAP_IN is not
-   * assignable. If there are duplicates with one node having no InstanceOperation and the other
-   * having SWAP_OUT, the node with no InstanceOperation will be chosen. This signifies SWAP
-   * completion, therefore making the node assignable.
-   * TODO: Eventually when we refactor DataProvider to have getAssignableInstances() and
-   * TODO: getAssignableEnabledLiveInstances() this will not need to be called in the rebalancer.
-   * @param clusterTopologyConfig the cluster topology configuration
-   * @param instanceConfigMap     the map of instance name to corresponding InstanceConfig
-   * @param instances             the set of instances to filter out duplicate logicalIDs for
-   * @return the set of instances with duplicate logicalIDs filtered out, there will only be one
-   * instance per logicalID
-   */
-  public static Set<String> filterOutInstancesWithDuplicateLogicalIds(
-      ClusterTopologyConfig clusterTopologyConfig, Map<String, InstanceConfig> instanceConfigMap,
-      Set<String> instances) {
-    Set<String> filteredNodes = new HashSet<>();
-    Map<String, String> filteredInstancesByLogicalId = new HashMap<>();
-
-    instances.forEach(node -> {
-      InstanceConfig thisInstanceConfig = instanceConfigMap.get(node);
-      if (thisInstanceConfig == null) {
-        return;
-      }
-      String thisLogicalId =
-          thisInstanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType());
-
-      if (filteredInstancesByLogicalId.containsKey(thisLogicalId)) {
-        InstanceConfig filteredDuplicateInstanceConfig =
-            instanceConfigMap.get(filteredInstancesByLogicalId.get(thisLogicalId));
-        if ((filteredDuplicateInstanceConfig.getInstanceOperation()
-            .equals(InstanceConstants.InstanceOperation.SWAP_IN.name())
-            && thisInstanceConfig.getInstanceOperation()
-            .equals(InstanceConstants.InstanceOperation.SWAP_OUT.name()))
-            || thisInstanceConfig.getInstanceOperation().isEmpty()) {
-          // If the already filtered instance is SWAP_IN and this instance is in SWAP_OUT, then replace the filtered
-          // instance with this instance. If this instance has no InstanceOperation, then replace the filtered instance
-          // with this instance. This is the case where the SWAP_IN node has been marked as complete or SWAP_IN exists and
-          // SWAP_OUT does not. There can never be a case where both have no InstanceOperation set.
-          filteredNodes.remove(filteredInstancesByLogicalId.get(thisLogicalId));
-          filteredNodes.add(node);
-          filteredInstancesByLogicalId.put(thisLogicalId, node);
-        }
-      } else {
-        filteredNodes.add(node);
-        filteredInstancesByLogicalId.put(thisLogicalId, node);
-      }
-    });
-
-    return filteredNodes;
-  }
-
-  /**
-   * Look through the provided mapping and add corresponding SWAP_IN node if a SWAP_OUT node exists
-   * in the partition's preference list.
-   *
-   * @param mapping                      the mapping to be updated (IdealState ZNRecord)
-   * @param swapOutToSwapInInstancePairs the map of SWAP_OUT to SWAP_IN instances
-   */
-  public static void addSwapInInstanceToPreferenceListsIfSwapOutInstanceExists(ZNRecord mapping,
-      Map<String, String> swapOutToSwapInInstancePairs, Set<String> enabledLiveSwapInInstances) {
-    Map<String, List<String>> preferenceListsByPartition = mapping.getListFields();
-    for (String partition : preferenceListsByPartition.keySet()) {
-      List<String> preferenceList = preferenceListsByPartition.get(partition);
-      if (preferenceList == null) {
-        continue;
-      }
-      List<String> newInstancesToAdd = new ArrayList<>();
-      for (String instanceName : preferenceList) {
-        if (swapOutToSwapInInstancePairs.containsKey(instanceName)
-            && enabledLiveSwapInInstances.contains(
-            swapOutToSwapInInstancePairs.get(instanceName))) {
-          String swapInInstanceName = swapOutToSwapInInstancePairs.get(instanceName);
-          if (!preferenceList.contains(swapInInstanceName) && !newInstancesToAdd.contains(
-              swapInInstanceName)) {
-            newInstancesToAdd.add(swapInInstanceName);
-          }
-        }
-      }
-      if (!newInstancesToAdd.isEmpty()) {
-        preferenceList.addAll(newInstancesToAdd);
-      }
-    }
-  }
-
-  /**
    * Return the time when an offline or disabled instance should be treated as inactive. Return -1
    * if it is inactive now or forced to be rebalanced by an on-demand rebalance.
    *
@@ -505,7 +419,7 @@ public class DelayedRebalanceUtil {
       ResourceAssignment resourceAssignment) {
     String resourceName = resourceAssignment.getResourceName();
     IdealState currentIdealState = clusterData.getIdealState(resourceName);
-    Set<String> enabledLiveInstances = clusterData.getEnabledLiveInstances();
+    Set<String> enabledLiveInstances = clusterData.getAssignableEnabledLiveInstances();
     int numReplica = currentIdealState.getReplicaCount(enabledLiveInstances.size());
     int minActiveReplica = DelayedRebalanceUtil.getMinActiveReplica(ResourceConfig
         .mergeIdealStateWithResourceConfig(clusterData.getResourceConfig(resourceName),
@@ -526,7 +440,7 @@ public class DelayedRebalanceUtil {
 
   private static int getMinActiveReplica(ResourceControllerDataProvider clusterData, String resourceName) {
     IdealState currentIdealState = clusterData.getIdealState(resourceName);
-    Set<String> enabledLiveInstances = clusterData.getEnabledLiveInstances();
+    Set<String> enabledLiveInstances = clusterData.getAssignableEnabledLiveInstances();
     int numReplica = currentIdealState.getReplicaCount(enabledLiveInstances.size());
     return DelayedRebalanceUtil.getMinActiveReplica(ResourceConfig
         .mergeIdealStateWithResourceConfig(clusterData.getResourceConfig(resourceName),

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
@@ -182,29 +182,6 @@ class GlobalRebalanceRunner implements AutoCloseable {
         _assignmentMetadataStore != null && _assignmentMetadataStore.isBaselineChanged(newBaseline);
     // Write the new baseline to metadata store
     if (isBaselineChanged) {
-      System.out.println("Baseline has changed: Persisting the new baseline assignment.");
-
-      System.out.println("All Assignable Instances: " + allAssignableInstances);
-
-      Map<String, ResourceAssignment> oldBaseline = _assignmentMetadataStore.getBaseline();
-
-//      System.out.println("Old Baseline: " + _assignmentMetadataStore.getBaseline());
-//      System.out.println("New Baseline: " + newBaseline);
-
-      for (String resource : newBaseline.keySet()) {
-        ResourceAssignment oldAssignment = oldBaseline.get(resource);
-        if (oldAssignment == null) {
-          System.out.println("Resource " + resource + " is new.");
-          continue;
-        }
-        ResourceAssignment assignment = newBaseline.get(resource);
-        for (Partition partition : assignment.getMappedPartitions()) {
-          Map<String, String> oldPartitionMap = oldAssignment.getReplicaMap(partition);
-          Map<String, String> newPartitionMap = assignment.getReplicaMap(partition);
-          printMapDifferences(oldPartitionMap, newPartitionMap);
-        }
-      }
-
       try {
         _writeLatency.startMeasuringLatency();
         _assignmentMetadataStore.persistBaseline(newBaseline);
@@ -225,37 +202,6 @@ class GlobalRebalanceRunner implements AutoCloseable {
     if (isBaselineChanged && shouldTriggerMainPipeline) {
       LOG.info("Schedule a new rebalance after the new baseline calculation has finished.");
       RebalanceUtil.scheduleOnDemandPipeline(clusterData.getClusterName(), 0L, false);
-    }
-  }
-
-  private static void printMapDifferences(Map<String, String> map1, Map<String, String> map2) {
-    // StringBuilder to concatenate differences
-    StringBuilder diffBuilder = new StringBuilder();
-
-    // Iterate over the keys in map1
-    for (String key : map1.keySet()) {
-      String value1 = map1.get(key);
-      String value2 = map2.get(key);
-
-      // Compare values and append differences to the StringBuilder
-      if (!value1.equals(value2)) {
-        diffBuilder.append(key).append(": old: ").append(value1).append(", new: ").append(value2)
-            .append(" | ");
-      }
-    }
-
-    // Check for keys present in map2 but not in map1
-    for (String key : map2.keySet()) {
-      if (!map1.containsKey(key)) {
-        diffBuilder.append(key).append(": old: null").append(", new: ").append(map2.get(key))
-            .append(" | ");
-      }
-    }
-
-    // Print the differences on one line
-    String diffResult = diffBuilder.toString().trim();
-    if (!diffResult.isEmpty()) {
-      System.out.println("Differences: " + diffResult);
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
@@ -181,29 +181,6 @@ class GlobalRebalanceRunner implements AutoCloseable {
         _assignmentMetadataStore != null && _assignmentMetadataStore.isBaselineChanged(newBaseline);
     // Write the new baseline to metadata store
     if (isBaselineChanged) {
-      System.out.println("Baseline has changed: Persisting the new baseline assignment.");
-
-      System.out.println("All Assignable Instances: " + allAssignableInstances);
-
-      Map<String, ResourceAssignment> oldBaseline = _assignmentMetadataStore.getBaseline();
-
-//      System.out.println("Old Baseline: " + _assignmentMetadataStore.getBaseline());
-//      System.out.println("New Baseline: " + newBaseline);
-
-      for (String resource : newBaseline.keySet()) {
-        ResourceAssignment oldAssignment = oldBaseline.get(resource);
-        if (oldAssignment == null) {
-          System.out.println("Resource " + resource + " is new.");
-          continue;
-        }
-        ResourceAssignment assignment = newBaseline.get(resource);
-        for (Partition partition : assignment.getMappedPartitions()) {
-          Map<String, String> oldPartitionMap = oldAssignment.getReplicaMap(partition);
-          Map<String, String> newPartitionMap = assignment.getReplicaMap(partition);
-          printMapDifferences(oldPartitionMap, newPartitionMap);
-        }
-      }
-
       try {
         _writeLatency.startMeasuringLatency();
         _assignmentMetadataStore.persistBaseline(newBaseline);
@@ -213,9 +190,6 @@ class GlobalRebalanceRunner implements AutoCloseable {
             HelixRebalanceException.Type.INVALID_REBALANCER_STATUS, ex);
       }
     } else {
-      System.out.println("No Baseline change detected.");
-
-      System.out.println("All Assignable Instances: " + allAssignableInstances);
       LOG.debug("Assignment Metadata Store is null. Skip persisting the baseline assignment.");
     }
     _baselineCalcLatency.endMeasuringLatency();
@@ -224,37 +198,6 @@ class GlobalRebalanceRunner implements AutoCloseable {
     if (isBaselineChanged && shouldTriggerMainPipeline) {
       LOG.info("Schedule a new rebalance after the new baseline calculation has finished.");
       RebalanceUtil.scheduleOnDemandPipeline(clusterData.getClusterName(), 0L, false);
-    }
-  }
-
-  private static void printMapDifferences(Map<String, String> map1, Map<String, String> map2) {
-    // StringBuilder to concatenate differences
-    StringBuilder diffBuilder = new StringBuilder();
-
-    // Iterate over the keys in map1
-    for (String key : map1.keySet()) {
-      String value1 = map1.get(key);
-      String value2 = map2.get(key);
-
-      // Compare values and append differences to the StringBuilder
-      if (!value1.equals(value2)) {
-        diffBuilder.append(key).append(": old: ").append(value1).append(", new: ").append(value2)
-            .append(" | ");
-      }
-    }
-
-    // Check for keys present in map2 but not in map1
-    for (String key : map2.keySet()) {
-      if (!map1.containsKey(key)) {
-        diffBuilder.append(key).append(": old: null").append(", new: ").append(map2.get(key))
-            .append(" | ");
-      }
-    }
-
-    // Print the differences on one line
-    String diffResult = diffBuilder.toString().trim();
-    if (!diffResult.isEmpty()) {
-      System.out.println("Differences: " + diffResult);
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
@@ -166,7 +166,6 @@ class GlobalRebalanceRunner implements AutoCloseable {
     // 1. Ignore node status (disable/offline).
     // 2. Use the previous Baseline as the only parameter about the previous assignment.
     Map<String, ResourceAssignment> currentBaseline =
-        // TODO: Look into use of currentStateOutput here.
         _assignmentManager.getBaselineAssignment(_assignmentMetadataStore, currentStateOutput, resourceMap.keySet());
     ClusterModel clusterModel;
     try {
@@ -182,6 +181,29 @@ class GlobalRebalanceRunner implements AutoCloseable {
         _assignmentMetadataStore != null && _assignmentMetadataStore.isBaselineChanged(newBaseline);
     // Write the new baseline to metadata store
     if (isBaselineChanged) {
+      System.out.println("Baseline has changed: Persisting the new baseline assignment.");
+
+      System.out.println("All Assignable Instances: " + allAssignableInstances);
+
+      Map<String, ResourceAssignment> oldBaseline = _assignmentMetadataStore.getBaseline();
+
+//      System.out.println("Old Baseline: " + _assignmentMetadataStore.getBaseline());
+//      System.out.println("New Baseline: " + newBaseline);
+
+      for (String resource : newBaseline.keySet()) {
+        ResourceAssignment oldAssignment = oldBaseline.get(resource);
+        if (oldAssignment == null) {
+          System.out.println("Resource " + resource + " is new.");
+          continue;
+        }
+        ResourceAssignment assignment = newBaseline.get(resource);
+        for (Partition partition : assignment.getMappedPartitions()) {
+          Map<String, String> oldPartitionMap = oldAssignment.getReplicaMap(partition);
+          Map<String, String> newPartitionMap = assignment.getReplicaMap(partition);
+          printMapDifferences(oldPartitionMap, newPartitionMap);
+        }
+      }
+
       try {
         _writeLatency.startMeasuringLatency();
         _assignmentMetadataStore.persistBaseline(newBaseline);
@@ -202,6 +224,37 @@ class GlobalRebalanceRunner implements AutoCloseable {
     if (isBaselineChanged && shouldTriggerMainPipeline) {
       LOG.info("Schedule a new rebalance after the new baseline calculation has finished.");
       RebalanceUtil.scheduleOnDemandPipeline(clusterData.getClusterName(), 0L, false);
+    }
+  }
+
+  private static void printMapDifferences(Map<String, String> map1, Map<String, String> map2) {
+    // StringBuilder to concatenate differences
+    StringBuilder diffBuilder = new StringBuilder();
+
+    // Iterate over the keys in map1
+    for (String key : map1.keySet()) {
+      String value1 = map1.get(key);
+      String value2 = map2.get(key);
+
+      // Compare values and append differences to the StringBuilder
+      if (!value1.equals(value2)) {
+        diffBuilder.append(key).append(": old: ").append(value1).append(", new: ").append(value2)
+            .append(" | ");
+      }
+    }
+
+    // Check for keys present in map2 but not in map1
+    for (String key : map2.keySet()) {
+      if (!map1.containsKey(key)) {
+        diffBuilder.append(key).append(": old: null").append(", new: ").append(map2.get(key))
+            .append(" | ");
+      }
+    }
+
+    // Print the differences on one line
+    String diffResult = diffBuilder.toString().trim();
+    if (!diffResult.isEmpty()) {
+      System.out.println("Differences: " + diffResult);
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -404,7 +404,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     // TODO: Move evacuation into BaseControllerDataProvider assignableNode logic.
     final Set<String> enabledLiveInstances = DelayedRebalanceUtil.filterOutEvacuatingInstances(
         clusterData.getAssignableInstanceConfigMap(),
-        clusterData.getAssignableEnabledLiveInstances()); // TODO: May need to pass in enabled live instances because race condition
+        clusterData.getAssignableEnabledLiveInstances());
 
     if (activeNodes.equals(enabledLiveInstances) || !requireRebalanceOverwrite(clusterData, currentResourceAssignment)) {
       // no need for additional process, return the current resource assignment

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/AbstractPartitionMovementConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/AbstractPartitionMovementConstraint.java
@@ -64,16 +64,16 @@ abstract class AbstractPartitionMovementConstraint extends SoftConstraint {
     return assignment.get(resourceName).getReplicaMap(new Partition(partitionName));
   }
 
-  protected double calculateAssignmentScore(String nodeName, String state,
+  protected double calculateAssignmentScore(String logicalId, String state,
       Map<String, String> instanceToStateMap) {
-    if (instanceToStateMap.containsKey(nodeName)) {
+    if (instanceToStateMap.containsKey(logicalId)) {
       // The score when the proposed allocation partially matches the assignment plan but will
       // require a state transition.
       double scoreWithStateTransitionCost =
           MIN_SCORE + (MAX_SCORE - MIN_SCORE) * STATE_TRANSITION_COST_FACTOR;
       // if state matches, no state transition required for the proposed assignment; if state does
       // not match, then the proposed assignment requires state transition.
-      return state.equals(instanceToStateMap.get(nodeName)) ? MAX_SCORE
+      return state.equals(instanceToStateMap.get(logicalId)) ? MAX_SCORE
           : scoreWithStateTransitionCost;
     }
     return MIN_SCORE;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/BaselineInfluenceConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/BaselineInfluenceConstraint.java
@@ -44,7 +44,7 @@ public class BaselineInfluenceConstraint extends AbstractPartitionMovementConstr
 
     Map<String, String> baselineAssignment =
         getStateMap(replica, clusterContext.getBaselineAssignment());
-    return calculateAssignmentScore(node.getInstanceName(), replica.getReplicaState(),
+    return calculateAssignmentScore(node.getLogicalId(), replica.getReplicaState(),
         baselineAssignment);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -148,10 +148,10 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
           if (scoreCompareResult == 0) {
             // If the evaluation scores of 2 nodes are the same, the algorithm assigns the replica
             // to the idle node first.
-            String instanceName1 = nodeEntry1.getKey().getInstanceName();
-            String instanceName2 = nodeEntry2.getKey().getInstanceName();
-            int idleScore1 = busyInstances.contains(instanceName1) ? 0 : 1;
-            int idleScore2 = busyInstances.contains(instanceName2) ? 0 : 1;
+            String logicalId1 = nodeEntry1.getKey().getLogicalId();
+            String logicalId2 = nodeEntry2.getKey().getLogicalId();
+            int idleScore1 = busyInstances.contains(logicalId1) ? 0 : 1;
+            int idleScore2 = busyInstances.contains(logicalId2) ? 0 : 1;
             return idleScore1 != idleScore2 ? (idleScore1 - idleScore2)
                 : -nodeEntry1.getKey().compareTo(nodeEntry2.getKey());
           } else {
@@ -271,7 +271,7 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
 
   /**
    * @param assignments A collection of resource replicas assignment.
-   * @return A set of instance names that have at least one replica assigned in the input assignments.
+   * @return A set of logicalIds that have at least one replica assigned in the input assignments.
    */
   private Set<String> getBusyInstances(Collection<ResourceAssignment> assignments) {
     return assignments.stream().flatMap(

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/PartitionMovementConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/PartitionMovementConstraint.java
@@ -40,14 +40,14 @@ public class PartitionMovementConstraint extends AbstractPartitionMovementConstr
         getStateMap(replica, clusterContext.getBestPossibleAssignment());
     Map<String, String> baselineAssignment =
         getStateMap(replica, clusterContext.getBaselineAssignment());
-    String nodeName = node.getInstanceName();
+    String logicalId = node.getLogicalId();
     String state = replica.getReplicaState();
 
     if (bestPossibleAssignment.isEmpty()) {
       // if best possible is missing, it means the replica belongs to a newly added resource, so
       // baseline assignment should be used instead.
-      return calculateAssignmentScore(nodeName, state, baselineAssignment);
+      return calculateAssignmentScore(logicalId, state, baselineAssignment);
     }
-    return calculateAssignmentScore(nodeName, state, bestPossibleAssignment);
+    return calculateAssignmentScore(logicalId, state, bestPossibleAssignment);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -207,18 +207,15 @@ public class ClusterModelProvider {
                 dataProvider);
 
     // Get the set of active logical ids.
-    Set<String> activeLogicalIds = activeInstances.parallelStream().map(instanceName -> {
-      InstanceConfig instanceConfig =
-          dataProvider.getAssignableInstanceConfigMap().get(instanceName);
-      return instanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType());
-    }).collect(Collectors.toSet());
+    Set<String> activeLogicalIds = activeInstances.parallelStream().map(
+        instanceName -> dataProvider.getAssignableInstanceConfigMap().get(instanceName)
+            .getLogicalId(clusterTopologyConfig.getEndNodeType())).collect(Collectors.toSet());
 
+    Set<String> assignableLiveInstanceNames = dataProvider.getAssignableLiveInstances().keySet();
     Set<String> assignableLiveInstanceLogicalIds =
-        dataProvider.getAssignableLiveInstances().keySet().parallelStream().map(instanceName -> {
-          InstanceConfig instanceConfig =
-              dataProvider.getAssignableInstanceConfigMap().get(instanceName);
-          return instanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType());
-        }).collect(Collectors.toSet());
+        assignableLiveInstanceNames.parallelStream().map(
+            instanceName -> dataProvider.getAssignableInstanceConfigMap().get(instanceName)
+                .getLogicalId(clusterTopologyConfig.getEndNodeType())).collect(Collectors.toSet());
 
     // Generate replica objects for all the resource partitions.
     // <resource, replica set>

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -191,7 +191,7 @@ public class ClusterModelProvider {
       Map<String, ResourceAssignment> currentAssignment, RebalanceScopeType scopeType) {
     // Construct all the assignable nodes and initialize with the allocated replicas.
     Set<AssignableNode> assignableNodes =
-        getAllAssignableNodes(dataProvider.getClusterConfig(), dataProvider.getInstanceConfigMap(),
+        getAllAssignableNodes(dataProvider.getClusterConfig(), dataProvider.getAssignableInstanceConfigMap(),
             activeInstances);
 
     // Generate replica objects for all the resource partitions.
@@ -206,7 +206,7 @@ public class ClusterModelProvider {
     switch (scopeType) {
       case GLOBAL_BASELINE:
         toBeAssignedReplicas = findToBeAssignedReplicasByClusterChanges(replicaMap, activeInstances,
-            dataProvider.getLiveInstances().keySet(), clusterChanges, currentAssignment,
+            dataProvider.getAssignableLiveInstances().keySet(), clusterChanges, currentAssignment,
             allocatedReplicas);
         break;
       case PARTIAL:
@@ -241,7 +241,7 @@ public class ClusterModelProvider {
         generateResourceAssignmentMapLogicalIdView(idealAssignment, clusterTopologyConfig,
             dataProvider.getAssignableInstanceConfigMap());
     Map<String, ResourceAssignment> logicalIdCurrentAssignment =
-        generateResourceAssignmentMapLogicalIdView(idealAssignment, clusterTopologyConfig,
+        generateResourceAssignmentMapLogicalIdView(currentAssignment, clusterTopologyConfig,
             dataProvider.getAssignableInstanceConfigMap());
 
     // Construct and initialize cluster context.

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -189,9 +189,10 @@ public class ClusterModelProvider {
       Map<HelixConstants.ChangeType, Set<String>> clusterChanges,
       Map<String, ResourceAssignment> idealAssignment,
       Map<String, ResourceAssignment> currentAssignment, RebalanceScopeType scopeType) {
+    Map<String, InstanceConfig> assignableInstanceConfigMap = dataProvider.getAssignableInstanceConfigMap();
     // Construct all the assignable nodes and initialize with the allocated replicas.
     Set<AssignableNode> assignableNodes =
-        getAllAssignableNodes(dataProvider.getClusterConfig(), dataProvider.getAssignableInstanceConfigMap(),
+        getAllAssignableNodes(dataProvider.getClusterConfig(), assignableInstanceConfigMap,
             activeInstances);
 
     // Generate the logical view of the ideal assignment and the current assignment.
@@ -208,13 +209,13 @@ public class ClusterModelProvider {
 
     // Get the set of active logical ids.
     Set<String> activeLogicalIds = activeInstances.parallelStream().map(
-        instanceName -> dataProvider.getAssignableInstanceConfigMap().get(instanceName)
+        instanceName -> assignableInstanceConfigMap.get(instanceName)
             .getLogicalId(clusterTopologyConfig.getEndNodeType())).collect(Collectors.toSet());
 
     Set<String> assignableLiveInstanceNames = dataProvider.getAssignableLiveInstances().keySet();
     Set<String> assignableLiveInstanceLogicalIds =
-        assignableLiveInstanceNames.parallelStream().map(
-            instanceName -> dataProvider.getAssignableInstanceConfigMap().get(instanceName)
+        assignableLiveInstanceNames.stream().map(
+            instanceName -> assignableInstanceConfigMap.get(instanceName)
                 .getLogicalId(clusterTopologyConfig.getEndNodeType())).collect(Collectors.toSet());
 
     // Generate replica objects for all the resource partitions.

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -208,7 +208,7 @@ public class ClusterModelProvider {
                 dataProvider);
 
     // Get the set of active logical ids.
-    Set<String> activeLogicalIds = activeInstances.parallelStream().map(
+    Set<String> activeLogicalIds = activeInstances.stream().map(
         instanceName -> assignableInstanceConfigMap.get(instanceName)
             .getLogicalId(clusterTopologyConfig.getEndNodeType())).collect(Collectors.toSet());
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -551,6 +551,10 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
       messagesThrottled.add(messageToThrottle.getId());
       return;
     }
+    // TODO: Currently throttling is applied for messages that are targeting all instances including those not considered as
+    //  assignable. They all share the same configured limits. After discussion, there was agreement that this is the proper
+    //  behavior. In addition to this, we should consider adding priority based on whether the instance is assignable and whether
+    //  the message is bringing replica count to configured replicas or above configured replicas.
     throttleStateTransitionsForReplica(throttleController, resource.getResourceName(), partition,
         messageToThrottle, messagesThrottled, RebalanceType.LOAD_BALANCE, cache,
         resourceMessageMap);

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -656,10 +656,12 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
     // Generate a state mapping, state -> required numbers based on the live and enabled instances for this partition
     // preference list
     if (preferenceList != null) {
-      return stateModelDefinition.getStateCountMap((int) preferenceList.stream().filter(i -> resourceControllerDataProvider.getEnabledLiveInstances().contains(i))
+      return stateModelDefinition.getStateCountMap((int) preferenceList.stream().filter(
+              i -> resourceControllerDataProvider.getAssignableEnabledLiveInstances().contains(i))
           .count(), requiredNumReplica); // StateModelDefinition's counts
     }
-    return stateModelDefinition.getStateCountMap(resourceControllerDataProvider.getEnabledLiveInstances().size(),
+    return stateModelDefinition.getStateCountMap(
+        resourceControllerDataProvider.getAssignableEnabledLiveInstances().size(),
         requiredNumReplica); // StateModelDefinition's counts
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MaintenanceRecoveryStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MaintenanceRecoveryStage.java
@@ -90,7 +90,7 @@ public class MaintenanceRecoveryStage extends AbstractAsyncBaseStage {
       }
       // Get the count of all instances that are either offline or disabled
       int offlineDisabledCount =
-          cache.getAllInstances().size() - cache.getEnabledLiveInstances().size();
+          cache.getAssignableInstances().size() - cache.getAssignableEnabledLiveInstances().size();
       shouldExitMaintenance = offlineDisabledCount <= numOfflineInstancesForAutoExit;
       reason = String.format(
           "Auto-exiting maintenance mode for cluster %s; Num. of offline/disabled instances is %d, less than or equal to the exit threshold %d",

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -266,7 +266,8 @@ public class MessageGenerationPhase extends AbstractBaseStage {
               LogUtil.logError(logger, _eventId, String.format(
                   "An invalid message was generated! Discarding this message. sessionIdMap: %s, CurrentStateMap: %s, InstanceStateMap: %s, AllInstances: %s, LiveInstances: %s, Message: %s",
                   sessionIdMap, currentStateOutput.getCurrentStateMap(resourceName, partition),
-                  instanceStateMap, cache.getAllInstances(), cache.getLiveInstances().keySet(),
+                  instanceStateMap, cache.getAssignableInstances(),
+                  cache.getLiveInstances().keySet(),
                   message));
               continue; // Do not add this message
             }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -266,7 +266,7 @@ public class MessageGenerationPhase extends AbstractBaseStage {
               LogUtil.logError(logger, _eventId, String.format(
                   "An invalid message was generated! Discarding this message. sessionIdMap: %s, CurrentStateMap: %s, InstanceStateMap: %s, AllInstances: %s, LiveInstances: %s, Message: %s",
                   sessionIdMap, currentStateOutput.getCurrentStateMap(resourceName, partition),
-                  instanceStateMap, cache.getAssignableInstances(),
+                  instanceStateMap, cache.getAllInstances(),
                   cache.getLiveInstances().keySet(),
                   message));
               continue; // Do not add this message

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -19,8 +19,6 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ResourceComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ResourceComputationStage.java
@@ -19,12 +19,10 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.helix.HelixProperty;
 import org.apache.helix.controller.LogUtil;
 import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
 import org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider;

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/task/TaskSchedulingStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/task/TaskSchedulingStage.java
@@ -40,7 +40,6 @@ import org.apache.helix.controller.stages.ClusterEvent;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
-import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
 import org.apache.helix.task.AssignableInstanceManager;
 import org.apache.helix.task.TaskConstants;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -643,16 +643,22 @@ public class ZKHelixAdmin implements HelixAdmin {
     HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, baseAccessor);
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
 
-    // 1. Check that both instances are alive.
+    // 1. Check that both instances are alive and enabled.
     LiveInstance swapOutLiveInstance =
         accessor.getProperty(keyBuilder.liveInstance(swapOutInstanceName));
     LiveInstance swapInLiveInstance =
         accessor.getProperty(keyBuilder.liveInstance(swapInInstanceName));
-    if (swapOutLiveInstance == null || swapInLiveInstance == null) {
+    InstanceConfig swapOutInstanceConfig = getInstanceConfig(clusterName, swapOutInstanceName);
+    InstanceConfig swapInInstanceConfig = getInstanceConfig(clusterName, swapInInstanceName);
+    if (swapOutLiveInstance == null || swapInLiveInstance == null
+        || !swapOutInstanceConfig.getInstanceEnabled()
+        || !swapInInstanceConfig.getInstanceEnabled()) {
       logger.warn(
-          "SwapOutInstance {} is {} and SwapInInstance {} is {} for cluster {}. Swap will not complete unless both instances are ONLINE.",
+          "SwapOutInstance {} is {} + {} and SwapInInstance {} is {} + {} for cluster {}. Swap will not complete unless both instances are ONLINE.",
           swapOutInstanceName, swapOutLiveInstance != null ? "ONLINE" : "OFFLINE",
-          swapInInstanceName, swapInLiveInstance != null ? "ONLINE" : "OFFLINE", clusterName);
+          swapOutInstanceConfig.getInstanceEnabled() ? "ENABLED" : "DISABLED", swapInInstanceName,
+          swapInLiveInstance != null ? "ONLINE" : "OFFLINE",
+          swapInInstanceConfig.getInstanceEnabled() ? "ENABLED" : "DISABLED", clusterName);
       return false;
     }
 

--- a/helix-core/src/main/java/org/apache/helix/model/ResourceAssignment.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ResourceAssignment.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.helix.HelixProperty;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;

--- a/helix-core/src/main/java/org/apache/helix/model/ResourceAssignment.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ResourceAssignment.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.helix.HelixProperty;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -39,7 +40,6 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
  * can be in s1.
  */
 public class ResourceAssignment extends HelixProperty {
-
   /**
    * Initialize an empty mapping
    * @param resourceName the resource being mapped

--- a/helix-core/src/main/java/org/apache/helix/task/AbstractTaskDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/AbstractTaskDispatcher.java
@@ -647,7 +647,8 @@ public abstract class AbstractTaskDispatcher {
       int jobCfgLimitation =
           jobCfg.getNumConcurrentTasksPerInstance() - assignedPartitions.get(instance).size();
       // 2. throttled by participant capacity
-      int participantCapacity = cache.getInstanceConfigMap().get(instance).getMaxConcurrentTask();
+      int participantCapacity =
+          cache.getAssignableInstanceConfigMap().get(instance).getMaxConcurrentTask();
       if (participantCapacity == InstanceConfig.MAX_CONCURRENT_TASK_NOT_SET) {
         participantCapacity = cache.getClusterConfig().getMaxConcurrentTaskPerInstance();
       }

--- a/helix-core/src/main/java/org/apache/helix/task/JobDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/JobDispatcher.java
@@ -141,8 +141,8 @@ public class JobDispatcher extends AbstractTaskDispatcher {
     // Will contain the list of partitions that must be explicitly dropped from the ideal state that
     // is stored in zk.
     Set<String> liveInstances =
-        jobCfg.getInstanceGroupTag() == null ? _dataProvider.getEnabledLiveInstances()
-            : _dataProvider.getEnabledLiveInstancesWithTag(jobCfg.getInstanceGroupTag());
+        jobCfg.getInstanceGroupTag() == null ? _dataProvider.getAssignableEnabledLiveInstances()
+            : _dataProvider.getAssignableEnabledLiveInstancesWithTag(jobCfg.getInstanceGroupTag());
 
     if (liveInstances.isEmpty()) {
       LOG.error("No available instance found for job: {}", jobName);
@@ -163,7 +163,7 @@ public class JobDispatcher extends AbstractTaskDispatcher {
       if (jobTgtState == TargetState.STOP) {
         // If the assigned instance is no longer live, so mark it as DROPPED in the context
         markPartitionsWithoutLiveInstance(jobCtx, liveInstances);
-        
+
         if (jobState != TaskState.NOT_STARTED && TaskUtil.checkJobStopped(jobCtx)) {
           workflowCtx.setJobState(jobName, TaskState.STOPPED);
         } else {

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterExternalViewVerifier.java
@@ -146,7 +146,7 @@ public class ClusterExternalViewVerifier extends ClusterVerifier {
     cache.refresh(_accessor);
 
     List<String> liveInstances = new ArrayList<String>();
-    liveInstances.addAll(cache.getLiveInstances().keySet());
+    liveInstances.addAll(cache.getAssignableLiveInstances().keySet());
     boolean success = verifyLiveNodes(liveInstances);
     if (!success) {
       LOG.info("liveNodes not match, expect: " + _expectSortedLiveNodes + ", actual: "

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
@@ -330,16 +330,16 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
     Map<String, Map<String, String>> idealPartitionState = new HashMap<>();
 
     for (String partition : idealState.getPartitionSet()) {
-      List<String> preferenceList = AbstractRebalancer
-          .getPreferenceList(new Partition(partition), idealState, cache.getEnabledLiveInstances());
+      List<String> preferenceList = AbstractRebalancer.getPreferenceList(new Partition(partition),
+          idealState, cache.getAssignableEnabledLiveInstances());
       Map<String, String> idealMapping;
       if (_isDeactivatedNodeAware) {
-        idealMapping = HelixUtil
-            .computeIdealMapping(preferenceList, stateModelDef, cache.getLiveInstances().keySet(),
+        idealMapping = HelixUtil.computeIdealMapping(preferenceList, stateModelDef,
+            cache.getAssignableLiveInstances().keySet(),
                 cache.getDisabledInstancesForPartition(idealState.getResourceName(), partition));
       } else {
-        idealMapping = HelixUtil
-            .computeIdealMapping(preferenceList, stateModelDef, cache.getEnabledLiveInstances(),
+        idealMapping = HelixUtil.computeIdealMapping(preferenceList, stateModelDef,
+            cache.getAssignableEnabledLiveInstances(),
                 Collections.emptySet());
       }
       idealPartitionState.put(partition, idealMapping);

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -294,9 +294,9 @@ public final class HelixUtil {
           .collect(Collectors.toMap(InstanceConfig::getInstanceName, Function.identity())));
       // For LiveInstances, we must preserve the existing session IDs
       // So read LiveInstance objects from the cluster and do a "retainAll" on them
-      // liveInstanceMap is an unmodifiableMap instances, so we filter using a stream
-      Map<String, LiveInstance> liveInstanceMap = dataProvider.getAssignableLiveInstances();
-      List<LiveInstance> filteredLiveInstances = liveInstanceMap.entrySet().stream()
+      // assignableLiveInstanceMap is an unmodifiableMap instances, so we filter using a stream
+      Map<String, LiveInstance> assignableLiveInstanceMap = dataProvider.getAssignableLiveInstances();
+      List<LiveInstance> filteredLiveInstances = assignableLiveInstanceMap.entrySet().stream()
           .filter(entry -> liveInstances.contains(entry.getKey())).map(Map.Entry::getValue)
           .collect(Collectors.toList());
       // Synthetically create LiveInstance objects that are passed in as the parameter

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -295,7 +295,7 @@ public final class HelixUtil {
       // For LiveInstances, we must preserve the existing session IDs
       // So read LiveInstance objects from the cluster and do a "retainAll" on them
       // liveInstanceMap is an unmodifiableMap instances, so we filter using a stream
-      Map<String, LiveInstance> liveInstanceMap = dataProvider.getLiveInstances();
+      Map<String, LiveInstance> liveInstanceMap = dataProvider.getAssignableLiveInstances();
       List<LiveInstance> filteredLiveInstances = liveInstanceMap.entrySet().stream()
           .filter(entry -> liveInstances.contains(entry.getKey())).map(Map.Entry::getValue)
           .collect(Collectors.toList());

--- a/helix-core/src/test/java/org/apache/helix/controller/changedetector/trimmer/TestHelixPropoertyTimmer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/changedetector/trimmer/TestHelixPropoertyTimmer.java
@@ -111,11 +111,11 @@ public class TestHelixPropoertyTimmer {
     ResourceControllerDataProvider dataProvider =
         Mockito.mock(ResourceControllerDataProvider.class);
     when(dataProvider.getRefreshedChangeTypes()).thenReturn(changeTypes);
-    when(dataProvider.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(dataProvider.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
     when(dataProvider.getIdealStates()).thenReturn(idealStateMap);
     when(dataProvider.getResourceConfigMap()).thenReturn(resourceConfigMap);
     when(dataProvider.getClusterConfig()).thenReturn(clusterConfig);
-    when(dataProvider.getLiveInstances()).thenReturn(Collections.emptyMap());
+    when(dataProvider.getAssignableLiveInstances()).thenReturn(Collections.emptyMap());
     return dataProvider;
   }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestAutoRebalanceStrategy.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestAutoRebalanceStrategy.java
@@ -243,7 +243,7 @@ public class TestAutoRebalanceStrategy {
           }
         }
         Map<String, String> assignment = new AutoRebalancer()
-            .computeBestPossibleStateForPartition(cache.getLiveInstances().keySet(), _stateModelDef,
+            .computeBestPossibleStateForPartition(cache.getAssignableLiveInstances().keySet(), _stateModelDef,
                 preferenceList, currentStateOutput, disabled, is, clusterConfig, p,
                 MonitoredAbnormalResolver.DUMMY_STATE_RESOLVER);
         mapResult.put(partition, assignment);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -886,6 +886,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     when(clusterData.getAssignableEnabledLiveInstances()).thenReturn(instances);
     Map<String, InstanceConfig> instanceConfigMap = clusterData.getAssignableInstanceConfigMap();
     when(clusterData.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(clusterData.getInstanceConfigMap()).thenReturn(instanceConfigMap);
 
     Map<String, IdealState> isMap = new HashMap<>();
     for (String resource : _resourceNames) {

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -20,7 +20,7 @@ package org.apache.helix.controller.rebalancer.waged;
  */
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -108,17 +108,17 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
       _instances.add(instanceName);
       // 1. Set up the default instance information with capacity configuration.
       InstanceConfig testInstanceConfig = createMockInstanceConfig(instanceName);
-      Map<String, InstanceConfig> instanceConfigMap = testCache.getInstanceConfigMap();
+      Map<String, InstanceConfig> instanceConfigMap = testCache.getAssignableInstanceConfigMap();
       instanceConfigMap.put(instanceName, testInstanceConfig);
-      when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+      when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
       // 2. Mock the live instance node for the default instance.
       LiveInstance testLiveInstance = createMockLiveInstance(instanceName);
-      Map<String, LiveInstance> liveInstanceMap = testCache.getLiveInstances();
+      Map<String, LiveInstance> liveInstanceMap = testCache.getAssignableLiveInstances();
       liveInstanceMap.put(instanceName, testLiveInstance);
-      when(testCache.getLiveInstances()).thenReturn(liveInstanceMap);
-      when(testCache.getEnabledInstances()).thenReturn(liveInstanceMap.keySet());
-      when(testCache.getEnabledLiveInstances()).thenReturn(liveInstanceMap.keySet());
-      when(testCache.getAllInstances()).thenReturn(_instances);
+      when(testCache.getAssignableLiveInstances()).thenReturn(liveInstanceMap);
+      when(testCache.getAssignableEnabledInstances()).thenReturn(liveInstanceMap.keySet());
+      when(testCache.getAssignableEnabledLiveInstances()).thenReturn(liveInstanceMap.keySet());
+      when(testCache.getAssignableInstances()).thenReturn(_instances);
     }
 
     return testCache;
@@ -370,7 +370,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
         Collectors.toMap(resourceName -> resourceName, Resource::new));
     try {
       rebalancer.computeBestPossibleAssignment(clusterData, resourceMap,
-          clusterData.getEnabledLiveInstances(), new CurrentStateOutput(), _algorithm);
+          clusterData.getAssignableEnabledLiveInstances(), new CurrentStateOutput(), _algorithm);
       Assert.fail("Rebalance shall fail.");
     } catch (HelixRebalanceException ex) {
       Assert.assertEquals(ex.getFailureType(), HelixRebalanceException.Type.FAILED_TO_CALCULATE);
@@ -434,7 +434,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     // Calculation will fail
     try {
       rebalancer.computeBestPossibleAssignment(clusterData, resourceMap,
-          clusterData.getEnabledLiveInstances(), new CurrentStateOutput(), badAlgorithm);
+          clusterData.getAssignableEnabledLiveInstances(), new CurrentStateOutput(), badAlgorithm);
       Assert.fail("Rebalance shall fail.");
     } catch (HelixRebalanceException ex) {
       Assert.assertEquals(ex.getFailureType(), HelixRebalanceException.Type.FAILED_TO_CALCULATE);
@@ -649,13 +649,13 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     Set<String> instances = new HashSet<>(_instances);
     String offlineInstance = "offlineInstance";
     instances.add(offlineInstance);
-    when(clusterData.getAllInstances()).thenReturn(instances);
+    when(clusterData.getAssignableInstances()).thenReturn(instances);
     Map<String, Long> instanceOfflineTimeMap = new HashMap<>();
     instanceOfflineTimeMap.put(offlineInstance, System.currentTimeMillis() + Integer.MAX_VALUE);
     when(clusterData.getInstanceOfflineTimeMap()).thenReturn(instanceOfflineTimeMap);
-    Map<String, InstanceConfig> instanceConfigMap = clusterData.getInstanceConfigMap();
+    Map<String, InstanceConfig> instanceConfigMap = clusterData.getAssignableInstanceConfigMap();
     instanceConfigMap.put(offlineInstance, createMockInstanceConfig(offlineInstance));
-    when(clusterData.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(clusterData.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
 
     // Set minActiveReplica to 0 so that requireRebalanceOverwrite returns false
     Map<String, IdealState> isMap = new HashMap<>();
@@ -737,16 +737,16 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     // force create a fake offlineInstance that's in delay window
     Set<String> instances = new HashSet<>(_instances);
     instances.add(offlineInstance);
-    when(clusterData.getAllInstances()).thenReturn(instances);
-    when(clusterData.getEnabledInstances()).thenReturn(instances);
-    when(clusterData.getEnabledLiveInstances()).thenReturn(
+    when(clusterData.getAssignableInstances()).thenReturn(instances);
+    when(clusterData.getAssignableEnabledInstances()).thenReturn(instances);
+    when(clusterData.getAssignableEnabledLiveInstances()).thenReturn(
         new HashSet<>(Arrays.asList(instance0, instance1, instance2)));
     Map<String, Long> instanceOfflineTimeMap = new HashMap<>();
     instanceOfflineTimeMap.put(offlineInstance, System.currentTimeMillis() + Integer.MAX_VALUE);
     when(clusterData.getInstanceOfflineTimeMap()).thenReturn(instanceOfflineTimeMap);
-    Map<String, InstanceConfig> instanceConfigMap = clusterData.getInstanceConfigMap();
+    Map<String, InstanceConfig> instanceConfigMap = clusterData.getAssignableInstanceConfigMap();
     instanceConfigMap.put(offlineInstance, createMockInstanceConfig(offlineInstance));
-    when(clusterData.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(clusterData.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
 
     Map<String, IdealState> isMap = new HashMap<>();
     for (String resource : _resourceNames) {
@@ -881,11 +881,11 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
 
     // force create a fake offlineInstance that's in delay window
     Set<String> instances = new HashSet<>(_instances);
-    when(clusterData.getAllInstances()).thenReturn(instances);
-    when(clusterData.getEnabledInstances()).thenReturn(instances);
-    when(clusterData.getEnabledLiveInstances()).thenReturn(instances);
-    Map<String, InstanceConfig> instanceConfigMap = clusterData.getInstanceConfigMap();
-    when(clusterData.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(clusterData.getAssignableInstances()).thenReturn(instances);
+    when(clusterData.getAssignableEnabledInstances()).thenReturn(instances);
+    when(clusterData.getAssignableEnabledLiveInstances()).thenReturn(instances);
+    Map<String, InstanceConfig> instanceConfigMap = clusterData.getAssignableInstanceConfigMap();
+    when(clusterData.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
 
     Map<String, IdealState> isMap = new HashMap<>();
     for (String resource : _resourceNames) {

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -111,14 +111,19 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
       Map<String, InstanceConfig> instanceConfigMap = testCache.getAssignableInstanceConfigMap();
       instanceConfigMap.put(instanceName, testInstanceConfig);
       when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
+      when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
       // 2. Mock the live instance node for the default instance.
       LiveInstance testLiveInstance = createMockLiveInstance(instanceName);
       Map<String, LiveInstance> liveInstanceMap = testCache.getAssignableLiveInstances();
       liveInstanceMap.put(instanceName, testLiveInstance);
       when(testCache.getAssignableLiveInstances()).thenReturn(liveInstanceMap);
+      when(testCache.getLiveInstances()).thenReturn(liveInstanceMap);
       when(testCache.getAssignableEnabledInstances()).thenReturn(liveInstanceMap.keySet());
+      when(testCache.getEnabledInstances()).thenReturn(liveInstanceMap.keySet());
       when(testCache.getAssignableEnabledLiveInstances()).thenReturn(liveInstanceMap.keySet());
+      when(testCache.getEnabledLiveInstances()).thenReturn(liveInstanceMap.keySet());
       when(testCache.getAssignableInstances()).thenReturn(_instances);
+      when(testCache.getAllInstances()).thenReturn(_instances);
     }
 
     return testCache;
@@ -601,6 +606,11 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     String offlinePartition = _partitionNames.get(0);
     String offlineState = "MASTER";
     String offlineInstance = "offlineInstance";
+    InstanceConfig offlineInstanceConfig = createMockInstanceConfig(offlineInstance);
+    Map<String, InstanceConfig> instanceConfigMap = clusterData.getAssignableInstanceConfigMap();
+    instanceConfigMap.put(offlineInstance, offlineInstanceConfig);
+    when(clusterData.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(clusterData.getInstanceConfigMap()).thenReturn(instanceConfigMap);
     for (Partition partition : bestPossibleAssignment.get(offlineResource).getMappedPartitions()) {
       if (partition.getPartitionName().equals(offlinePartition)) {
         bestPossibleAssignment.get(offlineResource)
@@ -656,6 +666,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     Map<String, InstanceConfig> instanceConfigMap = clusterData.getAssignableInstanceConfigMap();
     instanceConfigMap.put(offlineInstance, createMockInstanceConfig(offlineInstance));
     when(clusterData.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(clusterData.getInstanceConfigMap()).thenReturn(instanceConfigMap);
 
     // Set minActiveReplica to 0 so that requireRebalanceOverwrite returns false
     Map<String, IdealState> isMap = new HashMap<>();
@@ -747,6 +758,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     Map<String, InstanceConfig> instanceConfigMap = clusterData.getAssignableInstanceConfigMap();
     instanceConfigMap.put(offlineInstance, createMockInstanceConfig(offlineInstance));
     when(clusterData.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(clusterData.getInstanceConfigMap()).thenReturn(instanceConfigMap);
 
     Map<String, IdealState> isMap = new HashMap<>();
     for (String resource : _resourceNames) {

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
@@ -256,17 +256,17 @@ public class TestWagedRebalancerMetrics extends AbstractTestClusterModel {
       _instances.add(instanceName);
       // 1. Set up the default instance information with capacity configuration.
       InstanceConfig testInstanceConfig = createMockInstanceConfig(instanceName);
-      Map<String, InstanceConfig> instanceConfigMap = testCache.getInstanceConfigMap();
+      Map<String, InstanceConfig> instanceConfigMap = testCache.getAssignableInstanceConfigMap();
       instanceConfigMap.put(instanceName, testInstanceConfig);
-      when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+      when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
       // 2. Mock the live instance node for the default instance.
       LiveInstance testLiveInstance = createMockLiveInstance(instanceName);
-      Map<String, LiveInstance> liveInstanceMap = testCache.getLiveInstances();
+      Map<String, LiveInstance> liveInstanceMap = testCache.getAssignableLiveInstances();
       liveInstanceMap.put(instanceName, testLiveInstance);
-      when(testCache.getLiveInstances()).thenReturn(liveInstanceMap);
-      when(testCache.getEnabledInstances()).thenReturn(liveInstanceMap.keySet());
-      when(testCache.getEnabledLiveInstances()).thenReturn(liveInstanceMap.keySet());
-      when(testCache.getAllInstances()).thenReturn(_instances);
+      when(testCache.getAssignableLiveInstances()).thenReturn(liveInstanceMap);
+      when(testCache.getAssignableEnabledInstances()).thenReturn(liveInstanceMap.keySet());
+      when(testCache.getAssignableEnabledLiveInstances()).thenReturn(liveInstanceMap.keySet());
+      when(testCache.getAssignableInstances()).thenReturn(_instances);
     }
 
     return testCache;

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
@@ -259,14 +259,19 @@ public class TestWagedRebalancerMetrics extends AbstractTestClusterModel {
       Map<String, InstanceConfig> instanceConfigMap = testCache.getAssignableInstanceConfigMap();
       instanceConfigMap.put(instanceName, testInstanceConfig);
       when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
+      when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
       // 2. Mock the live instance node for the default instance.
       LiveInstance testLiveInstance = createMockLiveInstance(instanceName);
       Map<String, LiveInstance> liveInstanceMap = testCache.getAssignableLiveInstances();
       liveInstanceMap.put(instanceName, testLiveInstance);
       when(testCache.getAssignableLiveInstances()).thenReturn(liveInstanceMap);
+      when(testCache.getLiveInstances()).thenReturn(liveInstanceMap);
       when(testCache.getAssignableEnabledInstances()).thenReturn(liveInstanceMap.keySet());
+      when(testCache.getEnabledInstances()).thenReturn(liveInstanceMap.keySet());
       when(testCache.getAssignableEnabledLiveInstances()).thenReturn(liveInstanceMap.keySet());
+      when(testCache.getEnabledLiveInstances()).thenReturn(liveInstanceMap.keySet());
       when(testCache.getAssignableInstances()).thenReturn(_instances);
+      when(testCache.getAllInstances()).thenReturn(_instances);
     }
 
     return testCache;

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestPartitionMovementConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestPartitionMovementConstraint.java
@@ -53,6 +53,7 @@ public class TestPartitionMovementConstraint {
     when(_testReplica.getResourceName()).thenReturn(RESOURCE);
     when(_testReplica.getPartitionName()).thenReturn(PARTITION);
     when(_testNode.getInstanceName()).thenReturn(INSTANCE);
+    when(_testNode.getLogicalId()).thenReturn(INSTANCE);
   }
 
   @Test
@@ -104,6 +105,7 @@ public class TestPartitionMovementConstraint {
 
     // when the replica's state matches with best possible, allocation matches with baseline
     when(testAssignableNode.getInstanceName()).thenReturn(instanceNameA);
+    when(testAssignableNode.getLogicalId()).thenReturn(instanceNameA);
     when(_testReplica.getReplicaState()).thenReturn("Master");
     verifyScore(_baselineInfluenceConstraint, testAssignableNode, _testReplica, _clusterContext,
         0.5, 0.5);
@@ -112,6 +114,7 @@ public class TestPartitionMovementConstraint {
 
     // when the replica's allocation matches with best possible only
     when(testAssignableNode.getInstanceName()).thenReturn(instanceNameB);
+    when(testAssignableNode.getLogicalId()).thenReturn(instanceNameB);
     when(_testReplica.getReplicaState()).thenReturn("Master");
     verifyScore(_baselineInfluenceConstraint, testAssignableNode, _testReplica, _clusterContext,
         0.0, 0.0);
@@ -120,6 +123,7 @@ public class TestPartitionMovementConstraint {
 
     // when the replica's state matches with baseline only
     when(testAssignableNode.getInstanceName()).thenReturn(instanceNameC);
+    when(testAssignableNode.getLogicalId()).thenReturn(instanceNameC);
     when(_testReplica.getReplicaState()).thenReturn("Master");
     verifyScore(_baselineInfluenceConstraint, testAssignableNode, _testReplica, _clusterContext,
         1.0, 1.0);
@@ -128,6 +132,7 @@ public class TestPartitionMovementConstraint {
 
     // when the replica's allocation matches with baseline only
     when(testAssignableNode.getInstanceName()).thenReturn(instanceNameC);
+    when(testAssignableNode.getLogicalId()).thenReturn(instanceNameC);
     when(_testReplica.getReplicaState()).thenReturn("Slave");
     verifyScore(_baselineInfluenceConstraint, testAssignableNode, _testReplica, _clusterContext,
         0.5, 0.5);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
@@ -103,7 +103,7 @@ public abstract class AbstractTestClusterModel {
     testInstanceConfig.setInstanceEnabledForPartition("TestResource", "TestPartition", false);
     Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
     instanceConfigMap.put(_testInstanceId, testInstanceConfig);
-    when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
 
     // 2. Set up the basic cluster configuration.
     ClusterConfig testClusterConfig = new ClusterConfig("testClusterConfigId");
@@ -121,7 +121,7 @@ public abstract class AbstractTestClusterModel {
     LiveInstance testLiveInstance = createMockLiveInstance(_testInstanceId);
     Map<String, LiveInstance> liveInstanceMap = new HashMap<>();
     liveInstanceMap.put(_testInstanceId, testLiveInstance);
-    when(testCache.getLiveInstances()).thenReturn(liveInstanceMap);
+    when(testCache.getAssignableLiveInstances()).thenReturn(liveInstanceMap);
 
     // 4. Mock two resources, each with 2 partitions on the default instance.
     // The instance will have the following partitions assigned
@@ -288,7 +288,7 @@ public abstract class AbstractTestClusterModel {
 
   protected Set<AssignableNode> generateNodes(ResourceControllerDataProvider testCache) {
     Set<AssignableNode> nodeSet = new HashSet<>();
-    testCache.getInstanceConfigMap().values().forEach(config -> nodeSet
+    testCache.getAssignableInstanceConfigMap().values().forEach(config -> nodeSet
         .add(new AssignableNode(testCache.getClusterConfig(), config, config.getInstanceName())));
     return nodeSet;
   }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
@@ -104,6 +104,7 @@ public abstract class AbstractTestClusterModel {
     Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
     instanceConfigMap.put(_testInstanceId, testInstanceConfig);
     when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
 
     // 2. Set up the basic cluster configuration.
     ClusterConfig testClusterConfig = new ClusterConfig("testClusterConfigId");

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelTestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelTestHelper.java
@@ -63,7 +63,7 @@ public class ClusterModelTestHelper extends AbstractTestClusterModel {
     Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
     instanceConfigMap.put(TEST_INSTANCE_ID_1, testInstanceConfig1);
     instanceConfigMap.put(TEST_INSTANCE_ID_2, testInstanceConfig2);
-    when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
     Set<AssignableReplica> assignableReplicas = generateReplicas(testCache);
     Set<AssignableNode> assignableNodes = generateNodes(testCache);
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestAssignableNode.java
@@ -64,7 +64,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     expectedCapacityMap.put("item3", 30);
 
     AssignableNode assignableNode = new AssignableNode(testCache.getClusterConfig(),
-        testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
+        testCache.getAssignableInstanceConfigMap().get(_testInstanceId), _testInstanceId);
     assignableNode.assignInitBatch(assignmentSet);
     Assert.assertEquals(assignableNode.getAssignedPartitionsMap(), expectedAssignment);
     Assert.assertEquals(assignableNode.getAssignedReplicaCount(), 4);
@@ -177,7 +177,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     ResourceControllerDataProvider testCache = setupClusterDataCache();
 
     AssignableNode assignableNode = new AssignableNode(testCache.getClusterConfig(),
-        testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
+        testCache.getAssignableInstanceConfigMap().get(_testInstanceId), _testInstanceId);
     AssignableReplica removingReplica = new AssignableReplica(testCache.getClusterConfig(),
         testCache.getResourceConfig(_resourceNames.get(1)), _partitionNames.get(2) + "non-exist",
         "MASTER", 1);
@@ -192,7 +192,7 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     Set<AssignableReplica> assignmentSet = generateReplicas(testCache);
 
     AssignableNode assignableNode = new AssignableNode(testCache.getClusterConfig(),
-        testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
+        testCache.getAssignableInstanceConfigMap().get(_testInstanceId), _testInstanceId);
     assignableNode.assignInitBatch(assignmentSet);
     AssignableReplica duplicateReplica = new AssignableReplica(testCache.getClusterConfig(),
         testCache.getResourceConfig(_resourceNames.get(0)), _partitionNames.get(0), "SLAVE", 2);
@@ -213,10 +213,10 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     testInstanceConfig.setDomain("instance=testInstance");
     Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
     instanceConfigMap.put(_testInstanceId, testInstanceConfig);
-    when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
 
     AssignableNode node = new AssignableNode(testCache.getClusterConfig(),
-        testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
+        testCache.getAssignableInstanceConfigMap().get(_testInstanceId), _testInstanceId);
     Assert.assertEquals(node.getFaultZone(), "Helix_default_zone");
   }
 
@@ -234,10 +234,10 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     testInstanceConfig.setDomain("zone=2, instance=testInstance");
     Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
     instanceConfigMap.put(_testInstanceId, testInstanceConfig);
-    when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
 
     AssignableNode assignableNode = new AssignableNode(testCache.getClusterConfig(),
-        testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
+        testCache.getAssignableInstanceConfigMap().get(_testInstanceId), _testInstanceId);
 
     Assert.assertEquals(assignableNode.getFaultZone(), "2");
 
@@ -251,10 +251,10 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     testInstanceConfig.setDomain("zone=2, instance=testInstance");
     instanceConfigMap = new HashMap<>();
     instanceConfigMap.put(_testInstanceId, testInstanceConfig);
-    when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
 
     assignableNode = new AssignableNode(testCache.getClusterConfig(),
-        testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
+        testCache.getAssignableInstanceConfigMap().get(_testInstanceId), _testInstanceId);
 
     Assert.assertEquals(assignableNode.getFaultZone(), "2/testInstance");
 
@@ -268,10 +268,10 @@ public class TestAssignableNode extends AbstractTestClusterModel {
     testInstanceConfig.setDomain("rack=3, zone=2, instance=testInstanceConfigId");
     instanceConfigMap = new HashMap<>();
     instanceConfigMap.put(_testInstanceId, testInstanceConfig);
-    when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+    when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
     when(testCache.getClusterConfig()).thenReturn(testClusterConfig);
     assignableNode = new AssignableNode(testCache.getClusterConfig(),
-        testCache.getInstanceConfigMap().get(_testInstanceId), _testInstanceId);
+        testCache.getAssignableInstanceConfigMap().get(_testInstanceId), _testInstanceId);
     Assert.assertEquals(assignableNode.getFaultZone(), "3/2");
   }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModelProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModelProvider.java
@@ -82,6 +82,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
       Map<String, InstanceConfig> instanceConfigMap = testCache.getAssignableInstanceConfigMap();
       instanceConfigMap.put(instanceName, testInstanceConfig);
       when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
+      when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
       // 2. Mock the live instance node for the default instance.
       LiveInstance testLiveInstance = createMockLiveInstance(instanceName);
       Map<String, LiveInstance> liveInstanceMap = testCache.getAssignableLiveInstances();

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModelProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModelProvider.java
@@ -79,14 +79,14 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
       _instances.add(instanceName);
       // 1. Set up the default instance information with capacity configuration.
       InstanceConfig testInstanceConfig = createMockInstanceConfig(instanceName);
-      Map<String, InstanceConfig> instanceConfigMap = testCache.getInstanceConfigMap();
+      Map<String, InstanceConfig> instanceConfigMap = testCache.getAssignableInstanceConfigMap();
       instanceConfigMap.put(instanceName, testInstanceConfig);
-      when(testCache.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+      when(testCache.getAssignableInstanceConfigMap()).thenReturn(instanceConfigMap);
       // 2. Mock the live instance node for the default instance.
       LiveInstance testLiveInstance = createMockLiveInstance(instanceName);
-      Map<String, LiveInstance> liveInstanceMap = testCache.getLiveInstances();
+      Map<String, LiveInstance> liveInstanceMap = testCache.getAssignableLiveInstances();
       liveInstanceMap.put(instanceName, testLiveInstance);
-      when(testCache.getLiveInstances()).thenReturn(liveInstanceMap);
+      when(testCache.getAssignableLiveInstances()).thenReturn(liveInstanceMap);
     }
 
     return testCache;
@@ -104,8 +104,8 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     Set<String> activeInstances = new HashSet<>();
     activeInstances.add(instance1);
     activeInstances.add(instance2);
-    when(testCache.getLiveInstances()).thenReturn(liveInstanceMap);
-    when(testCache.getEnabledLiveInstances()).thenReturn(activeInstances);
+    when(testCache.getAssignableLiveInstances()).thenReturn(liveInstanceMap);
+    when(testCache.getAssignableEnabledLiveInstances()).thenReturn(activeInstances);
 
     // test 0, empty input
     Assert.assertEquals(
@@ -142,8 +142,8 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
 
     // test 2, no additional replica to be assigned
     testCache = setupClusterDataCache();
-    when(testCache.getLiveInstances()).thenReturn(liveInstanceMap);
-    when(testCache.getEnabledLiveInstances()).thenReturn(activeInstances);
+    when(testCache.getAssignableLiveInstances()).thenReturn(liveInstanceMap);
+    when(testCache.getAssignableEnabledLiveInstances()).thenReturn(activeInstances);
     input = ImmutableMap.of(
         _resourceNames.get(0),
         ImmutableMap.of(
@@ -167,8 +167,8 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
 
     // test 3, minActiveReplica==2, two partitions falling short
     testCache = setupClusterDataCache();
-    when(testCache.getLiveInstances()).thenReturn(liveInstanceMap);
-    when(testCache.getEnabledLiveInstances()).thenReturn(activeInstances);
+    when(testCache.getAssignableLiveInstances()).thenReturn(liveInstanceMap);
+    when(testCache.getAssignableEnabledLiveInstances()).thenReturn(activeInstances);
     input = ImmutableMap.of(
         _resourceNames.get(0),
         ImmutableMap.of(
@@ -205,8 +205,8 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     Set<String> activeInstances = new HashSet<>();
     activeInstances.add(instance1);
     activeInstances.add(instance2);
-    when(testCache.getLiveInstances()).thenReturn(liveInstanceMap);
-    when(testCache.getEnabledLiveInstances()).thenReturn(activeInstances);
+    when(testCache.getAssignableLiveInstances()).thenReturn(liveInstanceMap);
+    when(testCache.getAssignableEnabledLiveInstances()).thenReturn(activeInstances);
 
     // test 1, one partition under minActiveReplica
     Map<String, Map<String, Map<String, String>>> input = ImmutableMap.of(
@@ -245,8 +245,8 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
 
     // test 2, minActiveReplica==2, three partitions falling short
     testCache = setupClusterDataCache();
-    when(testCache.getLiveInstances()).thenReturn(liveInstanceMap);
-    when(testCache.getEnabledLiveInstances()).thenReturn(activeInstances);
+    when(testCache.getAssignableLiveInstances()).thenReturn(liveInstanceMap);
+    when(testCache.getAssignableEnabledLiveInstances()).thenReturn(activeInstances);
     input = ImmutableMap.of(
         _resourceNames.get(0),
         ImmutableMap.of(
@@ -413,7 +413,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
         .allMatch(replicaSet -> replicaSet.size() == 4));
 
     // Adjust instance fault zone, so they have different fault zones.
-    testCache.getInstanceConfigMap().values().stream()
+    testCache.getAssignableInstanceConfigMap().values().stream()
         .forEach(config -> config.setZoneId(config.getInstanceName()));
     clusterModel = ClusterModelProvider.generateClusterModelForBaseline(testCache,
         _resourceNames.stream()
@@ -576,7 +576,7 @@ public class TestClusterModelProvider extends AbstractTestClusterModel {
     Assert.assertEquals(clusterModel.getAssignableReplicaMap().size(), 0);
 
     // Adjust instance fault zone, so they have different fault zones.
-    testCache.getInstanceConfigMap().values().stream()
+    testCache.getAssignableInstanceConfigMap().values().stream()
         .forEach(config -> config.setZoneId(config.getInstanceName()));
 
     // 2. test with a pair of identical best possible assignment and baseline assignment

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleCalcStageCompatibility.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleCalcStageCompatibility.java
@@ -49,8 +49,9 @@ public class TestBestPossibleCalcStageCompatibility extends BaseStageTest {
       "testResourceName"
     };
     setupIdealStateDeprecated(5, resources, 10, 1, IdealStateModeProperty.AUTO);
-    setupLiveInstances(5);
     setupStateModel();
+    setupInstances(5);
+    setupLiveInstances(5);
 
     Map<String, Resource> resourceMap = getResourceMap();
     CurrentStateOutput currentStateOutput = new CurrentStateOutput();

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
@@ -50,6 +50,7 @@ public class TestBestPossibleStateCalcStage extends BaseStageTest {
         BuiltInStateModelDefinitions.MasterSlave.name());
     setupLiveInstances(5);
     setupStateModel();
+    setupInstances(5);
 
     Map<String, Resource> resourceMap =
         getResourceMap(resources, numPartition, BuiltInStateModelDefinitions.MasterSlave.name());

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestCancellationMessageGeneration.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestCancellationMessageGeneration.java
@@ -81,7 +81,7 @@ public class TestCancellationMessageGeneration extends MessageGenerationPhase {
     when(mockLiveInstance.getInstanceName()).thenReturn(TEST_INSTANCE);
     when(mockLiveInstance.getEphemeralOwner()).thenReturn("TEST");
     when(liveInstances.values()).thenReturn(Arrays.asList(mockLiveInstance));
-    when(cache.getAssignableLiveInstances()).thenReturn(liveInstances);
+    when(cache.getLiveInstances()).thenReturn(liveInstances);
     ClusterConfig clusterConfig = mock(ClusterConfig.class);
     when(cache.getClusterConfig()).thenReturn(clusterConfig);
     when(clusterConfig.isStateTransitionCancelEnabled()).thenReturn(true);
@@ -177,7 +177,7 @@ public class TestCancellationMessageGeneration extends MessageGenerationPhase {
     when(mockLiveInstance.getInstanceName()).thenReturn(TEST_INSTANCE);
     when(mockLiveInstance.getEphemeralOwner()).thenReturn("TEST");
     when(liveInstances.values()).thenReturn(Collections.singletonList(mockLiveInstance));
-    when(cache.getAssignableLiveInstances()).thenReturn(liveInstances);
+    when(cache.getLiveInstances()).thenReturn(liveInstances);
     ClusterConfig clusterConfig = mock(ClusterConfig.class);
     when(cache.getClusterConfig()).thenReturn(clusterConfig);
     when(clusterConfig.isStateTransitionCancelEnabled()).thenReturn(true);

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestCancellationMessageGeneration.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestCancellationMessageGeneration.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.HelixManager;
 import org.apache.helix.controller.common.PartitionStateMap;
-import org.apache.helix.controller.common.ResourcesStateMap;
 import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.LiveInstance;
@@ -82,7 +81,7 @@ public class TestCancellationMessageGeneration extends MessageGenerationPhase {
     when(mockLiveInstance.getInstanceName()).thenReturn(TEST_INSTANCE);
     when(mockLiveInstance.getEphemeralOwner()).thenReturn("TEST");
     when(liveInstances.values()).thenReturn(Arrays.asList(mockLiveInstance));
-    when(cache.getLiveInstances()).thenReturn(liveInstances);
+    when(cache.getAssignableLiveInstances()).thenReturn(liveInstances);
     ClusterConfig clusterConfig = mock(ClusterConfig.class);
     when(cache.getClusterConfig()).thenReturn(clusterConfig);
     when(clusterConfig.isStateTransitionCancelEnabled()).thenReturn(true);
@@ -178,7 +177,7 @@ public class TestCancellationMessageGeneration extends MessageGenerationPhase {
     when(mockLiveInstance.getInstanceName()).thenReturn(TEST_INSTANCE);
     when(mockLiveInstance.getEphemeralOwner()).thenReturn("TEST");
     when(liveInstances.values()).thenReturn(Collections.singletonList(mockLiveInstance));
-    when(cache.getLiveInstances()).thenReturn(liveInstances);
+    when(cache.getAssignableLiveInstances()).thenReturn(liveInstances);
     ClusterConfig clusterConfig = mock(ClusterConfig.class);
     when(cache.getClusterConfig()).thenReturn(clusterConfig);
     when(clusterConfig.isStateTransitionCancelEnabled()).thenReturn(true);

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
@@ -572,6 +572,7 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
     setupIdealState(numOfLiveInstances, resources, numOfLiveInstances, numOfReplicas,
         IdealState.RebalanceMode.FULL_AUTO, "OnlineOffline");
     setupStateModel();
+    setupInstances(numOfLiveInstances);
     setupLiveInstances(numOfLiveInstances);
 
     // Set up cluster configs

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestManagementMessageGeneration.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestManagementMessageGeneration.java
@@ -104,7 +104,7 @@ public class TestManagementMessageGeneration extends ManagementMessageGeneration
     when(mockLiveInstance.getInstanceName()).thenReturn(TEST_INSTANCE);
     when(mockLiveInstance.getEphemeralOwner()).thenReturn("TEST");
     when(liveInstances.values()).thenReturn(Collections.singletonList(mockLiveInstance));
-    when(cache.getAssignableLiveInstances()).thenReturn(liveInstances);
+    when(cache.getLiveInstances()).thenReturn(liveInstances);
     ClusterConfig clusterConfig = mock(ClusterConfig.class);
     when(cache.getClusterConfig()).thenReturn(clusterConfig);
     when(clusterConfig.isStateTransitionCancelEnabled()).thenReturn(cancelPendingST);

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestManagementMessageGeneration.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestManagementMessageGeneration.java
@@ -104,7 +104,7 @@ public class TestManagementMessageGeneration extends ManagementMessageGeneration
     when(mockLiveInstance.getInstanceName()).thenReturn(TEST_INSTANCE);
     when(mockLiveInstance.getEphemeralOwner()).thenReturn("TEST");
     when(liveInstances.values()).thenReturn(Collections.singletonList(mockLiveInstance));
-    when(cache.getLiveInstances()).thenReturn(liveInstances);
+    when(cache.getAssignableLiveInstances()).thenReturn(liveInstances);
     ClusterConfig clusterConfig = mock(ClusterConfig.class);
     when(cache.getClusterConfig()).thenReturn(clusterConfig);
     when(clusterConfig.isStateTransitionCancelEnabled()).thenReturn(cancelPendingST);

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestRebalancePipeline.java
@@ -57,8 +57,10 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
   @Test
   public void testDuplicateMsg() throws Exception {
     String clusterName = "CLUSTER_" + _className + "_dup";
-    System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
 
+    System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+    admin.addCluster(clusterName);
     HelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_gZkClient));
     refreshClusterConfig(clusterName, accessor);
@@ -82,10 +84,11 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     setupIdealState(clusterName, new int[] {
         0
     }, resourceGroups, 1, 1);
+    setupStateModel(clusterName);
+    setupInstances(clusterName, new int[]{0});
     List<LiveInstance> liveInstances = setupLiveInstances(clusterName, new int[] {
         0
     });
-    setupStateModel(clusterName);
 
     // cluster data cache refresh pipeline
     Pipeline dataRefresh = new Pipeline();
@@ -321,10 +324,11 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     setupIdealState(clusterName, new int[] {
         0
     }, resourceGroups, 1, 1);
+    setupStateModel(clusterName);
+    setupInstances(clusterName, new int[]{0});
     List<LiveInstance> liveInstances = setupLiveInstances(clusterName, new int[] {
         0
     });
-    setupStateModel(clusterName);
 
     // cluster data cache refresh pipeline
     Pipeline dataRefresh = new Pipeline();
@@ -395,8 +399,10 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
   @Test
   public void testMasterXfer() throws Exception {
     String clusterName = "CLUSTER_" + _className + "_xfer";
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
 
     System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+    admin.addCluster(clusterName);
 
     HelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_gZkClient));
@@ -417,10 +423,11 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     setupIdealState(clusterName, new int[] {
         0, 1
     }, resourceGroups, 1, 2);
+    setupStateModel(clusterName);
+    setupInstances(clusterName, new int[]{0, 1});
     List<LiveInstance> liveInstances = setupLiveInstances(clusterName, new int[] {
         1
     });
-    setupStateModel(clusterName);
 
     // cluster data cache refresh pipeline
     Pipeline dataRefresh = new Pipeline();
@@ -474,8 +481,10 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
   @Test
   public void testNoDuplicatedMaster() throws Exception {
     String clusterName = "CLUSTER_" + _className + "_no_duplicated_master";
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
 
     System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+    admin.addCluster(clusterName);
 
     HelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_gZkClient));
@@ -496,10 +505,11 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     setupIdealState(clusterName, new int[] {
         0, 1
     }, resourceGroups, 1, 2);
+    setupStateModel(clusterName);
+    setupInstances(clusterName, new int[]{0, 1});
     List<LiveInstance> liveInstances = setupLiveInstances(clusterName, new int[] {
         0, 1
     });
-    setupStateModel(clusterName);
 
     // cluster data cache refresh pipeline
     Pipeline dataRefresh = new Pipeline();
@@ -553,6 +563,9 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
   public void testNoMessageSentOnControllerLeadershipLoss() throws Exception {
     String methodName = TestHelper.getTestMethodName();
     String clusterName = _className + "_" + methodName;
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
+
+    admin.addCluster(clusterName);
 
     final String resourceName = "testResource_" + methodName;
     final String partitionName = resourceName + "_0";
@@ -565,10 +578,11 @@ public class TestRebalancePipeline extends ZkUnitTestBase {
     setupIdealState(clusterName, new int[] {
         0
     }, resourceGroups, 1, 1);
+    setupStateModel(clusterName);
+    setupInstances(clusterName, new int[]{0});
     List<LiveInstance> liveInstances = setupLiveInstances(clusterName, new int[] {
         0
     });
-    setupStateModel(clusterName);
 
     HelixDataAccessor accessor =
         new ZKHelixDataAccessor(clusterName, new ZkBaseDataAccessor<>(_gZkClient));

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestReplicaLevelThrottling.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestReplicaLevelThrottling.java
@@ -73,7 +73,7 @@ public class TestReplicaLevelThrottling extends BaseStageTest {
         (StateModelDefinition) cacheMap.get(CacheKeys.stateModelDef.name()));
     when(mock.cache.getAssignableEnabledLiveInstances()).thenReturn(new HashSet<>(
         ((Map<String, List<String>>) cacheMap.get(CacheKeys.preferenceList.name())).values().iterator().next()));
-    when(mock.cache.getAssignableLiveInstances()).thenReturn(new HashSet<>(
+    when(mock.cache.getLiveInstances()).thenReturn(new HashSet<>(
         ((Map<String, List<String>>) cacheMap.get(CacheKeys.preferenceList.name())).values().iterator().next()).stream()
         .collect(Collectors.toMap(e -> e, e -> new LiveInstance(e))));
     when(mock.cache.getIdealState(RESOURCE_NAME)).thenReturn(

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestReplicaLevelThrottling.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestReplicaLevelThrottling.java
@@ -71,9 +71,9 @@ public class TestReplicaLevelThrottling extends BaseStageTest {
     when(mock.cache.getClusterConfig()).thenReturn((ClusterConfig) cacheMap.get(CacheKeys.clusterConfig.name()));
     when(mock.cache.getStateModelDef((String) cacheMap.get(CacheKeys.stateModelName.name()))).thenReturn(
         (StateModelDefinition) cacheMap.get(CacheKeys.stateModelDef.name()));
-    when(mock.cache.getEnabledLiveInstances()).thenReturn(new HashSet<>(
+    when(mock.cache.getAssignableEnabledLiveInstances()).thenReturn(new HashSet<>(
         ((Map<String, List<String>>) cacheMap.get(CacheKeys.preferenceList.name())).values().iterator().next()));
-    when(mock.cache.getLiveInstances()).thenReturn(new HashSet<>(
+    when(mock.cache.getAssignableLiveInstances()).thenReturn(new HashSet<>(
         ((Map<String, List<String>>) cacheMap.get(CacheKeys.preferenceList.name())).values().iterator().next()).stream()
         .collect(Collectors.toMap(e -> e, e -> new LiveInstance(e))));
     when(mock.cache.getIdealState(RESOURCE_NAME)).thenReturn(

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestOfflineNodeTimeoutDuringMaintenanceMode.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestOfflineNodeTimeoutDuringMaintenanceMode.java
@@ -208,15 +208,15 @@ public class TestOfflineNodeTimeoutDuringMaintenanceMode extends ZkTestBase {
         new ResourceControllerDataProvider(CLUSTER_NAME);
     resourceControllerDataProvider.refresh(_helixDataAccessor);
     Assert
-        .assertFalse(resourceControllerDataProvider.getLiveInstances().containsKey(instance3));
+        .assertFalse(resourceControllerDataProvider.getAssignableLiveInstances().containsKey(instance3));
     Assert
-        .assertFalse(resourceControllerDataProvider.getLiveInstances().containsKey(instance4));
-    Assert.assertTrue(resourceControllerDataProvider.getLiveInstances().containsKey(instance5));
+        .assertFalse(resourceControllerDataProvider.getAssignableLiveInstances().containsKey(instance4));
+    Assert.assertTrue(resourceControllerDataProvider.getAssignableLiveInstances().containsKey(instance5));
     Assert
-        .assertFalse(resourceControllerDataProvider.getLiveInstances().containsKey(instance6));
+        .assertFalse(resourceControllerDataProvider.getAssignableLiveInstances().containsKey(instance6));
     Assert
-        .assertFalse(resourceControllerDataProvider.getLiveInstances().containsKey(instance7));
-    Assert.assertTrue(resourceControllerDataProvider.getLiveInstances().containsKey(instance8));
+        .assertFalse(resourceControllerDataProvider.getAssignableLiveInstances().containsKey(instance7));
+    Assert.assertTrue(resourceControllerDataProvider.getAssignableLiveInstances().containsKey(instance8));
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PMessageSemiAuto.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PMessageSemiAuto.java
@@ -208,7 +208,7 @@ public class TestP2PMessageSemiAuto extends ZkTestBase {
     ResourceControllerDataProvider dataCache = new ResourceControllerDataProvider(CLUSTER_NAME);
     dataCache.refresh(_accessor);
 
-    Map<String, LiveInstance> liveInstanceMap = dataCache.getLiveInstances();
+    Map<String, LiveInstance> liveInstanceMap = dataCache.getAssignableLiveInstances();
     LiveInstance liveInstance = liveInstanceMap.get(instance);
 
     Map<String, CurrentState> currentStateMap =

--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PNoDuplicatedMessage.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestP2PNoDuplicatedMessage.java
@@ -192,7 +192,7 @@ public class TestP2PNoDuplicatedMessage extends ZkTestBase {
   private void verifyP2PDisabled() {
     ResourceControllerDataProvider dataCache = new ResourceControllerDataProvider(CLUSTER_NAME);
     dataCache.refresh(_accessor);
-    Map<String, LiveInstance> liveInstanceMap = dataCache.getLiveInstances();
+    Map<String, LiveInstance> liveInstanceMap = dataCache.getAssignableLiveInstances();
 
     for (LiveInstance instance : liveInstanceMap.values()) {
       Map<String, CurrentState> currentStateMap =
@@ -218,7 +218,7 @@ public class TestP2PNoDuplicatedMessage extends ZkTestBase {
   private void verifyP2PEnabled(long startTime) {
     ResourceControllerDataProvider dataCache = new ResourceControllerDataProvider(CLUSTER_NAME);
     dataCache.refresh(_accessor);
-    Map<String, LiveInstance> liveInstanceMap = dataCache.getLiveInstances();
+    Map<String, LiveInstance> liveInstanceMap = dataCache.getAssignableLiveInstances();
 
     for (LiveInstance instance : liveInstanceMap.values()) {
       Map<String, CurrentState> currentStateMap =

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalance.java
@@ -293,13 +293,13 @@ public class TestAutoRebalance extends ZkStandAloneCMTestBase {
       int replicas = Integer.parseInt(cache.getIdealState(_resourceName).getReplicas());
       String instanceGroupTag = cache.getIdealState(_resourceName).getInstanceGroupTag();
       int instances = 0;
-      for (String liveInstanceName : cache.getLiveInstances().keySet()) {
-        if (cache.getInstanceConfigMap().get(liveInstanceName).containsTag(instanceGroupTag)) {
+      for (String liveInstanceName : cache.getAssignableLiveInstances().keySet()) {
+        if (cache.getAssignableInstanceConfigMap().get(liveInstanceName).containsTag(instanceGroupTag)) {
           instances++;
         }
       }
       if (instances == 0) {
-        instances = cache.getLiveInstances().size();
+        instances = cache.getAssignableLiveInstances().size();
       }
       ExternalView ev = accessor.getProperty(keyBuilder.externalView(_resourceName));
       if (ev == null) {

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalancePartitionLimit.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalancePartitionLimit.java
@@ -222,7 +222,7 @@ public class TestAutoRebalancePartitionLimit extends ZkStandAloneCMTestBase {
       try {
         return verifyBalanceExternalView(
             accessor.getProperty(keyBuilder.externalView(_resourceName)).getRecord(),
-            numberOfPartitions, masterValue, replicas, cache.getLiveInstances().size(),
+            numberOfPartitions, masterValue, replicas, cache.getAssignableLiveInstances().size(),
             cache.getIdealState(_resourceName).getMaxPartitionsPerInstance());
       } catch (Exception e) {
         LOG.debug("Verify failed", e);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestCustomRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestCustomRebalancer.java
@@ -68,7 +68,7 @@ public class TestCustomRebalancer {
     when(cache.getStateModelDef(stateModelName)).thenReturn(stateModelDef);
     when(cache.getDisabledInstancesForPartition(resource.getResourceName(), partitionName))
         .thenReturn(ImmutableSet.of(instanceName));
-    when(cache.getLiveInstances())
+    when(cache.getAssignableLiveInstances())
         .thenReturn(ImmutableMap.of(instanceName, new LiveInstance(instanceName)));
 
     CurrentStateOutput currOutput = new CurrentStateOutput();

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestCustomizedIdealStateRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestCustomizedIdealStateRebalancer.java
@@ -62,7 +62,7 @@ public class TestCustomizedIdealStateRebalancer extends ZkStandAloneCMTestBase {
     public IdealState computeNewIdealState(String resourceName, IdealState currentIdealState,
         CurrentStateOutput currentStateOutput, ResourceControllerDataProvider clusterData) {
       testRebalancerInvoked = true;
-      List<String> liveNodes = Lists.newArrayList(clusterData.getLiveInstances().keySet());
+      List<String> liveNodes = Lists.newArrayList(clusterData.getAssignableLiveInstances().keySet());
       int i = 0;
       for (String partition : currentIdealState.getPartitionSet()) {
         int index = i++ % liveNodes.size();
@@ -139,13 +139,13 @@ public class TestCustomizedIdealStateRebalancer extends ZkStandAloneCMTestBase {
         int replicas = Integer.parseInt(cache.getIdealState(_resourceName).getReplicas());
         String instanceGroupTag = cache.getIdealState(_resourceName).getInstanceGroupTag();
         int instances = 0;
-        for (String liveInstanceName : cache.getLiveInstances().keySet()) {
-          if (cache.getInstanceConfigMap().get(liveInstanceName).containsTag(instanceGroupTag)) {
+        for (String liveInstanceName : cache.getAssignableLiveInstances().keySet()) {
+          if (cache.getAssignableInstanceConfigMap().get(liveInstanceName).containsTag(instanceGroupTag)) {
             instances++;
           }
         }
         if (instances == 0) {
-          instances = cache.getLiveInstances().size();
+          instances = cache.getAssignableLiveInstances().size();
         }
         return verifyBalanceExternalView(
             accessor.getProperty(keyBuilder.externalView(_resourceName)).getRecord(),

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -398,7 +398,7 @@ public class TestInstanceOperation extends ZkTestBase {
     addParticipant(PARTICIPANT_PREFIX + "_" + (START_PORT + NUM_NODE));
 
 
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
     Map<String, ExternalView> assignment = getEVs();
     for (String resource : _allDBs) {
       Assert.assertFalse(getParticipantsInEv(assignment.get(resource)).contains(_participantNames.get(NUM_NODE)));
@@ -875,7 +875,7 @@ public class TestInstanceOperation extends ZkTestBase {
         InstanceConstants.InstanceOperation.SWAP_OUT);
 
     // Validate that the assignment has not changed since setting the InstanceOperation to SWAP_OUT
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
         Collections.emptySet(), Collections.emptySet());
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -159,8 +159,8 @@ public class TestInstanceOperation extends ZkTestBase {
     for (int i = 0; i < _participants.size(); i++) {
       String participantName = _participantNames.get(i);
       if (!_originalParticipantNames.contains(participantName)) {
-        _participants.get(i).syncStop();
         _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, participantName, false);
+        _participants.get(i).syncStop();
         _gSetupTool.getClusterManagementTool()
             .dropInstance(CLUSTER_NAME, _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, participantName));
         droppedParticipants.add(participantName);
@@ -398,7 +398,7 @@ public class TestInstanceOperation extends ZkTestBase {
     addParticipant(PARTICIPANT_PREFIX + "_" + (START_PORT + NUM_NODE));
 
 
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
     Map<String, ExternalView> assignment = getEVs();
     for (String resource : _allDBs) {
       Assert.assertFalse(getParticipantsInEv(assignment.get(resource)).contains(_participantNames.get(NUM_NODE)));
@@ -875,7 +875,7 @@ public class TestInstanceOperation extends ZkTestBase {
         InstanceConstants.InstanceOperation.SWAP_OUT);
 
     // Validate that the assignment has not changed since setting the InstanceOperation to SWAP_OUT
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
         Collections.emptySet(), Collections.emptySet());
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedNodeSwap.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedNodeSwap.java
@@ -174,7 +174,7 @@ public class TestWagedNodeSwap extends ZkTestBase {
     _gSetupTool.addInstanceToCluster(CLUSTER_NAME, newParticipantName);
     InstanceConfig newConfig = configAccessor.getInstanceConfig(CLUSTER_NAME, newParticipantName);
     String zone = instanceConfig.getDomainAsMap().get("zone");
-    String domain = String.format("zone=%s,instance=%s", zone, newParticipantName);
+    String domain = String.format("zone=%s,instance=%s", zone, oldParticipantName);
     newConfig.setDomain(domain);
     _gSetupTool.getClusterManagementTool()
         .setInstanceConfig(CLUSTER_NAME, newParticipantName, newConfig);

--- a/helix-core/src/test/java/org/apache/helix/messaging/p2pMessage/TestP2PMessages.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/p2pMessage/TestP2PMessages.java
@@ -112,8 +112,8 @@ public class TestP2PMessages extends BaseStageTest {
       e.printStackTrace();
     }
 
-    _instances = _dataCache.getAllInstances();
-    _liveInstanceMap = _dataCache.getLiveInstances();
+    _instances = _dataCache.getAssignableInstances();
+    _liveInstanceMap = _dataCache.getAssignableLiveInstances();
 
     _initialStateMap = event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.name());
     _initialMaster = getTopStateInstance(_initialStateMap.getInstanceStateMap(_db, _partition),
@@ -218,7 +218,7 @@ public class TestP2PMessages extends BaseStageTest {
     // Old master (initialMaster) failed the M->S transition,
     // but has not forward p2p message to new master (secondMaster) yet.
     // Validate: Controller should ignore the ERROR partition and send S->M message to new master.
-    String session = _dataCache.getLiveInstances().get(_initialMaster).getEphemeralOwner();
+    String session = _dataCache.getAssignableLiveInstances().get(_initialMaster).getEphemeralOwner();
     PropertyKey currentStateKey =
         new PropertyKey.Builder(_clusterName).currentState(_initialMaster, session, _db);
     CurrentState currentState = accessor.getProperty(currentStateKey);
@@ -308,7 +308,7 @@ public class TestP2PMessages extends BaseStageTest {
   private void handleMessage(String instance, String resource) {
     PropertyKey propertyKey = new PropertyKey.Builder(_clusterName).messages(instance);
     List<Message> messages = accessor.getChildValues(propertyKey, true);
-    String session = _dataCache.getLiveInstances().get(instance).getEphemeralOwner();
+    String session = _dataCache.getAssignableLiveInstances().get(instance).getEphemeralOwner();
 
     for (Message m : messages) {
       if (m.getResourceName().equals(resource)) {

--- a/helix-core/src/test/java/org/apache/helix/messaging/p2pMessage/TestP2PWithStateCancellationMessage.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/p2pMessage/TestP2PWithStateCancellationMessage.java
@@ -102,7 +102,7 @@ public class TestP2PWithStateCancellationMessage extends BaseStageTest {
     event.addAttribute(AttributeName.ControllerDataProvider.name(), mock.cache);
     when(mock.cache.getStateModelDef("MasterSlave")).thenReturn(MasterSlaveSMD.build());
     when(mock.cache.getClusterConfig()).thenReturn(clusterConfig);
-    when(mock.cache.getAssignableLiveInstances()).thenReturn(Arrays.asList(l1, l2).stream().collect(
+    when(mock.cache.getLiveInstances()).thenReturn(Arrays.asList(l1, l2).stream().collect(
         Collectors.toMap(LiveInstance::getId, Function.identity())));
 
     // mock current state output. Generate 3 messages:

--- a/helix-core/src/test/java/org/apache/helix/messaging/p2pMessage/TestP2PWithStateCancellationMessage.java
+++ b/helix-core/src/test/java/org/apache/helix/messaging/p2pMessage/TestP2PWithStateCancellationMessage.java
@@ -102,7 +102,7 @@ public class TestP2PWithStateCancellationMessage extends BaseStageTest {
     event.addAttribute(AttributeName.ControllerDataProvider.name(), mock.cache);
     when(mock.cache.getStateModelDef("MasterSlave")).thenReturn(MasterSlaveSMD.build());
     when(mock.cache.getClusterConfig()).thenReturn(clusterConfig);
-    when(mock.cache.getLiveInstances()).thenReturn(Arrays.asList(l1, l2).stream().collect(
+    when(mock.cache.getAssignableLiveInstances()).thenReturn(Arrays.asList(l1, l2).stream().collect(
         Collectors.toMap(LiveInstance::getId, Function.identity())));
 
     // mock current state output. Generate 3 messages:

--- a/helix-core/src/test/java/org/apache/helix/task/TestTargetedTaskStateChange.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestTargetedTaskStateChange.java
@@ -86,8 +86,8 @@ public class TestTargetedTaskStateChange {
     when(mock._cache.getTaskDataCache()).thenReturn(mock._taskDataCache);
     when(mock._cache.getJobContext(JOB_NAME)).thenReturn(mock._jobContext);
     when(mock._cache.getIdealStates()).thenReturn(mock._idealStates);
-    when(mock._cache.getEnabledLiveInstances()).thenReturn(_liveInstances.keySet());
-    when(mock._cache.getInstanceConfigMap()).thenReturn(_instanceConfigs);
+    when(mock._cache.getAssignableEnabledLiveInstances()).thenReturn(_liveInstances.keySet());
+    when(mock._cache.getAssignableInstanceConfigMap()).thenReturn(_instanceConfigs);
     when(mock._cache.getClusterConfig()).thenReturn(_clusterConfig);
     when(mock._taskDataCache.getRuntimeJobDag(WORKFLOW_NAME)).thenReturn(mock._runtimeJobDag);
     _assignableInstanceManager.buildAssignableInstances(_clusterConfig, mock._taskDataCache,
@@ -123,8 +123,8 @@ public class TestTargetedTaskStateChange {
     when(mock._cache.getTaskDataCache()).thenReturn(mock._taskDataCache);
     when(mock._cache.getJobContext(JOB_NAME)).thenReturn(mock._jobContext);
     when(mock._cache.getIdealStates()).thenReturn(mock._idealStates);
-    when(mock._cache.getEnabledLiveInstances()).thenReturn(_liveInstances.keySet());
-    when(mock._cache.getInstanceConfigMap()).thenReturn(_instanceConfigs);
+    when(mock._cache.getAssignableEnabledLiveInstances()).thenReturn(_liveInstances.keySet());
+    when(mock._cache.getAssignableInstanceConfigMap()).thenReturn(_instanceConfigs);
     when(mock._cache.getClusterConfig()).thenReturn(_clusterConfig);
     when(mock._taskDataCache.getRuntimeJobDag(WORKFLOW_NAME)).thenReturn(mock._runtimeJobDag);
     _assignableInstanceManager.buildAssignableInstances(_clusterConfig, mock._taskDataCache,

--- a/helix-core/src/test/resources/log4j2.properties
+++ b/helix-core/src/test/resources/log4j2.properties
@@ -50,7 +50,7 @@ logger.i0itec.name = org.I0Itec
 logger.i0itec.level = error
 
 logger.apache.name = org.apache
-logger.apache.level = error
+logger.apache.level = warn
 
 logger.noelios.name = com.noelios
 logger.noelios.level = error

--- a/helix-core/src/test/resources/log4j2.properties
+++ b/helix-core/src/test/resources/log4j2.properties
@@ -50,7 +50,7 @@ logger.i0itec.name = org.I0Itec
 logger.i0itec.level = error
 
 logger.apache.name = org.apache
-logger.apache.level = warn
+logger.apache.level = error
 
 logger.noelios.name = com.noelios
 logger.noelios.level = error

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
@@ -322,7 +322,7 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
   }
 
   protected void setupHelixResources() throws Exception {
-    _clusters = createClusters(4);
+    _clusters = createClusters(5);
     _gSetupTool.addCluster(_superCluster, true);
     _gSetupTool.addCluster(TASK_TEST_CLUSTER, true);
     _clusters.add(_superCluster);

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -45,7 +45,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class TestInstancesAccessor extends AbstractTestClass {
-  private final static String CLUSTER_NAME = "TestCluster_0";
+  private final static String CLUSTER_NAME = "TestCluster_4";
 
   @DataProvider
   public Object[][] generatePayloadCrossZoneStoppableCheckWithZoneOrder() {


### PR DESCRIPTION
### Issues

We found that there was significant shuffling occurring when attempting to perform a Node Swap operation on WAGED clusters. 

### Description

After investigating, it was determined that the cause was due to the PartitionMovementConstraint and BaselineInfluenceConstraint soft constraints improperly scoring AssignableReplicas during the completion of a SWAP.

This was because those two soft-constraints were using InstanceName instead of LogicaId to determine if the SWAP_IN node was in the baseline or best possible state. It wouldn't be since the last time that the algorithm produced the baseline and best possible state, it contained the SWAP_OUT node instead. This causes the score to be lower and leads to incorrect assignment.

To fix this, those soft-constraints now look for LogicalId and the baseline and best possible state are passed in with instanceName replaced with logicalId.

Also, we are putting all of the logic for what instance's are assignable in one place, the BaseControllerDataProvider. We will also add Evacuation here in the future.

### Tests

The previous integration tests have been modified to cover the changes.

We have also tested this logic on a production cluster copied to a testing environment.

### Changes that Break Backward Compatibility (Optional)

NA

Despite adding new getters to BaseControllerDataProvider, the old signatures are kept with the same behavour.


### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
