### PR TITLE
[apache/helix] -- Updated Maps.of to Sets.of for Java-8 build complaince

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -1033,7 +1033,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // Validate that the SWAP_IN instance has the same partitions the SWAP_OUT instance had before
     // swap was completed.
     verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Collections.emptySet(), Set.of(instanceToSwapInName))), TIMEOUT);
+        Collections.emptySet(), ImmutableSet.of(instanceToSwapInName))), TIMEOUT);
   }
 
   @Test(dependsOnMethods = "testNodeSwapWithSwapOutInstanceOffline")
@@ -1077,7 +1077,7 @@ public class TestInstanceOperation extends ZkTestBase {
 
     // Validate that the SWAP_IN instance has the same partitions the SWAP_OUT instance had.
     verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Collections.emptySet(), Set.of(instanceToSwapInName))), TIMEOUT);
+        Collections.emptySet(), ImmutableSet.of(instanceToSwapInName))), TIMEOUT);
 
     // Assert isEvacuateFinished is true
     Assert.assertTrue(_gSetupTool.getClusterManagementTool()
@@ -1091,7 +1091,7 @@ public class TestInstanceOperation extends ZkTestBase {
 
     // Validate that dropping the instance has not changed the assignment
     verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Collections.emptySet(), Set.of(instanceToSwapInName))), TIMEOUT);
+        Collections.emptySet(), ImmutableSet.of(instanceToSwapInName))), TIMEOUT);
   }
 
   @Test(expectedExceptions = HelixException.class, dependsOnMethods = "testNodeSwapWithSwapOutInstanceOffline")

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
@@ -558,7 +559,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // but none of them are in a top state.
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Set.of(instanceToSwapInName), Collections.emptySet());
+        ImmutableSet.of(instanceToSwapInName), Collections.emptySet());
 
     // Assert canSwapBeCompleted is true
     Assert.assertTrue(_gSetupTool.getClusterManagementTool()
@@ -585,7 +586,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // Validate that the SWAP_IN instance has the same partitions the SWAP_OUT instance had before
     // swap was completed.
     verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Collections.emptySet(), Set.of(instanceToSwapInName))), TIMEOUT);
+        Collections.emptySet(), ImmutableSet.of(instanceToSwapInName))), TIMEOUT);
   }
 
   @Test(dependsOnMethods = "testNodeSwap")
@@ -624,7 +625,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // but none of them are in a top state.
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Set.of(instanceToSwapInName), Collections.emptySet());
+        ImmutableSet.of(instanceToSwapInName), Collections.emptySet());
 
     // Assert canSwapBeCompleted is true
     Assert.assertTrue(_gSetupTool.getClusterManagementTool()
@@ -676,7 +677,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // Validate that the SWAP_IN instance has the same partitions the SWAP_OUT instance had before
     // swap was completed.
     verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Collections.emptySet(), Set.of(instanceToSwapInName))), TIMEOUT);
+        Collections.emptySet(), ImmutableSet.of(instanceToSwapInName))), TIMEOUT);
   }
 
   @Test(dependsOnMethods = "testNodeSwapDisableAndReenable")
@@ -723,7 +724,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // but none of them are in a top state.
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Set.of(instanceToSwapInName), Collections.emptySet());
+        ImmutableSet.of(instanceToSwapInName), Collections.emptySet());
 
     // Validate that the SWAP_OUT instance is in routing tables and SWAP_IN is not.
     validateRoutingTablesInstance(getEVs(), instanceToSwapOutName, true);
@@ -745,7 +746,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // Validate that the SWAP_IN instance has the same partitions the SWAP_OUT instance had before
     // swap was completed.
     verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Collections.emptySet(), Set.of(instanceToSwapInName))), TIMEOUT);
+        Collections.emptySet(), ImmutableSet.of(instanceToSwapInName))), TIMEOUT);
   }
 
   @Test(dependsOnMethods = "testNodeSwapSwapInNodeNoInstanceOperationDisabled")
@@ -786,7 +787,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // but none of them are in a top state.
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Set.of(instanceToSwapInName), Collections.emptySet());
+        ImmutableSet.of(instanceToSwapInName), Collections.emptySet());
 
     // Validate that the SWAP_OUT instance is in routing tables and SWAP_IN is not.
     validateRoutingTablesInstance(getEVs(), instanceToSwapOutName, true);
@@ -877,7 +878,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // but none of them are in a top state.
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Set.of(instanceToSwapInName), Collections.emptySet());
+        ImmutableSet.of(instanceToSwapInName), Collections.emptySet());
 
     // Validate that the SWAP_OUT instance is in routing tables and SWAP_IN is not.
     validateRoutingTablesInstance(getEVs(), instanceToSwapOutName, true);
@@ -902,7 +903,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // Validate that the SWAP_IN instance has the same partitions the SWAP_OUT instance had before
     // swap was completed.
     verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Collections.emptySet(), Set.of(instanceToSwapInName))), TIMEOUT);
+        Collections.emptySet(), ImmutableSet.of(instanceToSwapInName))), TIMEOUT);
   }
 
   @Test(dependsOnMethods = "testNodeSwapAfterEMM")
