### PR TITLE
jackson-databind 2.12.7.1

### DIFF
--- a/helix-admin-webapp/pom.xml
+++ b/helix-admin-webapp/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.12.6</version>
+      <version>2.12.7</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -86,12 +86,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.6.1</version>
+      <version>2.12.7.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.12.6</version>
+      <version>2.12.7</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -126,12 +126,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.6.1</version>
+      <version>2.12.7.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.12.6</version>
+      <version>2.12.7</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/helix-view-aggregator/pom.xml
+++ b/helix-view-aggregator/pom.xml
@@ -84,7 +84,7 @@ under the License.
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.12.6</version>
+      <version>2.12.7</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/metadata-store-directory-common/pom.xml
+++ b/metadata-store-directory-common/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.6.1</version>
+      <version>2.12.7.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.6.1</version>
+      <version>2.12.7.1</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

resolves #2764 

### Description

jackson-databind 2.12.6.1 is insecure - see https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind


### Test

[ERROR] Failures: 
[ERROR]   TestInstanceOperation.testEvacuationWithOfflineInstancesInCluster:1357->verifier:1415 expected:<true> but was:<false>
[INFO] 
[ERROR] Tests run: 1414, Failures: 1, Errors: 0, Skipped: 6
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:12 h
[INFO] Finished at: 2024-02-29T16:23:33-08:00
[INFO] ------------------------------------------------------------------------

[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/jxue/tools/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 950 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  06:10 min
[INFO] Finished at: 2024-03-01T14:05:54-08:00
[INFO] ------------------------------------------------------------------------