### PR TITLE
[apache/helix] -- Provide JDK 1.8 (backward) compatibility of helix-core

### DIFF
--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -181,12 +181,50 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.12.1</version>
         <executions>
           <execution>
+            <id>JDK 8</id>
+            <phase>compile</phase>
             <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}_jdk8</outputDirectory>
+              <release>8</release>
+              <fork>true</fork>
+            </configuration>
+          </execution>
+          <execution>
+            <id>JDK 11</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>11</release>
+              <fork>true</fork>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>default-package-jdk11</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <classesDirectory>${project.build.outputDirectory}_jdk8</classesDirectory>
+              <classifier>jdk8</classifier>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes #2779 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
We have some consumers which are still running their (open-source) systems on JRE-8, hence they are not able to run helix libraries compiled with JDK11+. 

We would like to provide a backward compatible support to our consumers where they also have an option to use JDK-8 compiled helix-core jar, if they have such a requirement. By default we will generate JDK-11 jars and JDK-8 jars using a classifier. 
```
<major.minor.patch> will use JDK11 (default)
<major.minor.patch> classifier say jdk8 , will use JDK8
```
### For JDK-11 usecase
```
      <dependency>
          <groupId>org.apache</groupId>
          <artifactId>helix</artifactId>
          <version>1.3.4</version>
      </dependency>
```
### For JDK-8 usecase
```
      <dependency>
          <groupId>org.apache</groupId>
          <artifactId>helix</artifactId>
          <version>1.3.4</version>
          <classifier>jdk8</classifier>
      </dependency>
```

### Tests

- [x] The following tests are written for this issue:
N/A

<img src="https://github.com/apache/helix/assets/2539436/604a7405-fa96-4656-adff-4ce686e8e126" width="500" height="500">

```
---------------------------------------------------------------------------------------------------
mvn clean install -Dmaven.test.skip.exec=true
---------------------------------------------------------------------------------------------------
[INFO] 
[INFO] --- compiler:3.10.1:compile (JDK 8) @ helix-core ---
[WARNING]  Parameter 'outputDirectory' is read-only, must not be used in configuration
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 579 source files to /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/target/classes_jdk8
[INFO] 
[INFO] --- compiler:3.10.1:compile (JDK 11) @ helix-core ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 579 source files to /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/target/classes
[INFO] 
[INFO] --- bundle:5.1.4:manifest (bundle-manifest) @ helix-core ---
[WARNING] Manifest org.apache.helix:helix-core:bundle:1.3.2-SNAPSHOT : Unused Import-Package instructions: [org.apache.logging.log4j*, org.apache.logging.slf4j*] 
[INFO] Writing manifest: /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/target/classes/META-INF/MANIFEST.MF
[INFO] 
```

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
