### PR TITLE
Stabilize TestInstanceOperation

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -52,6 +52,8 @@ import org.apache.helix.spectator.RoutingTableProvider;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.apache.helix.tools.ClusterVerifiers.StrictMatchExternalViewVerifier;
 import org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -59,7 +61,8 @@ import org.testng.annotations.Test;
 
 
 public class TestInstanceOperation extends ZkTestBase {
-  public static final int TIMEOUT = 5000;
+  private static final Logger LOG = LoggerFactory.getLogger(TestHelper.class);
+  public static final int TIMEOUT = 10000;
   private final int ZONE_COUNT = 4;
   protected final int START_NUM_NODE = 10;
   protected static final int START_PORT = 12918;
@@ -171,7 +174,6 @@ public class TestInstanceOperation extends ZkTestBase {
     clusterConfig.setDelayRebalaceEnabled(true);
     clusterConfig.setRebalanceDelayTime(1800000L);
     _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
-    enabledTopologyAwareRebalance();
 
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
   }
@@ -196,13 +198,15 @@ public class TestInstanceOperation extends ZkTestBase {
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
   }
 
-  private void removeOfflineOrDisabledInstances() {
-    // Remove all instances that are not enabled or disabled.
+  private void removeOfflineOrDisabledOrSwapInInstances() {
+    // Remove all instances that are not live, disabled, or in SWAP_IN state.
     for (int i = 0; i < _participants.size(); i++) {
       String participantName = _participantNames.get(i);
       InstanceConfig instanceConfig =
           _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, participantName);
-      if (!_participants.get(i).isConnected() || !instanceConfig.getInstanceEnabled()) {
+      if (!_participants.get(i).isConnected() || !instanceConfig.getInstanceEnabled()
+          || instanceConfig.getInstanceOperation()
+          .equals(InstanceConstants.InstanceOperation.SWAP_IN.name())) {
         if (_participants.get(i).isConnected()) {
           _participants.get(i).syncStop();
         }
@@ -315,203 +319,36 @@ public class TestInstanceOperation extends ZkTestBase {
     }
   }
 
-  @Test(dependsOnMethods = "testAddingNodeWithEvacuationTag")
-  public void testEvacuateAndCancelBeforeBootstrapFinish() throws Exception {
-    System.out.println("START TestInstanceOperation.testEvacuateAndCancelBeforeBootstrapFinish() at " + new Date(System.currentTimeMillis()));
-    // add a resource where downward state transition is slow
-    createResourceWithDelayedRebalance(CLUSTER_NAME, "TEST_DB3_DELAYED_CRUSHED", "MasterSlave", PARTITIONS, REPLICA,
-        REPLICA - 1, 200000, CrushEdRebalanceStrategy.class.getName());
-    _allDBs.add("TEST_DB3_DELAYED_CRUSHED");
-    // add a resource where downward state transition is slow
-    createResourceWithWagedRebalance(CLUSTER_NAME, "TEST_DB4_DELAYED_WAGED", "MasterSlave",
-        PARTITIONS, REPLICA, REPLICA - 1);
-    _allDBs.add("TEST_DB4_DELAYED_WAGED");
-    // wait for assignment to finish
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  @Test(expectedExceptions = HelixException.class, dependsOnMethods = "testAddingNodeWithEvacuationTag")
+  public void testNodeSwapNoTopologySetup() throws Exception {
+    System.out.println("START TestInstanceOperation.testNodeSwapNoTopologySetup() at " + new Date(
+        System.currentTimeMillis()));
+    removeOfflineOrDisabledOrSwapInInstances();
 
-    // set bootstrap ST delay to a large number
-    _stateModelDelay = -10000L;
-    // evacuate an instance
-    String instanceToEvacuate = _participants.get(0).getInstanceName();
-    _gSetupTool.getClusterManagementTool()
-        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
-    // Messages should be pending at all instances besides the evacuate one
-    for (String participant : _participantNames) {
-      if (participant.equals(instanceToEvacuate)) {
-        continue;
-      }
-      TestHelper.verify(
-          () -> ((_dataAccessor.getChildNames(_dataAccessor.keyBuilder().messages(participant))).isEmpty()), 30000);
-    }
-    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
-    Assert.assertFalse(_admin.isReadyForPreparingJoiningCluster(CLUSTER_NAME, instanceToEvacuate));
+    // Set instance's InstanceOperation to SWAP_OUT
+    String instanceToSwapOutName = _participants.get(0).getInstanceName();
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToSwapOutName,
+        InstanceConstants.InstanceOperation.SWAP_OUT);
 
-    // sleep a bit so ST messages can start executing
-    Thread.sleep(Math.abs(_stateModelDelay / 100));
-    // before we cancel, check current EV
-    Map<String, ExternalView> assignment = getEVs();
-    for (String resource : _allDBs) {
-      // check every replica has >= 3 partitions and a top state partition
-      validateAssignmentInEv(assignment.get(resource));
-    }
-
-    // cancel the evacuation
-    _gSetupTool.getClusterManagementTool()
-        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, null);
-
-    assignment = getEVs();
-    for (String resource : _allDBs) {
-      // check every replica has >= 3 active replicas, even before cluster converge
-      validateAssignmentInEv(assignment.get(resource));
-    }
-
-    // check cluster converge. We have longer delay for ST then verifier timeout. It will only converge if we cancel ST.
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-
-    // EV should contain all participants, check resources one by one
-    assignment = getEVs();
-    for (String resource : _allDBs) {
-      Assert.assertTrue(getParticipantsInEv(assignment.get(resource)).containsAll(_participantNames));
-      // check every replica has >= 3 active replicas again
-      validateAssignmentInEv(assignment.get(resource));
-    }
+    // Add instance with InstanceOperation set to SWAP_IN
+    // There should be an error that the logicalId does not have SWAP_OUT instance because,
+    // helix can't determine what topology key to use to get the logicalId if TOPOLOGY is not set.
+    String instanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort;
+    InstanceConfig instanceToSwapOutInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName);
+    addParticipant(instanceToSwapInName, instanceToSwapOutInstanceConfig.getLogicalId(LOGICAL_ID),
+        instanceToSwapOutInstanceConfig.getDomainAsMap().get(ZONE),
+        InstanceConstants.InstanceOperation.SWAP_IN, true, -1);
   }
 
-  @Test(dependsOnMethods = "testEvacuateAndCancelBeforeBootstrapFinish")
-  public void testEvacuateAndCancelBeforeDropFinish() throws Exception {
-    System.out.println("START TestInstanceOperation.testEvacuateAndCancelBeforeDropFinish() at " + new Date(System.currentTimeMillis()));
-
-    // set DROP ST delay to a large number
-    _stateModelDelay = 10000L;
-
-    // evacuate an instance
-    String instanceToEvacuate = _participants.get(0).getInstanceName();
-    _gSetupTool.getClusterManagementTool()
-        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
-
-    // message should be pending at the to evacuate participant
-    TestHelper.verify(
-        () -> ((_dataAccessor.getChildNames(_dataAccessor.keyBuilder().messages(instanceToEvacuate))).isEmpty()), 30000);
-    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
-
-    // cancel evacuation
-    _gSetupTool.getClusterManagementTool()
-        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, null);
-    // check every replica has >= 3 active replicas, even before cluster converge
-    Map<String, ExternalView> assignment = getEVs();
-    for (String resource : _allDBs) {
-      validateAssignmentInEv(assignment.get(resource));
-    }
-
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-
-    // EV should contain all participants, check resources one by one
-    assignment = getEVs();
-    for (String resource : _allDBs) {
-      Assert.assertTrue(getParticipantsInEv(assignment.get(resource)).containsAll(_participantNames));
-      // check every replica has >= 3 active replicas
-      validateAssignmentInEv(assignment.get(resource));
-    }
-  }
-
-  @Test(dependsOnMethods = "testEvacuateAndCancelBeforeDropFinish")
-  public void testMarkEvacuationAfterEMM() throws Exception {
-    System.out.println("START TestInstanceOperation.testMarkEvacuationAfterEMM() at " + new Date(System.currentTimeMillis()));
-    _stateModelDelay = 1000L;
-    Assert.assertFalse(_gSetupTool.getClusterManagementTool().isInMaintenanceMode(CLUSTER_NAME));
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true, null,
-        null);
-    addParticipant(PARTICIPANT_PREFIX + "_" + (START_PORT + START_NUM_NODE));
-
-
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-    Map<String, ExternalView> assignment = getEVs();
-    for (String resource : _allDBs) {
-      Assert.assertFalse(getParticipantsInEv(assignment.get(resource)).contains(
-          _participantNames.get(START_NUM_NODE)));
-    }
-
-    // set evacuate operation
-    String instanceToEvacuate = _participants.get(0).getInstanceName();
-    _gSetupTool.getClusterManagementTool()
-        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
-
-    // there should be no evacuation happening
-    for (String resource : _allDBs) {
-      Assert.assertTrue(getParticipantsInEv(assignment.get(resource)).contains(instanceToEvacuate));
-    }
-
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-
-    // exit MM
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null,
-        null);
-
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-
-    assignment = getEVs();
-    List<String> currentActiveInstances =
-        _participantNames.stream().filter(n -> !n.equals(instanceToEvacuate)).collect(Collectors.toList());
-    for (String resource : _allDBs) {
-      validateAssignmentInEv(assignment.get(resource));
-      Set<String> newPAssignedParticipants = getParticipantsInEv(assignment.get(resource));
-      Assert.assertFalse(newPAssignedParticipants.contains(instanceToEvacuate));
-      Assert.assertTrue(newPAssignedParticipants.containsAll(currentActiveInstances));
-    }
-    Assert.assertTrue(_admin.isReadyForPreparingJoiningCluster(CLUSTER_NAME, instanceToEvacuate));
-
-    _stateModelDelay = 3L;
-  }
-
-  @Test(dependsOnMethods = "testMarkEvacuationAfterEMM")
-  public void testEvacuationWithOfflineInstancesInCluster() throws Exception {
-    System.out.println("START TestInstanceOperation.testEvacuationWithOfflineInstancesInCluster() at " + new Date(System.currentTimeMillis()));
-    _participants.get(1).syncStop();
-    _participants.get(2).syncStop();
-
-    String evacuateInstanceName =  _participants.get(_participants.size()-2).getInstanceName();
-    _gSetupTool.getClusterManagementTool()
-        .setInstanceOperation(CLUSTER_NAME, evacuateInstanceName, InstanceConstants.InstanceOperation.EVACUATE);
-
-    Map<String, ExternalView> assignment;
-    // EV should contain all participants, check resources one by one
-    assignment = getEVs();
-    for (String resource : _allDBs) {
-      TestHelper.verify(() -> {
-        ExternalView ev = assignment.get(resource);
-        for (String partition : ev.getPartitionSet()) {
-          AtomicInteger activeReplicaCount = new AtomicInteger();
-          ev.getStateMap(partition)
-              .values()
-              .stream()
-              .filter(v -> v.equals("MASTER") || v.equals("LEADER") || v.equals("SLAVE") || v.equals("FOLLOWER")
-                  || v.equals("STANDBY"))
-              .forEach(v -> activeReplicaCount.getAndIncrement());
-          if (activeReplicaCount.get() < REPLICA - 1 || (ev.getStateMap(partition).containsKey(evacuateInstanceName)
-              && ev.getStateMap(partition).get(evacuateInstanceName).equals("MASTER") && ev.getStateMap(partition)
-              .get(evacuateInstanceName)
-              .equals("LEADER"))) {
-            return false;
-          }
-        }
-        return true;
-      }, 30000);
-    }
-
-    removeOfflineOrDisabledInstances();
-    addParticipant(PARTICIPANT_PREFIX + "_" + _nextStartPort);
-    addParticipant(PARTICIPANT_PREFIX + "_" + _nextStartPort);
-    dropTestDBs(ImmutableSet.of("TEST_DB3_DELAYED_CRUSHED", "TEST_DB4_DELAYED_WAGED"));
-  }
-
-  @Test(expectedExceptions = HelixException.class, dependsOnMethods = "testEvacuationWithOfflineInstancesInCluster")
+  @Test(expectedExceptions = HelixException.class, dependsOnMethods = "testNodeSwapNoTopologySetup")
   public void testAddingNodeWithSwapOutInstanceOperation() throws Exception {
     System.out.println(
         "START TestInstanceOperation.testAddingNodeWithSwapOutInstanceOperation() at " + new Date(
             System.currentTimeMillis()));
 
     enabledTopologyAwareRebalance();
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Set instance's InstanceOperation to SWAP_OUT
     String instanceToSwapOutName = _participants.get(0).getInstanceName();
@@ -533,7 +370,7 @@ public class TestInstanceOperation extends ZkTestBase {
         "START TestInstanceOperation.testAddingNodeWithSwapOutNodeInstanceOperationUnset() at "
             + new Date(System.currentTimeMillis()));
 
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Set instance's InstanceOperation to null
     String instanceToSwapOutName = _participants.get(0).getInstanceName();
@@ -554,7 +391,7 @@ public class TestInstanceOperation extends ZkTestBase {
     System.out.println("START TestInstanceOperation.testNodeSwapWithNoSwapOutNode() at " + new Date(
         System.currentTimeMillis()));
 
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Add new instance with InstanceOperation set to SWAP_IN
     String instanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort;
@@ -568,7 +405,7 @@ public class TestInstanceOperation extends ZkTestBase {
         "START TestInstanceOperation.testNodeSwapSwapInNodeNoInstanceOperationEnabled() at "
             + new Date(System.currentTimeMillis()));
 
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Set instance's InstanceOperation to SWAP_OUT
     String instanceToSwapOutName = _participants.get(0).getInstanceName();
@@ -587,7 +424,7 @@ public class TestInstanceOperation extends ZkTestBase {
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
     Assert.assertTrue(_gSetupTool.getClusterManagementTool()
         .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName));
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
   }
 
   @Test(expectedExceptions = HelixException.class, dependsOnMethods = "testNodeSwapSwapInNodeNoInstanceOperationEnabled")
@@ -596,7 +433,7 @@ public class TestInstanceOperation extends ZkTestBase {
         "START TestInstanceOperation.testNodeSwapSwapInNodeWithAlreadySwappingPair() at "
             + new Date(System.currentTimeMillis()));
 
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Set instance's InstanceOperation to SWAP_OUT
     String instanceToSwapOutName = _participants.get(0).getInstanceName();
@@ -621,42 +458,10 @@ public class TestInstanceOperation extends ZkTestBase {
   }
 
   @Test(expectedExceptions = HelixException.class, dependsOnMethods = "testNodeSwapSwapInNodeWithAlreadySwappingPair")
-  public void testNodeSwapNoTopologySetup() throws Exception {
-    // Complete the swap from previous test
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-    String instanceToSwapOutName = _participants.get(0).getInstanceName();
-    Assert.assertTrue(_gSetupTool.getClusterManagementTool()
-        .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName));
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-
-    System.out.println("START TestInstanceOperation.testNodeSwapNoTopologySetup() at " + new Date(
-        System.currentTimeMillis()));
-    removeOfflineOrDisabledInstances();
-    disableTopologyAwareRebalance();
-
-    // Set instance's InstanceOperation to SWAP_OUT
-    instanceToSwapOutName = _participants.get(0).getInstanceName();
-    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToSwapOutName,
-        InstanceConstants.InstanceOperation.SWAP_OUT);
-
-    // Add instance with InstanceOperation set to SWAP_IN
-    // There should be an error that the logicalId does not have SWAP_OUT instance because,
-    // helix can't determine what topology key to use to get the logicalId if TOPOLOGY is not set.
-    String instanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort;
-    InstanceConfig instanceToSwapOutInstanceConfig = _gSetupTool.getClusterManagementTool()
-        .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName);
-    addParticipant(instanceToSwapInName, instanceToSwapOutInstanceConfig.getLogicalId(LOGICAL_ID),
-        instanceToSwapOutInstanceConfig.getDomainAsMap().get(ZONE),
-        InstanceConstants.InstanceOperation.SWAP_IN, true, -1);
-  }
-
-  @Test(expectedExceptions = HelixException.class, dependsOnMethods = "testNodeSwapNoTopologySetup")
   public void testNodeSwapWrongFaultZone() throws Exception {
     System.out.println("START TestInstanceOperation.testNodeSwapWrongFaultZone() at " + new Date(
         System.currentTimeMillis()));
-    // Re-enable topology aware rebalancing and set TOPOLOGY.
-    enabledTopologyAwareRebalance();
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Set instance's InstanceOperation to SWAP_OUT
     String instanceToSwapOutName = _participants.get(0).getInstanceName();
@@ -677,7 +482,7 @@ public class TestInstanceOperation extends ZkTestBase {
   public void testNodeSwapWrongCapacity() throws Exception {
     System.out.println("START TestInstanceOperation.testNodeSwapWrongCapacity() at " + new Date(
         System.currentTimeMillis()));
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Set instance's InstanceOperation to SWAP_OUT
     String instanceToSwapOutName = _participants.get(0).getInstanceName();
@@ -698,7 +503,7 @@ public class TestInstanceOperation extends ZkTestBase {
   public void testNodeSwap() throws Exception {
     System.out.println(
         "START TestInstanceOperation.testNodeSwap() at " + new Date(System.currentTimeMillis()));
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Store original EV
     Map<String, ExternalView> originalEVs = getEVs();
@@ -713,7 +518,7 @@ public class TestInstanceOperation extends ZkTestBase {
         InstanceConstants.InstanceOperation.SWAP_OUT);
 
     // Validate that the assignment has not changed since setting the InstanceOperation to SWAP_OUT
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
         Collections.emptySet(), Collections.emptySet());
 
@@ -744,7 +549,7 @@ public class TestInstanceOperation extends ZkTestBase {
     Assert.assertTrue(_gSetupTool.getClusterManagementTool()
         .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName));
 
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // Validate that the SWAP_IN instance is now in the routing tables.
     validateRoutingTablesInstance(getEVs(), instanceToSwapInName, true);
@@ -753,20 +558,11 @@ public class TestInstanceOperation extends ZkTestBase {
     // Assert that SWAP_OUT instance is disabled and has no partitions assigned to it.
     Assert.assertFalse(_gSetupTool.getClusterManagementTool()
         .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName).getInstanceEnabled());
-    Assert.assertEquals(getPartitionsAndStatesOnInstance(getEVs(), instanceToSwapOutName).size(),
-        0);
 
     // Validate that the SWAP_IN instance has the same partitions the SWAP_OUT instance had before
     // swap was completed.
-    TestHelper.verify(() -> {
-      try {
-        validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-            Collections.emptySet(), Set.of(instanceToSwapInName));
-      } catch (AssertionError e) {
-        return false;
-      }
-      return true;
-    }, TIMEOUT);
+    verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
+        Collections.emptySet(), Set.of(instanceToSwapInName))), TIMEOUT);
   }
 
   @Test(dependsOnMethods = "testNodeSwap")
