### PR TITLE
Prevent the spectator routing table from containing SWAP_IN instances

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -209,13 +209,15 @@ public class ClusterModelProvider {
 
     // Get the set of active logical ids.
     Set<String> activeLogicalIds = activeInstances.stream().map(
-        instanceName -> assignableInstanceConfigMap.get(instanceName)
+        instanceName -> assignableInstanceConfigMap.getOrDefault(instanceName,
+                new InstanceConfig(instanceName))
             .getLogicalId(clusterTopologyConfig.getEndNodeType())).collect(Collectors.toSet());
 
     Set<String> assignableLiveInstanceNames = dataProvider.getAssignableLiveInstances().keySet();
     Set<String> assignableLiveInstanceLogicalIds =
         assignableLiveInstanceNames.stream().map(
-            instanceName -> assignableInstanceConfigMap.get(instanceName)
+            instanceName -> assignableInstanceConfigMap.getOrDefault(instanceName,
+                    new InstanceConfig(instanceName))
                 .getLogicalId(clusterTopologyConfig.getEndNodeType())).collect(Collectors.toSet());
 
     // Generate replica objects for all the resource partitions.

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -145,6 +145,8 @@ class RoutingDataCache extends BasicClusterDataCache {
            * TODO: logic.
            **/
           _liveInstancePropertyCache.refresh(accessor);
+          updateRoutableLiveInstanceMap(getRoutableInstanceConfigMap(),
+              _liveInstancePropertyCache.getPropertyMap());
           Map<String, LiveInstance> liveInstanceMap = getRoutableLiveInstances();
           _currentStateCache.refresh(accessor, liveInstanceMap);
           LOG.info("Reload CurrentStates. Takes " + (System.currentTimeMillis() - start) + " ms");

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -62,8 +62,8 @@ class RoutingDataCache extends BasicClusterDataCache {
   // propertyCache, this hardcoded list of fields won't be necessary.
   private Map<String, CustomizedViewCache> _customizedViewCaches;
   private TargetExternalViewCache _targetExternalViewCache;
-  private Map<String, LiveInstance> _routableLiveInstancesMap;
-  private Map<String, InstanceConfig> _routableInstanceConfigsMap;
+  private Map<String, LiveInstance> _routableLiveInstanceMap;
+  private Map<String, InstanceConfig> _routableInstanceConfigMap;
 
   public RoutingDataCache(String clusterName, PropertyType sourceDataType) {
     this (clusterName, ImmutableMap.of(sourceDataType, Collections.emptyList()));
@@ -83,8 +83,8 @@ class RoutingDataCache extends BasicClusterDataCache {
         .forEach(customizedStateType -> _customizedViewCaches.put(customizedStateType,
             new CustomizedViewCache(clusterName, customizedStateType)));
     _targetExternalViewCache = new TargetExternalViewCache(clusterName);
-    _routableInstanceConfigsMap = new HashMap<>();
-    _routableLiveInstancesMap = new HashMap<>();
+    _routableInstanceConfigMap = new HashMap<>();
+    _routableLiveInstanceMap = new HashMap<>();
     requireFullRefresh();
   }
 
@@ -113,10 +113,10 @@ class RoutingDataCache extends BasicClusterDataCache {
     super.refresh(accessor);
 
     if (refreshRoutableInstanceConfigs) {
-      updateRoutableInstanceConfigs(_instanceConfigPropertyCache.getPropertyMap());
+      updateRoutableInstanceConfigMap(_instanceConfigPropertyCache.getPropertyMap());
     }
     if (refreshRoutableLiveInstances) {
-      updateRoutableLiveInstances(getRoutableInstanceConfigMap(),
+      updateRoutableLiveInstanceMap(getRoutableInstanceConfigMap(),
           _liveInstancePropertyCache.getPropertyMap());
     }
 
@@ -181,16 +181,16 @@ class RoutingDataCache extends BasicClusterDataCache {
     }
   }
 
-  private void updateRoutableInstanceConfigs(Map<String, InstanceConfig> instanceConfigMap) {
-    _routableInstanceConfigsMap = instanceConfigMap.entrySet().stream().filter(
+  private void updateRoutableInstanceConfigMap(Map<String, InstanceConfig> instanceConfigMap) {
+    _routableInstanceConfigMap = instanceConfigMap.entrySet().stream().filter(
             (instanceConfigEntry) -> !NON_ROUTABLE_INSTANCE_OPERATIONS.contains(
                 instanceConfigEntry.getValue().getInstanceOperation()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  private void updateRoutableLiveInstances(Map<String, InstanceConfig> instanceConfigMap,
+  private void updateRoutableLiveInstanceMap(Map<String, InstanceConfig> instanceConfigMap,
       Map<String, LiveInstance> liveInstanceMap) {
-    _routableLiveInstancesMap = liveInstanceMap.entrySet().stream().filter(
+    _routableLiveInstanceMap = liveInstanceMap.entrySet().stream().filter(
             (liveInstanceEntry) -> instanceConfigMap.containsKey(liveInstanceEntry.getKey())
                 && !NON_ROUTABLE_INSTANCE_OPERATIONS.contains(
                 instanceConfigMap.get(liveInstanceEntry.getKey()).getInstanceOperation()))
@@ -204,7 +204,7 @@ class RoutingDataCache extends BasicClusterDataCache {
    * @return a map of LiveInstances
    */
   public Map<String, LiveInstance> getRoutableLiveInstances() {
-    return Collections.unmodifiableMap(_routableLiveInstancesMap);
+    return Collections.unmodifiableMap(_routableLiveInstanceMap);
   }
 
   /**
@@ -213,7 +213,7 @@ class RoutingDataCache extends BasicClusterDataCache {
    * @return a map of InstanceConfigs
    */
   public Map<String, InstanceConfig> getRoutableInstanceConfigMap() {
-    return Collections.unmodifiableMap(_routableInstanceConfigsMap);
+    return Collections.unmodifiableMap(_routableInstanceConfigMap);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -23,8 +23,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
@@ -34,9 +36,11 @@ import org.apache.helix.common.caches.CurrentStateCache;
 import org.apache.helix.common.caches.CurrentStateSnapshot;
 import org.apache.helix.common.caches.CustomizedViewCache;
 import org.apache.helix.common.caches.TargetExternalViewCache;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.CustomizedView;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +51,10 @@ import org.slf4j.LoggerFactory;
 class RoutingDataCache extends BasicClusterDataCache {
   private static Logger LOG = LoggerFactory.getLogger(RoutingDataCache.class.getName());
 
+  // When an instance has any of these instance operations, it should not be routable.
+  private static final ImmutableSet<String> NON_ROUTABLE_INSTANCE_OPERATIONS =
+      ImmutableSet.of(InstanceConstants.InstanceOperation.SWAP_IN.name());
+
   private final Map<PropertyType, List<String>> _sourceDataTypeMap;
 
   private CurrentStateCache _currentStateCache;
@@ -54,6 +62,8 @@ class RoutingDataCache extends BasicClusterDataCache {
   // propertyCache, this hardcoded list of fields won't be necessary.
   private Map<String, CustomizedViewCache> _customizedViewCaches;
   private TargetExternalViewCache _targetExternalViewCache;
+  private Map<String, LiveInstance> _routableLiveInstancesMap;
+  private Map<String, InstanceConfig> _routableInstanceConfigsMap;
 
   public RoutingDataCache(String clusterName, PropertyType sourceDataType) {
     this (clusterName, ImmutableMap.of(sourceDataType, Collections.emptyList()));
@@ -73,6 +83,8 @@ class RoutingDataCache extends BasicClusterDataCache {
         .forEach(customizedStateType -> _customizedViewCaches.put(customizedStateType,
             new CustomizedViewCache(clusterName, customizedStateType)));
     _targetExternalViewCache = new TargetExternalViewCache(clusterName);
+    _routableInstanceConfigsMap = new HashMap<>();
+    _routableLiveInstancesMap = new HashMap<>();
     requireFullRefresh();
   }
 
@@ -88,7 +100,26 @@ class RoutingDataCache extends BasicClusterDataCache {
     LOG.info("START: RoutingDataCache.refresh() for cluster " + _clusterName);
     long startTime = System.currentTimeMillis();
 
+    // Store whether a refresh for routable instances is necessary, as the super.refresh() call will
+    // set the _propertyDataChangedMap values for the instance config and live instance change types to false.
+    boolean refreshRoutableInstanceConfigs =
+        _propertyDataChangedMap.getOrDefault(HelixConstants.ChangeType.INSTANCE_CONFIG, false);
+    // If there is an InstanceConfig change, update the routable instance configs and live instances.
+    // Must also do live instances because whether and instance is routable is based off of the instance config.
+    boolean refreshRoutableLiveInstances =
+        _propertyDataChangedMap.getOrDefault(HelixConstants.ChangeType.LIVE_INSTANCE, false)
+            || refreshRoutableInstanceConfigs;
+
     super.refresh(accessor);
+
+    if (refreshRoutableInstanceConfigs) {
+      updateRoutableInstanceConfigs(_instanceConfigPropertyCache.getPropertyMap());
+    }
+    if (refreshRoutableLiveInstances) {
+      updateRoutableLiveInstances(getRoutableInstanceConfigMap(),
+          _liveInstancePropertyCache.getPropertyMap());
+    }
+
     for (PropertyType propertyType : _sourceDataTypeMap.keySet()) {
       long start = System.currentTimeMillis();
       switch (propertyType) {
@@ -114,7 +145,7 @@ class RoutingDataCache extends BasicClusterDataCache {
            * TODO: logic.
            **/
           _liveInstancePropertyCache.refresh(accessor);
-          Map<String, LiveInstance> liveInstanceMap = getLiveInstances();
+          Map<String, LiveInstance> liveInstanceMap = getRoutableLiveInstances();
           _currentStateCache.refresh(accessor, liveInstanceMap);
           LOG.info("Reload CurrentStates. Takes " + (System.currentTimeMillis() - start) + " ms");
         }
@@ -148,6 +179,41 @@ class RoutingDataCache extends BasicClusterDataCache {
             _customizedViewCaches.get(customizedStateType).getCustomizedViewMap());
       }
     }
+  }
+
+  private void updateRoutableInstanceConfigs(Map<String, InstanceConfig> instanceConfigMap) {
+    _routableInstanceConfigsMap = instanceConfigMap.entrySet().stream().filter(
+            (instanceConfigEntry) -> !NON_ROUTABLE_INSTANCE_OPERATIONS.contains(
+                instanceConfigEntry.getValue().getInstanceOperation()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private void updateRoutableLiveInstances(Map<String, InstanceConfig> instanceConfigMap,
+      Map<String, LiveInstance> liveInstanceMap) {
+    _routableLiveInstancesMap = liveInstanceMap.entrySet().stream().filter(
+            (liveInstanceEntry) -> instanceConfigMap.containsKey(liveInstanceEntry.getKey())
+                && !NON_ROUTABLE_INSTANCE_OPERATIONS.contains(
+                instanceConfigMap.get(liveInstanceEntry.getKey()).getInstanceOperation()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  /**
+   * Returns the LiveInstances for each of the routable instances that are currently up and
+   * running.
+   *
+   * @return a map of LiveInstances
+   */
+  public Map<String, LiveInstance> getRoutableLiveInstances() {
+    return Collections.unmodifiableMap(_routableLiveInstancesMap);
+  }
+
+  /**
+   * Returns the instance config map for all the routable instances that are in the cluster.
+   *
+   * @return a map of InstanceConfigs
+   */
+  public Map<String, InstanceConfig> getRoutableInstanceConfigMap() {
+    return Collections.unmodifiableMap(_routableInstanceConfigsMap);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingTableProvider.java
@@ -923,14 +923,16 @@ public class RoutingTableProvider
           case EXTERNALVIEW: {
             String keyReference = generateReferenceKey(propertyType.name(), DEFAULT_STATE_TYPE);
             refreshExternalView(_dataCache.getExternalViews().values(),
-                _dataCache.getInstanceConfigMap().values(), _dataCache.getLiveInstances().values(),
+                _dataCache.getRoutableInstanceConfigMap().values(),
+                _dataCache.getRoutableLiveInstances().values(),
                 keyReference);
           }
             break;
           case TARGETEXTERNALVIEW: {
             String keyReference = generateReferenceKey(propertyType.name(), DEFAULT_STATE_TYPE);
             refreshExternalView(_dataCache.getTargetExternalViews().values(),
-                _dataCache.getInstanceConfigMap().values(), _dataCache.getLiveInstances().values(),
+                _dataCache.getRoutableInstanceConfigMap().values(),
+                _dataCache.getRoutableLiveInstances().values(),
                 keyReference);
           }
               break;
@@ -938,13 +940,15 @@ public class RoutingTableProvider
               for (String customizedStateType : _sourceDataTypeMap.getOrDefault(PropertyType.CUSTOMIZEDVIEW, Collections.emptyList())) {
                 String keyReference = generateReferenceKey(propertyType.name(),  customizedStateType);
                 refreshCustomizedView(_dataCache.getCustomizedView(customizedStateType).values(),
-                    _dataCache.getInstanceConfigMap().values(), _dataCache.getLiveInstances().values(), keyReference);
+                    _dataCache.getRoutableInstanceConfigMap().values(),
+                    _dataCache.getRoutableLiveInstances().values(), keyReference);
               }
               break;
             case CURRENTSTATES: {
               String keyReference = generateReferenceKey(propertyType.name(),  DEFAULT_STATE_TYPE);;
-              refreshCurrentState(_dataCache.getCurrentStatesMap(), _dataCache.getInstanceConfigMap().values(),
-                  _dataCache.getLiveInstances().values(), keyReference);
+              refreshCurrentState(_dataCache.getCurrentStatesMap(),
+                  _dataCache.getRoutableInstanceConfigMap().values(),
+                  _dataCache.getRoutableLiveInstances().values(), keyReference);
               recordPropagationLatency(System.currentTimeMillis(), _dataCache.getCurrentStateSnapshot());
             }
               break;

--- a/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderFromCurrentStates.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/spectator/TestRoutingTableProviderFromCurrentStates.java
@@ -263,7 +263,7 @@ public class TestRoutingTableProviderFromCurrentStates extends ZkTestBase {
   }
 
   @Test(dependsOnMethods = "testRoutingTableWithCurrentStates")
-  public void TestInconsistentStateEventProcessing() throws Exception {
+  public void testInconsistentStateEventProcessing() throws Exception {
     // This test requires an additional HelixManager since one of the provider event processing will
     // be blocked.
     HelixManager helixManager = HelixManagerFactory
@@ -305,10 +305,10 @@ public class TestRoutingTableProviderFromCurrentStates extends ZkTestBase {
       IdealState idealState =
           _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
       String targetPartitionName = idealState.getPartitionSet().iterator().next();
-      // Wait until the routingtable is updated.
+      // Wait until the routing table is updated.
       BlockingCurrentStateRoutingTableProvider finalRoutingTableCS = routingTableCS;
       Assert.assertTrue(TestHelper.verify(
-          () -> finalRoutingTableCS.getInstances(db, targetPartitionName, "MASTER").size() > 0,
+          () -> !finalRoutingTableCS.getInstances(db, targetPartitionName, "MASTER").isEmpty(),
           2000));
       String targetNodeName =
           routingTableCS.getInstances(db, targetPartitionName, "MASTER").get(0).getInstanceName();
@@ -352,7 +352,7 @@ public class TestRoutingTableProviderFromCurrentStates extends ZkTestBase {
     }
   }
 
-  @Test(dependsOnMethods = { "TestInconsistentStateEventProcessing" })
+  @Test(dependsOnMethods = {"testInconsistentStateEventProcessing"})
   public void testWithSupportSourceDataType() {
     new RoutingTableProvider(_manager, PropertyType.EXTERNALVIEW).shutdown();
     new RoutingTableProvider(_manager, PropertyType.TARGETEXTERNALVIEW).shutdown();


### PR DESCRIPTION
### Issues

- [x] not populate SWAP_IN replicas in routing tables until SWAP is completed to avoid spectator serving traffic for replicas on the swapping in instance. #2662

### Description

During a swap operation, we are essentially creating a mirror node which is labeled with the SWAP_IN instance operation. Until the point that the swap operation is complete we do not want to serve traffic to this node. To achieve this, the RoutingDataCache will have a notion of routableInstanceConfigs and routableLiveInstances. 

Only these nodes are used to create the routingTables. At this time, only SWAP_IN instances are considered not to be routable.

### Tests

- [x] Updated the swap tests in TestInstanceOperation to include starting a spectator and validating the EV, CS, and Default routing tables.

All TestInstanceOperation tests are passing.

### Changes that Break Backward Compatibility (Optional)

NA

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
