### PR TITLE
Add ZK multi set with updater to ZKBaseDataAccesor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
@@ -20,7 +20,9 @@ package org.apache.helix;
  */
 
 import java.util.List;
+import java.util.Map;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
@@ -90,6 +92,17 @@ public interface BaseDataAccessor<T> {
    * @return true if data update succeeded, false otherwise
    */
   boolean update(String path, DataUpdater<T> updater, int options);
+
+  /**
+   * This will attempt to update the data using the updater using
+   * each updater for the corresponding path.
+   * This should be used on existing ZNodes only.
+   * @param updaterByPath updaters for each path to update
+   * @return true if all the updates succeeded, false otherwise
+   */
+  default boolean multiSet(Map<String, DataUpdater<T>> updaterByPath) {
+    throw new NotImplementedException("multiSet is not implemented");
+  }
 
   /**
    * This will remove the ZNode and all its descendants if any


### PR DESCRIPTION
### Issues

- [x]  Add ZK multi set with updated to ZKBaseDataAccesor. Allows for version based transactional sets.

### Description

This will be used to transactionally update the InstanceOperations of 2 swapping instances in a cluster. It will ensure no more than 1 instance  per logicalId can ever hold an assignable InstanceOperation at a time.

### Tests

- [x] Added testSyncMultiSet

### Changes that Break Backward Compatibility (Optional)
NA

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