@@ -775,7 +571,7 @@ public class TestInstanceOperation extends ZkTestBase {
         "START TestInstanceOperation.testNodeSwapSwapInNodeNoInstanceOperationDisabled() at "
             + new Date(System.currentTimeMillis()));
 
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Store original EVs
     Map<String, ExternalView> originalEVs = getEVs();
@@ -790,7 +586,7 @@ public class TestInstanceOperation extends ZkTestBase {
         InstanceConstants.InstanceOperation.SWAP_OUT);
 
     // Validate that the assignment has not changed since setting the InstanceOperation to SWAP_OUT
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
         Collections.emptySet(), Collections.emptySet());
 
@@ -800,7 +596,7 @@ public class TestInstanceOperation extends ZkTestBase {
     addParticipant(instanceToSwapInName, instanceToSwapOutInstanceConfig.getLogicalId(LOGICAL_ID),
         instanceToSwapOutInstanceConfig.getDomainAsMap().get(ZONE), null, false, -1);
 
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
         Collections.emptySet(), Collections.emptySet());
 
@@ -826,25 +622,16 @@ public class TestInstanceOperation extends ZkTestBase {
     Assert.assertTrue(_gSetupTool.getClusterManagementTool()
         .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName));
 
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // Assert that SWAP_OUT instance is disabled and has no partitions assigned to it.
     Assert.assertFalse(_gSetupTool.getClusterManagementTool()
         .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName).getInstanceEnabled());
