### PR TITLE
Allow partitionAssignment API in maintenance mode

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -44,6 +44,7 @@ import org.apache.helix.controller.rebalancer.Rebalancer;
 import org.apache.helix.controller.rebalancer.SemiAutoRebalancer;
 import org.apache.helix.controller.rebalancer.internal.MappingCalculator;
 import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
+import org.apache.helix.controller.rebalancer.waged.ReadOnlyWagedRebalancer;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ExternalView;
@@ -355,7 +356,8 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
       WagedRebalancer wagedRebalancer, ResourceControllerDataProvider cache,
       CurrentStateOutput currentStateOutput, Map<String, Resource> resourceMap,
       BestPossibleStateOutput output, List<String> failureResources) {
-    if (cache.isMaintenanceModeEnabled()) {
+    // Allow calculation for readOnlyWagedRebalancer as it is used by partitionAssignment API
+    if (cache.isMaintenanceModeEnabled() && !(wagedRebalancer instanceof ReadOnlyWagedRebalancer)) {
       // The WAGED rebalancer won't be used while maintenance mode is enabled.
       return Collections.emptyMap();
     }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
@@ -350,10 +350,10 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
     // If the cluster is in Maintenance mode, throw an exception
     // TODO: we should return the partitionAssignment regardless of the cluster is in Maintenance
     // mode or not
-    if (getHelixAdmin().isInMaintenanceMode(clusterId)) {
-      throw new UnsupportedOperationException(
-          "Can not query potential Assignment when cluster is in Maintenance mode.");
-    }
+    // if (getHelixAdmin().isInMaintenanceMode(clusterId)) {
+    //   throw new UnsupportedOperationException(
+    //       "Can not query potential Assignment when cluster is in Maintenance mode.");
+    // }
 
     // Use getTargetAssignmentForWagedFullAuto for Waged resources.
     ConfigAccessor cfgAccessor = getConfigAccessor();

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ResourceAssignmentOptimizerAccessor.java
@@ -347,14 +347,6 @@ public class ResourceAssignmentOptimizerAccessor extends AbstractHelixResource {
       InputFields inputFields, ClusterState clusterState, String clusterId,
       AssignmentResult result) {
 
-    // If the cluster is in Maintenance mode, throw an exception
-    // TODO: we should return the partitionAssignment regardless of the cluster is in Maintenance
-    // mode or not
-    // if (getHelixAdmin().isInMaintenanceMode(clusterId)) {
-    //   throw new UnsupportedOperationException(
-    //       "Can not query potential Assignment when cluster is in Maintenance mode.");
-    // }
-
     // Use getTargetAssignmentForWagedFullAuto for Waged resources.
     ConfigAccessor cfgAccessor = getConfigAccessor();
     List<ResourceConfig> wagedResourceConfigs = new ArrayList<>();

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPartitionAssignmentAPI.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPartitionAssignmentAPI.java
@@ -376,6 +376,7 @@ public class TestPartitionAssignmentAPI extends AbstractTestClass {
 
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
   }
+
   @Test
   private void testComputePartitionAssignmentMaintenanceMode() throws Exception {
 
@@ -447,7 +448,7 @@ public class TestPartitionAssignmentAPI extends AbstractTestClass {
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     // Assert that all resource idealStates calculated by the partitionAssignment API during MM
-      // is identical to the idealStates calculated by the controller after it exits MM
+    // is identical to the idealStates calculated by the controller after it exits MM.
     Assert.assertTrue(TestHelper.verify(() -> {
       try {
         Map<String, Map<String, Map<String, String>>> idealStatesMap = new HashMap<>();

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestResourceAssignmentOptimizerAccessor.java
@@ -329,13 +329,6 @@ public class TestResourceAssignmentOptimizerAccessor extends AbstractTestClass {
     post(urlBase, null, Entity.entity(payload5, MediaType.APPLICATION_JSON_TYPE),
         Response.Status.BAD_REQUEST.getStatusCode(), true);
 
-    // Currently we do not support maintenance mode
-    _gSetupTool.getClusterManagementTool()
-        .enableMaintenanceMode(cluster, true, TestHelper.getTestMethodName());
-    String payload6 = "{}";
-    post(urlBase, null, Entity.entity(payload6, MediaType.APPLICATION_JSON_TYPE),
-        Response.Status.BAD_REQUEST.getStatusCode(), true);
-
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 }


### PR DESCRIPTION
### Issues
Currently we do not return a partitionAssignment result if the cluster is in maintenance mode. 

Allowing this would enable customers to make a series of changes to their cluster while in maintenance and then query the partitionAssignment one single time to get the expected assignments, without each change to the cluster triggering a rebalance. 

### Description

Allow partitionAssignment API to calculate an assignment while the cluster is in maintenance mode. This also includes a minor change to WAGED rebalancer in BestPossibleCalcStage, as `computeResourceBestPossibleStateWithWagedRebalancer` currently returns an empty map if the cluster is in maintenance mode. 

### Tests

- [x] The following tests are written for this issue:

testComputePartitionAssignmentMaintenanceMode


### Changes that Break Backward Compatibility (Optional)

- [x] My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)