### PR TITLE
Flaky test fix - Close config accessors after use

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkConnectionConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/multizk/TestMultiZkConnectionConfig.java
@@ -646,6 +646,7 @@ public class TestMultiZkConnectionConfig extends MultiZkTestBase {
       // Clean up
       clusterConfig = new ClusterConfig(cluster);
       configAccessorMultiZk.setClusterConfig(cluster, clusterConfig);
+      configAccessorSingleZk.close();
     });
   }
 


### PR DESCRIPTION
### Issues

#2690 [Failed CI Test] testGenericBaseDataAccessorBuilder

### Description

testGenericBaseDataAccessorBuilder makes assertions based on the number of sharedZKClient connections that are open. However, there are 3 connections opened by setClusterConfigAndVerify and not closed. If these connections close during the test run, then the assertion will fail.

I currently believe this can happen due to Java's garbage collection, specifically if the 3 ConfigAccessors (which no longer have a reference to them) are gc'd near the time the flaky test runs. The test will not fail if gc occurs and connections are closed prior to the test or if gc does not occur until after the test. You can more reliably reproduce this failure by calling system.gc() at the start of the testGenericBaseDataAccessorBuilder method, though it may still pass if gc occurs before the test. 


Example of connections closing during a test and causing assertion to fail (I added custom log statements)
```
Before test connection count is: 0
START TestMultiZkConnectionConfig_testConfigAccessor at Thu Nov 30 18:34:39 PST 2023
END TestMultiZkConnectionConfig_testConfigAccessor at Thu Nov 30 18:34:39 PST 2023
After test connection count is: 3
Before test connection count is: 3
START TestMultiZkConnectionConfig_testTaskFramework at Thu Nov 30 18:34:39 PST 2023
END TestMultiZkConnectionConfig_testTaskFramework at Thu Nov 30 18:34:40 PST 2023
After test connection count is: 3
Before test connection count is: 3
START TestMultiZkConnectionConfig_testGetAllClusters at Thu Nov 30 18:34:40 PST 2023
END TestMultiZkConnectionConfig_testGetAllClusters at Thu Nov 30 18:34:40 PST 2023
After test connection count is: 3
Before test connection count is: 3
START TestMultiZkConnectionConfig_testGenericBaseDataAccessorBuilder at Thu Nov 30 18:34:40 PST 2023
Active connection BEFORE accessor opened is: 3
Active connection BEFORE accessor closed is: 2
Active connection AFTER accessor closed is: 0
currentSharedZkClientActiveConnection count is still: 3
```

### Tests
* The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/gspencer/Desktop/git-repos/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 802 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:36 min
[INFO] Finished at: 2023-11-30T20:06:27-08:00
[INFO] ------------------------------------------------------------------------

```
