### PR TITLE
MetaClient leader election isLeader method NPE

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionClient.java
@@ -121,7 +121,8 @@ public class LeaderElectionClient implements AutoCloseable {
    * Returns true if current participant is the current leadership.
    */
   public boolean isLeader(String leaderPath) {
-    return getLeader(leaderPath).equalsIgnoreCase(_participant);
+    String leader = getLeader(leaderPath);
+    return leader != null && getLeader(leaderPath).equalsIgnoreCase(_participant);
   }
 
   /**

--- a/meta-client/src/main/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionClient.java
@@ -122,7 +122,7 @@ public class LeaderElectionClient implements AutoCloseable {
    */
   public boolean isLeader(String leaderPath) {
     String leader = getLeader(leaderPath);
-    return leader != null && getLeader(leaderPath).equalsIgnoreCase(_participant);
+    return leader != null && leader.equalsIgnoreCase(_participant);
   }
 
   /**

--- a/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
@@ -42,6 +42,19 @@ public class TestLeaderElection extends ZkMetaClientTestBase {
   }
 
   @Test
+  public void testIsLeaderBeforeJoiningParticipantPool() throws Exception {
+    String leaderPath = LEADER_PATH + "/testIsLeaderBeforeJoiningPool";
+    LeaderElectionClient clt1 = createLeaderElectionClient(PARTICIPANT_NAME1);
+    try {
+      boolean isLeader = clt1.isLeader(leaderPath);
+      Assert.assertFalse(isLeader, "Expected isLeader to return false before joining participant pool");
+    } catch (NullPointerException npe) {
+      Assert.fail("isLeader threw NPE before joining participant pool: " + npe.getMessage());
+    }
+    clt1.close();
+  }
+
+  @Test (dependsOnMethods = "testIsLeaderBeforeJoiningParticipantPool")
   public void testAcquireLeadership() throws Exception {
     System.out.println("START TestLeaderElection.testAcquireLeadership");
     String leaderPath = LEADER_PATH + "/testAcquireLeadership";

--- a/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
@@ -41,6 +41,7 @@ public class TestLeaderElection extends ZkMetaClientTestBase {
     }
   }
 
+  // Test that calling isLeader before client joins LeaderElectionParticipantPool returns false and does not throw NPE
   @Test
   public void testIsLeaderBeforeJoiningParticipantPool() throws Exception {
     String leaderPath = LEADER_PATH + "/testIsLeaderBeforeJoiningPool";


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
LeaderElectionClient throws NPE if isLeader() is called before client joins leader election participant pool
```
Caused by: java.lang.NullPointerException
      at org.apache.helix.metaclient.recipes.leaderelection.LeaderElectionClient.isLeader(LeaderElectionClient.java:124) ~[org.apache.helix.meta-client-1.3.2.jar:?]
```

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add null pointer check to isLeader() method. isLeader() will now return false when isLeader() is called before the client joins the leader election participant pool. 
Added test to assert NPE no longer thrown and that isLeader() returns false in above scenario. 

### Tests

- [x] The following tests are written for this issue:

testIsLeaderBeforeJoiningParticipantPool in TestLeaderElection.java

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
N/A, no backwards incompatibilities


### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