-    Assert.assertEquals(getPartitionsAndStatesOnInstance(getEVs(), instanceToSwapOutName).size(),
-        0);
 
     // Validate that the SWAP_IN instance has the same partitions the SWAP_OUT instance had before
     // swap was completed.
-    TestHelper.verify(() -> {
-      try {
-        validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-            Collections.emptySet(), Set.of(instanceToSwapInName));
-      } catch (AssertionError e) {
-        return false;
-      }
-      return true;
-    }, TIMEOUT);
+    verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
+        Collections.emptySet(), Set.of(instanceToSwapInName))), TIMEOUT);
   }
 
   @Test(dependsOnMethods = "testNodeSwapSwapInNodeNoInstanceOperationDisabled")
@@ -853,7 +640,7 @@ public class TestInstanceOperation extends ZkTestBase {
         "START TestInstanceOperation.testNodeSwapCancelSwapWhenReadyToComplete() at " + new Date(
             System.currentTimeMillis()));
 
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Store original EVs
     Map<String, ExternalView> originalEVs = getEVs();
@@ -868,7 +655,7 @@ public class TestInstanceOperation extends ZkTestBase {
         InstanceConstants.InstanceOperation.SWAP_OUT);
 
     // Validate that the assignment has not changed since setting the InstanceOperation to SWAP_OUT
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
         Collections.emptySet(), Collections.emptySet());
 
