### PR TITLE
Flaky test fix, add NPE protection in TestCloudEventCallbackProperty

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/cloud/event/TestCloudEventCallbackProperty.java
+++ b/helix-core/src/test/java/org/apache/helix/cloud/event/TestCloudEventCallbackProperty.java
@@ -58,21 +58,18 @@ public class TestCloudEventCallbackProperty {
   }
 
   @AfterTest
-  public void afterTest() {
+  public void cleanupCallbackProperty() {
     _helixManager.disconnect();
-    _cloudProperty.getCloudEventCallbackProperty()
-        .setHelixOperationEnabled(HelixOperation.ENABLE_DISABLE_INSTANCE, false);
-    _cloudProperty.getCloudEventCallbackProperty()
-        .setHelixOperationEnabled(HelixOperation.MAINTENANCE_MODE, false);
-    _cloudProperty.getCloudEventCallbackProperty()
-        .unregisterUserDefinedCallback(UserDefinedCallbackType.PRE_ON_PAUSE);
-    _cloudProperty.getCloudEventCallbackProperty()
-        .unregisterUserDefinedCallback(UserDefinedCallbackType.POST_ON_PAUSE);
-    _cloudProperty.getCloudEventCallbackProperty()
-        .unregisterUserDefinedCallback(UserDefinedCallbackType.PRE_ON_RESUME);
-    _cloudProperty.getCloudEventCallbackProperty()
-        .unregisterUserDefinedCallback(UserDefinedCallbackType.POST_ON_RESUME);
+    CloudEventCallbackProperty callbackProperty = _cloudProperty.getCloudEventCallbackProperty();
     MockCloudEventCallbackImpl.triggeredOperation.clear();
+    if (callbackProperty != null) {
+      callbackProperty.setHelixOperationEnabled(HelixOperation.ENABLE_DISABLE_INSTANCE, false);
+      callbackProperty.setHelixOperationEnabled(HelixOperation.MAINTENANCE_MODE, false);
+      callbackProperty.unregisterUserDefinedCallback(UserDefinedCallbackType.PRE_ON_PAUSE);
+      callbackProperty.unregisterUserDefinedCallback(UserDefinedCallbackType.POST_ON_PAUSE);
+      callbackProperty.unregisterUserDefinedCallback(UserDefinedCallbackType.PRE_ON_RESUME);
+      callbackProperty.unregisterUserDefinedCallback(UserDefinedCallbackType.POST_ON_RESUME);
+    }
   }
 
   @Test
@@ -134,7 +131,7 @@ public class TestCloudEventCallbackProperty {
 
   @Test
   public void testUserDefinedCallback() throws Exception {
-    afterTest();
+    cleanupCallbackProperty();
     // Cloud event callback property
     CloudEventCallbackProperty property = new CloudEventCallbackProperty(Collections
         .singletonMap(CloudEventCallbackProperty.UserArgsInputKey.CALLBACK_IMPL_CLASS_NAME,


### PR DESCRIPTION
### Issues

#2700 [Failed CI Test] testUserDefinedCallback


### Description

afterTest cleanup method assumes that callbackProperty has already been instantiated and is not null. Tests are run sequentially but the order is not guaranteed unless specifically set, so we can't assume the property is not null. 

Added null check and also renamed the method for clarity

### Tests

- [ ] The following tests are written for this issue:

N/A

- The following is the result of the "mvn test" command on the appropriate module:

You can reproduce this issue by running the test method on its own using the master branch:

$ mvn test -Dtest=TestCloudEventCallbackProperty#testUserDefinedCallback -pl=helix-core

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.helix.cloud.event.TestCloudEventCallbackProperty
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.493 s <<< FAILURE! - in org.apache.helix.cloud.event.TestCloudEventCallbackProperty
[ERROR] testUserDefinedCallback(org.apache.helix.cloud.event.TestCloudEventCallbackProperty)  Time elapsed: 0.01 s  <<< FAILURE!
java.lang.NullPointerException
at org.apache.helix.cloud.event.TestCloudEventCallbackProperty.afterTest(TestCloudEventCallbackProperty.java:64)
at org.apache.helix.cloud.event.TestCloudEventCallbackProperty.testUserDefinedCallback(TestCloudEventCallbackProperty.java:137)

[ERROR] afterTest(org.apache.helix.cloud.event.TestCloudEventCallbackProperty)  Time elapsed: 0.01 s  <<< FAILURE!
java.lang.NullPointerException
at org.apache.helix.cloud.event.TestCloudEventCallbackProperty.afterTest(TestCloudEventCallbackProperty.java:64)
```


After the change:
$ mvn test -Dtest=TestCloudEventCallbackProperty#testUserDefinedCallback -pl=helix-core
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.helix.cloud.event.TestCloudEventCallbackProperty
Using handler: org.apache.helix.cloud.event.CloudEventHandler
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.505 s - in org.apache.helix.cloud.event.TestCloudEventCallbackProperty
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/gspencer/Desktop/git-repos/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 802 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```

