### PR TITLE
Fix BestPossibleExternalViewVerifier to use a ZkClient that has the serializer set to ByteArraySerializer

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentManager.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentManager.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.ResourceAssignment;
@@ -86,7 +88,11 @@ class AssignmentManager {
     if (assignmentMetadataStore != null) {
       try {
         _stateReadLatency.startMeasuringLatency();
-        currentBestAssignment = new HashMap<>(assignmentMetadataStore.getBestPossibleAssignment());
+        currentBestAssignment =
+            assignmentMetadataStore.getBestPossibleAssignment().entrySet().stream().collect(
+                Collectors.toMap(Map.Entry::getKey,
+                    entry -> new ResourceAssignment(entry.getValue().getRecord())));
+        ;
         _stateReadLatency.endMeasuringLatency();
       } catch (Exception ex) {
         throw new HelixRebalanceException(


### PR DESCRIPTION
### Summary

Cherry-pick: 
* Fix BestPossibleExternalViewVerifier to use a ZkClient that has the serializer set to ByteArraySerializer so it can read the assignment meta store best possible state. Fix BestPossibleExternalViewVerifier to actually calculate BEST_POSSIBLE instead of returning last persisted to ZK because we now need to consider handleDelayedRebalanceMinActiveReplica not being persisted to ZK(#2447). Fix handleDelayedRebalanceMinActiveReplica modifying in-memory _bestPossibleState in the _assignmentMetadataStore which was causing best possible state to continuosly be persisted until handleDelayedRebalanceMinActiveReplica wasn't kicking in anymore.

### Issues

- without fix for this condition, many znodes can be created under ASSIGNMENT_METADATA store faster than the controller can GC them