### PR TITLE
Deprecate HELIX_DISABLED_REASON and refactor how InstanceOperation is represented in instance configs.

### DIFF
--- a/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
+++ b/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
@@ -29,13 +29,6 @@ public class InstanceConstants {
   public static final Set<InstanceOperation> UNROUTABLE_INSTANCE_OPERATIONS =
       Set.of(InstanceOperation.SWAP_IN, InstanceOperation.UNKNOWN);
 
-  /**
-   * The set of InstanceOperations that are not considered to be servable.
-   * These InstanceOperations will no allow any online replicas be hosted.
-   */
-  public static final Set<InstanceOperation> NON_SERVABLE_INSTANCE_OPERATIONS =
-      Set.of(InstanceOperation.DISABLE, InstanceOperation.UNKNOWN);
-
   @Deprecated
   public enum InstanceDisabledType {
     CLOUD_EVENT,

--- a/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
+++ b/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
@@ -27,7 +27,7 @@ public class InstanceConstants {
    * The set of InstanceOperations that are not allowed to be populated in the RoutingTableProvider.
    */
   public static final Set<InstanceOperation> UNROUTABLE_INSTANCE_OPERATIONS =
-      Set.of(InstanceOperation.SWAP_IN, InstanceOperation.UNKNOWN);
+      ImmutableSet.of(InstanceOperation.SWAP_IN, InstanceOperation.UNKNOWN);
 
   @Deprecated
   public enum InstanceDisabledType {

--- a/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
+++ b/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
@@ -20,7 +20,7 @@ public class InstanceConstants {
    * TODO: Remove this when the deprecated HELIX_ENABLED is removed.
    */
   public static final Set<InstanceOperation> INSTANCE_DISABLED_OVERRIDABLE_OPERATIONS =
-      ImmutableSet.of(InstanceOperation.ENABLE, InstanceOperation.DISABLE, InstanceOperation.EVACUATE);
+      ImmutableSet.of(InstanceOperation.ENABLE, InstanceOperation.EVACUATE);
 
 
   /**

--- a/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
+++ b/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
@@ -37,22 +37,16 @@ public class InstanceConstants {
   }
 
   public enum InstanceOperationSource {
-    AUTOMATION, ADMIN, USER;
+    ADMIN(0), USER(1), AUTOMATION(2), DEFAULT(3);
 
-    /**
-     * Convert from InstanceOperationTrigger to DisabledType
-     *
-     * @param trigger InstanceOperationTrigger
-     * @return InstanceDisabledType
-     */
-    public static InstanceDisabledType instanceOperationSourceToInstanceDisabledType(
-        InstanceOperationSource trigger) {
-      switch (trigger) {
-        case AUTOMATION:
-          return InstanceDisabledType.CLOUD_EVENT;
-        default:
-          return InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE;
-      }
+    private final int _priority;
+
+    InstanceOperationSource(int priority) {
+      _priority = priority;
+    }
+
+    public int getPriority() {
+      return _priority;
     }
 
     /**
@@ -66,8 +60,10 @@ public class InstanceConstants {
       switch (disabledType) {
         case CLOUD_EVENT:
           return InstanceOperationSource.AUTOMATION;
-        default:
+        case USER_OPERATION:
           return InstanceOperationSource.USER;
+        default:
+          return InstanceOperationSource.DEFAULT;
       }
     }
   }

--- a/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
+++ b/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
@@ -26,8 +26,15 @@ public class InstanceConstants {
   /**
    * The set of InstanceOperations that are not allowed to be populated in the RoutingTableProvider.
    */
-  public static final Set<InstanceOperation> UNSERVABLE_INSTANCE_OPERATIONS =
-      ImmutableSet.of(InstanceOperation.SWAP_IN, InstanceOperation.UNKNOWN);
+  public static final Set<InstanceOperation> UNROUTABLE_INSTANCE_OPERATIONS =
+      Set.of(InstanceOperation.SWAP_IN, InstanceOperation.UNKNOWN);
+
+  /**
+   * The set of InstanceOperations that are not considered to be servable.
+   * These InstanceOperations will no allow any online replicas be hosted.
+   */
+  public static final Set<InstanceOperation> NON_SERVABLE_INSTANCE_OPERATIONS =
+      Set.of(InstanceOperation.DISABLE, InstanceOperation.UNKNOWN);
 
   public enum InstanceDisabledType {
     CLOUD_EVENT,

--- a/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
+++ b/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
@@ -36,10 +36,51 @@ public class InstanceConstants {
   public static final Set<InstanceOperation> NON_SERVABLE_INSTANCE_OPERATIONS =
       Set.of(InstanceOperation.DISABLE, InstanceOperation.UNKNOWN);
 
+  @Deprecated
   public enum InstanceDisabledType {
     CLOUD_EVENT,
     USER_OPERATION,
     DEFAULT_INSTANCE_DISABLE_TYPE
+  }
+
+  public enum InstanceOperationTrigger {
+    CLOUD, USER, DEFAULT;
+
+    /**
+     * Convert from InstanceOperationTrigger to DisabledType
+     *
+     * @param trigger InstanceOperationTrigger
+     * @return InstanceDisabledType
+     */
+    public static InstanceDisabledType instanceOperationTriggerToInstanceDisabledType(
+        InstanceOperationTrigger trigger) {
+      switch (trigger) {
+        case CLOUD:
+          return InstanceDisabledType.CLOUD_EVENT;
+        case USER:
+          return InstanceDisabledType.USER_OPERATION;
+        default:
+          return InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE;
+      }
+    }
+
+    /**
+     * Convert from InstanceDisabledType to InstanceOperationTrigger
+     *
+     * @param disabledType InstanceDisabledType
+     * @return InstanceOperationTrigger
+     */
+    public static InstanceOperationTrigger instanceDisabledTypeToInstanceOperationTrigger(
+        InstanceDisabledType disabledType) {
+      switch (disabledType) {
+        case CLOUD_EVENT:
+          return InstanceOperationTrigger.CLOUD;
+        case USER_OPERATION:
+          return InstanceOperationTrigger.USER;
+        default:
+          return InstanceOperationTrigger.DEFAULT;
+      }
+    }
   }
 
   public enum InstanceOperation {

--- a/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
+++ b/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
@@ -36,8 +36,8 @@ public class InstanceConstants {
     DEFAULT_INSTANCE_DISABLE_TYPE
   }
 
-  public enum InstanceOperationTrigger {
-    CLOUD, USER, DEFAULT;
+  public enum InstanceOperationSource {
+    AUTOMATION, ADMIN, USER;
 
     /**
      * Convert from InstanceOperationTrigger to DisabledType
@@ -45,13 +45,11 @@ public class InstanceConstants {
      * @param trigger InstanceOperationTrigger
      * @return InstanceDisabledType
      */
-    public static InstanceDisabledType instanceOperationTriggerToInstanceDisabledType(
-        InstanceOperationTrigger trigger) {
+    public static InstanceDisabledType instanceOperationSourceToInstanceDisabledType(
+        InstanceOperationSource trigger) {
       switch (trigger) {
-        case CLOUD:
+        case AUTOMATION:
           return InstanceDisabledType.CLOUD_EVENT;
-        case USER:
-          return InstanceDisabledType.USER_OPERATION;
         default:
           return InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE;
       }
@@ -63,15 +61,13 @@ public class InstanceConstants {
      * @param disabledType InstanceDisabledType
      * @return InstanceOperationTrigger
      */
-    public static InstanceOperationTrigger instanceDisabledTypeToInstanceOperationTrigger(
+    public static InstanceOperationSource instanceDisabledTypeToInstanceOperationSource(
         InstanceDisabledType disabledType) {
       switch (disabledType) {
         case CLOUD_EVENT:
-          return InstanceOperationTrigger.CLOUD;
-        case USER_OPERATION:
-          return InstanceOperationTrigger.USER;
+          return InstanceOperationSource.AUTOMATION;
         default:
-          return InstanceOperationTrigger.DEFAULT;
+          return InstanceOperationSource.USER;
       }
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -310,27 +310,24 @@ public interface HelixAdmin {
   void enableInstance(String clusterName, List<String> instances, boolean enabled);
 
   /**
-   * Set the instanceOperation field. Setting it to null is equivalent to
-   * ENABLE.
+   * Set the instanceOperation of and instance with {@link InstanceConstants.InstanceOperation}.
    *
    * @param clusterName       The cluster name
    * @param instanceName      The instance name
-   * @param instanceOperation The instance operation
+   * @param instanceOperation The instance operation type
    */
   void setInstanceOperation(String clusterName, String instanceName,
-      @Nullable InstanceConstants.InstanceOperation instanceOperation);
+      InstanceConstants.InstanceOperation instanceOperation);
 
   /**
-   * Set the instanceOperation field. Setting it to null is equivalent to ENABLE.
+   * Set the instanceOperation of an instance with {@link InstanceConfig.InstanceOperation}.
    *
    * @param clusterName       The cluster name
    * @param instanceName      The instance name
    * @param instanceOperation The instance operation
-   * @param reason            The reason for setting the instance operation (only works with
-   *                          {@link InstanceConstants#NON_SERVABLE_INSTANCE_OPERATIONS})
    */
   void setInstanceOperation(String clusterName, String instanceName,
-      @Nullable InstanceConstants.InstanceOperation instanceOperation, String reason);
+      InstanceConfig.InstanceOperation instanceOperation);
 
   /**
    * Disable or enable a resource

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -320,14 +320,28 @@ public interface HelixAdmin {
       InstanceConstants.InstanceOperation instanceOperation);
 
   /**
-   * Set the instanceOperation of an instance with {@link InstanceConfig.InstanceOperation}.
+   * Set the instanceOperation of and instance with {@link InstanceConstants.InstanceOperation}.
    *
    * @param clusterName       The cluster name
    * @param instanceName      The instance name
-   * @param instanceOperation The instance operation
+   * @param instanceOperation The instance operation type
+   * @param reason            The reason for the operation
    */
   void setInstanceOperation(String clusterName, String instanceName,
-      InstanceConfig.InstanceOperation instanceOperation);
+      InstanceConstants.InstanceOperation instanceOperation, String reason);
+
+  /**
+   * Set the instanceOperation of and instance with {@link InstanceConstants.InstanceOperation}.
+   *
+   * @param clusterName       The cluster name
+   * @param instanceName      The instance name
+   * @param instanceOperation The instance operation type
+   * @param reason            The reason for the operation
+   * @param overrideAll       Whether to override all existing instance operations from all other
+   *                          instance operations
+   */
+  void setInstanceOperation(String clusterName, String instanceName,
+      InstanceConstants.InstanceOperation instanceOperation, String reason, boolean overrideAll);
 
   /**
    * Disable or enable a resource

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -321,6 +321,18 @@ public interface HelixAdmin {
       @Nullable InstanceConstants.InstanceOperation instanceOperation);
 
   /**
+   * Set the instanceOperation field. Setting it to null is equivalent to ENABLE.
+   *
+   * @param clusterName       The cluster name
+   * @param instanceName      The instance name
+   * @param instanceOperation The instance operation
+   * @param reason            The reason for setting the instance operation (only works with
+   *                          {@link InstanceConstants#NON_SERVABLE_INSTANCE_OPERATIONS})
+   */
+  void setInstanceOperation(String clusterName, String instanceName,
+      @Nullable InstanceConstants.InstanceOperation instanceOperation, String reason);
+
+  /**
    * Disable or enable a resource
    * @param clusterName
    * @param resourceName

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/helix/DefaultCloudEventCallbackImpl.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/helix/DefaultCloudEventCallbackImpl.java
@@ -23,6 +23,7 @@ import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.util.InstanceValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,8 +51,11 @@ public class DefaultCloudEventCallbackImpl {
     if (InstanceValidationUtil
         .isEnabled(manager.getHelixDataAccessor(), manager.getInstanceName())) {
       manager.getClusterManagmentTool()
-          .enableInstance(manager.getClusterName(), manager.getInstanceName(), false,
-              InstanceConstants.InstanceDisabledType.CLOUD_EVENT, message);
+          .setInstanceOperation(manager.getClusterName(), manager.getInstanceName(),
+              new InstanceConfig.InstanceOperation.Builder().setOperation(
+                      InstanceConstants.InstanceOperation.DISABLE)
+                  .setTrigger(InstanceConstants.InstanceOperationTrigger.CLOUD).setReason(message)
+                  .build());
     }
     HelixEventHandlingUtil.updateCloudEventOperationInClusterConfig(manager.getClusterName(),
         manager.getInstanceName(), manager.getHelixDataAccessor().getBaseDataAccessor(), false,
@@ -72,10 +76,12 @@ public class DefaultCloudEventCallbackImpl {
     HelixEventHandlingUtil
         .updateCloudEventOperationInClusterConfig(manager.getClusterName(), instanceName,
             manager.getHelixDataAccessor().getBaseDataAccessor(), true, message);
-    if (HelixEventHandlingUtil.isInstanceDisabledForCloudEvent(instanceName, accessor)) {
-      manager.getClusterManagmentTool().enableInstance(manager.getClusterName(), instanceName, true,
-          InstanceConstants.InstanceDisabledType.CLOUD_EVENT, message);
-    }
+    manager.getClusterManagmentTool()
+        .setInstanceOperation(manager.getClusterName(), manager.getInstanceName(),
+            new InstanceConfig.InstanceOperation.Builder().setOperation(
+                    InstanceConstants.InstanceOperation.ENABLE)
+                .setTrigger(InstanceConstants.InstanceOperationTrigger.CLOUD).setReason(message)
+                .build());
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/helix/DefaultCloudEventCallbackImpl.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/helix/DefaultCloudEventCallbackImpl.java
@@ -51,10 +51,9 @@ public class DefaultCloudEventCallbackImpl {
     LOG.info("DefaultCloudEventCallbackImpl disable Instance {}", manager.getInstanceName());
     if (InstanceValidationUtil
         .isEnabled(manager.getHelixDataAccessor(), manager.getInstanceName())) {
-      InstanceUtil instanceUtil = new InstanceUtil(manager.getConfigAccessor(),
-          manager.getHelixDataAccessor().getBaseDataAccessor());
-      instanceUtil
-          .setInstanceOperation(manager.getClusterName(), manager.getInstanceName(),
+      InstanceUtil.setInstanceOperation(manager.getConfigAccessor(),
+          manager.getHelixDataAccessor().getBaseDataAccessor(), manager.getClusterName(),
+          manager.getInstanceName(),
               new InstanceConfig.InstanceOperation.Builder().setOperation(
                       InstanceConstants.InstanceOperation.DISABLE)
                   .setSource(InstanceConstants.InstanceOperationSource.AUTOMATION)
@@ -80,10 +79,9 @@ public class DefaultCloudEventCallbackImpl {
     HelixEventHandlingUtil
         .updateCloudEventOperationInClusterConfig(manager.getClusterName(), instanceName,
             manager.getHelixDataAccessor().getBaseDataAccessor(), true, message);
-    InstanceUtil instanceUtil = new InstanceUtil(manager.getConfigAccessor(),
-        manager.getHelixDataAccessor().getBaseDataAccessor());
-    instanceUtil
-        .setInstanceOperation(manager.getClusterName(), manager.getInstanceName(),
+    InstanceUtil.setInstanceOperation(manager.getConfigAccessor(),
+        manager.getHelixDataAccessor().getBaseDataAccessor(), manager.getClusterName(),
+        manager.getInstanceName(),
             new InstanceConfig.InstanceOperation.Builder().setOperation(
                     InstanceConstants.InstanceOperation.ENABLE)
                 .setSource(InstanceConstants.InstanceOperationSource.AUTOMATION).setReason(message)

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/helix/DefaultCloudEventCallbackImpl.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/helix/DefaultCloudEventCallbackImpl.java
@@ -24,6 +24,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.util.InstanceUtil;
 import org.apache.helix.util.InstanceValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,11 +51,14 @@ public class DefaultCloudEventCallbackImpl {
     LOG.info("DefaultCloudEventCallbackImpl disable Instance {}", manager.getInstanceName());
     if (InstanceValidationUtil
         .isEnabled(manager.getHelixDataAccessor(), manager.getInstanceName())) {
-      manager.getClusterManagmentTool()
+      InstanceUtil instanceUtil = new InstanceUtil(manager.getConfigAccessor(),
+          manager.getHelixDataAccessor().getBaseDataAccessor());
+      instanceUtil
           .setInstanceOperation(manager.getClusterName(), manager.getInstanceName(),
               new InstanceConfig.InstanceOperation.Builder().setOperation(
                       InstanceConstants.InstanceOperation.DISABLE)
-                  .setTrigger(InstanceConstants.InstanceOperationTrigger.CLOUD).setReason(message)
+                  .setSource(InstanceConstants.InstanceOperationSource.AUTOMATION)
+                  .setReason(message)
                   .build());
     }
     HelixEventHandlingUtil.updateCloudEventOperationInClusterConfig(manager.getClusterName(),
@@ -76,11 +80,13 @@ public class DefaultCloudEventCallbackImpl {
     HelixEventHandlingUtil
         .updateCloudEventOperationInClusterConfig(manager.getClusterName(), instanceName,
             manager.getHelixDataAccessor().getBaseDataAccessor(), true, message);
-    manager.getClusterManagmentTool()
+    InstanceUtil instanceUtil = new InstanceUtil(manager.getConfigAccessor(),
+        manager.getHelixDataAccessor().getBaseDataAccessor());
+    instanceUtil
         .setInstanceOperation(manager.getClusterName(), manager.getInstanceName(),
             new InstanceConfig.InstanceOperation.Builder().setOperation(
                     InstanceConstants.InstanceOperation.ENABLE)
-                .setTrigger(InstanceConstants.InstanceOperationTrigger.CLOUD).setReason(message)
+                .setSource(InstanceConstants.InstanceOperationSource.AUTOMATION).setReason(message)
                 .build());
   }
 

--- a/helix-core/src/main/java/org/apache/helix/cloud/event/helix/HelixEventHandlingUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/cloud/event/helix/HelixEventHandlingUtil.java
@@ -48,7 +48,10 @@ class HelixEventHandlingUtil {
    * @param dataAccessor
    * @return return true only when instance is Helix disabled and the disabled reason in
    * instanceConfig is cloudEvent
+   * @deprecated No need to check this if using InstanceOperation and specifying the trigger as CLOUD
+   *            when enabling.
    */
+  @Deprecated
   static boolean isInstanceDisabledForCloudEvent(String instanceName,
       HelixDataAccessor dataAccessor) {
     InstanceConfig instanceConfig =

--- a/helix-core/src/main/java/org/apache/helix/controller/changedetector/trimmer/InstanceConfigTrimmer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/changedetector/trimmer/InstanceConfigTrimmer.java
@@ -19,6 +19,7 @@ package org.apache.helix.controller.changedetector.trimmer;
  * under the License.
  */
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -60,6 +61,21 @@ public class InstanceConfigTrimmer extends HelixPropertyTrimmer<InstanceConfig> 
   @Override
   protected Map<FieldType, Set<String>> getNonTrimmableFields(InstanceConfig instanceConfig) {
     return STATIC_TOPOLOGY_RELATED_FIELD_MAP;
+  }
+
+  /**
+   * We should trim HELIX_INSTANCE_OPERATIONS field, it is used to filter instances in the
+   * BaseControllerDataProvider. That filtering will be used to determine if ResourceChangeSnapshot
+   * has changed as opposed to checking the actual value of the field.
+   *
+   * @param property the instance config
+   * @return a map contains all non-trimmable field keys that need to be kept.
+   */
+  protected Map<FieldType, Set<String>> getNonTrimmableKeys(InstanceConfig property) {
+    Map<FieldType, Set<String>> nonTrimmableKeys = super.getNonTrimmableKeys(property);
+    nonTrimmableKeys.get(FieldType.LIST_FIELD)
+        .remove(InstanceConfigProperty.HELIX_INSTANCE_OPERATIONS.name());
+    return nonTrimmableKeys;
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -413,14 +413,15 @@ public class BaseControllerDataProvider implements ControlContextProvider {
           currentInstanceConfig.getLogicalId(clusterTopologyConfig.getEndNodeType());
 
       newInstanceConfigMapByInstanceOperation.computeIfAbsent(
-              currentInstanceConfig.getInstanceOperation(), k -> new HashMap<>())
+              currentInstanceConfig.getInstanceOperation().getOperation(),
+              k -> new HashMap<>())
           .put(node, currentInstanceConfig);
 
       if (currentInstanceConfig.isAssignable()) {
         newAssignableInstanceConfigMap.put(node, currentInstanceConfig);
       }
 
-      if (currentInstanceConfig.getInstanceOperation()
+      if (currentInstanceConfig.getInstanceOperation().getOperation()
           .equals(InstanceConstants.InstanceOperation.SWAP_IN)) {
         swapInLogicalIdsByInstanceName.put(currentInstanceConfig.getInstanceName(),
             currentInstanceLogicalId);
@@ -1079,7 +1080,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     _disabledInstanceSet.clear();
     for (InstanceConfig config : allInstanceConfigs) {
       Map<String, List<String>> disabledPartitionMap = config.getDisabledPartitionsMap();
-      if (config.getInstanceOperation().equals(InstanceConstants.InstanceOperation.DISABLE)) {
+      if (config.getInstanceOperation().getOperation()
+          .equals(InstanceConstants.InstanceOperation.DISABLE)) {
         _disabledInstanceSet.add(config.getInstanceName());
       }
       for (String resource : disabledPartitionMap.keySet()) {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -36,7 +36,6 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.LogUtil;
-import org.apache.helix.controller.common.ResourcesStateMap;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.pipeline.AbstractBaseStage;
 import org.apache.helix.controller.pipeline.StageException;
@@ -358,10 +357,10 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     if (maxInstancesUnableToAcceptOnlineReplicas >= 0) {
       // Instead of only checking the offline instances, we consider how many instances in the cluster
       // are not assignable and live. This is because some instances may be online but have an unassignable
-      // InstanceOperation such as EVACUATE, DISABLE, or UNKNOWN. We will exclude SWAP_IN instances from
+      // InstanceOperation such as EVACUATE, and DISABLE. We will exclude SWAP_IN and UNKNOWN instances from
       // they should not account against the capacity of the cluster.
       int instancesUnableToAcceptOnlineReplicas = cache.getInstanceConfigMap().entrySet().stream()
-          .filter(instanceEntry -> !InstanceConstants.UNSERVABLE_INSTANCE_OPERATIONS.contains(
+          .filter(instanceEntry -> !InstanceConstants.UNROUTABLE_INSTANCE_OPERATIONS.contains(
               instanceEntry.getValue().getInstanceOperation())).collect(Collectors.toSet())
           .size() - cache.getEnabledLiveInstances().size();
       if (instancesUnableToAcceptOnlineReplicas > maxInstancesUnableToAcceptOnlineReplicas) {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -361,7 +361,8 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
       // they should not account against the capacity of the cluster.
       int instancesUnableToAcceptOnlineReplicas = cache.getInstanceConfigMap().entrySet().stream()
           .filter(instanceEntry -> !InstanceConstants.UNROUTABLE_INSTANCE_OPERATIONS.contains(
-              instanceEntry.getValue().getInstanceOperation())).collect(Collectors.toSet())
+              instanceEntry.getValue().getInstanceOperation().getOperation()))
+          .collect(Collectors.toSet())
           .size() - cache.getEnabledLiveInstances().size();
       if (instancesUnableToAcceptOnlineReplicas > maxInstancesUnableToAcceptOnlineReplicas) {
         String errMsg = String.format(

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -109,6 +109,7 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
 
       // Only update the currentStateExcludingUnknown if the instance is not in UNKNOWN InstanceOperation.
       if (instanceConfig == null || !instanceConfig.getInstanceOperation()
+          .getOperation()
           .equals(InstanceConstants.InstanceOperation.UNKNOWN)) {
         // update current states.
         updateCurrentStates(instance,

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -208,7 +208,8 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     List<InstanceConfig> matchingLogicalIdInstances =
-        InstanceUtil.findInstancesMatchingLogicalId(_configAccessor, clusterName, instanceConfig);
+        InstanceUtil.findInstancesWithMatchingLogicalId(_configAccessor, clusterName,
+            instanceConfig);
     if (matchingLogicalIdInstances.size() > 1) {
       throw new HelixException(
           "There are already more than one instance with the same logicalId in the cluster: "
@@ -220,8 +221,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     InstanceConstants.InstanceOperation attemptedInstanceOperation =
         instanceConfig.getInstanceOperation().getOperation();
     try {
-      InstanceUtil.validateInstanceOperationTransition(
-          !matchingLogicalIdInstances.isEmpty() ? matchingLogicalIdInstances.get(0) : null,
+      InstanceUtil.validateInstanceOperationTransition(_configAccessor, clusterName, instanceConfig,
           InstanceConstants.InstanceOperation.UNKNOWN, attemptedInstanceOperation);
     } catch (HelixException e) {
       instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN);
@@ -619,7 +619,8 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     List<InstanceConfig> swappingInstances =
-        InstanceUtil.findInstancesMatchingLogicalId(_configAccessor, clusterName, instanceConfig);
+        InstanceUtil.findInstancesWithMatchingLogicalId(_configAccessor, clusterName,
+            instanceConfig);
     if (swappingInstances.size() != 1) {
       logger.warn(
           "Instance {} in cluster {} is not swapping with any other instance. Cannot determine if the swap is complete.",
@@ -657,7 +658,8 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     List<InstanceConfig> swappingInstances =
-        InstanceUtil.findInstancesMatchingLogicalId(_configAccessor, clusterName, instanceConfig);
+        InstanceUtil.findInstancesWithMatchingLogicalId(_configAccessor, clusterName,
+            instanceConfig);
     if (swappingInstances.size() != 1) {
       logger.warn(
           "Instance {} in cluster {} is not swapping with any other instance. Cannot determine if the swap is complete.",

--- a/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/InstanceConfig.java
@@ -514,7 +514,7 @@ public class InstanceConfig extends HelixProperty {
     if (operation.getSource() == InstanceConstants.InstanceOperationSource.ADMIN) {
       deserializedInstanceOperations.clear();
     } else {
-      // Remove the instance operation with the same trigger if it exists.
+      // Remove the instance operation with the same source if it exists.
       deserializedInstanceOperations.removeIf(
           instanceOperation -> instanceOperation.getSource() == operation.getSource());
     }
@@ -547,8 +547,7 @@ public class InstanceConfig extends HelixProperty {
       _record.setSimpleField(InstanceConfigProperty.HELIX_DISABLED_REASON.name(),
           operation.getReason());
       _record.setSimpleField(InstanceConfigProperty.HELIX_DISABLED_TYPE.name(),
-          InstanceConstants.InstanceOperationSource.instanceOperationSourceToInstanceDisabledType(
-              operation.getSource()).name());
+          InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE.name());
     } else if (operation.getOperation() == InstanceConstants.InstanceOperation.ENABLE) {
       // If any of the other InstanceOperations are of type DISABLE, set that in the HELIX_ENABLED,
       // HELIX_DISABLED_REASON, and HELIX_DISABLED_TYPE fields.
@@ -565,8 +564,7 @@ public class InstanceConfig extends HelixProperty {
         _record.setSimpleField(InstanceConfigProperty.HELIX_DISABLED_REASON.name(),
             latestDisableInstanceOperation.getReason());
         _record.setSimpleField(InstanceConfigProperty.HELIX_DISABLED_TYPE.name(),
-            InstanceConstants.InstanceOperationSource.instanceOperationSourceToInstanceDisabledType(
-                latestDisableInstanceOperation.getSource()).name());
+            InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE.name());
       } else {
         setInstanceEnabledHelper(true, operation.getTimestamp());
       }
@@ -575,7 +573,7 @@ public class InstanceConfig extends HelixProperty {
 
   /**
    * Set the instance operation for this instance. Provide the InstanceOperation enum and the reason
-   * and trigger will be set to default values.
+   * and source will be set to default values.
    *
    * @param operation the instance operation
    */

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -182,7 +182,7 @@ class RoutingDataCache extends BasicClusterDataCache {
   private void updateRoutableInstanceConfigMap(Map<String, InstanceConfig> instanceConfigMap) {
     _routableInstanceConfigMap = instanceConfigMap.entrySet().stream().filter(
             (instanceConfigEntry) -> !InstanceConstants.UNROUTABLE_INSTANCE_OPERATIONS.contains(
-                instanceConfigEntry.getValue().getInstanceOperation()))
+                instanceConfigEntry.getValue().getInstanceOperation().getOperation()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
@@ -191,7 +191,8 @@ class RoutingDataCache extends BasicClusterDataCache {
     _routableLiveInstanceMap = liveInstanceMap.entrySet().stream().filter(
             (liveInstanceEntry) -> instanceConfigMap.containsKey(liveInstanceEntry.getKey())
                 && !InstanceConstants.UNROUTABLE_INSTANCE_OPERATIONS.contains(
-                instanceConfigMap.get(liveInstanceEntry.getKey()).getInstanceOperation()))
+                instanceConfigMap.get(liveInstanceEntry.getKey()).getInstanceOperation()
+                    .getOperation()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 

--- a/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/spectator/RoutingDataCache.java
@@ -181,7 +181,7 @@ class RoutingDataCache extends BasicClusterDataCache {
 
   private void updateRoutableInstanceConfigMap(Map<String, InstanceConfig> instanceConfigMap) {
     _routableInstanceConfigMap = instanceConfigMap.entrySet().stream().filter(
-            (instanceConfigEntry) -> !InstanceConstants.UNSERVABLE_INSTANCE_OPERATIONS.contains(
+            (instanceConfigEntry) -> !InstanceConstants.UNROUTABLE_INSTANCE_OPERATIONS.contains(
                 instanceConfigEntry.getValue().getInstanceOperation()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
@@ -190,7 +190,7 @@ class RoutingDataCache extends BasicClusterDataCache {
       Map<String, LiveInstance> liveInstanceMap) {
     _routableLiveInstanceMap = liveInstanceMap.entrySet().stream().filter(
             (liveInstanceEntry) -> instanceConfigMap.containsKey(liveInstanceEntry.getKey())
-                && !InstanceConstants.UNSERVABLE_INSTANCE_OPERATIONS.contains(
+                && !InstanceConstants.UNROUTABLE_INSTANCE_OPERATIONS.contains(
                 instanceConfigMap.get(liveInstanceEntry.getKey()).getInstanceOperation()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
@@ -63,27 +64,28 @@ public class InstanceUtil {
               .getOperation().equals(InstanceConstants.InstanceOperation.DISABLE));
 
   // Validator map for valid instance operation transitions <currentOperation>:<targetOperation>:<validator>
-  private static final Map<InstanceConstants.InstanceOperation, Map<InstanceConstants.InstanceOperation, Function<List<InstanceConfig>, Boolean>>>
-      validInstanceOperationTransitions = Map.of(InstanceConstants.InstanceOperation.ENABLE,
+  private static final ImmutableMap<InstanceConstants.InstanceOperation, ImmutableMap<InstanceConstants.InstanceOperation, Function<List<InstanceConfig>, Boolean>>>
+      validInstanceOperationTransitions =
+      ImmutableMap.of(InstanceConstants.InstanceOperation.ENABLE,
       // ENABLE and DISABLE can be set to UNKNOWN when matching instance is in SWAP_IN and set to ENABLE in a transaction.
-      Map.of(InstanceConstants.InstanceOperation.ENABLE, ALWAYS_ALLOWED,
+          ImmutableMap.of(InstanceConstants.InstanceOperation.ENABLE, ALWAYS_ALLOWED,
           InstanceConstants.InstanceOperation.DISABLE, ALWAYS_ALLOWED,
           InstanceConstants.InstanceOperation.EVACUATE, ALWAYS_ALLOWED),
       InstanceConstants.InstanceOperation.DISABLE,
-      Map.of(InstanceConstants.InstanceOperation.DISABLE, ALWAYS_ALLOWED,
+          ImmutableMap.of(InstanceConstants.InstanceOperation.DISABLE, ALWAYS_ALLOWED,
           InstanceConstants.InstanceOperation.ENABLE, ALWAYS_ALLOWED,
           InstanceConstants.InstanceOperation.EVACUATE, ALWAYS_ALLOWED),
       InstanceConstants.InstanceOperation.SWAP_IN,
       // SWAP_IN can be set to ENABLE when matching instance is in UNKNOWN state in a transaction.
-      Map.of(InstanceConstants.InstanceOperation.SWAP_IN, ALWAYS_ALLOWED,
+          ImmutableMap.of(InstanceConstants.InstanceOperation.SWAP_IN, ALWAYS_ALLOWED,
           InstanceConstants.InstanceOperation.UNKNOWN, ALWAYS_ALLOWED),
       InstanceConstants.InstanceOperation.EVACUATE,
-      Map.of(InstanceConstants.InstanceOperation.EVACUATE, ALWAYS_ALLOWED,
+          ImmutableMap.of(InstanceConstants.InstanceOperation.EVACUATE, ALWAYS_ALLOWED,
           InstanceConstants.InstanceOperation.ENABLE, ALL_MATCHES_ARE_UNKNOWN,
           InstanceConstants.InstanceOperation.DISABLE, ALL_MATCHES_ARE_UNKNOWN,
           InstanceConstants.InstanceOperation.UNKNOWN, ALWAYS_ALLOWED),
       InstanceConstants.InstanceOperation.UNKNOWN,
-      Map.of(InstanceConstants.InstanceOperation.UNKNOWN, ALWAYS_ALLOWED,
+          ImmutableMap.of(InstanceConstants.InstanceOperation.UNKNOWN, ALWAYS_ALLOWED,
           InstanceConstants.InstanceOperation.ENABLE, ALL_MATCHES_ARE_UNKNOWN_OR_EVACUATE,
           InstanceConstants.InstanceOperation.DISABLE, ALL_MATCHES_ARE_UNKNOWN_OR_EVACUATE,
           InstanceConstants.InstanceOperation.SWAP_IN, ANY_MATCH_ENABLE_OR_DISABLE));

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
@@ -1,0 +1,176 @@
+package org.apache.helix.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.helix.AccessOption;
+import org.apache.helix.BaseDataAccessor;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixException;
+import org.apache.helix.PropertyPathBuilder;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.model.ClusterTopologyConfig;
+import org.apache.helix.model.HelixConfigScope;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.builder.HelixConfigScopeBuilder;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.zkclient.DataUpdater;
+
+public class InstanceUtil {
+  private final BaseDataAccessor<ZNRecord> _baseDataAccessor;
+  private final ConfigAccessor _configAccessor;
+
+  public InstanceUtil(RealmAwareZkClient zkClient) {
+    _baseDataAccessor = new ZkBaseDataAccessor<>(zkClient);
+    _configAccessor = new ConfigAccessor(zkClient);
+  }
+
+  public InstanceUtil(ConfigAccessor configAccessor, BaseDataAccessor<ZNRecord> baseAccessor) {
+    _baseDataAccessor = baseAccessor;
+    _configAccessor = configAccessor;
+  }
+
+  public static void validateInstanceOperationTransition(InstanceConfig matchingLogicalIdInstance,
+      InstanceConstants.InstanceOperation currentOperation,
+      InstanceConstants.InstanceOperation targetOperation) {
+    boolean targetStateEnableOrDisable =
+        targetOperation.equals(InstanceConstants.InstanceOperation.ENABLE)
+            || targetOperation.equals(InstanceConstants.InstanceOperation.DISABLE);
+    switch (currentOperation) {
+      case ENABLE:
+      case DISABLE:
+        // ENABLE or DISABLE can be set to ENABLE, DISABLE, or EVACUATE at any time.
+        if (ImmutableSet.of(InstanceConstants.InstanceOperation.ENABLE,
+            InstanceConstants.InstanceOperation.DISABLE,
+            InstanceConstants.InstanceOperation.EVACUATE).contains(targetOperation)) {
+          return;
+        }
+      case SWAP_IN:
+        // We can only ENABLE or DISABLE a SWAP_IN instance if there is an instance with matching logicalId
+        // with an InstanceOperation set to UNKNOWN.
+        if ((targetStateEnableOrDisable && (matchingLogicalIdInstance == null
+            || matchingLogicalIdInstance.getInstanceOperation().getOperation()
+            .equals(InstanceConstants.InstanceOperation.UNKNOWN))) || targetOperation.equals(
+            InstanceConstants.InstanceOperation.UNKNOWN)) {
+          return;
+        }
+      case EVACUATE:
+        // EVACUATE can only be set to ENABLE or DISABLE when there is no instance with the same
+        // logicalId in the cluster.
+        if ((targetStateEnableOrDisable && matchingLogicalIdInstance == null)
+            || targetOperation.equals(InstanceConstants.InstanceOperation.UNKNOWN)) {
+          return;
+        }
+      case UNKNOWN:
+        // UNKNOWN can be set to ENABLE or DISABLE when there is no instance with the same logicalId in the cluster
+        // or the instance with the same logicalId in the cluster has InstanceOperation set to EVACUATE.
+        // UNKNOWN can be set to SWAP_IN when there is an instance with the same logicalId in the cluster set to ENABLE,
+        // or DISABLE.
+        if ((targetStateEnableOrDisable && (matchingLogicalIdInstance == null
+            || matchingLogicalIdInstance.getInstanceOperation().getOperation()
+            .equals(InstanceConstants.InstanceOperation.EVACUATE)))) {
+          return;
+        } else if (targetOperation.equals(InstanceConstants.InstanceOperation.SWAP_IN)
+            && matchingLogicalIdInstance != null && !ImmutableSet.of(
+                InstanceConstants.InstanceOperation.UNKNOWN,
+                InstanceConstants.InstanceOperation.EVACUATE)
+            .contains(matchingLogicalIdInstance.getInstanceOperation().getOperation())) {
+          return;
+        }
+      default:
+        throw new HelixException(
+            "InstanceOperation cannot be set to " + targetOperation + " when the instance is in "
+                + currentOperation + " state");
+    }
+  }
+
+  /**
+   * Find the instance that the passed instance has a matching logicalId with.
+   *
+   * @param clusterName    The cluster name
+   * @param instanceConfig The instance to find the matching instance for
+   * @return The matching instance if found, null otherwise.
+   */
+  public List<InstanceConfig> findInstancesMatchingLogicalId(String clusterName,
+      InstanceConfig instanceConfig) {
+    String logicalIdKey =
+        ClusterTopologyConfig.createFromClusterConfig(_configAccessor.getClusterConfig(clusterName))
+            .getEndNodeType();
+    return _configAccessor.getKeys(
+            new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.PARTICIPANT,
+                clusterName).build()).stream()
+        .map(instanceName -> _configAccessor.getInstanceConfig(clusterName, instanceName)).filter(
+            potentialInstanceConfig ->
+                !potentialInstanceConfig.getInstanceName().equals(instanceConfig.getInstanceName())
+                    && potentialInstanceConfig.getLogicalId(logicalIdKey)
+                    .equals(instanceConfig.getLogicalId(logicalIdKey)))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Set the instance operation for the given instance.
+   *
+   * @param clusterName       The cluster name
+   * @param instanceName      The instance name
+   * @param instanceOperation The instance operation to set
+   */
+  public void setInstanceOperation(String clusterName, String instanceName,
+      InstanceConfig.InstanceOperation instanceOperation) {
+    String path = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
+
+    InstanceConfig instanceConfig = _configAccessor.getInstanceConfig(clusterName, instanceName);
+    if (instanceConfig == null) {
+      throw new HelixException("Cluster " + clusterName + ", instance: " + instanceName
+          + ", instance config does not exist");
+    }
+    List<InstanceConfig> matchingLogicalIdInstances =
+        findInstancesMatchingLogicalId(clusterName, instanceConfig);
+    validateInstanceOperationTransition(
+        !matchingLogicalIdInstances.isEmpty() ? matchingLogicalIdInstances.get(0) : null,
+        instanceConfig.getInstanceOperation().getOperation(),
+        instanceOperation == null ? InstanceConstants.InstanceOperation.ENABLE
+            : instanceOperation.getOperation());
+
+    boolean succeeded = _baseDataAccessor.update(path, new DataUpdater<ZNRecord>() {
+      @Override
+      public ZNRecord update(ZNRecord currentData) {
+        if (currentData == null) {
+          throw new HelixException("Cluster: " + clusterName + ", instance: " + instanceName
+              + ", participant config is null");
+        }
+
+        InstanceConfig config = new InstanceConfig(currentData);
+        config.setInstanceOperation(instanceOperation);
+        return config.getRecord();
+      }
+    }, AccessOption.PERSISTENT);
+
+    if (!succeeded) {
+      throw new HelixException(
+          "Failed to update instance operation. Please check if instance is disabled.");
+    }
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
@@ -70,11 +70,13 @@ public class InstanceUtil {
       // ENABLE and DISABLE can be set to UNKNOWN when matching instance is in SWAP_IN and set to ENABLE in a transaction.
           ImmutableMap.of(InstanceConstants.InstanceOperation.ENABLE, ALWAYS_ALLOWED,
           InstanceConstants.InstanceOperation.DISABLE, ALWAYS_ALLOWED,
-          InstanceConstants.InstanceOperation.EVACUATE, ALWAYS_ALLOWED),
+          InstanceConstants.InstanceOperation.EVACUATE, ALWAYS_ALLOWED,
+          InstanceConstants.InstanceOperation.UNKNOWN, ALWAYS_ALLOWED),
       InstanceConstants.InstanceOperation.DISABLE,
           ImmutableMap.of(InstanceConstants.InstanceOperation.DISABLE, ALWAYS_ALLOWED,
           InstanceConstants.InstanceOperation.ENABLE, ALWAYS_ALLOWED,
-          InstanceConstants.InstanceOperation.EVACUATE, ALWAYS_ALLOWED),
+          InstanceConstants.InstanceOperation.EVACUATE, ALWAYS_ALLOWED,
+          InstanceConstants.InstanceOperation.UNKNOWN, ALWAYS_ALLOWED),
       InstanceConstants.InstanceOperation.SWAP_IN,
       // SWAP_IN can be set to ENABLE when matching instance is in UNKNOWN state in a transaction.
           ImmutableMap.of(InstanceConstants.InstanceOperation.SWAP_IN, ALWAYS_ALLOWED,

--- a/helix-core/src/test/java/org/apache/helix/cloud/event/TestDefaultCloudEventCallbackImpl.java
+++ b/helix-core/src/test/java/org/apache/helix/cloud/event/TestDefaultCloudEventCallbackImpl.java
@@ -52,8 +52,8 @@ public class TestDefaultCloudEventCallbackImpl extends ZkStandAloneCMTestBase {
     Assert.assertFalse(InstanceValidationUtil
         .isEnabled(_manager.getHelixDataAccessor(), _instanceManager.getInstanceName()));
     Assert.assertEquals(_manager.getConfigAccessor()
-        .getInstanceConfig(CLUSTER_NAME, _instanceManager.getInstanceName())
-        .getInstanceDisabledType(), InstanceConstants.InstanceDisabledType.CLOUD_EVENT.name());
+        .getInstanceConfig(CLUSTER_NAME, _instanceManager.getInstanceName()).getInstanceOperation()
+        .getSource(), InstanceConstants.InstanceOperationSource.AUTOMATION);
 
     _admin.enableInstance(CLUSTER_NAME, _instanceManager.getInstanceName(), false);
     _impl.disableInstance(_instanceManager, null);
@@ -61,8 +61,7 @@ public class TestDefaultCloudEventCallbackImpl extends ZkStandAloneCMTestBase {
         .isEnabled(_manager.getHelixDataAccessor(), _instanceManager.getInstanceName()));
     Assert.assertEquals(_manager.getConfigAccessor()
             .getInstanceConfig(CLUSTER_NAME, _instanceManager.getInstanceName())
-            .getInstanceDisabledType(),
-        InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE.name());
+        .getInstanceOperation().getSource(), InstanceConstants.InstanceOperationSource.USER);
 
     _admin.enableInstance(CLUSTER_NAME, _instanceManager.getInstanceName(), true);
     _admin.enableInstance(CLUSTER_NAME, _instanceManager.getInstanceName(), false,

--- a/helix-core/src/test/java/org/apache/helix/cloud/event/TestDefaultCloudEventCallbackImpl.java
+++ b/helix-core/src/test/java/org/apache/helix/cloud/event/TestDefaultCloudEventCallbackImpl.java
@@ -55,8 +55,6 @@ public class TestDefaultCloudEventCallbackImpl extends ZkStandAloneCMTestBase {
         .getInstanceConfig(CLUSTER_NAME, _instanceManager.getInstanceName())
         .getInstanceDisabledType(), InstanceConstants.InstanceDisabledType.CLOUD_EVENT.name());
 
-    // Should not disable instance if it is already disabled due to other reasons
-    // And disabled type should remain unchanged
     _admin.enableInstance(CLUSTER_NAME, _instanceManager.getInstanceName(), false);
     _impl.disableInstance(_instanceManager, null);
     Assert.assertFalse(InstanceValidationUtil
@@ -66,6 +64,7 @@ public class TestDefaultCloudEventCallbackImpl extends ZkStandAloneCMTestBase {
             .getInstanceDisabledType(),
         InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE.name());
 
+    _admin.enableInstance(CLUSTER_NAME, _instanceManager.getInstanceName(), true);
     _admin.enableInstance(CLUSTER_NAME, _instanceManager.getInstanceName(), false,
         InstanceConstants.InstanceDisabledType.CLOUD_EVENT, null);
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -211,7 +211,7 @@ public class TestInstanceOperation extends ZkTestBase {
       InstanceConfig instanceConfig =
           _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, participantName);
       if (!_participants.get(i).isConnected() || !instanceConfig.getInstanceEnabled()
-          || instanceConfig.getInstanceOperation()
+          || instanceConfig.getInstanceOperation().getOperation()
           .equals(InstanceConstants.InstanceOperation.SWAP_IN)) {
         if (_participants.get(i).isConnected()) {
           _participants.get(i).syncStop();
@@ -338,7 +338,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // now remove operation tag
     String instanceToEvacuate = _participants.get(0).getInstanceName();
     _gSetupTool.getClusterManagementTool()
-        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, null);
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.ENABLE);
 
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
@@ -370,7 +370,8 @@ public class TestInstanceOperation extends ZkTestBase {
 
     Assert.assertEquals(
         _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, instanceToSwapInName)
-            .getInstanceOperation(), InstanceConstants.InstanceOperation.UNKNOWN);
+            .getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.UNKNOWN);
   }
 
   @Test(dependsOnMethods = "testNodeSwapNoTopologySetup")
@@ -397,7 +398,8 @@ public class TestInstanceOperation extends ZkTestBase {
 
     Assert.assertEquals(
         _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, instanceToSwapInName)
-            .getInstanceOperation(), InstanceConstants.InstanceOperation.UNKNOWN);
+            .getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.UNKNOWN);
   }
 
   @Test(dependsOnMethods = "testAddingNodeWithEnableInstanceOperation")
@@ -416,7 +418,8 @@ public class TestInstanceOperation extends ZkTestBase {
 
     Assert.assertEquals(
         _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, instanceToSwapInName)
-            .getInstanceOperation(), InstanceConstants.InstanceOperation.UNKNOWN);
+            .getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.UNKNOWN);
   }
 
   @Test(dependsOnMethods = "testNodeSwapWithNoSwapOutNode")
@@ -440,7 +443,8 @@ public class TestInstanceOperation extends ZkTestBase {
 
     Assert.assertEquals(
         _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, instanceToSwapInName)
-            .getInstanceOperation(), InstanceConstants.InstanceOperation.UNKNOWN);
+            .getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.UNKNOWN);
 
     // Setting the InstanceOperation to SWAP_IN should work because there is a matching logicalId in
     // the cluster and the InstanceCapacityWeights and FaultZone match.
@@ -481,7 +485,8 @@ public class TestInstanceOperation extends ZkTestBase {
 
     // Instance should be UNKNOWN since there was already a swapping pair.
     Assert.assertEquals(_gSetupTool.getClusterManagementTool()
-            .getInstanceConfig(CLUSTER_NAME, secondInstanceToSwapInName).getInstanceOperation(),
+            .getInstanceConfig(CLUSTER_NAME, secondInstanceToSwapInName).getInstanceOperation()
+            .getOperation(),
         InstanceConstants.InstanceOperation.UNKNOWN);
 
     // Try to set the InstanceOperation to SWAP_IN, it should throw an exception since there is already
@@ -576,7 +581,8 @@ public class TestInstanceOperation extends ZkTestBase {
     Assert.assertFalse(_gSetupTool.getClusterManagementTool()
         .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName).getInstanceEnabled());
     Assert.assertEquals(_gSetupTool.getClusterManagementTool()
-            .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName).getInstanceOperation(),
+            .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName).getInstanceOperation()
+            .getOperation(),
         InstanceConstants.InstanceOperation.UNKNOWN);
 
     // Check to make sure the throttle was enabled again after the swap was completed.
@@ -681,7 +687,8 @@ public class TestInstanceOperation extends ZkTestBase {
     Assert.assertFalse(_gSetupTool.getClusterManagementTool()
         .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName).getInstanceEnabled());
     Assert.assertEquals(_gSetupTool.getClusterManagementTool()
-            .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName).getInstanceOperation(),
+            .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName).getInstanceOperation()
+            .getOperation(),
         InstanceConstants.InstanceOperation.UNKNOWN);
 
     // Validate that the SWAP_IN instance has the same partitions the swap out instance had before
@@ -824,7 +831,7 @@ public class TestInstanceOperation extends ZkTestBase {
         Collections.emptySet(), Collections.emptySet());
 
     _gSetupTool.getClusterManagementTool()
-        .setInstanceOperation(CLUSTER_NAME, instanceToSwapOutName, null);
+        .setInstanceOperation(CLUSTER_NAME, instanceToSwapOutName, InstanceConstants.InstanceOperation.ENABLE);
 
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
@@ -1110,7 +1117,7 @@ public class TestInstanceOperation extends ZkTestBase {
     // This should throw exception because we cannot ever have two instances with the same logicalId and both have InstanceOperation
     // unset.
     _gSetupTool.getClusterManagementTool()
-        .setInstanceOperation(CLUSTER_NAME, instanceToSwapInName, null);
+        .setInstanceOperation(CLUSTER_NAME, instanceToSwapInName, InstanceConstants.InstanceOperation.ENABLE);
   }
 
   @Test(dependsOnMethods = "testUnsetInstanceOperationOnSwapInWhenSwapping")
@@ -1180,7 +1187,7 @@ public class TestInstanceOperation extends ZkTestBase {
 
     // cancel the evacuation
     _gSetupTool.getClusterManagementTool()
-        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, null);
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.ENABLE);
 
     assignment = getEVs();
     for (String resource : _allDBs) {
@@ -1222,7 +1229,7 @@ public class TestInstanceOperation extends ZkTestBase {
 
     // cancel evacuation
     _gSetupTool.getClusterManagementTool()
-        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, null);
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.ENABLE);
     // check every replica has >= 3 active replicas, even before cluster converge
     Map<String, ExternalView> assignment = getEVs();
     for (String resource : _allDBs) {
@@ -1311,7 +1318,7 @@ public class TestInstanceOperation extends ZkTestBase {
 
     // Remove EVACUATE instance's InstanceOperation
     _gSetupTool.getClusterManagementTool()
-        .setInstanceOperation(CLUSTER_NAME, instanceToSwapOutName, null);
+        .setInstanceOperation(CLUSTER_NAME, instanceToSwapOutName, InstanceConstants.InstanceOperation.ENABLE);
   }
 
   @Test(dependsOnMethods = "testSwapEvacuateAddRemoveEvacuate")
@@ -1392,7 +1399,7 @@ public class TestInstanceOperation extends ZkTestBase {
     @Override
     public void onInstanceConfigChange(List<InstanceConfig> instanceConfig,
         NotificationContext context) {
-      if (instanceConfig.get(0).getInstanceOperation()
+      if (instanceConfig.get(0).getInstanceOperation().getOperation()
           .equals(InstanceConstants.InstanceOperation.SWAP_IN)) {
         throttlesEnabled = false;
       } else {

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -178,17 +178,15 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     }
 
     Assert.assertTrue(
-        tool.getInstanceConfig(clusterName, instanceName).getInstanceNonServingReason().isEmpty());
+        tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledReason().isEmpty());
     String disableReason = "Reason";
     tool.enableInstance(clusterName, instanceName, false,
         InstanceConstants.InstanceDisabledType.CLOUD_EVENT, disableReason);
-    Assert.assertTrue(
-        tool.getInstanceConfig(clusterName, instanceName).getInstanceNonServingReason()
-        .equals(disableReason));
+    Assert.assertEquals(disableReason, tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledReason());
     tool.enableInstance(clusterName, instanceName, true,
         InstanceConstants.InstanceDisabledType.CLOUD_EVENT, disableReason);
     Assert.assertTrue(
-        tool.getInstanceConfig(clusterName, instanceName).getInstanceNonServingReason().isEmpty());
+        tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledReason().isEmpty());
     Assert.assertEquals(tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledType(),
         InstanceConstants.INSTANCE_NOT_DISABLED);
 
@@ -375,29 +373,35 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
 
     // Set instance operation to DISABLE
     tool.setInstanceOperation(clusterName, instanceName,
-        InstanceConstants.InstanceOperation.DISABLE, "disableReason");
-    Assert.assertEquals(tool.getInstanceConfig(clusterName, instanceName).getInstanceOperation(),
+        new InstanceConfig.InstanceOperation.Builder().setOperation(
+            InstanceConstants.InstanceOperation.DISABLE).setReason("disableReason").build());
+    Assert.assertEquals(tool.getInstanceConfig(clusterName, instanceName).getInstanceOperation()
+            .getOperation(),
         InstanceConstants.InstanceOperation.DISABLE);
     Assert.assertEquals(
-        tool.getInstanceConfig(clusterName, instanceName).getInstanceNonServingReason(),
+        tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledReason(),
         "disableReason");
 
     // Set instance operation to ENABLE
-    tool.setInstanceOperation(clusterName, instanceName, InstanceConstants.InstanceOperation.ENABLE,
-        "enableReason");
-    Assert.assertEquals(tool.getInstanceConfig(clusterName, instanceName).getInstanceOperation(),
+    tool.setInstanceOperation(clusterName, instanceName,
+        new InstanceConfig.InstanceOperation.Builder().setOperation(
+            InstanceConstants.InstanceOperation.ENABLE).setReason("enableReason").build());
+    Assert.assertEquals(tool.getInstanceConfig(clusterName, instanceName).getInstanceOperation()
+            .getOperation(),
         InstanceConstants.InstanceOperation.ENABLE);
     // InstanceNonServingReason should be empty after setting operation to ENABLE
     Assert.assertEquals(
-        tool.getInstanceConfig(clusterName, instanceName).getInstanceNonServingReason(), "");
+        tool.getInstanceConfig(clusterName, instanceName).getInstanceDisabledReason(), "");
 
     // Set instance operation to UNKNOWN
     tool.setInstanceOperation(clusterName, instanceName,
-        InstanceConstants.InstanceOperation.UNKNOWN, "unknownReason");
-    Assert.assertEquals(tool.getInstanceConfig(clusterName, instanceName).getInstanceOperation(),
+        new InstanceConfig.InstanceOperation.Builder().setOperation(
+            InstanceConstants.InstanceOperation.UNKNOWN).setReason("unknownReason").build());
+    Assert.assertEquals(tool.getInstanceConfig(clusterName, instanceName).getInstanceOperation()
+            .getOperation(),
         InstanceConstants.InstanceOperation.UNKNOWN);
     Assert.assertEquals(
-        tool.getInstanceConfig(clusterName, instanceName).getInstanceNonServingReason(),
+        tool.getInstanceConfig(clusterName, instanceName).getInstanceOperation().getReason(),
         "unknownReason");
 
     deleteCluster(clusterName);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -373,8 +373,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
 
     // Set instance operation to DISABLE
     tool.setInstanceOperation(clusterName, instanceName,
-        new InstanceConfig.InstanceOperation.Builder().setOperation(
-            InstanceConstants.InstanceOperation.DISABLE).setReason("disableReason").build());
+        InstanceConstants.InstanceOperation.DISABLE, "disableReason");
     Assert.assertEquals(tool.getInstanceConfig(clusterName, instanceName).getInstanceOperation()
             .getOperation(),
         InstanceConstants.InstanceOperation.DISABLE);
@@ -383,9 +382,8 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
         "disableReason");
 
     // Set instance operation to ENABLE
-    tool.setInstanceOperation(clusterName, instanceName,
-        new InstanceConfig.InstanceOperation.Builder().setOperation(
-            InstanceConstants.InstanceOperation.ENABLE).setReason("enableReason").build());
+    tool.setInstanceOperation(clusterName, instanceName, InstanceConstants.InstanceOperation.ENABLE,
+        "enableReason");
     Assert.assertEquals(tool.getInstanceConfig(clusterName, instanceName).getInstanceOperation()
             .getOperation(),
         InstanceConstants.InstanceOperation.ENABLE);
@@ -395,8 +393,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
 
     // Set instance operation to UNKNOWN
     tool.setInstanceOperation(clusterName, instanceName,
-        new InstanceConfig.InstanceOperation.Builder().setOperation(
-            InstanceConstants.InstanceOperation.UNKNOWN).setReason("unknownReason").build());
+        InstanceConstants.InstanceOperation.UNKNOWN, "unknownReason");
     Assert.assertEquals(tool.getInstanceConfig(clusterName, instanceName).getInstanceOperation()
             .getOperation(),
         InstanceConstants.InstanceOperation.UNKNOWN);

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -285,18 +285,12 @@ public class MockHelixAdmin implements HelixAdmin {
 
     ZNRecord record = (ZNRecord) _baseDataAccessor.get(instanceConfigPath, null, 0);
     InstanceConfig instanceConfig = new InstanceConfig(record);
-    instanceConfig.setInstanceOperation(enabled ? InstanceConstants.InstanceOperation.ENABLE
-        : InstanceConstants.InstanceOperation.DISABLE);
+    instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
+            enabled ? InstanceConstants.InstanceOperation.ENABLE
+                : InstanceConstants.InstanceOperation.DISABLE).setReason(reason).build());
     if (!enabled) {
-      instanceConfig.resetInstanceNonServingReason();
       // TODO: Replace this when the HELIX_ENABLED and HELIX_DISABLED fields are removed.
       instanceConfig.resetInstanceDisabledTypeAndReason();
-      if (reason != null) {
-        instanceConfig.setInstanceNonServingReason(reason);
-      }
-      if (disabledType != null) {
-        instanceConfig.setInstanceDisabledType(disabledType);
-      }
     }
     _baseDataAccessor.set(instanceConfigPath, instanceConfig.getRecord(), 0);
   }
@@ -314,7 +308,7 @@ public class MockHelixAdmin implements HelixAdmin {
 
   @Override
   public void setInstanceOperation(String clusterName, String instanceName,
-      InstanceConstants.InstanceOperation instanceOperation, String reason) {
+      InstanceConfig.InstanceOperation instanceOperation) {
   }
 
   @Override

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
@@ -303,12 +305,20 @@ public class MockHelixAdmin implements HelixAdmin {
 
   @Override
   public void setInstanceOperation(String clusterName, String instanceName,
-      InstanceConstants.InstanceOperation instanceOperation) {
+      @Nullable InstanceConstants.InstanceOperation instanceOperation) {
+    setInstanceOperation(clusterName, instanceName, instanceOperation, null, false);
   }
 
   @Override
   public void setInstanceOperation(String clusterName, String instanceName,
-      InstanceConfig.InstanceOperation instanceOperation) {
+      @Nullable InstanceConstants.InstanceOperation instanceOperation, String reason) {
+    setInstanceOperation(clusterName, instanceName, instanceOperation, reason, false);
+  }
+
+  @Override
+  public void setInstanceOperation(String clusterName, String instanceName,
+      @Nullable InstanceConstants.InstanceOperation instanceOperation, String reason,
+      boolean overrideAll) {
   }
 
   @Override

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -288,9 +288,11 @@ public class MockHelixAdmin implements HelixAdmin {
     instanceConfig.setInstanceOperation(enabled ? InstanceConstants.InstanceOperation.ENABLE
         : InstanceConstants.InstanceOperation.DISABLE);
     if (!enabled) {
+      instanceConfig.resetInstanceNonServingReason();
+      // TODO: Replace this when the HELIX_ENABLED and HELIX_DISABLED fields are removed.
       instanceConfig.resetInstanceDisabledTypeAndReason();
       if (reason != null) {
-        instanceConfig.setInstanceDisabledReason(reason);
+        instanceConfig.setInstanceNonServingReason(reason);
       }
       if (disabledType != null) {
         instanceConfig.setInstanceDisabledType(disabledType);
@@ -308,6 +310,11 @@ public class MockHelixAdmin implements HelixAdmin {
   @Override
   public void setInstanceOperation(String clusterName, String instanceName,
       InstanceConstants.InstanceOperation instanceOperation) {
+  }
+
+  @Override
+  public void setInstanceOperation(String clusterName, String instanceName,
+      InstanceConstants.InstanceOperation instanceOperation, String reason) {
   }
 
   @Override

--- a/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
@@ -52,7 +52,6 @@ public class TestInstanceConfig {
   public void testSetInstanceEnableWithReason() {
     InstanceConfig instanceConfig = new InstanceConfig(new ZNRecord("id"));
     instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.ENABLE);
-    instanceConfig.setInstanceNonServingReason("NoShowReason");
     instanceConfig.setInstanceDisabledType(InstanceConstants.InstanceDisabledType.USER_OPERATION);
 
     Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
@@ -62,16 +61,15 @@ public class TestInstanceConfig {
     Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
         .get(InstanceConfig.InstanceConfigProperty.HELIX_DISABLED_TYPE.toString()), null);
 
-
-    instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.DISABLE);
     String reasonCode = "ReasonCode";
-    instanceConfig.setInstanceNonServingReason(reasonCode);
+    instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
+        InstanceConstants.InstanceOperation.DISABLE).setReason(reasonCode).build());
     instanceConfig.setInstanceDisabledType(InstanceConstants.InstanceDisabledType.USER_OPERATION);
     Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
         .get(InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.toString()), "false");
     Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
         .get(InstanceConfig.InstanceConfigProperty.HELIX_DISABLED_REASON.toString()), reasonCode);
-    Assert.assertEquals(instanceConfig.getInstanceNonServingReason(), reasonCode);
+    Assert.assertEquals(instanceConfig.getInstanceDisabledReason(), reasonCode);
     Assert.assertEquals(instanceConfig.getInstanceDisabledType(),
         InstanceConstants.InstanceDisabledType.USER_OPERATION.toString());
   }
@@ -204,22 +202,22 @@ public class TestInstanceConfig {
     instanceConfig.setInstanceEnabled(false);
     instanceConfig.setInstanceDisabledReason("disableReason");
     Assert.assertEquals(instanceConfig.getInstanceDisabledReason(), "disableReason");
-    Assert.assertEquals(instanceConfig.getInstanceNonServingReason(), "disableReason");
-
-    instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN);
-    instanceConfig.setInstanceNonServingReason("unknownReason");
     Assert.assertEquals(instanceConfig.getInstanceDisabledReason(), "disableReason");
-    Assert.assertEquals(instanceConfig.getInstanceNonServingReason(), "unknownReason");
+
+    instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
+        InstanceConstants.InstanceOperation.UNKNOWN).setReason("unknownReason").build());
+    Assert.assertEquals(instanceConfig.getInstanceDisabledReason(), "disableReason");
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getReason(), "unknownReason");
 
     instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.DISABLE);
-    instanceConfig.setInstanceNonServingReason("disableReason2");
+    instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
+        InstanceConstants.InstanceOperation.DISABLE).setReason("disableReason2").build());
     Assert.assertEquals(instanceConfig.getInstanceDisabledReason(), "disableReason2");
-    Assert.assertEquals(instanceConfig.getInstanceNonServingReason(), "disableReason2");
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getReason(), "disableReason2");
 
     instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.ENABLE);
-    instanceConfig.setInstanceNonServingReason("should not set");
     Assert.assertEquals(instanceConfig.getInstanceDisabledReason(), "");
-    Assert.assertEquals(instanceConfig.getInstanceNonServingReason(), "");
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getReason(), "");
   }
 
   @Test
@@ -257,7 +255,7 @@ public class TestInstanceConfig {
     Assert.assertTrue(instanceConfig.getTags().contains("tag4"));
     Assert.assertFalse(instanceConfig.getRecord().getSimpleFields()
         .containsKey(InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.toString()));
-    Assert.assertEquals(instanceConfig.getInstanceOperation(),
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
         InstanceConstants.InstanceOperation.EVACUATE);
     Assert.assertFalse(instanceConfig.getInstanceCapacityMap().containsKey("weight1"));
     Assert.assertEquals(instanceConfig.getInstanceCapacityMap().get("weight2"), Integer.valueOf(2));

--- a/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
@@ -197,7 +197,7 @@ public class TestInstanceConfig {
   }
 
   @Test
-  public void testInstanceNonServingReason() {
+  public void testInstanceOperationReason() {
     InstanceConfig instanceConfig = new InstanceConfig("instance1");
     instanceConfig.setInstanceEnabled(false);
     instanceConfig.setInstanceDisabledReason("disableReason");
@@ -259,5 +259,84 @@ public class TestInstanceConfig {
         InstanceConstants.InstanceOperation.EVACUATE);
     Assert.assertFalse(instanceConfig.getInstanceCapacityMap().containsKey("weight1"));
     Assert.assertEquals(instanceConfig.getInstanceCapacityMap().get("weight2"), Integer.valueOf(2));
+  }
+
+  @Test
+  public void testInstanceOperationMultipleSources() {
+    InstanceConfig instanceConfig = new InstanceConfig("instance1");
+
+    // Check that the instance operation is ENABLE from the DEFAULT source
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.ENABLE);
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getSource(),
+        InstanceConstants.InstanceOperationSource.DEFAULT);
+
+    // Set instance operation from user source
+    instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
+            InstanceConstants.InstanceOperation.DISABLE).setReason("userReason")
+        .setSource(InstanceConstants.InstanceOperationSource.USER).build());
+    // Get enabled time
+    long op1EnabledTime = instanceConfig.getInstanceEnabledTime();
+
+    // Set instance operation from automation source
+    instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
+            InstanceConstants.InstanceOperation.DISABLE).setReason("automationReason")
+        .setSource(InstanceConstants.InstanceOperationSource.AUTOMATION).build());
+    // Check that the enabled time is the same as op1 but the source and reason is changed to automation
+
+    Assert.assertEquals(instanceConfig.getInstanceEnabledTime(), op1EnabledTime);
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getSource(),
+        InstanceConstants.InstanceOperationSource.AUTOMATION);
+
+    // Set instance operation from user source to be ENABLE
+    instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
+            InstanceConstants.InstanceOperation.ENABLE)
+        .setSource(InstanceConstants.InstanceOperationSource.USER).build());
+
+    // Check that the operation is DISABLE, the enabled time is the same as op1, and the source is still automation
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.DISABLE);
+    Assert.assertEquals(instanceConfig.getInstanceEnabledTime(), op1EnabledTime);
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getSource(),
+        InstanceConstants.InstanceOperationSource.AUTOMATION);
+
+    // Set the instance operation from the automation source to be ENABLE
+    instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
+            InstanceConstants.InstanceOperation.ENABLE)
+        .setSource(InstanceConstants.InstanceOperationSource.AUTOMATION).build());
+
+    // Check that the operation is ENABLE, the enabled time is the different from op1, and the source is still automation
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.ENABLE);
+    Assert.assertFalse(instanceConfig.getInstanceEnabledTime() == op1EnabledTime);
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getSource(),
+        InstanceConstants.InstanceOperationSource.AUTOMATION);
+
+    // Set the instance operation from the automation source to be EVACUATE
+    instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
+            InstanceConstants.InstanceOperation.EVACUATE)
+        .setSource(InstanceConstants.InstanceOperationSource.AUTOMATION).build());
+
+    // Set the instance operation from the user source to be DISABLE
+    instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
+            InstanceConstants.InstanceOperation.DISABLE)
+        .setSource(InstanceConstants.InstanceOperationSource.USER).build());
+
+    // Check that the instance operation is DISABLE and the source is user
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.DISABLE);
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getSource(),
+        InstanceConstants.InstanceOperationSource.USER);
+
+    // Set the instance operation from the admin source to be ENABLE
+    instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
+            InstanceConstants.InstanceOperation.ENABLE)
+        .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+
+    // Check that the instance operation is ENABLE and the source is admin
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.ENABLE);
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getSource(),
+        InstanceConstants.InstanceOperationSource.ADMIN);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
@@ -52,7 +52,7 @@ public class TestInstanceConfig {
   public void testSetInstanceEnableWithReason() {
     InstanceConfig instanceConfig = new InstanceConfig(new ZNRecord("id"));
     instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.ENABLE);
-    instanceConfig.setInstanceDisabledReason("NoShowReason");
+    instanceConfig.setInstanceNonServingReason("NoShowReason");
     instanceConfig.setInstanceDisabledType(InstanceConstants.InstanceDisabledType.USER_OPERATION);
 
     Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
@@ -65,13 +65,13 @@ public class TestInstanceConfig {
 
     instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.DISABLE);
     String reasonCode = "ReasonCode";
-    instanceConfig.setInstanceDisabledReason(reasonCode);
+    instanceConfig.setInstanceNonServingReason(reasonCode);
     instanceConfig.setInstanceDisabledType(InstanceConstants.InstanceDisabledType.USER_OPERATION);
     Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
         .get(InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.toString()), "false");
     Assert.assertEquals(instanceConfig.getRecord().getSimpleFields()
         .get(InstanceConfig.InstanceConfigProperty.HELIX_DISABLED_REASON.toString()), reasonCode);
-    Assert.assertEquals(instanceConfig.getInstanceDisabledReason(), reasonCode);
+    Assert.assertEquals(instanceConfig.getInstanceNonServingReason(), reasonCode);
     Assert.assertEquals(instanceConfig.getInstanceDisabledType(),
         InstanceConstants.InstanceDisabledType.USER_OPERATION.toString());
   }
@@ -196,6 +196,30 @@ public class TestInstanceConfig {
     Assert.assertEquals(instanceConfig.getInstanceInfoMap().get("CAGE"), "H");
     Assert.assertEquals(instanceConfig.getInstanceInfoMap().get("CABINET"), "30");
     Assert.assertEquals(instanceConfig.getInstanceCapacityMap().get("weight1"), Integer.valueOf(1));
+  }
+
+  @Test
+  public void testInstanceNonServingReason() {
+    InstanceConfig instanceConfig = new InstanceConfig("instance1");
+    instanceConfig.setInstanceEnabled(false);
+    instanceConfig.setInstanceDisabledReason("disableReason");
+    Assert.assertEquals(instanceConfig.getInstanceDisabledReason(), "disableReason");
+    Assert.assertEquals(instanceConfig.getInstanceNonServingReason(), "disableReason");
+
+    instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN);
+    instanceConfig.setInstanceNonServingReason("unknownReason");
+    Assert.assertEquals(instanceConfig.getInstanceDisabledReason(), "disableReason");
+    Assert.assertEquals(instanceConfig.getInstanceNonServingReason(), "unknownReason");
+
+    instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.DISABLE);
+    instanceConfig.setInstanceNonServingReason("disableReason2");
+    Assert.assertEquals(instanceConfig.getInstanceDisabledReason(), "disableReason2");
+    Assert.assertEquals(instanceConfig.getInstanceNonServingReason(), "disableReason2");
+
+    instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.ENABLE);
+    instanceConfig.setInstanceNonServingReason("should not set");
+    Assert.assertEquals(instanceConfig.getInstanceDisabledReason(), "");
+    Assert.assertEquals(instanceConfig.getInstanceNonServingReason(), "");
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestInstanceConfig.java
@@ -262,7 +262,7 @@ public class TestInstanceConfig {
   }
 
   @Test
-  public void testInstanceOperationMultipleSources() {
+  public void testInstanceOperationMultipleSources() throws InterruptedException {
     InstanceConfig instanceConfig = new InstanceConfig("instance1");
 
     // Check that the instance operation is ENABLE from the DEFAULT source
@@ -278,16 +278,18 @@ public class TestInstanceConfig {
     // Get enabled time
     long op1EnabledTime = instanceConfig.getInstanceEnabledTime();
 
+    Thread.sleep(1000);
     // Set instance operation from automation source
     instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
             InstanceConstants.InstanceOperation.DISABLE).setReason("automationReason")
         .setSource(InstanceConstants.InstanceOperationSource.AUTOMATION).build());
-    // Check that the enabled time is the same as op1 but the source and reason is changed to automation
 
+    // Check that the enabled time is the same as op1 but the source and reason is changed to automation
     Assert.assertEquals(instanceConfig.getInstanceEnabledTime(), op1EnabledTime);
     Assert.assertEquals(instanceConfig.getInstanceOperation().getSource(),
         InstanceConstants.InstanceOperationSource.AUTOMATION);
 
+    Thread.sleep(1000);
     // Set instance operation from user source to be ENABLE
     instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
             InstanceConstants.InstanceOperation.ENABLE)
@@ -300,6 +302,7 @@ public class TestInstanceConfig {
     Assert.assertEquals(instanceConfig.getInstanceOperation().getSource(),
         InstanceConstants.InstanceOperationSource.AUTOMATION);
 
+    Thread.sleep(1000);
     // Set the instance operation from the automation source to be ENABLE
     instanceConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder().setOperation(
             InstanceConstants.InstanceOperation.ENABLE)

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/StoppableInstancesSelector.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/StoppableInstancesSelector.java
@@ -268,8 +268,8 @@ public class StoppableInstancesSelector {
       PropertyKey.Builder propertyKeyBuilder = _dataAccessor.keyBuilder();
       InstanceConfig instanceConfig =
           _dataAccessor.getProperty(propertyKeyBuilder.instanceConfig(instance));
-      if (InstanceConstants.InstanceOperation.EVACUATE
-          .equals(instanceConfig.getInstanceOperation())) {
+      if (InstanceConstants.InstanceOperation.EVACUATE.equals(
+          instanceConfig.getInstanceOperation().getOperation())) {
         toBeStoppedInstances.add(instance);
       }
     }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
@@ -38,6 +38,7 @@ import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.rest.metadatastore.ZkMetadataStoreDirectory;
 import org.apache.helix.task.TaskDriver;
 import org.apache.helix.tools.ClusterSetup;
+import org.apache.helix.util.InstanceUtil;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.constant.RoutingDataReaderType;
@@ -68,6 +69,7 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
   private volatile RealmAwareZkClient _byteArrayZkClient;
 
   private volatile ZKHelixAdmin _zkHelixAdmin;
+  private volatile InstanceUtil _instanceUtil;
   private volatile ClusterSetup _clusterSetup;
   private volatile ConfigAccessor _configAccessor;
   // A lazily-initialized base data accessor that reads/writes byte array to ZK
@@ -212,6 +214,17 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
       }
     }
     return _zkHelixAdmin;
+  }
+
+  public InstanceUtil getInstanceUtil() {
+    if (_instanceUtil == null) {
+      synchronized (this) {
+        if (_instanceUtil == null) {
+          _instanceUtil = new InstanceUtil(getRealmAwareZkClient());
+        }
+      }
+    }
+    return _instanceUtil;
   }
 
   public ClusterSetup getClusterSetup() {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
@@ -38,7 +38,6 @@ import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.rest.metadatastore.ZkMetadataStoreDirectory;
 import org.apache.helix.task.TaskDriver;
 import org.apache.helix.tools.ClusterSetup;
-import org.apache.helix.util.InstanceUtil;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.constant.RoutingDataReaderType;
@@ -69,7 +68,6 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
   private volatile RealmAwareZkClient _byteArrayZkClient;
 
   private volatile ZKHelixAdmin _zkHelixAdmin;
-  private volatile InstanceUtil _instanceUtil;
   private volatile ClusterSetup _clusterSetup;
   private volatile ConfigAccessor _configAccessor;
   // A lazily-initialized base data accessor that reads/writes byte array to ZK

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/ServerContext.java
@@ -216,17 +216,6 @@ public class ServerContext implements IZkDataListener, IZkChildListener, IZkStat
     return _zkHelixAdmin;
   }
 
-  public InstanceUtil getInstanceUtil() {
-    if (_instanceUtil == null) {
-      synchronized (this) {
-        if (_instanceUtil == null) {
-          _instanceUtil = new InstanceUtil(getRealmAwareZkClient());
-        }
-      }
-    }
-    return _instanceUtil;
-  }
-
   public ClusterSetup getClusterSetup() {
     if (_clusterSetup == null) {
       synchronized (this) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/AbstractHelixResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/AbstractHelixResource.java
@@ -31,6 +31,7 @@ import org.apache.helix.rest.server.ServerContext;
 import org.apache.helix.rest.server.resources.AbstractResource;
 import org.apache.helix.task.TaskDriver;
 import org.apache.helix.tools.ClusterSetup;
+import org.apache.helix.util.InstanceUtil;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
@@ -56,6 +57,11 @@ public class AbstractHelixResource extends AbstractResource {
   public HelixAdmin getHelixAdmin() {
     ServerContext serverContext = getServerContext();
     return serverContext.getHelixAdmin();
+  }
+
+  public InstanceUtil getInstanceUtil() {
+    ServerContext serverContext = getServerContext();
+    return serverContext.getInstanceUtil();
   }
 
   public ClusterSetup getClusterSetup() {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/AbstractHelixResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/AbstractHelixResource.java
@@ -31,7 +31,6 @@ import org.apache.helix.rest.server.ServerContext;
 import org.apache.helix.rest.server.resources.AbstractResource;
 import org.apache.helix.task.TaskDriver;
 import org.apache.helix.tools.ClusterSetup;
-import org.apache.helix.util.InstanceUtil;
 import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
@@ -57,11 +56,6 @@ public class AbstractHelixResource extends AbstractResource {
   public HelixAdmin getHelixAdmin() {
     ServerContext serverContext = getServerContext();
     return serverContext.getHelixAdmin();
-  }
-
-  public InstanceUtil getInstanceUtil() {
-    ServerContext serverContext = getServerContext();
-    return serverContext.getInstanceUtil();
   }
 
   public ClusterSetup getClusterSetup() {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -389,8 +389,8 @@ public class PerInstanceAccessor extends AbstractHelixResource {
   public Response updateInstance(@PathParam("clusterId") String clusterId,
       @PathParam("instanceName") String instanceName, @QueryParam("command") String command,
       @QueryParam("instanceOperation") InstanceConstants.InstanceOperation instanceOperation,
+      @QueryParam("instanceOperationSource") InstanceConstants.InstanceOperationSource instanceOperationSource,
       @QueryParam("reason") String reason,
-      @QueryParam("trigger") InstanceConstants.InstanceOperationTrigger trigger,
       @Deprecated @QueryParam("instanceDisabledType") String disabledType,
       @Deprecated @QueryParam("instanceDisabledReason") String disabledReason,
       @QueryParam("force") boolean force, String content) {
@@ -447,9 +447,11 @@ public class PerInstanceAccessor extends AbstractHelixResource {
                       .getTypeFactory().constructCollectionType(List.class, String.class)));
           break;
         case setInstanceOperation:
-          admin.setInstanceOperation(clusterId, instanceName,
+          getInstanceUtil().setInstanceOperation(clusterId, instanceName,
               new InstanceConfig.InstanceOperation.Builder().setOperation(instanceOperation)
-                  .setReason(reason).setTrigger(trigger).build());
+                  .setReason(reason).setSource(
+                      force ? InstanceConstants.InstanceOperationSource.ADMIN : instanceOperationSource)
+                  .build());
           break;
         case canCompleteSwap:
           return OK(OBJECT_MAPPER.writeValueAsString(

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -390,7 +390,8 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       @PathParam("instanceName") String instanceName, @QueryParam("command") String command,
       @QueryParam("instanceOperation") InstanceConstants.InstanceOperation state,
       @QueryParam("instanceDisabledType") String disabledType,
-      @QueryParam("instanceDisabledReason") String disabledReason,
+      @Deprecated @QueryParam("instanceDisabledReason") String disabledReason,
+      @QueryParam("instanceOperationReason") String instanceOperationReason,
       @QueryParam("force") boolean force, String content) {
     Command cmd;
     try {
@@ -445,7 +446,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
                       .getTypeFactory().constructCollectionType(List.class, String.class)));
           break;
         case setInstanceOperation:
-          admin.setInstanceOperation(clusterId, instanceName, state);
+          admin.setInstanceOperation(clusterId, instanceName, state, instanceOperationReason);
           break;
         case canCompleteSwap:
           return OK(OBJECT_MAPPER.writeValueAsString(

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -45,12 +45,14 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
+import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.Error;
 import org.apache.helix.model.HealthStat;
@@ -66,6 +68,7 @@ import org.apache.helix.rest.common.HttpConstants;
 import org.apache.helix.rest.server.filters.ClusterAuth;
 import org.apache.helix.rest.server.json.instance.InstanceInfo;
 import org.apache.helix.rest.server.json.instance.StoppableCheck;
+import org.apache.helix.util.InstanceUtil;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
@@ -447,7 +450,8 @@ public class PerInstanceAccessor extends AbstractHelixResource {
                       .getTypeFactory().constructCollectionType(List.class, String.class)));
           break;
         case setInstanceOperation:
-          getInstanceUtil().setInstanceOperation(clusterId, instanceName,
+          InstanceUtil.setInstanceOperation(new ConfigAccessor(getRealmAwareZkClient()),
+              new ZkBaseDataAccessor<>(getRealmAwareZkClient()), clusterId, instanceName,
               new InstanceConfig.InstanceOperation.Builder().setOperation(instanceOperation)
                   .setReason(reason).setSource(
                       force ? InstanceConstants.InstanceOperationSource.ADMIN : instanceOperationSource)

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -388,10 +388,11 @@ public class PerInstanceAccessor extends AbstractHelixResource {
   @POST
   public Response updateInstance(@PathParam("clusterId") String clusterId,
       @PathParam("instanceName") String instanceName, @QueryParam("command") String command,
-      @QueryParam("instanceOperation") InstanceConstants.InstanceOperation state,
-      @QueryParam("instanceDisabledType") String disabledType,
+      @QueryParam("instanceOperation") InstanceConstants.InstanceOperation instanceOperation,
+      @QueryParam("reason") String reason,
+      @QueryParam("trigger") InstanceConstants.InstanceOperationTrigger trigger,
+      @Deprecated @QueryParam("instanceDisabledType") String disabledType,
       @Deprecated @QueryParam("instanceDisabledReason") String disabledReason,
-      @QueryParam("instanceOperationReason") String instanceOperationReason,
       @QueryParam("force") boolean force, String content) {
     Command cmd;
     try {
@@ -446,7 +447,9 @@ public class PerInstanceAccessor extends AbstractHelixResource {
                       .getTypeFactory().constructCollectionType(List.class, String.class)));
           break;
         case setInstanceOperation:
-          admin.setInstanceOperation(clusterId, instanceName, state, instanceOperationReason);
+          admin.setInstanceOperation(clusterId, instanceName,
+              new InstanceConfig.InstanceOperation.Builder().setOperation(instanceOperation)
+                  .setReason(reason).setTrigger(trigger).build());
           break;
         case canCompleteSwap:
           return OK(OBJECT_MAPPER.writeValueAsString(

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -394,7 +394,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
         _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledType(),
         InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE.toString());
     Assert.assertEquals(
-        _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledReason(),
+        _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceNonServingReason(),
         "reason1");
 
     // Enable instance
@@ -407,7 +407,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
         _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledType(),
         InstanceConstants.INSTANCE_NOT_DISABLED);
     Assert.assertEquals(
-        _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledReason(),
+        _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceNonServingReason(),
         "");
 
     // We should see no instance disable related field in to clusterConfig

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -394,7 +394,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
         _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledType(),
         InstanceConstants.InstanceDisabledType.DEFAULT_INSTANCE_DISABLE_TYPE.toString());
     Assert.assertEquals(
-        _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceNonServingReason(),
+        _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledReason(),
         "reason1");
 
     // Enable instance
@@ -407,7 +407,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
         _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledType(),
         InstanceConstants.INSTANCE_NOT_DISABLED);
     Assert.assertEquals(
-        _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceNonServingReason(),
+        _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME).getInstanceDisabledReason(),
         "");
 
     // We should see no instance disable related field in to clusterConfig
@@ -495,14 +495,14 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=setInstanceOperation&instanceOperation=EVACUATE")
         .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
     instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME);
-    Assert.assertEquals(instanceConfig.getInstanceOperation(),
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
         InstanceConstants.InstanceOperation.EVACUATE);
     new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=setInstanceOperation&instanceOperation=INVALIDOP")
         .expectedReturnStatusCode(Response.Status.NOT_FOUND.getStatusCode()).format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
     new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=setInstanceOperation&instanceOperation=")
         .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
     instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME);
-    Assert.assertEquals(instanceConfig.getInstanceOperation(),
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
         InstanceConstants.InstanceOperation.ENABLE);
 
     // test canCompleteSwap
@@ -543,7 +543,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=setInstanceOperation&instanceOperation=EVACUATE")
         .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
     instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME);
-    Assert.assertEquals(instanceConfig.getInstanceOperation(),
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
         InstanceConstants.InstanceOperation.EVACUATE);
 
     Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=isEvacuateFinished")
@@ -586,7 +586,7 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=setInstanceOperation&instanceOperation=EVACUATE")
         .format(CLUSTER_NAME, test_instance_name).post(this, entity);
     instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, test_instance_name);
-    Assert.assertEquals(instanceConfig.getInstanceOperation(),
+    Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
         InstanceConstants.InstanceOperation.EVACUATE);
 
     response = new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=isEvacuateFinished")


### PR DESCRIPTION
### Issues

- [x] Deprecate HELIX_DISABLED_REASON and HELIX_DISABLED_TYPE as we will no longer be using the HELIX_ENABLED field and this reason field is too specific to HELIX_ENABLED.
- [x] Refactor InstanceOperation into listField which will look like:
```
"HELIX_INSTANCE_OPERATIONS" : ["{\"OPERATION\":\"ENABLE\",\"SOURCE\":\"AUTOMATION\",\"TIMESTAMP\":\"1716510701306\",\"REASON\":\"Cloud event in DefaultCloudEventCallback at 1716510701283\"}","{\"OPERATION\":\"ENABLE\",\"SOURCE\":\"DEFAULT\",\"TIMESTAMP\":\"1716510659104\",\"REASON\":\"\"}"]
```

### Description

Deprecate HELIX_DISABLED_REASON and HELIX_DISABLED_TYPE and refactor INSTANCE_OPERATION to be HELIX_INSTANCE_OPERATIONS listField.

In order to prevent conflicts from different clients setting the InstanceOperation. We will now introduce the HELIX_INSTANCE_OPERATIONS.

The list will be ordered by the earliest to the most recent operations. As before, any client using the old helix enabled APIs will always take precedence over the INSTANCE_DISABLED_OVERRIDABLE_OPERATIONS when those fields are set.

When users of the new InstanceOperation APIs set the operation type to be DISABLE, we will also set the old HELIX_ENABLED field for backwards compatibility.

For all invocations of InstanceOperation APIs, the source will be USER unless otherwise specified. In most cases, this is the trigger used. If an AUTOMATION source is used a separate entry will made in the list. Whichever non ENABLE InstanceOperation entry was created last is the active InstanceOperation that is used in the controller and the returned from getInstanceOperation API.

### Tests

- [x] Added TestInstanceConfig#testInstanceOperationReason
- [x] Added TestInstanceConfig#testInstanceOperationMultipleSources
- [x] Added TestZkHelixAdmin#testSetInstanceOperation
- [x] Fix lots of tests to use new APIs 

### Changes that Break Backward Compatibility (Optional)

- This change is backwards compatible with HELIX_DISABLED_REASON and HELIX_DISABLED_TYPE.
- This is backwards incompatible with InstanceOperation simpleField being removed, but that has not been released in open source yet, so it is only a consideration for internal release.

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
