### PR TITLE
Instance Evacuation prevent baseline re-computation after dropped

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -344,7 +344,6 @@ public class BaseControllerDataProvider implements ControlContextProvider {
    * Refreshes the assignable instances and SWAP related caches. This should be called after
    * liveInstance and instanceConfig caches are refreshed. To determine what instances are
    * assignable and live, it takes a combination of both the all instanceConfigs and liveInstances.
-   * TODO: Add EVACUATE InstanceOperation to be filtered out in assignable nodes.
    *
    * @param instanceConfigMap InstanceConfig map from instanceConfig cache
    * @param liveInstancesMap  LiveInstance map from liveInstance cache
@@ -404,7 +403,9 @@ public class BaseControllerDataProvider implements ControlContextProvider {
           _assignableInstanceConfigMap.put(node, currentInstanceConfig);
           filteredInstancesByLogicalId.put(currentInstanceLogicalId, node);
         }
-      } else {
+      } else if (!currentInstanceConfig.getInstanceOperation()
+          .equals(InstanceConstants.InstanceOperation.EVACUATE.name())) {
+        // EVACUATE instances are not considered to be assignable.
         _assignableInstanceConfigMap.put(node, currentInstanceConfig);
         filteredInstancesByLogicalId.put(currentInstanceLogicalId, node);
       }

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -127,7 +127,9 @@ public class BaseControllerDataProvider implements ControlContextProvider {
   private final Set<String> _enabledLiveSwapInInstanceNames = new HashSet<>();
   private final Map<String, MonitoredAbnormalResolver> _abnormalStateResolverMap = new HashMap<>();
   private final Set<String> _timedOutInstanceDuringMaintenance = new HashSet<>();
-  private Map<String, LiveInstance> _liveInstanceExcludeTimedOutForMaintenance = new HashMap<>();
+  private Map<String, LiveInstance> _allLiveInstanceExcludeTimedOutForMaintenance = new HashMap<>();
+  private Map<String, LiveInstance> _assignableLiveInstanceExcludeTimedOutForMaintenance =
+      new HashMap<>();
 
   public BaseControllerDataProvider() {
     this(AbstractDataCache.UNKNOWN_CLUSTER, AbstractDataCache.UNKNOWN_PIPELINE);
@@ -469,7 +471,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     // If maintenance mode has exited, clear cached timed-out nodes
     if (!_isMaintenanceModeEnabled) {
       _timedOutInstanceDuringMaintenance.clear();
-      _liveInstanceExcludeTimedOutForMaintenance.clear();
+      _allLiveInstanceExcludeTimedOutForMaintenance.clear();
+      _assignableLiveInstanceExcludeTimedOutForMaintenance.clear();
     }
   }
 
@@ -481,21 +484,26 @@ public class BaseControllerDataProvider implements ControlContextProvider {
       timeOutWindow = clusterConfig.getOfflineNodeTimeOutForMaintenanceMode();
     }
     if (timeOutWindow >= 0 && isMaintenanceModeEnabled) {
-      for (String instance : _assignableLiveInstancesMap.keySet()) {
+      for (String instance : _allLiveInstanceCache.getPropertyMap().keySet()) {
         // 1. Check timed-out cache and don't do repeated work;
         // 2. Check for nodes that didn't exist in the last iteration, because it has been checked;
         // 3. For all other nodes, check if it's timed-out.
         // When maintenance mode is first entered, all nodes will be checked as a result.
         if (!_timedOutInstanceDuringMaintenance.contains(instance)
-            && !_liveInstanceExcludeTimedOutForMaintenance.containsKey(instance)
+            && !_allLiveInstanceExcludeTimedOutForMaintenance.containsKey(instance)
             && isInstanceTimedOutDuringMaintenance(accessor, instance, timeOutWindow)) {
           _timedOutInstanceDuringMaintenance.add(instance);
         }
       }
     }
     if (isMaintenanceModeEnabled) {
-      _liveInstanceExcludeTimedOutForMaintenance = _assignableLiveInstancesMap.entrySet().stream()
-          .filter(e -> !_timedOutInstanceDuringMaintenance.contains(e.getKey()))
+      _allLiveInstanceExcludeTimedOutForMaintenance =
+          _allLiveInstanceCache.getPropertyMap().entrySet().stream()
+              .filter(e -> !_timedOutInstanceDuringMaintenance.contains(e.getKey()))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      _assignableLiveInstanceExcludeTimedOutForMaintenance =
+          _assignableLiveInstancesMap.entrySet().stream()
+              .filter(e -> !_timedOutInstanceDuringMaintenance.contains(e.getKey()))
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
   }
@@ -646,7 +654,7 @@ public class BaseControllerDataProvider implements ControlContextProvider {
    */
   public Map<String, LiveInstance> getAssignableLiveInstances() {
     if (isMaintenanceModeEnabled()) {
-      return Collections.unmodifiableMap(_liveInstanceExcludeTimedOutForMaintenance);
+      return Collections.unmodifiableMap(_assignableLiveInstanceExcludeTimedOutForMaintenance);
     }
 
     return Collections.unmodifiableMap(_assignableLiveInstancesMap);
@@ -660,6 +668,10 @@ public class BaseControllerDataProvider implements ControlContextProvider {
    * @return A map of LiveInstances to their instance names
    */
   public Map<String, LiveInstance> getLiveInstances() {
+    if (isMaintenanceModeEnabled()) {
+      return Collections.unmodifiableMap(_allLiveInstanceExcludeTimedOutForMaintenance);
+    }
+
     return _allLiveInstanceCache.getPropertyMap();
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/AbstractRebalancer.java
@@ -104,7 +104,7 @@ public abstract class AbstractRebalancer<T extends BaseControllerDataProvider> i
       List<String> preferenceList = getPreferenceList(partition, idealState,
           Collections.unmodifiableSet(cache.getAssignableLiveInstances().keySet()));
       Map<String, String> bestStateForPartition =
-          computeBestPossibleStateForPartition(cache.getAssignableLiveInstances().keySet(),
+          computeBestPossibleStateForPartition(cache.getLiveInstances().keySet(),
               stateModelDef,
               preferenceList, currentStateOutput, disabledInstancesForPartition, idealState,
               cache.getClusterConfig(), partition,

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -401,7 +401,11 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
         bestPossibleStateMap, preferenceList, combinedPreferenceList)) {
       for (int i = 0; i < combinedPreferenceList.size() - numReplicas; i++) {
         String instanceToDrop = combinedPreferenceList.get(combinedPreferenceList.size() - i - 1);
-        bestPossibleStateMap.put(instanceToDrop, HelixDefinedState.DROPPED.name());
+        // We do not want to drop a SWAP_IN node if it is at the end of the preferenceList,
+        // because partitions are actively being added on this node to prepare for SWAP completion.
+        if (cache == null || !cache.getEnabledLiveSwapInInstanceNames().contains(instanceToDrop)) {
+          bestPossibleStateMap.put(instanceToDrop, HelixDefinedState.DROPPED.name());
+        }
       }
     }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
@@ -85,28 +85,28 @@ public class DelayedRebalanceUtil {
   }
 
   /**
-   * @return all active nodes (live nodes not marked as evacuate plus offline-yet-active nodes)
+   * @return all active nodes (live nodes plus offline-yet-active nodes)
    * while considering cluster delay rebalance configurations.
    */
   public static Set<String> getActiveNodes(Set<String> allNodes, Set<String> liveEnabledNodes,
       Map<String, Long> instanceOfflineTimeMap, Set<String> liveNodes,
       Map<String, InstanceConfig> instanceConfigMap, ClusterConfig clusterConfig) {
     if (!isDelayRebalanceEnabled(clusterConfig)) {
-      return filterOutEvacuatingInstances(instanceConfigMap, liveEnabledNodes);
+      return liveEnabledNodes;
     }
     return getActiveNodes(allNodes, liveEnabledNodes, instanceOfflineTimeMap, liveNodes,
         instanceConfigMap, clusterConfig.getRebalanceDelayTime(), clusterConfig);
   }
 
   /**
-   * @return all active nodes (live nodes not marked as evacuate plus offline-yet-active nodes)
+   * @return all active nodes (live nodes plus offline-yet-active nodes)
    * while considering cluster delay rebalance configurations.
    */
   public static Set<String> getActiveNodes(Set<String> allNodes, IdealState idealState,
       Set<String> liveEnabledNodes, Map<String, Long> instanceOfflineTimeMap, Set<String> liveNodes,
       Map<String, InstanceConfig> instanceConfigMap, long delay, ClusterConfig clusterConfig) {
     if (!isDelayRebalanceEnabled(idealState, clusterConfig)) {
-      return filterOutEvacuatingInstances(instanceConfigMap, liveEnabledNodes);
+      return liveEnabledNodes;
     }
     return getActiveNodes(allNodes, liveEnabledNodes, instanceOfflineTimeMap, liveNodes,
         instanceConfigMap, delay, clusterConfig);
@@ -128,17 +128,7 @@ public class DelayedRebalanceUtil {
         activeNodes.add(ins);
       }
     }
-    // TODO: change this after merging operation and helix-enable field.
-    return filterOutEvacuatingInstances(instanceConfigMap, activeNodes);
-  }
-
-  public static Set<String> filterOutEvacuatingInstances(Map<String, InstanceConfig> instanceConfigMap,
-      Set<String> nodes) {
-    return nodes.stream()
-        .filter(instance -> (instanceConfigMap.get(instance) != null && !instanceConfigMap.get(instance)
-            .getInstanceOperation()
-            .equals(InstanceConstants.InstanceOperation.EVACUATE.name())))
-        .collect(Collectors.toSet());
+    return activeNodes;
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -401,10 +401,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
       RebalanceAlgorithm algorithm) throws HelixRebalanceException {
 
     // the "real" live nodes at the time
-    // TODO: Move evacuation into BaseControllerDataProvider assignableNode logic.
-    final Set<String> enabledLiveInstances = DelayedRebalanceUtil.filterOutEvacuatingInstances(
-        clusterData.getAssignableInstanceConfigMap(),
-        clusterData.getAssignableEnabledLiveInstances());
+    final Set<String> enabledLiveInstances = clusterData.getAssignableEnabledLiveInstances();
 
     if (activeNodes.equals(enabledLiveInstances) || !requireRebalanceOverwrite(clusterData, currentResourceAssignment)) {
       // no need for additional process, return the current resource assignment
@@ -626,10 +623,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
       String resourceName = resourceAssignment.getResourceName();
       IdealState currentIdealState = clusterData.getIdealState(resourceName);
 
-      // TODO: Move evacuation into BaseControllerDataProvider assignableNode logic.
-      Set<String> enabledLiveInstances = DelayedRebalanceUtil.filterOutEvacuatingInstances(
-          clusterData.getAssignableInstanceConfigMap(),
-          clusterData.getAssignableEnabledLiveInstances());
+      Set<String> enabledLiveInstances = clusterData.getAssignableEnabledLiveInstances();
 
       int numReplica = currentIdealState.getReplicaCount(enabledLiveInstances.size());
       int minActiveReplica = DelayedRebalanceUtil.getMinActiveReplica(ResourceConfig

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -121,6 +121,8 @@ public class ZKHelixAdmin implements HelixAdmin {
   private static final int DEFAULT_SUPERCLUSTER_REPLICA = 3;
   private static final ImmutableSet<String> ALLOWED_INSTANCE_OPERATIONS_FOR_ADD_INSTANCE =
       ImmutableSet.of("", InstanceConstants.InstanceOperation.SWAP_IN.name());
+  private static final ImmutableSet<String> INSTANCE_OPERATION_TO_EXCLUDE_FROM_ASSIGNMENT =
+      ImmutableSet.of(InstanceConstants.InstanceOperation.EVACUATE.name());
 
   private final RealmAwareZkClient _zkClient;
   private final ConfigAccessor _configAccessor;
@@ -840,7 +842,7 @@ public class ZKHelixAdmin implements HelixAdmin {
   public boolean isReadyForPreparingJoiningCluster(String clusterName, String instanceName) {
     if (!instanceHasFullAutoCurrentStateOrMessage(clusterName, instanceName)) {
       InstanceConfig config = getInstanceConfig(clusterName, instanceName);
-      return config != null && DelayedAutoRebalancer.INSTANCE_OPERATION_TO_EXCLUDE_FROM_ASSIGNMENT.contains(
+      return config != null && INSTANCE_OPERATION_TO_EXCLUDE_FROM_ASSIGNMENT.contains(
           config.getInstanceOperation());
     }
     return false;

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -262,7 +262,17 @@ public class TestInstanceOperation extends ZkTestBase {
     // Drop semi-auto DBs
     _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, semiAutoDB);
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
-  }
+
+    // Disable, stop, and drop the instance from the cluster.
+    _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, instanceToEvacuate, false);
+    _participants.get(0).syncStop();
+    removeOfflineOrDisabledOrSwapInInstances();
+
+    // Compare the current ev with the previous one, it should be exactly the same since the baseline should not change
+    // after the instance is dropped.
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Assert.assertEquals(getEVs(), assignment);
+}
 
   @Test(dependsOnMethods = "testEvacuate")
   public void testRevertEvacuation() throws Exception {
@@ -1155,7 +1165,7 @@ public class TestInstanceOperation extends ZkTestBase {
       Assert.assertTrue(getParticipantsInEv(assignment.get(resource)).contains(instanceToEvacuate));
     }
 
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
 
     // exit MM
     _gSetupTool.getClusterManagementTool()


### PR DESCRIPTION
### Issues

- [x] Instance Evacuation is causing shuffling after dropping an evacuated node. This is a result of new baseline being computed.

### Description

We are now controlling the filtering of certain "Assignable" instances through the BaseControllerDataProvider. This will help centralize the logic and decouple it with the rebalancers. This PR migrates EVACUATE to this approach. Putting this logic here, allows methods like getAssignableInstanceConfigMap to respect the "Assignable" states. When the return value for this changes, a new baseline is computed. If it differs, which it will for evacuate, it will cause shuffling.

When the baseline is calculated, whether it is enabled, live, or set to EVACUATE is not respected. The assignment assumes the "happy path" where all of these instances are assignable or will be assignable. When and EVACUATE node is dropped, it will force a differing baseline to be calculated. This will cause shuffling after the evacuation is complete.

To fix this, setting and InstanceOperation to EVACUATE will ensure that it does not get returned in getAssignable*. This forces the baseline to be recomputed without considering the EVACUATE instance. When the instance is dropped, the arguments to baseline computation are the same as the previous computation and there is no change.

To maintain N -> N + 1 -> N behavior, we change the computeBestPossiblePartition state to pass all liveInstances so that the replicas on the EVACUATE instance can still be part of the stateMap until the new replica is created.

### Tests

- [x] Update testEvacuate to ensure no additional shuffling after the evacuated instance is dropped.


### Changes that Break Backward Compatibility (Optional)

- Removed some public methods; however, they were relatively new and would likely cause more confusion if they were left. If objections, I can deprecate them instead. Also, I don't think any were part of an open-source release.

### Documentation (Optional)

NA

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