@@ -900,7 +687,7 @@ public class TestInstanceOperation extends ZkTestBase {
         .enableInstance(CLUSTER_NAME, instanceToSwapInName, false);
 
     // Wait for cluster to converge.
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // Validate that the SWAP_OUT instance is in routing tables and SWAP_IN is not.
     validateRoutingTablesInstance(getEVs(), instanceToSwapOutName, true);
@@ -916,21 +703,11 @@ public class TestInstanceOperation extends ZkTestBase {
     _gSetupTool.getClusterManagementTool()
         .setInstanceOperation(CLUSTER_NAME, instanceToSwapOutName, null);
 
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-
-    // Validate there are no partitions on the SWAP_IN instance.
-    Assert.assertEquals(getPartitionsAndStatesOnInstance(getEVs(), instanceToSwapInName).size(), 0);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // Validate that the SWAP_OUT instance has the same partitions as it had before.
-    TestHelper.verify(() -> {
-      try {
-        validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-            Collections.emptySet(), Collections.emptySet());
-      } catch (AssertionError e) {
-        return false;
-      }
-      return true;
-    }, TIMEOUT);
+    verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
+        Collections.emptySet(), Collections.emptySet())), TIMEOUT);
   }
 
   @Test(dependsOnMethods = "testNodeSwapCancelSwapWhenReadyToComplete")