@@ -1095,7 +1096,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // but none of them are in a top state.
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Set.of(instanceToSwapInName), Collections.emptySet());
+        ImmutableSet.of(instanceToSwapInName), Collections.emptySet());
 
     // Validate that the SWAP_OUT instance is in routing tables and SWAP_IN is not.
     validateRoutingTablesInstance(getEVs(), instanceToSwapOutName, true);
@@ -1120,7 +1121,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // Validate that the SWAP_IN instance has the same partitions the SWAP_OUT instance had before
     // swap was completed.
     verifier(() -> (validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
-        Collections.emptySet(), Set.of(instanceToSwapInName))), TIMEOUT);
+        Collections.emptySet(), ImmutableSet.of(instanceToSwapInName))), TIMEOUT);
   }
 
   @Test(dependsOnMethods = "testNodeSwapAddSwapInFirst")
@@ -1364,7 +1365,7 @@ public class TestInstanceOperation extends ZkTestBase {
         .build(participantName);
 
     if (capacity >= 0) {
-      config.setInstanceCapacityMap(Map.of(TEST_CAPACITY_KEY, capacity));
+      config.setInstanceCapacityMap(ImmutableMap.of(TEST_CAPACITY_KEY, capacity));
     }
     _gSetupTool.getClusterManagementTool().addInstance(CLUSTER_NAME, config);
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -44,6 +44,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
@@ -437,10 +438,10 @@ public class PerInstanceAccessor extends AbstractHelixResource {
           break;
         case canCompleteSwap:
           return OK(OBJECT_MAPPER.writeValueAsString(
-              Map.of("successful", admin.canCompleteSwap(clusterId, instanceName))));
+              ImmutableMap.of("successful", admin.canCompleteSwap(clusterId, instanceName))));
         case completeSwapIfPossible:
           return OK(OBJECT_MAPPER.writeValueAsString(
-              Map.of("successful", admin.completeSwapIfPossible(clusterId, instanceName))));
+              ImmutableMap.of("successful", admin.completeSwapIfPossible(clusterId, instanceName))));
         case addInstanceTag:
           if (!validInstance(node, instanceName)) {
             return badRequest("Instance names are not match!");
@@ -486,7 +487,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
                 + "{}, instance: {}", clusterId, instanceName), e);
             return serverError(e);
           }
-          return OK(OBJECT_MAPPER.writeValueAsString(Map.of("successful", evacuateFinished)));
+          return OK(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of("successful", evacuateFinished)));
         default:
           LOG.error("Unsupported command :" + command);
           return badRequest("Unsupported command :" + command);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -442,7 +442,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
               ImmutableMap.of("successful", admin.canCompleteSwap(clusterId, instanceName))));
         case completeSwapIfPossible:
           return OK(OBJECT_MAPPER.writeValueAsString(
-              ImmutableMap.of("successful", admin.completeSwapIfPossible(clusterId, instanceName))));
+              ImmutableMap.of("successful", admin.completeSwapIfPossible(clusterId, instanceName, force))));
         case addInstanceTag:
           if (!validInstance(node, instanceName)) {
             return badRequest("Instance names are not match!");

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPartitionAssignmentAPI.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPartitionAssignmentAPI.java
@@ -32,6 +32,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableList;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.TestHelper;
@@ -88,7 +89,7 @@ public class TestPartitionAssignmentAPI extends AbstractTestClass {
     clusterConfig.setPersistBestPossibleAssignment(true);
     clusterConfig.setDefaultInstanceCapacityMap(
         Collections.singletonMap(INSTANCE_CAPACITY_KEY, DEFAULT_INSTANCE_CAPACITY));
-    clusterConfig.setInstanceCapacityKeys(List.of(INSTANCE_CAPACITY_KEY));
+    clusterConfig.setInstanceCapacityKeys(ImmutableList.of(INSTANCE_CAPACITY_KEY));
     _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
     _controller = startController(CLUSTER_NAME);
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Updated codebase to be build with JDK-8.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
We will releasing the Open source Helix on Java 11, but we are updating the codebase to be build compatible with Java-8, so that we can internally release it on Java-8.

### Tests

- [x] The following tests are written for this issue:
N/A

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Reactor Summary for Apache Helix 1.3.2-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  0.876 s]
[INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  1.524 s]
[INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [  0.647 s]
[INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [  2.410 s]
[INFO] Apache Helix :: Helix Common ....................... SUCCESS [  0.488 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [  8.677 s]
[INFO] Apache Helix :: Admin Webapp ....................... SUCCESS [  1.093 s]
[INFO] Apache Helix :: Restful Interface .................. SUCCESS [  2.057 s]
[INFO] Apache Helix :: Distributed Lock ................... SUCCESS [  0.378 s]
[INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  0.792 s]
[INFO] Apache Helix :: Front End .......................... SUCCESS [02:16 min]
[INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.017 s]
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  0.547 s]
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  0.512 s]
[INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  0.391 s]
[INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  0.426 s]
[INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  0.393 s]
[INFO] Apache Helix :: View Aggregator .................... SUCCESS [  0.983 s]
[INFO] Apache Helix :: Meta Client ........................ SUCCESS [  0.610 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:39 min
[INFO] Finished at: 2024-02-09T12:51:40-08:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
