### PR TITLE
Use secret in .env instead of hard-coded one

### DIFF
--- a/helix-front/server/app.ts
+++ b/helix-front/server/app.ts
@@ -58,7 +58,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(
   session({
     store: SESSION_STORE,
-    secret: 'helix',
+    secret: process.env.SECRET_TOKEN,
     resave: true,
     saveUninitialized: true,
     cookie: { expires: new Date(2147483647000) },


### PR DESCRIPTION
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We have a predefined secret in `.env` file called `SECRET_TOKEN`. User is supposed to override the value with the environment variable. We were not use the secret in our helix-front server side. This PR is to apply the logic, so secret can be generated by the user to align with the security requirements.

### Tests

Manually tested with the secret override.

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
