### PR TITLE
Fix BestPossibleExternalViewVerifier to use a ZkClient that has the serializer set to ByteArraySerializer 

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentManager.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentManager.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.ResourceAssignment;
@@ -86,7 +88,11 @@ class AssignmentManager {
     if (assignmentMetadataStore != null) {
       try {
         _stateReadLatency.startMeasuringLatency();
-        currentBestAssignment = new HashMap<>(assignmentMetadataStore.getBestPossibleAssignment());
+        currentBestAssignment =
+            assignmentMetadataStore.getBestPossibleAssignment().entrySet().stream().collect(
+                Collectors.toMap(Map.Entry::getKey,
+                    entry -> new ResourceAssignment(entry.getValue().getRecord())));
+        ;
         _stateReadLatency.endMeasuringLatency();
       } catch (Exception ex) {
         throw new HelixRebalanceException(

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -55,8 +55,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * verifier that the ExternalViews of given resources (or all resources in the cluster)
- * match its best possible mapping states.
+ * Verify that the ExternalViews of given resources (or all resources in the cluster)
+ * match its best possible mapping states. The best possible mapping states are computed
+ * by running the BestPossibleStateCalc stage with the same inputs that the controller would
+ * use to calculate the best possible state. The mappings produced by this stage are compared
+ * to the external view to ensure that they match. When they match, the cluster has converged.
+ * Note: The best possible state compared to the external view includes the non-persisted state
+ * mappings generated when handling MIN_ACTIVE replicas.
  */
 public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
   private static Logger LOG = LoggerFactory.getLogger(BestPossibleExternalViewVerifier.class);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -1070,7 +1070,6 @@ public class TestInstanceOperation extends ZkTestBase {
         InstanceConstants.InstanceOperation.EVACUATE);
 
     // Validate that the assignment has not changed since setting the InstanceOperation to EVACUATE
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
     validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
         Collections.emptySet(), Collections.emptySet());
 
@@ -1105,7 +1104,7 @@ public class TestInstanceOperation extends ZkTestBase {
         Collections.emptySet(), ImmutableSet.of(instanceToSwapInName))), TIMEOUT);
   }
 
-  @Test(expectedExceptions = HelixException.class, dependsOnMethods = "testNodeSwapWithSwapOutInstanceOffline")
+  @Test(expectedExceptions = HelixException.class, dependsOnMethods = "testSwapEvacuateAdd")
   public void testNodeSwapAddSwapInFirstEnabledBeforeSwapOutSet() throws Exception {
     System.out.println(
         "START TestInstanceOperation.testNodeSwapAddSwapInFirstEnabledBeforeSwapOutSet() at "
@@ -1325,8 +1324,6 @@ public class TestInstanceOperation extends ZkTestBase {
     for (String resource : _allDBs) {
       Assert.assertTrue(getParticipantsInEv(assignment.get(resource)).contains(instanceToEvacuate));
     }
-
-    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
 
     // exit MM
     _gSetupTool.getClusterManagementTool()


### PR DESCRIPTION
- Fix BestPossibleExternalViewVerifier to use a ZkClient that has the serializer set to ByteArraySerializer so it can read the assignment meta store best possible state.
- Fix BestPossibleExternalViewVerifier to actually calculate BEST_POSSIBLE instead of returning last persisted to ZK because we now need to consider handleDelayedRebalanceMinActiveReplica not being persisted to ZK(#2447).
- Fix handleDelayedRebalanceMinActiveReplica modifying in-memory _bestPossibleState in the _assignmentMetadataStore which was causing best possible state to continuosly be persisted until handleDelayedRebalanceMinActiveReplica wasn't kicking in anymore.

### Issues

- [x] Fix BestPossibleExternalViewVerifier to use a ZkClient that has the serializer set to ByteArraySerializer so it can read the assignment meta store best possible state.
- [x] Fix BestPossibleExternalViewVerifier to actually calculate BEST_POSSIBLE instead of returning last persisted to ZK because we now need to consider handleDelayedRebalanceMinActiveReplica not being persisted to ZK(#2447).
- [x] Fix handleDelayedRebalanceMinActiveReplica modifying in-memory _bestPossibleState in the _assignmentMetadataStore which was causing best possible state to continuosly be persisted until handleDelayedRebalanceMinActiveReplica wasn't kicking in anymore.

### Description

PR #2180 introduced a bug to BestPossibleExternalViewVerifier by reusing the zkClient passed to the builder. This can be an issue because the serializer is often set to ZNRecordSerializer instead of ByteArraySerializer. This failing verifier was not accurate since it was unable to read from the persisted best possible state in the assignment metadata store.

PR #2447 moves the logic for handling min active replicas into the emergency rebalance method. This will make the DryRunWagedRebalancer inaccurate because it would previously just return the ZK persisted best possible state for due to the override of `computeBestPossibleAssignment`. We are removing this method because we need to recompute the idealAssignment in addition to just reading the ZK persisted best possible state in order to retain the overwrites for handling min active replicas.

handleDelayedRebalanceMinActiveReplica modifies the currentResourceAssignment map passed into it. Because the reference actually points to map in the assignmentMetaStore, hanledDelayedRebalanceMinActiveReplica is actually modifying the cache. This causes isBestPossibleChanged to evaluate to true whenever hanledDelayedRebalanceMinActiveReplica is kicking in and causes continuous writes of the same best possible produced by partial rebalance over and over. 

### Tests

NA, issue with hanledDelayedRebalanceMinActiveReplica was caught after fixing BestPossibleExternalViewVerifier. Current tests are sufficient.

### Changes that Break Backward Compatibility (Optional)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