@@ -938,7 +715,7 @@ public class TestInstanceOperation extends ZkTestBase {
     System.out.println("START TestInstanceOperation.testNodeSwapAfterEMM() at " + new Date(
         System.currentTimeMillis()));
 
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Store original EVs
     Map<String, ExternalView> originalEVs = getEVs();
@@ -957,7 +734,7 @@ public class TestInstanceOperation extends ZkTestBase {
         InstanceConstants.InstanceOperation.SWAP_OUT);
 
     // Validate that the assignment has not changed since setting the InstanceOperation to SWAP_OUT
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
         Collections.emptySet(), Collections.emptySet());
 
@@ -997,7 +774,7 @@ public class TestInstanceOperation extends ZkTestBase {
     Assert.assertTrue(_gSetupTool.getClusterManagementTool()
         .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName));
 
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // Validate that the SWAP_IN instance is now in the routing tables.
     validateRoutingTablesInstance(getEVs(), instanceToSwapInName, true);
@@ -1005,20 +782,11 @@ public class TestInstanceOperation extends ZkTestBase {
     // Assert that SWAP_OUT instance is disabled and has no partitions assigned to it.
     Assert.assertFalse(_gSetupTool.getClusterManagementTool()
         .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName).getInstanceEnabled());
-    Assert.assertEquals(getPartitionsAndStatesOnInstance(getEVs(), instanceToSwapOutName).size(),
-        0);
 
     // Validate that the SWAP_IN instance has the same partitions the SWAP_OUT instance had before
     // swap was completed.
-    TestHelper.verify(() -> {
-      try {
-        validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-            Collections.emptySet(), Set.of(instanceToSwapInName));
-      } catch (AssertionError e) {
-        return false;
-      }
-      return true;
-    }, TIMEOUT);
+    verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
+        Collections.emptySet(), Set.of(instanceToSwapInName))), TIMEOUT);
   }
 
   @Test(dependsOnMethods = "testNodeSwapAfterEMM")
@@ -1027,7 +795,7 @@ public class TestInstanceOperation extends ZkTestBase {
         "START TestInstanceOperation.testNodeSwapWithSwapOutInstanceDisabled() at " + new Date(
             System.currentTimeMillis()));
 
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Store original EVs
     Map<String, ExternalView> originalEVs = getEVs();
