### PR TITLE
[apache/helix] -- Handling Throwable during Helix message processing

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.Criteria;
@@ -276,7 +277,8 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
   /** Dedicated Thread pool can be provided in configuration or by client.
    *  This method is to check it and update the thread pool if necessary.
    */
-  private void updateStateTransitionMessageThreadPool(Message message, HelixManager manager) {
+  @VisibleForTesting
+  void updateStateTransitionMessageThreadPool(Message message, HelixManager manager) {
     if (!message.getMsgType().equals(MessageType.STATE_TRANSITION.name())) {
       return;
     }
@@ -344,7 +346,7 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
       final String key = msgInfo.getMessageIdentifier(Message.MessageInfo.MessageIdentifierBase.PER_RESOURCE);
       if (threadpoolSize > 0) {
         _executorMap.put(key, Executors.newFixedThreadPool(threadpoolSize,
-            r -> new Thread(r, "GerenricHelixController-message_handle_" + key)));
+            r -> new Thread(r, "GenericHelixController-message_handle_" + key)));
         LOG.info("Added dedicate threadpool for resource: " + resourceName + " with size: " + threadpoolSize);
       } else {
         // if threadpool is not configured
@@ -488,10 +490,10 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
               "Message handling task already sheduled for " + taskId, manager);
         }
       }
-    } catch (Exception e) {
-      LOG.error("Error while executing task. " + message, e);
+    } catch (Throwable t) {
+      LOG.error("Error while executing task. " + message, t);
       _statusUpdateUtil
-          .logError(message, HelixTaskExecutor.class, e, "Error while executing task " + e,
+          .logError(message, HelixTaskExecutor.class, t, "Error while executing task " + t,
               manager);
     }
     return false;

--- a/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
@@ -397,7 +397,7 @@ public class StatusUpdateUtil {
     logMessageStatusUpdateRecord(message, Level.HELIX_ERROR, classInfo, additionalInfo, manager);
   }
 
-  public void logError(Message message, Class classInfo, Exception e, String additionalInfo,
+  public void logError(Message message, Class classInfo, Throwable e, String additionalInfo,
       HelixManager manager) {
     StringWriter sw = new StringWriter();
     PrintWriter pw = new PrintWriter(sw);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes https://github.com/apache/helix/issues/2695

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
When we encounter any java,lang.Error like [OutOfMemoryError](https://docs.oracle.com/javase/8/docs/api/java/lang/OutOfMemoryError.html), we do not handle it currently. This error is transient that are thrown while trying to create threads and such errors are rather common due to the need to allocate a native stack in Thread.start. This error goes away after some when native stack is cleaned up. We should ideally cleanup ZK state (remove the message) and allow Helix to continue working on failed task. Clean-up and retry code path should be executed on encountering Throwable of any type.

We are extending the scope from Exception to Throwable, to allow ZK state clean-up and retry code path to be executed on encountering java.lang.Error of any type as well.

![Screenshot 2024-01-09 at 2 05 09 PM](https://github.com/apache/helix/assets/2539436/4b3d5adc-6926-427b-a1ba-3951e28f553d)

### Tests

- [x] The following tests are written for this issue:

Added `testHandleThrowableErrors` in TestHelixTaskExecutor.

- The following is the result of the "mvn test" command on the appropriate module:

```
END testUpdateAndFindMessageThreadpool
START TestHelixTaskExecutor.testStaledMessage()
49954 [main] ERROR org.apache.helix.messaging.handling.HelixTaskExecutor [] - Message 2466f4bc-1aff-4aea-ad1d-e50829e96698 cannot be processed: 2466f4bc-1aff-4aea-ad1d-e50829e96698, {CREATE_TIMESTAMP=0, FROM_STATE=SLAVE, MSG_ID=2466f4bc-1aff-4aea-ad1d-e50829e96698, MSG_STATE=new, MSG_TYPE=STATE_TRANSITION, PARTITION_NAME=Partition, RESOURCE_NAME=testStaledMessageResource, SRC_NAME=127.101.1.23_2234, STATE_MODEL_DEF=DummyMasterSlave, TGT_NAME=Localhost_1123, TGT_SESSION_ID=123, TO_STATE=MASTER}{}{}Partition Partition current state is same as toState (SLAVE->MASTER) from message.
49959 [pool-23-thread-1] ERROR org.apache.helix.messaging.handling.HelixStateTransitionHandler [] - Current state of stateModel does not match the fromState in Message, CurrentState: null, Message: Offline->Online, Partition: TestPartition, from: null, to: TgtInstance
50015 [pool-23-thread-1] ERROR org.apache.helix.messaging.handling.HelixTask [] - Message execution failed. msgId: testMsgId, errorMsg: org.apache.helix.messaging.handling.HelixStateTransitionHandler$HelixStateMismatchException: Current state of stateModel does not match the fromState in Message, CurrentState: null, Message: Offline->Online, Partition: TestPartition, from: null, to: TgtInstance
50064 [pool-22-thread-1] ERROR org.apache.helix.messaging.handling.HelixStateTransitionHandler [] - Current state of stateModel does not match the fromState in Message, CurrentState: null, Message: Offline->Online, Partition: TestPartition, from: null, to: TgtInstance
50120 [pool-22-thread-1] ERROR org.apache.helix.messaging.handling.HelixTask [] - Message execution failed. msgId: testMsgId, errorMsg: org.apache.helix.messaging.handling.HelixStateTransitionHandler$HelixStateMismatchException: Current state of stateModel does not match the fromState in Message, CurrentState: null, Message: Offline->Online, Partition: TestPartition, from: null, to: TgtInstance
50126 [pool-23-thread-1] ERROR org.apache.helix.messaging.handling.HelixStateTransitionHandler [] - Skip internal error. errCode: ERROR, errMsg: Current state of stateModel does not match the fromState in Message, CurrentState: null, Message: Offline->Online, Partition: TestPartition, from: null, to: TgtInstance
50163 [pool-24-thread-1] ERROR org.apache.helix.messaging.handling.HelixStateTransitionHandler [] - Current state of stateModel does not match the fromState in Message, CurrentState: null, Message: Offline->Online, Partition: TestPartition, from: null, to: TgtInstance
50216 [pool-24-thread-1] ERROR org.apache.helix.messaging.handling.HelixTask [] - Message execution failed. msgId: testMsgId, errorMsg: org.apache.helix.messaging.handling.HelixStateTransitionHandler$HelixStateMismatchException: Current state of stateModel does not match the fromState in Message, CurrentState: null, Message: Offline->Online, Partition: TestPartition, from: null, to: TgtInstance
50228 [pool-22-thread-1] ERROR org.apache.helix.messaging.handling.HelixStateTransitionHandler [] - Skip internal error. errCode: ERROR, errMsg: Current state of stateModel does not match the fromState in Message, CurrentState: null, Message: Offline->Online, Partition: TestPartition, from: null, to: TgtInstance
END TestHelixTaskExecutor.testStaledMessage()
End TestHelixTaskExecutor
50342 [pool-24-thread-1] ERROR org.apache.helix.messaging.handling.HelixStateTransitionHandler [] - Skip internal error. errCode: ERROR, errMsg: Current state of stateModel does not match the fromState in Message, CurrentState: null, Message: Offline->Online, Partition: TestPartition, from: null, to: TgtInstance
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 49.893 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 947 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:00 min
[INFO] Finished at: 2024-01-09T13:54:46-08:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
