### PR TITLE
Support Simple Greedy Rebalance Strategy

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/common/CapacityNode.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/common/CapacityNode.java
@@ -1,0 +1,91 @@
+package org.apache.helix.controller.common;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A Node is an entity that can serve capacity recording purpose. It has a capacity and knowledge
+ * of partitions assigned to it, so it can decide if it can receive additional partitions.
+ */
+public class CapacityNode {
+  private int _currentlyAssigned;
+  private int _capacity;
+  private final String _id;
+  private final Map<String, Set<String>> _partitionMap;
+
+  public CapacityNode(String id) {
+    _partitionMap = new HashMap<>();
+    _currentlyAssigned = 0;
+    this._id = id;
+  }
+
+  /**
+   * Check if this replica can be legally added to this node
+   *
+   * @param resource  The resource to assign
+   * @param partition The partition to assign
+   * @return true if the assignment can be made, false otherwise
+   */
+  public boolean canAdd(String resource, String partition) {
+    if (_currentlyAssigned >= _capacity || (_partitionMap.containsKey(resource)
+        && _partitionMap.get(resource).contains(partition))) {
+      return false;
+    }
+    _partitionMap.computeIfAbsent(resource, k -> new HashSet<>()).add(partition);
+    _currentlyAssigned++;
+    return true;
+  }
+
+  /**
+   * Set the capacity of this node
+   * @param capacity  The capacity to set
+   */
+  public void setCapacity(int capacity) {
+    _capacity = capacity;
+  }
+
+  /**
+   * Get the ID of this node
+   * @return The ID of this node
+   */
+  public String getId() {
+    return _id;
+  }
+
+  /**
+   * Get number of partitions currently assigned to this node
+   * @return The number of partitions currently assigned to this node
+   */
+  public int getCurrentlyAssigned() {
+    return _currentlyAssigned;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("##########\nname=").append(_id).append("\nassigned:").append(_currentlyAssigned)
+        .append("\ncapacity:").append(_capacity);
+    return sb.toString();
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/GreedyRebalanceStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/GreedyRebalanceStrategy.java
@@ -1,0 +1,100 @@
+package org.apache.helix.controller.rebalancer.strategy;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.helix.controller.common.CapacityNode;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GreedyRebalanceStrategy implements RebalanceStrategy<ResourceControllerDataProvider> {
+  private static Logger logger = LoggerFactory.getLogger(GreedyRebalanceStrategy.class);
+  private String _resourceName;
+  private List<String> _partitions;
+  private LinkedHashMap<String, Integer> _states;
+
+  public GreedyRebalanceStrategy() {
+  }
+
+  @Override
+  public void init(String resourceName, final List<String> partitions,
+      final LinkedHashMap<String, Integer> states, int maximumPerNode) {
+    _resourceName = resourceName;
+    _partitions = partitions;
+    _states = states;
+  }
+
+  @Override
+  public ZNRecord computePartitionAssignment(final List<String> allNodes, final List<String> liveNodes,
+      final Map<String, Map<String, String>> currentMapping, ResourceControllerDataProvider clusterData) {
+    int numReplicas = countStateReplicas();
+    ZNRecord znRecord = new ZNRecord(_resourceName);
+    if (liveNodes.size() == 0) {
+      return znRecord;
+    }
+
+    if (clusterData.getSimpleCapacitySet() == null) {
+      logger.warn("No capacity set for resource: " + _resourceName);
+      return znRecord;
+    }
+
+    List<CapacityNode> assignableNodes = new ArrayList<>(clusterData.getSimpleCapacitySet());
+    Collections.sort(assignableNodes, Comparator.comparing(CapacityNode::getId));
+
+    for (int i = 0, index = 0; i < _partitions.size(); i++) {
+      int startIndex = index;
+      List<String> preferenceList = new ArrayList<>();
+      for (int j = 0; j < numReplicas; j++) {
+        if (index - startIndex >= assignableNodes.size()) {
+          logger.warn("No enough assignable nodes for resource: " + _resourceName);
+          break;
+        }
+        while (index - startIndex < assignableNodes.size()) {
+          CapacityNode node = assignableNodes.get(index++ % assignableNodes.size());
+          if (node.canAdd(_resourceName, _partitions.get(i))) {
+            preferenceList.add(node.getId());
+            break;
+          }
+        }
+      }
+      znRecord.setListField(_partitions.get(i), preferenceList);
+    }
+
+    return znRecord;
+  }
+
+  private int countStateReplicas() {
+    int total = 0;
+    for (Integer count : _states.values()) {
+      total += count;
+    }
+    return total;
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -70,6 +70,10 @@ public class ClusterConfig extends HelixProperty {
 
     // The following concerns maintenance mode
     MAX_PARTITIONS_PER_INSTANCE,
+    // The maximum number of partitions that an instance can serve in this cluster.
+    // This only works for GreedyRebalanceStrategy.
+    // TODO: if we want to support this for other rebalancers, we need to implement that logic
+    GLOBAL_MAX_PARTITIONS_ALLOWED_PER_INSTANCE,
     // The following two include offline AND disabled instances
     MAX_OFFLINE_INSTANCES_ALLOWED,
     NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT, // For auto-exiting maintenance mode
@@ -509,6 +513,26 @@ public class ClusterConfig extends HelixProperty {
    */
   public int getMaxPartitionsPerInstance() {
     return _record.getIntField(ClusterConfigProperty.MAX_PARTITIONS_PER_INSTANCE.name(), -1);
+  }
+
+  /**
+   * Set the maximum number of partitions allowed to assign to an instance in this cluster.
+   *
+   * @param globalMaxPartitionAllowedPerInstance the maximum number of partitions allowed
+   */
+  public void setGlobalMaxPartitionAllowedPerInstance(int globalMaxPartitionAllowedPerInstance) {
+    _record.setIntField(ClusterConfigProperty.GLOBAL_MAX_PARTITIONS_ALLOWED_PER_INSTANCE.name(),
+        globalMaxPartitionAllowedPerInstance);
+  }
+
+  /**
+   * Get the maximum number of partitions allowed to assign to an instance in this cluster.
+   *
+   * @return the maximum number of partitions allowed, or Integer.MAX_VALUE
+   */
+  public int getGlobalMaxPartitionAllowedPerInstance() {
+    return _record.getIntField(
+        ClusterConfigProperty.GLOBAL_MAX_PARTITIONS_ALLOWED_PER_INSTANCE.name(), -1);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestGreedyRebalanceStrategy.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestGreedyRebalanceStrategy.java
@@ -1,0 +1,85 @@
+package org.apache.helix.controller.rebalancer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.helix.controller.common.CapacityNode;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.rebalancer.strategy.GreedyRebalanceStrategy;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+
+public class TestGreedyRebalanceStrategy {
+  private static final String TEST_CLUSTER_NAME = "TestCluster";
+  private static final String TEST_RESOURCE_PREFIX = "TestResource_";
+
+  @Test
+  public void testAssignmentWithGlobalPartitionLimit() {
+
+    ResourceControllerDataProvider clusterDataCache =
+        Mockito.mock(ResourceControllerDataProvider.class);
+    LinkedHashMap<String, Integer> states = new LinkedHashMap<String, Integer>(2);
+    states.put("OFFLINE", 0);
+    states.put("ONLINE", 1);
+
+    Set<CapacityNode> capacityNodeSet = new HashSet<>();
+    for (int i = 0; i < 5; i++) {
+      CapacityNode capacityNode = new CapacityNode("Node-" + i);
+      capacityNode.setCapacity(1);
+      capacityNodeSet.add(capacityNode);
+    }
+
+    List<String> liveNodes =
+        capacityNodeSet.stream().map(CapacityNode::getId).collect(Collectors.toList());
+
+    List<String> partitions = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      partitions.add(TEST_RESOURCE_PREFIX + "0_" + i);
+    }
+    when(clusterDataCache.getSimpleCapacitySet()).thenReturn(capacityNodeSet);
+
+    GreedyRebalanceStrategy greedyRebalanceStrategy = new GreedyRebalanceStrategy();
+    greedyRebalanceStrategy.init(TEST_RESOURCE_PREFIX + 0, partitions, states, 1);
+    greedyRebalanceStrategy.computePartitionAssignment(null, liveNodes, null, clusterDataCache);
+
+    partitions = new ArrayList<>();
+    for (int i = 0; i < 2; i++) {
+      partitions.add(TEST_RESOURCE_PREFIX + "1_" + i);
+    }
+    greedyRebalanceStrategy = new GreedyRebalanceStrategy();
+    greedyRebalanceStrategy.init(TEST_RESOURCE_PREFIX + 1, partitions, states, 1);
+    greedyRebalanceStrategy.computePartitionAssignment(null, liveNodes, null, clusterDataCache);
+
+    Assert.assertEquals(
+        capacityNodeSet.stream().filter(node -> node.getCurrentlyAssigned() != 1).count(), 0);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestGreedyRebalanceWithGlobalPerInstancePartitionLimit.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestGreedyRebalanceWithGlobalPerInstancePartitionLimit.java
@@ -1,0 +1,82 @@
+package org.apache.helix.integration.rebalancer;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.integration.task.WorkflowGenerator;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestGreedyRebalanceWithGlobalPerInstancePartitionLimit extends TaskTestBase {
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _numNodes = 10;
+    _numReplicas = 2;
+    _numDbs = 1;
+    _numPartitions = 4;
+    super.beforeClass();
+  }
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    /*
+     * shutdown order: 1) disconnect the controller 2) disconnect participants
+     */
+    _controller.syncStop();
+    for (MockParticipantManager participant : _participants) {
+      participant.syncStop();
+    }
+    deleteCluster(CLUSTER_NAME);
+    System.out.println("END " + CLUSTER_NAME + " at " + new Date(System.currentTimeMillis()));
+  }
+
+  @Test
+  public void testGreedyRebalanceWithGlobalPerInstancePartitionLimit() throws InterruptedException {
+    // Update cluster config and greedy rebalance strategy
+    ClusterConfig clusterConfig = _manager.getConfigAccessor().getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setGlobalMaxPartitionAllowedPerInstance(1);
+    _manager.getConfigAccessor().setClusterConfig(CLUSTER_NAME, clusterConfig);
+    IdealState idealState = _gSetupTool.getClusterManagementTool()
+        .getResourceIdealState(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB);
+    idealState.setRebalanceStrategy(
+        "org.apache.helix.controller.rebalancer.strategy.GreedyRebalanceStrategy");
+    _gSetupTool.getClusterManagementTool()
+        .setResourceIdealState(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB, idealState);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    _gSetupTool.getClusterManagementTool().addResource(CLUSTER_NAME, "NewDB", 2, "OnlineOffline",
+        IdealState.RebalanceMode.FULL_AUTO.name(),
+        "org.apache.helix.controller.rebalancer.strategy.GreedyRebalanceStrategy");
+    _gSetupTool.getClusterManagementTool().rebalance(CLUSTER_NAME, "NewDB", 1);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Process instance -> number of assigned partitions
+    ExternalView TGTDBView = _gSetupTool.getClusterManagementTool()
+        .getResourceExternalView(CLUSTER_NAME, WorkflowGenerator.DEFAULT_TGT_DB);
+    ExternalView newDBView =
+        _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, "NewDB");
+    Map<String, Integer> instancePartitionCountMap = new HashMap<>();
+    TGTDBView.getPartitionSet().stream()
+        .forEach(partition -> TGTDBView.getStateMap(partition).keySet().forEach(instance -> {
+          instancePartitionCountMap.put(instance,
+              instancePartitionCountMap.getOrDefault(instance, 0) + 1);
+        }));
+    newDBView.getPartitionSet().stream()
+        .forEach(partition -> newDBView.getStateMap(partition).keySet().forEach(instance -> {
+          instancePartitionCountMap.put(instance,
+              instancePartitionCountMap.getOrDefault(instance, 0) + 1);
+        }));
+
+    Assert.assertEquals(
+        instancePartitionCountMap.values().stream().filter(count -> count != 1).count(), 0);
+  }
+}


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

resolves #2757 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Support Simple Greedy Rebalance Strategy for RoundRobin assignment. It also supported with global limitation on how many partition assigned for each of the instance.

It also contains:
1. Unit test for GreedyRebalanceStrategy
2. Integration test across resources for limitation of partition

### Tests

- [x] The following tests are written for this issue:

Unit: TestGreedyRebalanceStrategy
Integration: TestGreedyRebalanceWithGlobalPerInstancePartitionLimit

- The following is the result of the "mvn test" command on the appropriate module:

[WARNING] Tests run: 1411, Failures: 0, Errors: 0, Skipped: 5, Time elapsed: 7,210.927 s - in TestSuite
[INFO] Total time:  02:00 h
[INFO] Finished at: 2024-02-13T00:15:59-08:00

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

1. Default ClusterConfig entry
2. No refresh / cache if entry not set in ClusterConfig.
3. Separate RebalanceStrategy

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
