### PR TITLE
[apache/helix] -- Add SetPartitionToError for participants to self annotate a node to ERROR state

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -422,6 +422,18 @@ public interface HelixAdmin {
   ClusterManagementMode getClusterManagementMode(String clusterName);
 
   /**
+   * Set a list of partitions for an instance to ERROR state from any state.
+   * The partitions could be in any state and setPartitionsToError will bring them to ERROR
+   * state. ANY to ERROR state transition is required for this.
+   * @param clusterName
+   * @param instanceName
+   * @param resourceName
+   * @param partitionNames
+   */
+  void setPartitionsToError(String clusterName, String instanceName, String resourceName,
+      List<String> partitionNames);
+
+  /**
    * Reset a list of partitions in error state for an instance
    * The partitions are assume to be in error state and reset will bring them from error
    * to initial state. An error to initial state transition is required for reset.

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixStateTransitionHandler.java
@@ -176,7 +176,8 @@ public class HelixStateTransitionHandler extends MessageHandler {
         deltaList.add(delta);
         _currentStateDelta.setDeltaList(deltaList);
         _stateModelFactory.removeStateModel(_message.getResourceName(), partitionKey);
-      } else if (_stateModel.getCurrentState().equals(_message.getFromState())) {
+      } else if (_message.getFromState().equals("*")
+          || _stateModel.getCurrentState().equals(_message.getFromState())) {
         // if the partition is not to be dropped, update _stateModel to the TO_STATE
         // need this check because TaskRunner may change _stateModel before reach here.
         _stateModel.updateState(toState);

--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTask.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTask.java
@@ -323,6 +323,7 @@ public class HelixTask implements MessageTask {
         String fromState = message.getFromState();
         String toState = message.getToState();
         String transition = fromState + "--" + toState;
+        transition = transition.replaceAll("\\*", "ANY");
 
         StateTransitionContext cxt =
             new StateTransitionContext(manager.getClusterName(), manager.getInstanceName(),

--- a/helix-core/src/main/java/org/apache/helix/participant/statemachine/StateModel.java
+++ b/helix-core/src/main/java/org/apache/helix/participant/statemachine/StateModel.java
@@ -115,4 +115,15 @@ public abstract class StateModel {
   public boolean isCancelled() {
     return _cancelled;
   }
+
+  /*
+   * default transition to set partition in any state to error state
+   * @param message
+   * @param context
+   * @throws InterruptedException
+   */
+  @Transition(to = "ERROR", from = "*")
+  public void onBecomeErrorFromAny(Message message, NotificationContext context) throws Exception {
+    logger.info("Default *->ERROR transition invoked.");
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterSetup.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterSetup.java
@@ -134,6 +134,9 @@ public class ClusterSetup {
   public static final String resetInstance = "resetInstance";
   public static final String resetResource = "resetResource";
 
+  // set partitions to ERROR
+  public static final String setPartitionsToError = "setPartitionsToError";
+
   // help
   public static final String help = "help";
 
@@ -1114,6 +1117,13 @@ public class ClusterSetup {
     removeCloudConfigOption.setRequired(false);
     removeCloudConfigOption.setArgName("clusterName");
 
+    Option setPartitionsToErrorOption =
+        OptionBuilder.withLongOpt(setPartitionsToError)
+            .withDescription("Set a Partition to Error State").create();
+    setPartitionsToErrorOption.setArgs(4);
+    setPartitionsToErrorOption.setRequired(false);
+    setPartitionsToErrorOption.setArgName("clusterName instanceName resourceName partitionName");
+
     OptionGroup group = new OptionGroup();
     group.setRequired(true);
     group.addOption(rebalanceOption);
@@ -1153,6 +1163,7 @@ public class ClusterSetup {
     group.addOption(listStateModelOption);
     group.addOption(addResourcePropertyOption);
     group.addOption(removeResourcePropertyOption);
+    group.addOption(setPartitionsToErrorOption);
 
     // set/get/remove config options
     group.addOption(setConfOption);
@@ -1561,6 +1572,16 @@ public class ClusterSetup {
       String newInstanceName = cmd.getOptionValues(swapInstance)[2];
 
       setupTool.swapInstance(clusterName, oldInstanceName, newInstanceName);
+    } else if (cmd.hasOption(setPartitionsToError)) {
+      String[] args = cmd.getOptionValues(setPartitionsToError);
+
+      String clusterName = args[0];
+      String instanceName = args[1];
+      String resourceName = args[2];
+      List<String> partitionNames = Arrays.asList(Arrays.copyOfRange(args, 3, args.length));
+
+      setupTool.getClusterManagementTool().setPartitionsToError(clusterName, instanceName, resourceName, partitionNames);
+      return 0;
     }
     // set/get/remove config options
     else if (cmd.hasOption(setConfig)) {

--- a/helix-core/src/test/java/org/apache/helix/integration/TestSetPartitionsToErrorState.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestSetPartitionsToErrorState.java
@@ -1,0 +1,99 @@
+package org.apache.helix.integration;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.tools.ClusterSetup;
+import org.apache.helix.tools.ClusterStateVerifier;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestSetPartitionsToErrorState extends ZkTestBase {
+
+  @Test()
+  public void testSetPartitionsToErrorState() throws Exception {
+    String className = TestHelper.getTestClassName();
+    String methodName = TestHelper.getTestMethodName();
+    String clusterName = className + "_" + methodName;
+    final int n = 5;
+
+    System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+
+    TestHelper.setupCluster(clusterName, ZK_ADDR, 12918, // participant port
+        "localhost", // participant name prefix
+        "TestDB", // resource name prefix
+        1, // resources
+        10, // partitions per resource
+        n, // number of nodes
+        3, // replicas
+        "MasterSlave", true); // do rebalance
+
+    ClusterControllerManager controller =
+        new ClusterControllerManager(ZK_ADDR, clusterName, "controller_0");
+    controller.syncStart();
+
+    // start mock participants
+    MockParticipantManager[] participants = new MockParticipantManager[n];
+    for (int i = 0; i < n; i++) {
+      String instanceName = "localhost_" + (12918 + i);
+      participants[i] = new MockParticipantManager(ZK_ADDR, clusterName, instanceName);
+      participants[i].syncStart();
+    }
+
+    // verify cluster
+    HashMap<String, Map<String, String>> errStateMap = new HashMap<>();
+    errStateMap.put("TestDB0", new HashMap<>());
+    boolean result = ClusterStateVerifier.verifyByZkCallback(
+        (new ClusterStateVerifier.BestPossAndExtViewZkVerifier(ZK_ADDR, clusterName, errStateMap)));
+    Assert.assertTrue(result, "Cluster verification fails");
+
+    // set a non exist partition to ERROR, should throw exception
+    try {
+      String command = "--zkSvr " + ZK_ADDR + " --setPartitionsToError " + clusterName
+          + " localhost_12918 TestDB0 TestDB0_nonExist";
+      ClusterSetup.processCommandLineArgs(command.split("\\s+"));
+      Assert.fail("Should throw exception on setting a non-exist partition to error");
+    } catch (Exception e) {
+      // OK
+    }
+
+    // set one partition not in ERROR state to ERROR
+    String command = "--zkSvr " + ZK_ADDR + " --setPartitionsToError " + clusterName
+        + " localhost_12918 TestDB0 TestDB0_4";
+    ClusterSetup.processCommandLineArgs(command.split("\\s+"));
+    errStateMap.get("TestDB0").put("TestDB0_4", "localhost_12918");
+    result = ClusterStateVerifier.verifyByZkCallback(
+        (new ClusterStateVerifier.BestPossAndExtViewZkVerifier(ZK_ADDR, clusterName, errStateMap)));
+    Assert.assertTrue(result, "Cluster verification fails");
+
+    // set another partition not in ERROR state to ERROR
+    command = "--zkSvr " + ZK_ADDR + " --setPartitionsToError " + clusterName
+        + " localhost_12918 TestDB0 TestDB0_7";
+    ClusterSetup.processCommandLineArgs(command.split("\\s+"));
+    errStateMap.get("TestDB0").put("TestDB0_7", "localhost_12918");
+    result = ClusterStateVerifier.verifyByZkCallback(
+        (new ClusterStateVerifier.BestPossAndExtViewZkVerifier(ZK_ADDR, clusterName, errStateMap)));
+    Assert.assertTrue(result, "Cluster verification fails");
+
+    // setting a partition already in ERROR state to ERROR - message does not get processed
+    command = "--zkSvr " + ZK_ADDR + " --setPartitionsToError " + clusterName
+        + " localhost_12918 TestDB0 TestDB0_7";
+    ClusterSetup.processCommandLineArgs(command.split("\\s+"));
+    result = ClusterStateVerifier.verifyByZkCallback(
+        (new ClusterStateVerifier.BestPossAndExtViewZkVerifier(ZK_ADDR, clusterName, errStateMap)));
+    Assert.assertTrue(result, "Cluster verification fails");
+
+    // clean up
+    controller.syncStop();
+    for (int i = 0; i < 5; i++) {
+      participants[i].syncStop();
+    }
+    deleteCluster(clusterName);
+
+    System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -589,6 +589,117 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
         2);
   }
 
+  @Test(description = "Unit test for sanity check in setPartitionsToError()")
+  public void testSetPartitionsToError() throws Exception {
+    String className = TestHelper.getTestClassName();
+    String methodName = TestHelper.getTestMethodName();
+    String clusterName = className + "_" + methodName;
+    String instanceName = "TestInstance";
+    String testResource = "TestResource";
+    String wrongTestInstance = "WrongTestInstance";
+    String wrongTestResource = "WrongTestResource";
+    System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
+    admin.addCluster(clusterName, true);
+    admin.addInstance(clusterName, new InstanceConfig(instanceName));
+    admin.enableInstance(clusterName, instanceName, true);
+    InstanceConfig instanceConfig = admin.getInstanceConfig(clusterName, instanceName);
+
+    IdealState idealState = new IdealState(testResource);
+    idealState.setNumPartitions(3);
+    admin.addStateModelDef(clusterName, "MasterSlave", new MasterSlaveSMD());
+    idealState.setStateModelDefRef("MasterSlave");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+    admin.addResource(clusterName, testResource, idealState);
+    admin.enableResource(clusterName, testResource, true);
+
+    /*
+     * This is a unit test for sanity check in setPartitionsToError().
+     * There is no running controller in this test. We have end-to-end tests for
+     * setPartitionsToError()
+     * under integration/TestSetPartitionsToError.
+     */
+    // setPartitionsToError is expected to throw an exception when provided with a nonexistent
+    // instance.
+    try {
+      admin.setPartitionsToError(clusterName, wrongTestInstance, testResource,
+          Arrays.asList("1", "2"));
+      Assert.fail("Should throw HelixException");
+    } catch (HelixException expected) {
+      // This exception is expected because the instance name is made up.
+      Assert.assertEquals(expected.getMessage(), String.format(
+          "Can't SET_TO_ERROR state for %s.[1, 2] on WrongTestInstance, because %s does not exist in cluster %s",
+          testResource, wrongTestInstance, clusterName));
+    }
+
+    // setPartitionsToError is expected to throw an exception when provided with a non-live
+    // instance.
+    try {
+      admin.setPartitionsToError(clusterName, instanceName, testResource, Arrays.asList("1", "2"));
+      Assert.fail("Should throw HelixException");
+    } catch (HelixException expected) {
+      // This exception is expected because the instance is not alive.
+      Assert.assertEquals(expected.getMessage(),
+          String.format(
+              "Can't SET_TO_ERROR state for %s.[1, 2] on %s, because %s is not alive in cluster %s",
+              testResource, instanceName, instanceName, clusterName));
+    }
+
+    HelixManager manager = initializeHelixManager(clusterName, instanceConfig.getInstanceName());
+    manager.connect();
+
+    // setPartitionsToError is expected to throw an exception when provided with a nonexistent
+    // resource.
+    try {
+      admin.setPartitionsToError(clusterName, instanceName, wrongTestResource,
+          Arrays.asList("1", "2"));
+      Assert.fail("Should throw HelixException");
+    } catch (HelixException expected) {
+      // This exception is expected because the resource is not added.
+      Assert.assertEquals(expected.getMessage(), String.format(
+          "Can't SET_TO_ERROR state for %s.[1, 2] on %s, because resource %s is not added to cluster %s",
+          wrongTestResource, instanceName, wrongTestResource, clusterName));
+    }
+
+    // setPartitionsToError is expected to throw an exception when partition does not exist.
+    try {
+      admin.setPartitionsToError(clusterName, instanceName, testResource, Arrays.asList("1", "2"));
+      Assert.fail("Should throw HelixException");
+    } catch (HelixException expected) {
+      // This exception is expected because partitions do not exist.
+      Assert.assertEquals(expected.getMessage(), String.format(
+          "Can't SET_TO_ERROR state for %s.[1, 2] on %s, because not all [1, 2] exist in cluster %s",
+          testResource, instanceName, clusterName));
+    }
+
+    // clean up
+    manager.disconnect();
+    admin.dropCluster(clusterName);
+
+    // verify the cluster has been removed successfully
+    HelixDataAccessor dataAccessor =
+        new ZKHelixDataAccessor(className, new ZkBaseDataAccessor<>(_gZkClient));
+    try {
+      Assert.assertTrue(TestHelper.verify(
+          () -> dataAccessor.getChildNames(dataAccessor.keyBuilder().liveInstances()).isEmpty(),
+          1000));
+    } catch (Exception e) {
+      e.printStackTrace();
+      System.out.println("There're live instances not cleaned up yet");
+      assert false;
+    }
+
+    try {
+      Assert.assertTrue(TestHelper.verify(
+          () -> dataAccessor.getChildNames(dataAccessor.keyBuilder().clusterConfig()).isEmpty(),
+          1000));
+    } catch (Exception e) {
+      e.printStackTrace();
+      System.out.println("The cluster is not cleaned up yet");
+      assert false;
+    }
+  }
+
   @Test
   public void testResetPartition() throws Exception {
     String className = TestHelper.getTestClassName();
@@ -625,7 +736,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     } catch (HelixException expected) {
       // This exception is expected because the instance name is made up.
       Assert.assertEquals(expected.getMessage(), String.format(
-          "Can't reset state for %s.[1, 2] on WrongTestInstance, because %s does not exist in cluster %s",
+          "Can't RESET state for %s.[1, 2] on WrongTestInstance, because %s does not exist in cluster %s",
           testResource, wrongTestInstance, clusterName));
     }
 
@@ -636,7 +747,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     } catch (HelixException expected) {
       // This exception is expected because the instance is not alive.
       Assert.assertEquals(expected.getMessage(), String
-          .format("Can't reset state for %s.[1, 2] on %s, because %s is not alive in cluster %s",
+          .format("Can't RESET state for %s.[1, 2] on %s, because %s is not alive in cluster %s",
               testResource, instanceName, instanceName, clusterName));
     }
 
@@ -650,7 +761,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     } catch (HelixException expected) {
       // This exception is expected because the resource is not added.
       Assert.assertEquals(expected.getMessage(), String.format(
-          "Can't reset state for %s.[1, 2] on %s, because resource %s is not added to cluster %s",
+          "Can't RESET state for %s.[1, 2] on %s, because resource %s is not added to cluster %s",
           wrongTestResource, instanceName, wrongTestResource, clusterName));
     }
 
@@ -660,7 +771,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     } catch (HelixException expected) {
       // This exception is expected because partitions do not exist.
       Assert.assertEquals(expected.getMessage(), String.format(
-          "Can't reset state for %s.[1, 2] on %s, because not all [1, 2] exist in cluster %s",
+          "Can't RESET state for %s.[1, 2] on %s, because not all [1, 2] exist in cluster %s",
           testResource, instanceName, clusterName));
     }
 

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -364,6 +364,12 @@ public class MockHelixAdmin implements HelixAdmin {
     return null;
   }
 
+  @Override
+  public void setPartitionsToError(String clusterName, String instanceName, String resourceName,
+      List<String> partitionNames) {
+
+  }
+
   @Override public void resetPartition(String clusterName, String instanceName, String resourceName,
       List<String> partitionNames) {
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -89,7 +89,8 @@ public class AbstractResource {
     canCompleteSwap,
     completeSwapIfPossible,
     onDemandRebalance,
-    isEvacuateFinished
+    isEvacuateFinished,
+    setPartitionsToError
   }
 
   @Context

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -434,6 +434,16 @@ public class PerInstanceAccessor extends AbstractHelixResource {
                   OBJECT_MAPPER.getTypeFactory()
                       .constructCollectionType(List.class, String.class)));
           break;
+        case setPartitionsToError:
+          if (!validInstance(node, instanceName)) {
+            return badRequest("Instance names are not a match!");
+          }
+          admin.setPartitionsToError(clusterId, instanceName,
+              node.get(PerInstanceProperties.resource.name()).textValue(),
+              (List<String>) OBJECT_MAPPER.readValue(
+                  node.get(PerInstanceProperties.partitions.name()).toString(), OBJECT_MAPPER
+                      .getTypeFactory().constructCollectionType(List.class, String.class)));
+          break;
         case setInstanceOperation:
           admin.setInstanceOperation(clusterId, instanceName, state);
           break;

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -37,11 +37,13 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixDefinedState;
 import org.apache.helix.HelixException;
 import org.apache.helix.TestHelper;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Message;
@@ -377,7 +379,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
   }
 
   @Test(dependsOnMethods = "testDeleteInstance")
-  public void updateInstance() throws IOException {
+  public void updateInstance() throws Exception {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     // Disable instance
     Entity entity = Entity.entity("", MediaType.APPLICATION_JSON_TYPE);
@@ -461,11 +463,11 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     String dbName = "_db_0_";
     List<String> partitionsToDisable = Arrays.asList(CLUSTER_NAME + dbName + "0",
         CLUSTER_NAME + dbName + "1", CLUSTER_NAME + dbName + "3");
+    String RESOURCE_NAME = CLUSTER_NAME + dbName.substring(0, dbName.length() - 1);
 
     entity = Entity.entity(
         OBJECT_MAPPER.writeValueAsString(ImmutableMap.of(AbstractResource.Properties.id.name(),
-            INSTANCE_NAME, PerInstanceAccessor.PerInstanceProperties.resource.name(),
-            CLUSTER_NAME + dbName.substring(0, dbName.length() - 1),
+            INSTANCE_NAME, PerInstanceAccessor.PerInstanceProperties.resource.name(), RESOURCE_NAME,
             PerInstanceAccessor.PerInstanceProperties.partitions.name(), partitionsToDisable)),
         MediaType.APPLICATION_JSON_TYPE);
 
@@ -474,13 +476,11 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
 
     InstanceConfig instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME);
     Assert.assertEquals(
-        new HashSet<>(instanceConfig.getDisabledPartitionsMap()
-            .get(CLUSTER_NAME + dbName.substring(0, dbName.length() - 1))),
+        new HashSet<>(instanceConfig.getDisabledPartitionsMap().get(RESOURCE_NAME)),
         new HashSet<>(partitionsToDisable));
     entity = Entity.entity(OBJECT_MAPPER.writeValueAsString(ImmutableMap
         .of(AbstractResource.Properties.id.name(), INSTANCE_NAME,
-            PerInstanceAccessor.PerInstanceProperties.resource.name(),
-            CLUSTER_NAME + dbName.substring(0, dbName.length() - 1),
+            PerInstanceAccessor.PerInstanceProperties.resource.name(), RESOURCE_NAME,
             PerInstanceAccessor.PerInstanceProperties.partitions.name(),
             ImmutableList.of(CLUSTER_NAME + dbName + "1"))), MediaType.APPLICATION_JSON_TYPE);
 
@@ -488,8 +488,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
         .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
 
     instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME);
-    Assert.assertEquals(new HashSet<>(instanceConfig.getDisabledPartitionsMap()
-            .get(CLUSTER_NAME + dbName.substring(0, dbName.length() - 1))),
+    Assert.assertEquals(new HashSet<>(instanceConfig.getDisabledPartitionsMap().get(RESOURCE_NAME)),
         new HashSet<>(Arrays.asList(CLUSTER_NAME + dbName + "0", CLUSTER_NAME + dbName + "3")));
 
     // test set instance operation
@@ -595,6 +594,32 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     evacuateFinishedResult = OBJECT_MAPPER.readValue(response.readEntity(String.class), Map.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     Assert.assertTrue(evacuateFinishedResult.get("successful"));
+
+    // test setPartitionsToError
+    List<String> partitionsToSetToError = Arrays.asList(CLUSTER_NAME + dbName + "7");
+
+    entity = Entity.entity(
+        OBJECT_MAPPER.writeValueAsString(ImmutableMap.of(AbstractResource.Properties.id.name(),
+            INSTANCE_NAME, PerInstanceAccessor.PerInstanceProperties.resource.name(), RESOURCE_NAME,
+            PerInstanceAccessor.PerInstanceProperties.partitions.name(), partitionsToSetToError)),
+        MediaType.APPLICATION_JSON_TYPE);
+
+    response = new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=setPartitionsToError")
+        .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
+
+    Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+
+    TestHelper.verify(() -> {
+      ExternalView externalView = _gSetupTool.getClusterManagementTool()
+          .getResourceExternalView(CLUSTER_NAME, RESOURCE_NAME);
+      Set responseForAllPartitions = new HashSet();
+      for (String partition : partitionsToSetToError) {
+        responseForAllPartitions.add(externalView.getStateMap(partition)
+            .get(INSTANCE_NAME) == HelixDefinedState.ERROR.toString());
+      }
+      return !responseForAllPartitions.contains(Boolean.FALSE);
+    }, TestHelper.WAIT_DURATION);
+
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 


### PR DESCRIPTION
### Issues

Fixes #2791 


### Description

What: An API endpoint that validates the incoming request and sends a state transition message to sets one or more partitions from any current state to ERROR state.

Why: Currently, the participants are unable to set a partition to an ERROR state explicitly when they seem to be stuck in a specific current state. The only way a replica can be set to ERROR is from within a state model. Having an endpoint to allow this behavior would allow the clients to call the resetPartition endpoint to set it back to INIT state and recover the replica. resetPartition works only on partitions in error state.


### Tests
  

```

  [INFO] ------------------------------------------------------------------------
  [INFO] Reactor Summary for Apache Helix 1.3.2-SNAPSHOT:
  [INFO] 
  [INFO] Apache Helix ....................................... SUCCESS [  1.504 s]
  [INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  0.244 s]
  [INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [  0.363 s]
  [INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [  0.380 s]
  [INFO] Apache Helix :: Helix Common ....................... SUCCESS [  0.291 s]
  [INFO] Apache Helix :: Core ............................... SUCCESS [  0.306 s]
  [INFO] Apache Helix :: Admin Webapp ....................... SUCCESS [  0.606 s]
  [INFO] Apache Helix :: Restful Interface .................. SUCCESS [  0.941 s]
  [INFO] Apache Helix :: Distributed Lock ................... SUCCESS [  0.228 s]
  [INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  0.187 s]
  [INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.033 s]
  [INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  0.205 s]
  [INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  0.248 s]
  [INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  0.169 s]
  [INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  0.246 s]
  [INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  0.186 s]
  [INFO] Apache Helix :: View Aggregator .................... SUCCESS [  0.167 s]
  [INFO] Apache Helix :: Meta Client ........................ SUCCESS [  0.146 s]
  [INFO] ------------------------------------------------------------------------
  [INFO] BUILD SUCCESS
  [INFO] ------------------------------------------------------------------------
  [INFO] Total time:  9.219 s
  [INFO] Finished at: 2024-04-16T13:13:02-07:00
  [INFO] ------------------------------------------------------------------------
```


- [ ] The following tests are written/updated for this issue:

          - TestSetPartitionToErrorState (Integration)
          - TestZkHelixAdmin : testSetPartitionToError 
          - TestPerInstanceAccessor : updateInstance





    mvn test -o -Dtest=TestSetPartitionToErrorState -pl=helix-core
    
    
            AfterClass: TestSetPartitionToErrorState called.
            Shut down zookeeper at port 2183 in thread main
            [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.697 s - in   org.apache.helix.integration.TestSetPartitionToErrorState
            [INFO] 
            [INFO] Results:
            [INFO] 
            [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
            [INFO] 
            [INFO] 
            [INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
            [INFO] Loading execution data file /Users/csudhars/Apr15Helix-ForkedHelix/helix/helix-core/target/jacoco.exec
            [INFO] Analyzed bundle 'Apache Helix :: Core' with 806 classes
            [INFO] ------------------------------------------------------------------------
            [INFO] BUILD SUCCESS
            [INFO] ------------------------------------------------------------------------
            [INFO] Total time:  59.426 s
            [INFO] Finished at: 2024-04-16T14:14:54-07:00
            [INFO] ------------------------------------------------------------------------


    mvn test -o -Dtest=TestZkHelixAdmin -pl=helix-core
          
          END testZkHelixAdmin at Tue Apr 16 12:57:29 PDT 2024
          AfterClass: TestZkHelixAdmin called.
          Shut down zookeeper at port 2183 in thread main
          [INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 66.246 s - in TestSuite
          [INFO] 
          [INFO] Results:
          [INFO] 
          [INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
          [INFO] 
          [INFO] 
          [INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
          [INFO] Loading execution data file /Users/csudhars/Apr15Helix-ForkedHelix/helix/helix-core/target/jacoco.exec
          [INFO] Analyzed bundle 'Apache Helix :: Core' with 951 classes
          [INFO] ------------------------------------------------------------------------
          [INFO] BUILD SUCCESS
          [INFO] ------------------------------------------------------------------------
          [INFO] Total time:  02:00 min
          [INFO] Finished at: 2024-04-16T12:57:38-07:00
          [INFO] -

    mvn test -o -Dtest=TestPerInstanceAccessor -pl=helix-rest  

          [INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 219.352 s - in org.apache.helix.rest.server.TestPerInstanceAccessor
          [INFO] 
          [INFO] Results:
          [INFO] 
          [INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
          [INFO] 
          [INFO] 
          [INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
          [INFO] Loading execution data file /Users/csudhars/Apr15Helix-ForkedHelix/helix/helix-rest/target/jacoco.exec
          [INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 95 classes
          [INFO] ------------------------------------------------------------------------
          [INFO] BUILD SUCCESS
          [INFO] ------------------------------------------------------------------------
          [INFO] Total time:  03:52 min
          [INFO] Finished at: 2024-04-16T13:03:56-07:00
          [INFO] -



### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
