### PR TITLE
[apache/helix] -- Issue during onboarding resources without instances

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ResourceComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ResourceComputationStage.java
@@ -91,7 +91,7 @@ public class ResourceComputationStage extends AbstractBaseStage {
       Map<String, IdealState> idealStates, boolean isTaskCache) {
     if (idealStates != null && idealStates.size() > 0) {
       for (IdealState idealState : idealStates.values()) {
-        if (idealState == null) {
+        if (idealState == null || idealState.getNumPartitions() == 0) {
           continue;
         }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedClusterExpansionWithAddingResourcesBeforeInstances.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedClusterExpansionWithAddingResourcesBeforeInstances.java
@@ -1,0 +1,199 @@
+package org.apache.helix.integration.rebalancer.WagedRebalancer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.apache.helix.tools.ClusterVerifiers.HelixClusterVerifier;
+import org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.helix.model.BuiltInStateModelDefinitions.LeaderStandby;
+
+public class TestWagedClusterExpansionWithAddingResourcesBeforeInstances extends ZkTestBase {
+
+  protected static final AtomicLong PORT_GENERATOR = new AtomicLong(12918);
+  protected static final int PARTITIONS = 4;
+
+  protected final String CLASS_NAME = getShortClassName();
+  protected final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + CLASS_NAME;
+  protected ClusterControllerManager _controller;
+  protected HelixClusterVerifier _clusterVerifier;
+
+  List<MockParticipantManager> _participants = new ArrayList<>();
+  Set<String> _allDBs = new HashSet<>();
+  int _replica = 3;
+
+  @BeforeClass
+  public void setupCluster() throws Exception {
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+
+    ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    ClusterConfig clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setTopology("/zone/instance");
+    clusterConfig.setFaultZoneType("zone");
+    clusterConfig.setDelayRebalaceEnabled(true);
+    // Set a long enough time to ensure delayed rebalance is activate
+    clusterConfig.setRebalanceDelayTime(3000000);
+
+    Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> preference = new HashMap<>();
+    preference.put(ClusterConfig.GlobalRebalancePreferenceKey.EVENNESS, 0);
+    preference.put(ClusterConfig.GlobalRebalancePreferenceKey.LESS_MOVEMENT, 10);
+    clusterConfig.setGlobalRebalancePreference(preference);
+    configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    // create resource - 1 with instances
+    String testResource1 = "Test-resource-1";
+    createResource(testResource1, 4, 4, "Tag-1");
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    enablePersistBestPossibleAssignment(_gZkClient, CLUSTER_NAME, true);
+    enableTopologyAwareRebalance(_gZkClient, CLUSTER_NAME, true);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, testResource1, _replica);
+    _allDBs.add(testResource1);
+
+    _clusterVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).setResources(_allDBs)
+        .build();
+    Assert.assertTrue(_clusterVerifier.verify(5000));
+  }
+
+  private void createResource(String resourceName, int numInstances, int numPartitions, String tagName) {
+    ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    Set<String> nodes = new HashSet<>();
+    for (int i = 0; i < numInstances; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + PORT_GENERATOR.incrementAndGet();
+      _gSetupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+      _gSetupTool.addInstanceTag(CLUSTER_NAME, storageNodeName, tagName);
+      String zone = "zone-" + i % numInstances;
+      String domain = String.format("zone=%s,instance=%s", zone, storageNodeName);
+
+      InstanceConfig instanceConfig = configAccessor.getInstanceConfig(CLUSTER_NAME, storageNodeName);
+      instanceConfig.setDomain(domain);
+      _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, storageNodeName, instanceConfig);
+      nodes.add(storageNodeName);
+    }
+
+    // start dummy participants
+    for (String node : nodes) {
+      MockParticipantManager participant = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, node);
+      participant.syncStart();
+      _participants.add(participant);
+    }
+
+    createResourceWithWagedRebalance(CLUSTER_NAME, resourceName, LeaderStandby.name(), numPartitions, _replica, _replica - 1);
+    IdealState idealState = _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, resourceName);
+    idealState.setInstanceGroupTag(tagName);
+    _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, resourceName, idealState);
+  }
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    _controller.syncStop();
+    for (MockParticipantManager p : _participants) {
+      p.syncStop();
+    }
+    deleteCluster(CLUSTER_NAME);
+  }
+
+  @Test
+  public void testExpandClusterWithResourceWithoutInstances() {
+    String testResource2 = "Test-resource-2";
+    createResource(testResource2, 0, 0, "Tag-2");
+
+    _allDBs.add(testResource2);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, testResource2, _replica);
+
+    ZkHelixClusterVerifier _clusterVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
+        .setZkClient(_gZkClient)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    for (String db : _allDBs) {
+      IdealState is = _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
+      validateIsolation(is, ev, _replica);
+    }
+  }
+
+  @Test(dependsOnMethods = "testExpandClusterWithResourceWithoutInstances")
+  public void testExpandClusterWithResourceWithoutPartitions() {
+    String testResource3 = "Test-resource-3";
+    createResource(testResource3, 4, 0, "Tag-3");
+
+    _allDBs.add(testResource3);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, testResource3, _replica);
+
+    ZkHelixClusterVerifier _clusterVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
+        .setZkClient(_gZkClient)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    for (String db : _allDBs) {
+      IdealState is = _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
+      validateIsolation(is, ev, _replica);
+    }
+  }
+
+  /**
+   * Validate each partition is different instances and with necessary tagged instances.
+   */
+  private void validateIsolation(IdealState is, ExternalView ev, int expectedReplica) {
+    String tag = is.getInstanceGroupTag();
+    for (String partition : is.getPartitionSet()) {
+      Map<String, String> assignmentMap = ev.getRecord().getMapField(partition);
+      Set<String> instancesInEV = assignmentMap.keySet();
+      Assert.assertEquals(instancesInEV.size(), expectedReplica);
+      for (String instance : instancesInEV) {
+        if (tag != null) {
+          InstanceConfig config = _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, instance);
+          Assert.assertTrue(config.containsTag(tag));
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes #2781 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
When adding a new WAGED resource with a tag and without any instances against that tag, we are observing NPE coming from the system. This in turn fails the complete WAGED cluster rebalance pipeline. This particularly happen when the `numPartitions = 0`.

To solve this issue we are adding a check in the `ResourceComputationStage` to have such resources excluded from the pipeline computation and only be considered when there are actual resource partitions (`>0`) to be assigned to the instances.

```
org.apache.helix.HelixRebalanceException: Failed to compute for delayed rebalance overwrites in cluster ZnRecord=CLUSTER_TestWagedClusterExpansionWithAddingResourcesBeforeInstances, {DELAY_REBALANCE_ENABLED=true, DELAY_REBALANCE_TIME=3000000, FAULT_ZONE_TYPE=zone, PERSIST_BEST_POSSIBLE_ASSIGNMENT=true, TOPOLOGY=/zone/instance, TOPOLOGY_AWARE_ENABLED=true}{REBALANCE_PREFERENCE={EVENNESS=0, LESS_MOVEMENT=10}}{}, Stat=Stat {_version=4, _creationTime=1710804015571, _modifiedTime=1710804047240, _ephemeralOwner=0} Failure Type: INVALID_CLUSTER_STATUS
	at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.handleDelayedRebalanceMinActiveReplica(WagedRebalancer.java:428) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.emergencyRebalance(WagedRebalancer.java:501) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.computeBestPossibleAssignment(WagedRebalancer.java:339) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.computeBestPossibleStates(WagedRebalancer.java:316) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.computeNewIdealStates(WagedRebalancer.java:248) [classes/:?]
	at org.apache.helix.controller.stages.BestPossibleStateCalcStage.computeResourceBestPossibleStateWithWagedRebalancer(BestPossibleStateCalcStage.java:406) [classes/:?]
	at org.apache.helix.controller.stages.BestPossibleStateCalcStage.compute(BestPossibleStateCalcStage.java:258) [classes/:?]
	at org.apache.helix.controller.stages.BestPossibleStateCalcStage.process(BestPossibleStateCalcStage.java:91) [classes/:?]
	at org.apache.helix.controller.pipeline.Pipeline.handle(Pipeline.java:75) [classes/:?]
	at org.apache.helix.controller.GenericHelixController.handleEvent(GenericHelixController.java:903) [classes/:?]
	at org.apache.helix.controller.GenericHelixController$ClusterEventProcessor.run(GenericHelixController.java:1554) [classes/:?]
Caused by: java.lang.NullPointerException
	at org.apache.helix.controller.rebalancer.util.DelayedRebalanceUtil.findToBeAssignedReplicasForMinActiveReplica(DelayedRebalanceUtil.java:335) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.model.ClusterModelProvider.generateClusterModel(ClusterModelProvider.java:257) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.model.ClusterModelProvider.generateClusterModelForDelayedRebalanceOverwrites(ClusterModelProvider.java:82) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.handleDelayedRebalanceMinActiveReplica(WagedRebalancer.java:415) ~[classes/:?]
	... 10 more
94184 [main] ERROR org.apache.helix.controller.rebalancer.waged.WagedRebalancer [] - Failed to compute for delayed rebalance overwrites in cluster CLUSTER_TestWagedClusterExpansionWithAddingResourcesBeforeInstances
94188 [main] ERROR org.apache.helix.controller.rebalancer.waged.WagedRebalancer [] - Failed to calculate the new assignments.
org.apache.helix.HelixRebalanceException: Failed to compute for delayed rebalance overwrites in cluster ZnRecord=CLUSTER_TestWagedClusterExpansionWithAddingResourcesBeforeInstances, {DELAY_REBALANCE_ENABLED=true, DELAY_REBALANCE_TIME=3000000, FAULT_ZONE_TYPE=zone, PERSIST_BEST_POSSIBLE_ASSIGNMENT=true, TOPOLOGY=/zone/instance, TOPOLOGY_AWARE_ENABLED=true}{REBALANCE_PREFERENCE={EVENNESS=0, LESS_MOVEMENT=10}}{}, Stat=Stat {_version=4, _creationTime=1710804015571, _modifiedTime=1710804047240, _ephemeralOwner=0} Failure Type: INVALID_CLUSTER_STATUS
	at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.handleDelayedRebalanceMinActiveReplica(WagedRebalancer.java:428) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.emergencyRebalance(WagedRebalancer.java:514) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.computeBestPossibleAssignment(WagedRebalancer.java:339) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.computeBestPossibleStates(WagedRebalancer.java:316) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.computeNewIdealStates(WagedRebalancer.java:248) [classes/:?]
	at org.apache.helix.controller.stages.BestPossibleStateCalcStage.computeResourceBestPossibleStateWithWagedRebalancer(BestPossibleStateCalcStage.java:406) [classes/:?]
	at org.apache.helix.controller.stages.BestPossibleStateCalcStage.compute(BestPossibleStateCalcStage.java:258) [classes/:?]
	at org.apache.helix.controller.stages.BestPossibleStateCalcStage.process(BestPossibleStateCalcStage.java:91) [classes/:?]
	at org.apache.helix.util.RebalanceUtil.runStage(RebalanceUtil.java:235) [classes/:?]
	at org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier.calcBestPossState(BestPossibleExternalViewVerifier.java:444) [classes/:?]
	at org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier.verifyState(BestPossibleExternalViewVerifier.java:293) [classes/:?]
	at org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier.verifyByPolling(ZkHelixClusterVerifier.java:209) [classes/:?]
	at org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier.verifyByPolling(ZkHelixClusterVerifier.java:229) [classes/:?]
	at org.apache.helix.integration.rebalancer.WagedRebalancer.TestWagedClusterExpansionWithAddingResourcesBeforeInstances.testExpandClusterWithResourceWithoutInstances(TestWagedClusterExpansionWithAddingResourcesBeforeInstances.java:151) [test-classes/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
Caused by: java.lang.NullPointerException
	at org.apache.helix.controller.rebalancer.util.DelayedRebalanceUtil.findToBeAssignedReplicasForMinActiveReplica(DelayedRebalanceUtil.java:335) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.model.ClusterModelProvider.generateClusterModel(ClusterModelProvider.java:257) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.model.ClusterModelProvider.generateClusterModelForDelayedRebalanceOverwrites(ClusterModelProvider.java:82) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.handleDelayedRebalanceMinActiveReplica(WagedRebalancer.java:415) ~[classes/:?]
	... 37 more
```

### Tests

- [x] The following tests are written for this issue:

(List the names of added unit/integration tests)

* TestWagedClusterExpansionWithAddingResourcesBeforeInstances.testExpandClusterWithResourceWithoutInstances

- The following is the result of the "mvn test" command on the appropriate module:

```
➜  helix_os_hk git:(hkandwal/waged-adding-resources-without-capacity) mvn clean install -Dmaven.test.skip.exec=true && mvn test -o -Dtest=TestWagedClusterExpansionWithAddingResourcesBeforeInstances -pl=helix-core

[INFO] --- surefire:3.0.0-M3:test (default-test) @ helix-core ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.helix.integration.rebalancer.WagedRebalancer.TestWagedClusterExpansionWithAddingResourcesBeforeInstances
Start zookeeper at localhost:2183 in thread main
AfterClass: TestWagedClusterExpansionWithAddingResourcesBeforeInstances called.
Shut down zookeeper at port 2183 in thread main
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.354 s - in org.apache.helix.integration.rebalancer.WagedRebalancer.TestWagedClusterExpansionWithAddingResourcesBeforeInstances
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 950 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  54.225 s
[INFO] Finished at: 2024-03-27T16:29:31-07:00
[INFO] ------------------------------------------------------------------------

```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