@@ -1046,7 +814,7 @@ public class TestInstanceOperation extends ZkTestBase {
     _gSetupTool.getClusterManagementTool()
         .enableInstance(CLUSTER_NAME, instanceToSwapOutName, false);
 
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // Validate that the SWAP_OUT instance has all partitions in OFFLINE state
     Set<String> swapOutInstanceOfflineStates =
@@ -1091,13 +859,13 @@ public class TestInstanceOperation extends ZkTestBase {
     Assert.assertTrue(_gSetupTool.getClusterManagementTool()
         .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName));
 
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // Assert that SWAP_OUT instance is disabled and has no partitions assigned to it.
     Assert.assertFalse(_gSetupTool.getClusterManagementTool()
         .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName).getInstanceEnabled());
 
-    TestHelper.verify(
+    verifier(
         () -> (getPartitionsAndStatesOnInstance(getEVs(), instanceToSwapOutName).isEmpty()),
         TIMEOUT);
   }
@@ -1107,7 +875,7 @@ public class TestInstanceOperation extends ZkTestBase {
     System.out.println(
         "START TestInstanceOperation.testNodeSwapAddSwapInFirstEnabledBeforeSwapOutSet() at "
             + new Date(System.currentTimeMillis()));
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Get the SWAP_OUT instance.
     String instanceToSwapOutName = _participants.get(0).getInstanceName();
@@ -1125,7 +893,7 @@ public class TestInstanceOperation extends ZkTestBase {
     System.out.println(
         "START TestInstanceOperation.testNodeSwapAddSwapInFirstEnableBeforeSwapOutSet() at "
             + new Date(System.currentTimeMillis()));
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Get the SWAP_OUT instance.
     String instanceToSwapOutName = _participants.get(0).getInstanceName();
@@ -1148,7 +916,7 @@ public class TestInstanceOperation extends ZkTestBase {
     System.out.println(
         "START TestInstanceOperation.testUnsetInstanceOperationOnSwapInWhenAlreadyUnsetOnSwapOut() at "
             + new Date(System.currentTimeMillis()));
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Get the SWAP_OUT instance.
     String instanceToSwapOutName = _participants.get(0).getInstanceName();
@@ -1173,7 +941,7 @@ public class TestInstanceOperation extends ZkTestBase {
   public void testNodeSwapAddSwapInFirst() throws Exception {
     System.out.println("START TestInstanceOperation.testNodeSwapAddSwapInFirst() at " + new Date(
         System.currentTimeMillis()));
-    removeOfflineOrDisabledInstances();
+    removeOfflineOrDisabledOrSwapInInstances();
 
     // Store original EV
     Map<String, ExternalView> originalEVs = getEVs();
@@ -1200,7 +968,7 @@ public class TestInstanceOperation extends ZkTestBase {
     _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToSwapOutName,
         InstanceConstants.InstanceOperation.SWAP_OUT);
 
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // Enable the SWAP_IN instance to begin the swap operation.
     _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, instanceToSwapInName, true);
@@ -1224,7 +992,7 @@ public class TestInstanceOperation extends ZkTestBase {
     Assert.assertTrue(_gSetupTool.getClusterManagementTool()
         .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName));
 
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // Validate that the SWAP_IN instance is now in the routing tables.
     validateRoutingTablesInstance(getEVs(), instanceToSwapInName, true);
@@ -1232,20 +1000,234 @@ public class TestInstanceOperation extends ZkTestBase {
     // Assert that SWAP_OUT instance is disabled and has no partitions assigned to it.
     Assert.assertFalse(_gSetupTool.getClusterManagementTool()
         .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName).getInstanceEnabled());
-    Assert.assertEquals(getPartitionsAndStatesOnInstance(getEVs(), instanceToSwapOutName).size(),
-        0);
 
     // Validate that the SWAP_IN instance has the same partitions the SWAP_OUT instance had before
     // swap was completed.
-    TestHelper.verify(() -> {
+    verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
+        Collections.emptySet(), Set.of(instanceToSwapInName))), TIMEOUT);
+  }
+
+  @Test(dependsOnMethods = "testNodeSwapAddSwapInFirst")
+  public void testEvacuateAndCancelBeforeBootstrapFinish() throws Exception {
+    System.out.println(
+        "START TestInstanceOperation.testEvacuateAndCancelBeforeBootstrapFinish() at " + new Date(
+            System.currentTimeMillis()));
+    removeOfflineOrDisabledOrSwapInInstances();
+
+    // add a resource where downward state transition is slow
+    createResourceWithDelayedRebalance(CLUSTER_NAME, "TEST_DB3_DELAYED_CRUSHED", "MasterSlave",
+        PARTITIONS, REPLICA, REPLICA - 1, 200000, CrushEdRebalanceStrategy.class.getName());
+    _allDBs.add("TEST_DB3_DELAYED_CRUSHED");
+    // add a resource where downward state transition is slow
+    createResourceWithWagedRebalance(CLUSTER_NAME, "TEST_DB4_DELAYED_WAGED", "MasterSlave",
+        PARTITIONS, REPLICA, REPLICA - 1);
+    _allDBs.add("TEST_DB4_DELAYED_WAGED");
+    // wait for assignment to finish
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // set bootstrap ST delay to a large number
+    _stateModelDelay = -10000L;
+    // evacuate an instance
+    String instanceToEvacuate = _participants.get(0).getInstanceName();
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+        InstanceConstants.InstanceOperation.EVACUATE);
+    // Messages should be pending at all instances besides the evacuate one
+    for (String participant : _participantNames) {
+      if (participant.equals(instanceToEvacuate)) {
+        continue;
+      }
+      verifier(() -> ((_dataAccessor.getChildNames(
+          _dataAccessor.keyBuilder().messages(participant))).isEmpty()), 30000);
+    }
+    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
+    Assert.assertFalse(_admin.isReadyForPreparingJoiningCluster(CLUSTER_NAME, instanceToEvacuate));
+
+    // sleep a bit so ST messages can start executing
+    Thread.sleep(Math.abs(_stateModelDelay / 100));
+    // before we cancel, check current EV
+    Map<String, ExternalView> assignment = getEVs();
+    for (String resource : _allDBs) {
+      // check every replica has >= 3 partitions and a top state partition
+      validateAssignmentInEv(assignment.get(resource));
+    }
+
+    // cancel the evacuation
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, null);
+
+    assignment = getEVs();
+    for (String resource : _allDBs) {
+      // check every replica has >= 3 active replicas, even before cluster converge
+      validateAssignmentInEv(assignment.get(resource));
+    }
+
+    // check cluster converge. We have longer delay for ST then verifier timeout. It will only converge if we cancel ST.
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // EV should contain all participants, check resources one by one
+    assignment = getEVs();
+    for (String resource : _allDBs) {
+      Assert.assertTrue(
+          getParticipantsInEv(assignment.get(resource)).containsAll(_participantNames));
+      // check every replica has >= 3 active replicas again
+      validateAssignmentInEv(assignment.get(resource));
+    }
+  }
+
+  @Test(dependsOnMethods = "testEvacuateAndCancelBeforeBootstrapFinish")
+  public void testEvacuateAndCancelBeforeDropFinish() throws Exception {
+    System.out.println(
+        "START TestInstanceOperation.testEvacuateAndCancelBeforeDropFinish() at " + new Date(
+            System.currentTimeMillis()));
+
+    // set DROP ST delay to a large number
+    _stateModelDelay = 10000L;
+
+    // evacuate an instance
+    String instanceToEvacuate = _participants.get(0).getInstanceName();
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+        InstanceConstants.InstanceOperation.EVACUATE);
+
+    // message should be pending at the to evacuate participant
+    verifier(() -> ((_dataAccessor.getChildNames(
+        _dataAccessor.keyBuilder().messages(instanceToEvacuate))).isEmpty()), 30000);
+    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
+
+    // cancel evacuation
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, null);
+    // check every replica has >= 3 active replicas, even before cluster converge
+    Map<String, ExternalView> assignment = getEVs();
+    for (String resource : _allDBs) {
+      validateAssignmentInEv(assignment.get(resource));
+    }
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // EV should contain all participants, check resources one by one
+    assignment = getEVs();
+    for (String resource : _allDBs) {
+      Assert.assertTrue(
+          getParticipantsInEv(assignment.get(resource)).containsAll(_participantNames));
+      // check every replica has >= 3 active replicas
+      validateAssignmentInEv(assignment.get(resource));
+    }
+  }
+
+  @Test(dependsOnMethods = "testEvacuateAndCancelBeforeDropFinish")
+  public void testMarkEvacuationAfterEMM() throws Exception {
+    System.out.println("START TestInstanceOperation.testMarkEvacuationAfterEMM() at " + new Date(
+        System.currentTimeMillis()));
+    _stateModelDelay = 1000L;
+    Assert.assertFalse(_gSetupTool.getClusterManagementTool().isInMaintenanceMode(CLUSTER_NAME));
+    _gSetupTool.getClusterManagementTool()
+        .manuallyEnableMaintenanceMode(CLUSTER_NAME, true, null, null);
+    String newParticipantName = PARTICIPANT_PREFIX + "_" + _nextStartPort;
+    addParticipant(newParticipantName);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Map<String, ExternalView> assignment = getEVs();
+    for (String resource : _allDBs) {
+      Assert.assertFalse(
+          getParticipantsInEv(assignment.get(resource)).contains(newParticipantName));
+    }
+
+    // set evacuate operation
+    String instanceToEvacuate = _participants.get(0).getInstanceName();
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+        InstanceConstants.InstanceOperation.EVACUATE);
+
+    // there should be no evacuation happening
+    for (String resource : _allDBs) {
+      Assert.assertTrue(getParticipantsInEv(assignment.get(resource)).contains(instanceToEvacuate));
+    }
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // exit MM
+    _gSetupTool.getClusterManagementTool()
+        .manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    assignment = getEVs();
+    List<String> currentActiveInstances =
+        _participantNames.stream().filter(n -> !n.equals(instanceToEvacuate))
+            .collect(Collectors.toList());
+    for (String resource : _allDBs) {
+      validateAssignmentInEv(assignment.get(resource));
+      Set<String> newPAssignedParticipants = getParticipantsInEv(assignment.get(resource));
+      Assert.assertFalse(newPAssignedParticipants.contains(instanceToEvacuate));
+      Assert.assertTrue(newPAssignedParticipants.containsAll(currentActiveInstances));
+    }
+    Assert.assertTrue(_admin.isReadyForPreparingJoiningCluster(CLUSTER_NAME, instanceToEvacuate));
+
+    _stateModelDelay = 3L;
+  }
+
+  @Test(dependsOnMethods = "testMarkEvacuationAfterEMM")
+  public void testEvacuationWithOfflineInstancesInCluster() throws Exception {
+    System.out.println(
+        "START TestInstanceOperation.testEvacuationWithOfflineInstancesInCluster() at " + new Date(
+            System.currentTimeMillis()));
+    _participants.get(1).syncStop();
+    _participants.get(2).syncStop();
+
+    String evacuateInstanceName = _participants.get(_participants.size() - 2).getInstanceName();
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, evacuateInstanceName,
+        InstanceConstants.InstanceOperation.EVACUATE);
+
+    Map<String, ExternalView> assignment;
+    // EV should contain all participants, check resources one by one
+    assignment = getEVs();
+    for (String resource : _allDBs) {
+      verifier(() -> {
+        ExternalView ev = assignment.get(resource);
+        for (String partition : ev.getPartitionSet()) {
+          AtomicInteger activeReplicaCount = new AtomicInteger();
+          ev.getStateMap(partition).values().stream().filter(
+                  v -> v.equals("MASTER") || v.equals("LEADER") || v.equals("SLAVE") || v.equals(
+                      "FOLLOWER") || v.equals("STANDBY"))
+              .forEach(v -> activeReplicaCount.getAndIncrement());
+          if (activeReplicaCount.get() < REPLICA - 1 || (
+              ev.getStateMap(partition).containsKey(evacuateInstanceName) && ev.getStateMap(
+                  partition).get(evacuateInstanceName).equals("MASTER") && ev.getStateMap(partition)
+                  .get(evacuateInstanceName).equals("LEADER"))) {
+            return false;
+          }
+        }
+        return true;
+      }, 30000);
+    }
+
+    removeOfflineOrDisabledOrSwapInInstances();
+    addParticipant(PARTICIPANT_PREFIX + "_" + _nextStartPort);
+    addParticipant(PARTICIPANT_PREFIX + "_" + _nextStartPort);
+    dropTestDBs(ImmutableSet.of("TEST_DB3_DELAYED_CRUSHED", "TEST_DB4_DELAYED_WAGED"));
+  }
+
+  /**
+   * Verifies that the given verifier returns true within the given timeout. Handles AssertionError
+   * by returning false, which TestHelper.verify will not do. Asserts that return value from
+   * TestHelper.verify is true.
+   *
+   * @param verifier the verifier to run
+   * @param timeout  the timeout to wait for the verifier to return true
+   * @throws Exception if TestHelper.verify throws an exception
+   */
+  private static void verifier(TestHelper.Verifier verifier, long timeout) throws Exception {
+    Assert.assertTrue(TestHelper.verify(() -> {
       try {
-        validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-            Collections.emptySet(), Set.of(instanceToSwapInName));
+        boolean result = verifier.verify();
+        if (!result) {
+          LOG.error("Verifier returned false, retrying...");
+        }
+        return result;
       } catch (AssertionError e) {
+        LOG.error("Caught AssertionError on verifier attempt: ", e);
         return false;
       }
-      return true;
-    }, TIMEOUT);
+    }, timeout));
   }
 
   private MockParticipantManager createParticipant(String participantName) {
@@ -1296,10 +1278,10 @@ public class TestInstanceOperation extends ZkTestBase {
         PARTITIONS, REPLICA, REPLICA - 1);
     _allDBs.add("TEST_DB2_WAGED");
 
-     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+     Assert.assertTrue(_clusterVerifier.verifyByPolling());
   }
 
