### PR TITLE
Top state evenness

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestTopStateMaxCapacityUsageInstanceConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestTopStateMaxCapacityUsageInstanceConstraint.java
@@ -51,6 +51,9 @@ public class TestTopStateMaxCapacityUsageInstanceConstraint {
 
   @Test
   public void testGetNormalizedScore() {
+    // Node and Replica capacities are defined
+    when(_testNode.getMaxCapacity()).thenReturn(Collections.singletonMap("foo", 1));
+    when(_testReplica.getCapacity()).thenReturn(Collections.singletonMap("foo", 1));
     when(_testReplica.isReplicaTopState()).thenReturn(true);
     when(_testNode.getTopStateProjectedHighestUtilization(anyMap(), any())).thenReturn(0.8f);
     when(_clusterContext.getEstimatedTopStateMaxUtilization()).thenReturn(1f);
@@ -62,9 +65,11 @@ public class TestTopStateMaxCapacityUsageInstanceConstraint {
     Assert.assertTrue(normalizedScore > 0.99);
   }
 
-
   @Test
   public void testGetNormalizedScoreWithPreferredScoringKey() {
+    // Node and Replica capacities are defined
+    when(_testNode.getMaxCapacity()).thenReturn(Collections.singletonMap("foo", 1));
+    when(_testReplica.getCapacity()).thenReturn(Collections.singletonMap("foo", 1));
     List<String> preferredScoringKeys = Collections.singletonList("CU");
     when(_testReplica.isReplicaTopState()).thenReturn(true);
     when(_testNode.getTopStateProjectedHighestUtilization(anyMap(),
@@ -76,6 +81,23 @@ public class TestTopStateMaxCapacityUsageInstanceConstraint {
     Assert.assertEquals((float) score,0.5f);
     double normalizedScore =
             _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertTrue(normalizedScore > 0.99);
+  }
+
+  @Test
+  public void testGetNormalizedScoreNoCapacityKeysDefined() {
+    // Node and Replica capacities are NOT defined
+    when(_testNode.getMaxCapacity()).thenReturn(Collections.emptyMap());
+    when(_testReplica.getCapacity()).thenReturn(Collections.emptyMap());
+    when(_testReplica.isReplicaTopState()).thenReturn(true);
+
+    when(_testNode.getAssignedTopStatePartitionsCount()).thenReturn(1);
+    when(_clusterContext.getEstimatedMaxTopStateCount()).thenReturn(2);
+
+    double score = _constraint.getAssignmentScore(_testNode, _testReplica, _clusterContext);
+    Assert.assertEquals((float) score,0.5f);
+    double normalizedScore =
+        _constraint.getAssignmentNormalizedScore(_testNode, _testReplica, _clusterContext);
     Assert.assertTrue(normalizedScore > 0.99);
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPartitionAssignmentAPI.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPartitionAssignmentAPI.java
@@ -378,7 +378,7 @@ public class TestPartitionAssignmentAPI extends AbstractTestClass {
   }
 
   @Test
-  private void testComputePartitionAssignmentMaintenanceMode() throws Exception {
+  public void testComputePartitionAssignmentMaintenanceMode() throws Exception {
 
     // Create 5 WAGED resources
     String wagedResourcePrefix = "TEST_WAGED_DB_";


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

When no resource or instance capacity keys are defined for a WAGED cluster, then WAGED does not try to ensure topstate evenness. In a cluster where the # participants = # replicas, each instance will have the same assignment. 

If each resource has multiple partitions, then a degree of evenness will be achieved, but it could be improved. 

If there is only 1 partition per resource and the # participants = # replicas, then one instance will be assigned leader for all resources as the tiebreak is the participant's logical ID. 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Customers should define resource weights and instance capacities to fully utilize the benefits of WAGED. However, for those that do not we should still consider top state evenness in WAGED assignment calculations. This PR adds changes to the "TopStateMaxCapacityUsageInstanceConstraint" soft constraint. Currently it preferentially assigns top state replicas to nodes with less top states based off the replica's weight. If no weight is defined for the resource and the node, then the score will always be 0 and tiebreak will be determined by the node's logicalID. 

This change will make the soft constraint calculate the score based off the number of top states if there are no capacity keys defined for both the resource and the instance. 


This only includes a very minor change of changing one test method's access modifier from private to public. I checked the CI logs and testNG has been successfully running this method, but convention is to set it to public. 

### Tests

- [x] The following tests are written for this issue:

TestTopStateMaxCapacityUsageInstanceConstraint
- testGetNormalizedScoreNoCapacityKeysDefined

#### Manually tested distribution before and after change:
No Capacity keys defined for either the resources or the participants

**Test 1**
3 Participants, 20 WAGED Resources, 1 Partition Each. 

```
BEFORE CHANGE:
Count of Leader Assignments
{localhost_12919=0, localhost_12918=20, localhost_12920=0}

AFTER CHANGE:
Count of Leader Assignments
{localhost_12919=7, localhost_12918=7, localhost_12920=6}
```

**Test 2**
3 Participants, 20 WAGED Resources, 10 Partitios Each.
```
BEFORE CHANGE:
Count of Leader Assignments
{localhost_12919=60, localhost_12918=80, localhost_12920=60}

AFTER CHANGE:
Count of Leader Assignments
{localhost_12919=67, localhost_12918=67, localhost_12920=66}
```

- The following is the result of the "mvn test" command on the appropriate module:

Ran PR CI against my personal fork, failed due to flaky test testEvacuationWithOfflineInstancesInCluster #2721
https://github.com/GrantPSpencer/helix/actions/runs/7935782011/job/21669654755?pr=6

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
