### PR TITLE
Enable computation of evenness score based on a preferred scoring key

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/MaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/MaxCapacityUsageInstanceConstraint.java
@@ -37,7 +37,7 @@ class MaxCapacityUsageInstanceConstraint extends UsageSoftConstraint {
       ClusterContext clusterContext) {
     float estimatedMaxUtilization = clusterContext.getEstimatedMaxUtilization();
     float projectedHighestUtilization =
-        node.getGeneralProjectedHighestUtilization(replica.getCapacity());
+        node.getGeneralProjectedHighestUtilization(replica.getCapacity(), clusterContext.getPreferredScoringKeys());
     return computeUtilizationScore(estimatedMaxUtilization, projectedHighestUtilization);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/TopStateMaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/TopStateMaxCapacityUsageInstanceConstraint.java
@@ -41,7 +41,7 @@ class TopStateMaxCapacityUsageInstanceConstraint extends UsageSoftConstraint {
     }
     float estimatedTopStateMaxUtilization = clusterContext.getEstimatedTopStateMaxUtilization();
     float projectedHighestUtilization =
-        node.getTopStateProjectedHighestUtilization(replica.getCapacity());
+        node.getTopStateProjectedHighestUtilization(replica.getCapacity(), clusterContext.getPreferredScoringKeys());
     return computeUtilizationScore(estimatedTopStateMaxUtilization, projectedHighestUtilization);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/AssignableNode.java
@@ -249,7 +249,27 @@ public class AssignableNode implements Comparable<AssignableNode> {
    * @return The highest utilization number of the node among all the capacity category.
    */
   public float getGeneralProjectedHighestUtilization(Map<String, Integer> newUsage) {
-    return getProjectedHighestUtilization(newUsage, _remainingCapacity);
+    return getProjectedHighestUtilization(newUsage, _remainingCapacity, null);
+  }
+
+  /**
+   * Return the most concerning capacity utilization number for evenly partition assignment.
+   * The method dynamically calculates the projected highest utilization number among all the
+   * capacity categories assuming the new capacity usage is added to the node.
+   *
+   * If the list of preferredScoringKeys is specified then utilization number is computed based op the
+   * specified capacity category (keys) in the list only.
+   *
+   * For example, if the current node usage is {CPU: 0.9, MEM: 0.4, DISK: 0.6}, preferredScoringKeys: [ CPU ]
+   * Then this call shall return 0.9.
+   *
+   * @param newUsage            the proposed new additional capacity usage.
+   * @param preferredScoringKeys if provided, the capacity utilization will be calculated based on
+   *                            the supplied keys only, else across all capacity categories.
+   * @return The highest utilization number of the node among the specified capacity category.
+   */
+  public float getGeneralProjectedHighestUtilization(Map<String, Integer> newUsage, List<String> preferredScoringKeys) {
+    return getProjectedHighestUtilization(newUsage, _remainingCapacity, preferredScoringKeys);
   }
 
   /**
@@ -263,13 +283,39 @@ public class AssignableNode implements Comparable<AssignableNode> {
    * @return The highest utilization number of the node among all the capacity category.
    */
   public float getTopStateProjectedHighestUtilization(Map<String, Integer> newUsage) {
-    return getProjectedHighestUtilization(newUsage, _remainingTopStateCapacity);
+    return getProjectedHighestUtilization(newUsage, _remainingTopStateCapacity, null);
+  }
+
+  /**
+   * Return the most concerning capacity utilization number for evenly partition assignment.
+   * The method dynamically calculates the projected highest utilization number among all the
+   * capacity categories assuming the new capacity usage is added to the node.
+   *
+   * If the list of preferredScoringKeys is specified then utilization number is computed based op the
+   * specified capacity category (keys) in the list only.
+   *
+   * For example, if the current node usage is {CPU: 0.9, MEM: 0.4, DISK: 0.6}, preferredScoringKeys: [ CPU ]
+   * Then this call shall return 0.9.
+   *
+   * This function returns projected highest utilization for only top state partitions.
+   *
+   * @param newUsage            the proposed new additional capacity usage.
+   * @param preferredScoringKeys if provided, the capacity utilization will be calculated based on
+   *                            the supplied keys only, else across all capacity categories.
+   * @return The highest utilization number of the node among all the capacity category.
+   */
+  public float getTopStateProjectedHighestUtilization(Map<String, Integer> newUsage, List<String> preferredScoringKeys) {
+    return getProjectedHighestUtilization(newUsage, _remainingTopStateCapacity, preferredScoringKeys);
   }
 
   private float getProjectedHighestUtilization(Map<String, Integer> newUsage,
-      Map<String, Integer> remainingCapacity) {
+      Map<String, Integer> remainingCapacity, List<String> preferredScoringKeys) {
+    Set<String> capacityKeySet = _maxAllowedCapacity.keySet();
+    if (preferredScoringKeys != null && preferredScoringKeys.size() != 0 && capacityKeySet.contains(preferredScoringKeys.get(0))) {
+      capacityKeySet = preferredScoringKeys.stream().collect(Collectors.toSet());
+    }
     float highestCapacityUtilization = 0;
-    for (String capacityKey : _maxAllowedCapacity.keySet()) {
+    for (String capacityKey : capacityKeySet) {
       float capacityValue = _maxAllowedCapacity.get(capacityKey);
       float utilization = (capacityValue - remainingCapacity.get(capacityKey) + newUsage
           .getOrDefault(capacityKey, 0)) / capacityValue;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -268,7 +268,7 @@ public class ClusterModelProvider {
     // Construct and initialize cluster context.
     ClusterContext context = new ClusterContext(
         replicaMap.values().stream().flatMap(Set::stream).collect(Collectors.toSet()),
-        assignableNodes, logicalIdIdealAssignment, logicalIdCurrentAssignment);
+        assignableNodes, logicalIdIdealAssignment, logicalIdCurrentAssignment, dataProvider.getClusterConfig());
 
     // Initial the cluster context with the allocated assignments.
     context.setAssignmentForFaultZoneMap(mapAssignmentToFaultZone(assignableNodes));

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -154,7 +154,10 @@ public class ClusterConfig extends HelixProperty {
     HELIX_DISABLED_TYPE,
 
     // The last time when the on-demand rebalance is triggered.
-    LAST_ON_DEMAND_REBALANCE_TIMESTAMP
+    LAST_ON_DEMAND_REBALANCE_TIMESTAMP,
+
+    // List of Preferred scoring keys used in evenness score computation
+    PREFERRED_SCORING_KEYS
   }
 
   public enum GlobalRebalancePreferenceKey {
@@ -1197,5 +1200,26 @@ public class ClusterConfig extends HelixProperty {
   public void setLastOnDemandRebalanceTimestamp(long rebalanceTimestamp) {
     _record.setLongField(ClusterConfigProperty.LAST_ON_DEMAND_REBALANCE_TIMESTAMP.name(),
         rebalanceTimestamp);
+  }
+
+  /**
+   * Get the list of preferred scoring keys if set.
+   *
+   * @return PreferredScoringKeys that is used in computation of evenness score
+   */
+  public List<String> getPreferredScoringKeys() {
+    return _record.getListField(ClusterConfigProperty.PREFERRED_SCORING_KEYS.name());
+  }
+
+  /**
+   * Set list of preferred scoring keys for cluster.
+   * preferredScoringKeys is set as a List to make it generic and accommodate any future use case.
+   * preferredScoringKeys will be a singleton list for current use case.
+   *
+   * @param preferredScoringKeys value used in evenness score computation
+   */
+  public void setPreferredScoringKeys(List<String> preferredScoringKeys) {
+    _record.setListField(ClusterConfigProperty.PREFERRED_SCORING_KEYS.name(),
+        preferredScoringKeys);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestMaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestMaxCapacityUsageInstanceConstraint.java
@@ -19,6 +19,9 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
  * under the License.
  */
 
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
@@ -29,6 +32,8 @@ import org.testng.annotations.Test;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 
 public class TestMaxCapacityUsageInstanceConstraint {
   private AssignableReplica _testReplica;
@@ -45,13 +50,28 @@ public class TestMaxCapacityUsageInstanceConstraint {
 
   @Test
   public void testGetNormalizedScore() {
-    when(_testNode.getGeneralProjectedHighestUtilization(anyMap())).thenReturn(0.8f);
+    when(_testNode.getGeneralProjectedHighestUtilization(anyMap(), any())).thenReturn(0.8f);
     when(_clusterContext.getEstimatedMaxUtilization()).thenReturn(1f);
     double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
     // Convert to float so as to compare with equal.
     Assert.assertEquals((float) score,0.8f);
     double normalizedScore =
         _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertTrue(normalizedScore > 0.99);
+  }
+
+  @Test
+  public void testGetNormalizedScoreWithPreferredScoringKey() {
+    List<String> preferredScoringKeys = Collections.singletonList("CU");
+    when(_testNode.getGeneralProjectedHighestUtilization(anyMap(),
+        eq(preferredScoringKeys))).thenReturn(0.5f);
+    when(_clusterContext.getPreferredScoringKeys()).thenReturn(preferredScoringKeys);
+    when(_clusterContext.getEstimatedMaxUtilization()).thenReturn(1f);
+    double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    // Convert to float so as to compare with equal.
+    Assert.assertEquals((float) score,0.5f);
+    double normalizedScore =
+            _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
     Assert.assertTrue(normalizedScore > 0.99);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestTopStateMaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestTopStateMaxCapacityUsageInstanceConstraint.java
@@ -19,6 +19,9 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
  * under the License.
  */
 
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
@@ -26,6 +29,8 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -47,13 +52,30 @@ public class TestTopStateMaxCapacityUsageInstanceConstraint {
   @Test
   public void testGetNormalizedScore() {
     when(_testReplica.isReplicaTopState()).thenReturn(true);
-    when(_testNode.getTopStateProjectedHighestUtilization(anyMap())).thenReturn(0.8f);
+    when(_testNode.getTopStateProjectedHighestUtilization(anyMap(), any())).thenReturn(0.8f);
     when(_clusterContext.getEstimatedTopStateMaxUtilization()).thenReturn(1f);
     double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
     // Convert to float so as to compare with equal.
     Assert.assertEquals((float) score, 0.8f);
     double normalizedScore =
         _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertTrue(normalizedScore > 0.99);
+  }
+
+
+  @Test
+  public void testGetNormalizedScoreWithPreferredScoringKey() {
+    List<String> preferredScoringKeys = Collections.singletonList("CU");
+    when(_testReplica.isReplicaTopState()).thenReturn(true);
+    when(_testNode.getTopStateProjectedHighestUtilization(anyMap(),
+        eq(preferredScoringKeys))).thenReturn(0.5f);
+    when(_clusterContext.getPreferredScoringKeys()).thenReturn(preferredScoringKeys);
+    when(_clusterContext.getEstimatedTopStateMaxUtilization()).thenReturn(1f);
+    double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    // Convert to float so as to compare with equal.
+    Assert.assertEquals((float) score,0.5f);
+    double normalizedScore =
+            _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
     Assert.assertTrue(normalizedScore > 0.99);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterContext.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterContext.java
@@ -22,14 +22,18 @@ package org.apache.helix.controller.rebalancer.waged.model;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.helix.HelixException;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.model.ClusterConfig;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class TestClusterContext extends AbstractTestClusterModel {
@@ -93,5 +97,47 @@ public class TestClusterContext extends AbstractTestClusterModel {
     // Insert again and trigger the error.
     context
         .addPartitionToFaultZone(_testFaultZoneId, _resourceNames.get(0), _partitionNames.get(0));
+  }
+
+  @DataProvider(name = "preferredScoringKeys")
+  public static Object[][] preferredScoringKeys() {
+    return new Object[][]{
+            {Collections.singletonList("item1")},//valid key
+            {Collections.singletonList("item3")},//valid key
+            {Collections.singletonList("item-x")},//invalid key
+            {null}
+    };
+  }
+
+  @Test(dataProvider = "preferredScoringKeys")
+  public void testEstimateMaxUtilization(List<String> preferredScoringKeys) throws IOException {
+    ResourceControllerDataProvider testCache = setupClusterDataCache();
+    Set<AssignableReplica> assignmentSet = generateReplicas(testCache);
+    ClusterConfig clusterConfig = testCache.getClusterConfig();
+    clusterConfig.setPreferredScoringKeys(preferredScoringKeys);
+    ClusterContext context =
+            new ClusterContext(assignmentSet, generateNodes(testCache), new HashMap<>(),
+                    new HashMap<>(), clusterConfig);
+    /**
+     * Total Capacity and Total Usage values calculated from nodeSet and replicaSet above are as follows:
+     * TotalCapacity : {"item1",20, "item2",40, "item3",30}
+     * TotalUsage : {"item1",16, "item2",32, "item3",0}
+     * Using these values to validate the results of estimateMaxUtilization.
+     */
+
+    validateResult(ImmutableMap.of("item1", 20, "item2", 40, "item3", 30),
+            ImmutableMap.of("item1", 16, "item2", 32, "item3", 0),
+            preferredScoringKeys, context.getEstimatedMaxUtilization());
+  }
+
+  private void validateResult(Map<String, Integer> totalCapacity, Map<String, Integer> totalUsage,
+                              List<String> preferredScoringKeys, float actualEstimatedMaxUtilization) {
+    if (preferredScoringKeys == null || preferredScoringKeys.size() == 0 || !totalCapacity.keySet().contains(preferredScoringKeys.get(0))) {
+      //estimatedMaxUtilization calculated from all capacity keys
+      Assert.assertEquals(actualEstimatedMaxUtilization, 0.8f);
+      return;
+    }
+    //estimatedMaxUtilization calculated using preferredScoringKey only.
+    Assert.assertEquals(actualEstimatedMaxUtilization, (float) totalUsage.get(preferredScoringKeys.get(0)) / totalCapacity.get(preferredScoringKeys.get(0)));
   }
 }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description: 
        #2674 


### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Currently, WAGED consider many capacity categories/dimensions such as CPU, Disk, etc for the placement decision evenness scores. In some use case, only one dimension is relevant because the clusters are provisioned based on that category. And, if evenness scores are not based on that then it introduces more shuffle/movements.

So, we would like to provide a way for users to specify a prioritized evennessScoringKey that will help computing scores based on that category only.


### Tests

- [ ] The following tests are written for this issue:

1. TestClusterContext 

- testEstimateMaxUtilization

2. TestMaxCapacityUsageInstanceConstraint

- testGetNormalizedScoreWithPreferredScoringKey

3. TestTopStateMaxCapacityUsageInstanceConstraint

- testGetNormalizedScoreWithPreferredScoringKey

```
[INFO] Reactor Summary for Apache Helix 1.3.2-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  1.573 s]
[INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  0.432 s]
[INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [  0.537 s]
[INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [  0.502 s]
[INFO] Apache Helix :: Helix Common ....................... SUCCESS [  0.312 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [  0.417 s]
[INFO] Apache Helix :: Admin Webapp ....................... SUCCESS [  0.919 s]
[INFO] Apache Helix :: Restful Interface .................. SUCCESS [  1.260 s]
[INFO] Apache Helix :: Distributed Lock ................... SUCCESS [  0.292 s]
[INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  0.260 s]
[INFO] Apache Helix :: Front End .......................... SUCCESS [  0.060 s]
[INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.035 s]
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  0.344 s]
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  0.299 s]
[INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  0.277 s]
[INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  0.288 s]
[INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  0.248 s]
[INFO] Apache Helix :: View Aggregator .................... SUCCESS [  0.304 s]
[INFO] Apache Helix :: Meta Client ........................ SUCCESS [  0.232 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12.373 s
[INFO] Finished at: 2024-01-16T13:52:48-08:00
[INFO] ------------------------------------------------------------------------

```

**mvn test -o -Dtest=TestClusterContext -pl=helix-core**

```

[INFO] Results:
[INFO] 
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/csudhars/Documents/GitHub/csudharsanan_helix/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 947 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```
**mvn test -o -Dtest=TestMaxCapacityUsageInstanceConstraint -pl=helix-core**   

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.534 s - in org.apache.helix.controller.rebalancer.waged.constraints.TestMaxCapacityUsageInstanceConstraint
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/csudhars/Documents/GitHub/csudharsanan_helix/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 947 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

 **mvn test -o -Dtest=TestTopStateMaxCapacityUsageInstanceConstraint -pl=helix-core**

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.218 s - in org.apache.helix.controller.rebalancer.waged.constraints.TestTopStateMaxCapacityUsageInstanceConstraint
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/csudhars/Documents/GitHub/csudharsanan_helix/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 947 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