-  private void dropTestDBs(Set<String> dbs) {
+  private void dropTestDBs(Set<String> dbs) throws Exception {
     for (String db : dbs) {
       _gSetupTool.getClusterManagementTool().dropResource(CLUSTER_NAME, db);
       _allDBs.remove(db);
@@ -1433,7 +1415,7 @@ public class TestInstanceOperation extends ZkTestBase {
     }
   }
 
-  private void validateEVsCorrect(Map<String, ExternalView> actuals,
+  private boolean validateEVsCorrect(Map<String, ExternalView> actuals,
       Map<String, ExternalView> originals, Map<String, String> swapOutInstancesToSwapInInstances,
       Set<String> inFlightSwapInInstances, Set<String> completedSwapInInstanceNames) {
     Assert.assertEquals(actuals.keySet(), originals.keySet());
@@ -1441,6 +1423,7 @@ public class TestInstanceOperation extends ZkTestBase {
       validateEVCorrect(actuals.get(resource), originals.get(resource),
           swapOutInstancesToSwapInInstances, inFlightSwapInInstances, completedSwapInInstanceNames);
     }
+    return true;
   }
 
   private void validateAssignmentInEv(ExternalView ev) {


### PR DESCRIPTION
### Issues

- [x] TestInstanceOperation was flaky, using TestHelper.verify should stabilize the test.

### Description

Stabilize TestInstanceOperation. clusterVerifier is evaluating to true once the partitionAssignment matches the expected value; however, it is before the TopState is transfered back to the SWAP_IN node. This can be fixed by using TestHelper.verify to check that states converge within TIMEOUT.

### Tests

- [x] TestInstanceOperation, ran 3 times and did not see any failures.

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
