### PR TITLE
Delete expected version

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
@@ -99,11 +99,6 @@ public interface BaseDataAccessor<T> {
    */
   boolean remove(String path, int options);
 
-  // TODO: gspencer implement
-  // ZKBaseDataAccessor
-  // ZKCacheBaseDataAccessor
-  // MockBaseDataAccessor
-  // AutoFallbackProperty store
   boolean remove(String path, int expectedVersion, int options);
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
@@ -108,7 +108,7 @@ public interface BaseDataAccessor<T> {
    * version
    * @return true if the removal succeeded, false otherwise
    */
-  boolean remove(String path, int options, int expectedVersion);
+  boolean removeWithExpectedVersion(String path, int options, int expectedVersion);
 
   /**
    * Use it when creating children under a parent node. This will use async api for better

--- a/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
@@ -99,6 +99,13 @@ public interface BaseDataAccessor<T> {
    */
   boolean remove(String path, int options);
 
+  // TODO: gspencer implement
+  // ZKBaseDataAccessor
+  // ZKCacheBaseDataAccessor
+  // MockBaseDataAccessor
+  // AutoFallbackProperty store
+  boolean remove(String path, int expectedVersion, int options);
+
   /**
    * Use it when creating children under a parent node. This will use async api for better
    * performance. If the child already exists it will return false.

--- a/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
@@ -99,7 +99,16 @@ public interface BaseDataAccessor<T> {
    */
   boolean remove(String path, int options);
 
-  boolean remove(String path, int expectedVersion, int options);
+  /**
+   * This will remove the ZNode and all its descendants if any, if the ZNode's version matches
+   * the provided expectedVersion.
+   * @param path Path to the ZNode to update
+   * @param options Set the type of ZNode see the valid values in {@link AccessOption}
+   * @param expectedVersion the expected version of the node to be removed, -1 means match any
+   * version
+   * @return true if the removal succeeded, false otherwise
+   */
+  boolean remove(String path, int options, int expectedVersion);
 
   /**
    * Use it when creating children under a parent node. This will use async api for better

--- a/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
@@ -100,8 +100,8 @@ public interface BaseDataAccessor<T> {
   boolean remove(String path, int options);
 
   /**
-   * This will remove the ZNode and all its descendants if any, if the ZNode's version matches
-   * the provided expectedVersion.
+   * This will remove the ZNode, if the ZNode's version matches the provided expectedVersion. This
+   * operation will fail if the node has any children.
    * @param path Path to the ZNode to update
    * @param options Set the type of ZNode see the valid values in {@link AccessOption}
    * @param expectedVersion the expected version of the node to be removed, -1 means match any

--- a/helix-core/src/main/java/org/apache/helix/HelixDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixDataAccessor.java
@@ -112,7 +112,6 @@ public interface HelixDataAccessor {
    * @return true if removal was successful or node does not exist. false if the
    *         node existed and failed to remove it
    */
-  // TODO: gspencer -- add expectedVersion here too?
   boolean removeProperty(PropertyKey key);
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/HelixDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixDataAccessor.java
@@ -112,6 +112,7 @@ public interface HelixDataAccessor {
    * @return true if removal was successful or node does not exist. false if the
    *         node existed and failed to remove it
    */
+  // TODO: gspencer -- add expectedVersion here too?
   boolean removeProperty(PropertyKey key);
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -730,6 +730,13 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
       // despite real error, operation will throw exception when path not empty, and in this
       // case, we try to delete recursively
       _zkClient.delete(path, expectedVersion);
+    } catch (ZkBadVersionException e) {
+      LOG.error("Failed to delete {} recursively, znode version mismatch!", path, e);
+      return false;
+      // TODO: gspencer - can we do this? Or will this still allow for race condition where znode
+      // updated after this fails due another exception, then we call deleteRecursively, ignoring
+      // znode version but then the node has already been updated and so we don't respect version?
+      // Do we need to create a deleteRecursively that takes expected version for the intial parent node?
     } catch (ZkException e) {
       LOG.debug("Failed to delete {} with opts {}, err: {}. Try recursive delete", path, options,
           e.getMessage());

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -727,6 +727,9 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
    * Sync remove with expected version. It tries to remove the ZNode if the ZNode's version matches
    * the provided expectedVersion and all its descendants if any. Node does not exist is regarded as
    * success. If expectedVersion is set to -1, then the ZNode version match is not enforced.
+   * This method calls delete and checks the expected version, if the expectedVersion check passes
+   * but the delete call fails due to the node having children, it will call deleteRecursively,
+   * which does not enforce an expectedVersion check.
    */
   @Override
   public boolean remove(String path, int options, int expectedVersion) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -720,11 +720,16 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
    */
   @Override
   public boolean remove(String path, int options) {
+    return remove(path, -1, options);
+  }
+
+  @Override
+  public boolean remove(String path, int expectedVersion, int options) {
     try {
       // operation will not throw exception when path successfully deleted or does not exist
       // despite real error, operation will throw exception when path not empty, and in this
       // case, we try to delete recursively
-      _zkClient.delete(path);
+      _zkClient.delete(path, expectedVersion);
     } catch (ZkException e) {
       LOG.debug("Failed to delete {} with opts {}, err: {}. Try recursive delete", path, options,
           e.getMessage());

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -745,7 +745,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
    * match is not enforced.
    */
   @Override
-  public boolean remove(String path, int options, int expectedVersion) {
+  public boolean removeWithExpectedVersion(String path, int options, int expectedVersion) {
     try {
       // operation will not throw exception when path successfully deleted or does not exist
       // despite real error, operation will throw exception when path not empty, and in this

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -720,27 +720,11 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
    */
   @Override
   public boolean remove(String path, int options) {
-    return remove(path, options, -1);
-  }
-
-  /**
-   * Sync remove with expected version. It tries to remove the ZNode if the ZNode's version matches
-   * the provided expectedVersion and all its descendants if any. Node does not exist is regarded as
-   * success. If expectedVersion is set to -1, then the ZNode version match is not enforced.
-   * This method calls delete and checks the expected version, if the expectedVersion check passes
-   * but the delete call fails due to the node having children, it will call deleteRecursively,
-   * which does not enforce an expectedVersion check.
-   */
-  @Override
-  public boolean remove(String path, int options, int expectedVersion) {
     try {
       // operation will not throw exception when path successfully deleted or does not exist
       // despite real error, operation will throw exception when path not empty, and in this
       // case, we try to delete recursively
-      _zkClient.delete(path, expectedVersion);
-    } catch (ZkBadVersionException e) {
-      LOG.error("Failed to delete {} recursively, znode version mismatch!", path, e);
-      return false;
+      _zkClient.delete(path);
     } catch (ZkException e) {
       LOG.debug("Failed to delete {} with opts {}, err: {}. Try recursive delete", path, options,
           e.getMessage());
@@ -750,6 +734,27 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
         LOG.error("Failed to delete {} recursively with opts {}.", path, options, zce);
         return false;
       }
+    }
+    return true;
+  }
+
+  /**
+   * Sync remove with expected version. It tries to remove the ZNode if the ZNode's version matches
+   * the provided expectedVersion. This operation will FAIL if the node has any children. Node does
+   * not exist is regarded as success. If expectedVersion is set to -1, then the ZNode version
+   * match is not enforced.
+   */
+  @Override
+  public boolean remove(String path, int options, int expectedVersion) {
+    try {
+      // operation will not throw exception when path successfully deleted or does not exist
+      // despite real error, operation will throw exception when path not empty, and in this
+      // case, we do NOT try to delete recursively
+      _zkClient.delete(path, expectedVersion);
+    } catch (ZkException zkException) {
+      LOG.error("Failed to delete {} with opts {} and expected version {}.", path, options,
+          expectedVersion, zkException);
+      return false;
     }
     return true;
   }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -333,11 +333,11 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
 
   @Override
   public boolean remove(String path, int options) {
-    return remove(path, -1, options);
+    return remove(path, options, -1);
   }
 
   @Override
-  public boolean remove(String path, int expectedVersion, int options) {
+  public boolean remove(String path, int options, int expectedVersion) {
     String clientPath = path;
     String serverPath = prependChroot(clientPath);
 
@@ -346,7 +346,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       try {
         cache.lockWrite();
 
-        boolean success = _baseAccessor.remove(serverPath, expectedVersion, options);
+        boolean success = _baseAccessor.remove(serverPath, options, expectedVersion);
         if (success) {
           cache.purgeRecursive(serverPath);
         }
@@ -358,7 +358,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
     }
 
     // no cache
-    return _baseAccessor.remove(serverPath, expectedVersion, options);
+    return _baseAccessor.remove(serverPath, options, expectedVersion);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -333,6 +333,11 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
 
   @Override
   public boolean remove(String path, int options) {
+    return remove(path, -1, options);
+  }
+
+  @Override
+  public boolean remove(String path, int expectedVersion, int options) {
     String clientPath = path;
     String serverPath = prependChroot(clientPath);
 
@@ -341,7 +346,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       try {
         cache.lockWrite();
 
-        boolean success = _baseAccessor.remove(serverPath, options);
+        boolean success = _baseAccessor.remove(serverPath, expectedVersion, options);
         if (success) {
           cache.purgeRecursive(serverPath);
         }
@@ -353,7 +358,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
     }
 
     // no cache
-    return _baseAccessor.remove(serverPath, options);
+    return _baseAccessor.remove(serverPath, expectedVersion, options);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCacheBaseDataAccessor.java
@@ -357,7 +357,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
   }
 
   @Override
-  public boolean remove(String path, int options, int expectedVersion) {
+  public boolean removeWithExpectedVersion(String path, int options, int expectedVersion) {
     String clientPath = path;
     String serverPath = prependChroot(clientPath);
 
@@ -366,7 +366,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
       try {
         cache.lockWrite();
 
-        boolean success = _baseAccessor.remove(serverPath, options, expectedVersion);
+        boolean success = _baseAccessor.removeWithExpectedVersion(serverPath, options, expectedVersion);
         if (success) {
           cache.purgeRecursive(serverPath);
         }
@@ -378,7 +378,7 @@ public class ZkCacheBaseDataAccessor<T> implements HelixPropertyStore<T> {
     }
 
     // no cache
-    return _baseAccessor.remove(serverPath, options, expectedVersion);
+    return _baseAccessor.removeWithExpectedVersion(serverPath, options, expectedVersion);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/store/zk/AutoFallbackPropertyStore.java
+++ b/helix-core/src/main/java/org/apache/helix/store/zk/AutoFallbackPropertyStore.java
@@ -89,15 +89,15 @@ public class AutoFallbackPropertyStore<T> extends ZkHelixPropertyStore<T> {
 
   @Override
   public boolean remove(String path, int options) {
-    return remove(path, -1, options);
+    return remove(path, options, -1);
   }
 
   @Override
-  public boolean remove(String path, int expectedVersion, int options) {
+  public boolean remove(String path, int options, int expectedVersion) {
     if (_fallbackStore != null) {
-      _fallbackStore.remove(path, expectedVersion, options);
+      _fallbackStore.remove(path, options, expectedVersion);
     }
-    return super.remove(path, expectedVersion, options);
+    return super.remove(path, options, expectedVersion);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/store/zk/AutoFallbackPropertyStore.java
+++ b/helix-core/src/main/java/org/apache/helix/store/zk/AutoFallbackPropertyStore.java
@@ -89,10 +89,15 @@ public class AutoFallbackPropertyStore<T> extends ZkHelixPropertyStore<T> {
 
   @Override
   public boolean remove(String path, int options) {
+    return remove(path, -1, options);
+  }
+
+  @Override
+  public boolean remove(String path, int expectedVersion, int options) {
     if (_fallbackStore != null) {
-      _fallbackStore.remove(path, options);
+      _fallbackStore.remove(path, expectedVersion, options);
     }
-    return super.remove(path, options);
+    return super.remove(path, expectedVersion, options);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/store/zk/AutoFallbackPropertyStore.java
+++ b/helix-core/src/main/java/org/apache/helix/store/zk/AutoFallbackPropertyStore.java
@@ -89,7 +89,10 @@ public class AutoFallbackPropertyStore<T> extends ZkHelixPropertyStore<T> {
 
   @Override
   public boolean remove(String path, int options) {
-    return remove(path, options, -1);
+    if (_fallbackStore != null) {
+      _fallbackStore.remove(path, options);
+    }
+    return super.remove(path, options);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/store/zk/AutoFallbackPropertyStore.java
+++ b/helix-core/src/main/java/org/apache/helix/store/zk/AutoFallbackPropertyStore.java
@@ -96,11 +96,11 @@ public class AutoFallbackPropertyStore<T> extends ZkHelixPropertyStore<T> {
   }
 
   @Override
-  public boolean remove(String path, int options, int expectedVersion) {
+  public boolean removeWithExpectedVersion(String path, int options, int expectedVersion) {
     if (_fallbackStore != null) {
-      _fallbackStore.remove(path, options, expectedVersion);
+      _fallbackStore.removeWithExpectedVersion(path, options, expectedVersion);
     }
-    return super.remove(path, options, expectedVersion);
+    return super.removeWithExpectedVersion(path, options, expectedVersion);
   }
 
   @Override

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -483,12 +483,16 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     boolean success = accessor.create(path, record, AccessOption.PERSISTENT);
     Assert.assertTrue(success);
 
-    // Delete with wrong expected version. Should fail
+    // Create child node
+    success = accessor.create(path + "/child", record, AccessOption.PERSISTENT);
+    Assert.assertTrue(success);
+
+    // Delete parent with wrong expected version. Should fail
     int currentVersion = accessor.getStat(path, 0).getVersion();
     success = accessor.remove(path, 0, currentVersion+100);
     Assert.assertFalse(success);
 
-    // Delete with correct expected version. Should succeed
+    // Delete parent with correct expected version. Should succeed
     success = accessor.remove(path, 0, currentVersion);
     Assert.assertTrue(success);
   }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -488,16 +488,16 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
 
     // Delete parent with correct expected version. Should fail due to having a child
     int currentVersion = accessor.getStat(path, 0).getVersion();
-    Assert.assertFalse(accessor.remove(path, 0, currentVersion));
+    Assert.assertFalse(accessor.removeWithExpectedVersion(path, 0, currentVersion));
 
     // Remove Child
-    Assert.assertTrue(accessor.remove(childPath, 0, -1));
+    Assert.assertTrue(accessor.removeWithExpectedVersion(childPath, 0, -1));
 
     // Delete childless node with wrong expected version. Should fail due to version mismatch
-    Assert.assertFalse(accessor.remove(path, 0, currentVersion+100));
+    Assert.assertFalse(accessor.removeWithExpectedVersion(path, 0, currentVersion+100));
 
     // Delete childless node with correct expected version. Shoudl succeed
-    Assert.assertTrue(accessor.remove(path, 0, currentVersion));
+    Assert.assertTrue(accessor.removeWithExpectedVersion(path, 0, currentVersion));
 
   }
 

--- a/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
@@ -102,6 +102,18 @@ public class MockBaseDataAccessor implements BaseDataAccessor<ZNRecord> {
 
   @Override
   public boolean remove(String path, int options) {
+    return remove(path, -1, options);
+  }
+
+  @Override
+  public boolean remove(String path, int expectedVersion, int options) {
+    if (expectedVersion != -1) {
+      ZNode node = _recordMap.get(path);
+      if (node != null && node.getStat().getVersion() != expectedVersion) {
+        return false;
+      }
+    }
+
     _recordMap.remove(path);
     try {
       Thread.sleep(50);

--- a/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
@@ -102,11 +102,11 @@ public class MockBaseDataAccessor implements BaseDataAccessor<ZNRecord> {
 
   @Override
   public boolean remove(String path, int options) {
-    return remove(path, -1, options);
+    return remove(path, options, -1);
   }
 
   @Override
-  public boolean remove(String path, int expectedVersion, int options) {
+  public boolean remove(String path, int options, int expectedVersion) {
     if (expectedVersion != -1) {
       ZNode node = _recordMap.get(path);
       if (node != null && node.getStat().getVersion() != expectedVersion) {

--- a/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
@@ -102,7 +102,13 @@ public class MockBaseDataAccessor implements BaseDataAccessor<ZNRecord> {
 
   @Override
   public boolean remove(String path, int options) {
-    return remove(path, options, -1);
+    _recordMap.remove(path);
+    try {
+      Thread.sleep(50);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    return true;
   }
 
   @Override

--- a/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockBaseDataAccessor.java
@@ -112,7 +112,7 @@ public class MockBaseDataAccessor implements BaseDataAccessor<ZNRecord> {
   }
 
   @Override
-  public boolean remove(String path, int options, int expectedVersion) {
+  public boolean removeWithExpectedVersion(String path, int options, int expectedVersion) {
     if (expectedVersion != -1) {
       ZNode node = _recordMap.get(path);
       if (node != null && node.getStat().getVersion() != expectedVersion) {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -254,6 +254,13 @@ public interface RealmAwareZkClient {
 
   boolean delete(final String path);
 
+  // TODO: gspencer add to:
+  // ZKClient -- done
+  // DedicatedZKClient -- done
+  // SharedZKClient -- done
+  // FederatedZKClient
+  boolean delete(final String path, final int expectedVersion);
+
   <T extends Object> T readData(String path);
 
   <T extends Object> T readData(String path, boolean returnNullIfPathNotExists);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -254,11 +254,6 @@ public interface RealmAwareZkClient {
 
   boolean delete(final String path);
 
-  // TODO: gspencer add to:
-  // ZKClient -- done
-  // DedicatedZKClient -- done
-  // SharedZKClient -- done
-  // FederatedZKClient
   boolean delete(final String path, final int expectedVersion);
 
   <T extends Object> T readData(String path);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -391,7 +391,7 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   @Override
   public boolean delete(String path, int expectedVersion) {
     checkIfPathContainsShardingKey(path);
-    return _rawZkClient.delete(path);
+    return _rawZkClient.delete(path, expectedVersion);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -385,6 +385,11 @@ public class DedicatedZkClient implements RealmAwareZkClient {
 
   @Override
   public boolean delete(String path) {
+    return delete(path, -1);
+  }
+
+  @Override
+  public boolean delete(String path, int expectedVersion) {
     checkIfPathContainsShardingKey(path);
     return _rawZkClient.delete(path);
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -372,7 +372,12 @@ public class FederatedZkClient implements RealmAwareZkClient {
 
   @Override
   public boolean delete(String path) {
-    return getZkClient(path).delete(path);
+    return delete(path, -1);
+  }
+
+  @Override
+  public boolean delete(String path, int expectedVersion) {
+    return getZkClient(path).delete(path, expectedVersion);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -414,8 +414,13 @@ public class SharedZkClient implements RealmAwareZkClient {
 
   @Override
   public boolean delete(String path) {
+    return delete(path, -1);
+  }
+
+  @Override
+  public boolean delete(String path, int expectedVersion) {
     checkIfPathContainsShardingKey(path);
-    return _innerSharedZkClient.delete(path);
+    return _innerSharedZkClient.delete(path, expectedVersion);
   }
 
   @Override

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkConnection.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkConnection.java
@@ -44,6 +44,7 @@ public interface IZkConnection {
     public String create(String path, byte[] data, List<ACL> acl, CreateMode mode, long ttl) throws KeeperException, InterruptedException;
 
     public void delete(String path) throws InterruptedException, KeeperException;
+    public void delete (String path, int expectedVersion) throws InterruptedException, KeeperException;
 
     boolean exists(final String path, final boolean watch) throws KeeperException, InterruptedException;
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkConnection.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/IZkConnection.java
@@ -44,6 +44,7 @@ public interface IZkConnection {
     public String create(String path, byte[] data, List<ACL> acl, CreateMode mode, long ttl) throws KeeperException, InterruptedException;
 
     public void delete(String path) throws InterruptedException, KeeperException;
+
     public void delete (String path, int expectedVersion) throws InterruptedException, KeeperException;
 
     boolean exists(final String path, final boolean watch) throws KeeperException, InterruptedException;

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -2161,6 +2161,14 @@ public class ZkClient implements Watcher {
     return delete(path, -1);
   }
 
+  /**
+   * Delete the given path. Path should not have any children or the deletion will fail.
+   * This function will throw an exception if we fail to delete an existing path.
+   * @param path Path of the znode to delete
+   * @param expectedVersion The expected version of the node to be removed, -1 means match any
+   * version. ZK
+   * @return true if the path is successfully deleted, false if path does not exist
+   */
   public boolean delete(final String path, final int expectedVersion) {
     long startT = System.currentTimeMillis();
     boolean success;
@@ -2178,9 +2186,6 @@ public class ZkClient implements Watcher {
       } catch (ZkNoNodeException e) {
         success = false;
         LOG.debug("zkclient {}, Failed to delete path {}, znode does not exist!", _uid, path, e);
-      } catch (ZkBadVersionException e) {
-        success = false;
-        LOG.debug("zkclient {}, Failed to delete path {}, znode version mismatch!", _uid, path, e);
       }
       record(path, null, startT, ZkClientMonitor.AccessType.WRITE);
     } catch (Exception e) {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -2158,6 +2158,10 @@ public class ZkClient implements Watcher {
    * @return true if path is successfully deleted, false if path does not exist
    */
   public boolean delete(final String path) {
+    return delete(path, -1);
+  }
+
+  public boolean delete(final String path, final int expectedVersion) {
     long startT = System.currentTimeMillis();
     boolean success;
     try {
@@ -2166,7 +2170,7 @@ public class ZkClient implements Watcher {
 
           @Override
           public Object call() throws Exception {
-            getConnection().delete(path);
+            getConnection().delete(path, expectedVersion);
             return null;
           }
         });
@@ -2174,6 +2178,9 @@ public class ZkClient implements Watcher {
       } catch (ZkNoNodeException e) {
         success = false;
         LOG.debug("zkclient {}, Failed to delete path {}, znode does not exist!", _uid, path, e);
+      } catch (ZkBadVersionException e) {
+        success = false;
+        LOG.debug("zkclient {}, Failed to delete path {}, znode version mismatch!", _uid, path, e);
       }
       record(path, null, startT, ZkClientMonitor.AccessType.WRITE);
     } catch (Exception e) {

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkConnection.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkConnection.java
@@ -146,6 +146,11 @@ public class ZkConnection implements IZkConnection {
   }
 
   @Override
+  public void delete(String path, int expectedVersion) throws InterruptedException, KeeperException {
+    _zk.delete(path, expectedVersion);
+  }
+
+  @Override
   public boolean exists(String path, boolean watch) throws KeeperException, InterruptedException {
     return _zk.exists(path, watch) != null;
   }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

N/A

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
ZooKeeper allows for calling delete with an expected version, where the znode will only be deleted if the version in the znode's stat matches the passed version number. 

This PR adds APIs to the ZKClients to call delete with expected version
Also adds to the baseDataAccessors the API for remove with expected version. 

### Tests

- [x] The following tests are written for this issue:
```
TestZKBaseDataAccessor.java
- testRemoveWithExpectedVersion

RealmAwareZkClientFactoryTestBase.java
- testDeleteExpectedVersion


TestFederatedZkClient.java
- testDeleteExpectedVersion
```

- [x] The following is the result of the "mvn test" command on the appropriate module:
CI run against my fork passed
https://github.com/GrantPSpencer/helix/actions/runs/7909844995/job/21591541741?pr=5

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

N/A. The original delete and remove methods just call the new method and pass in -1 as the expected version (meaning no version match is forced) 

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
