### PR TITLE
[apache/helix] --> Update logic for metric calculation when replica is set to ANY_LIVEINSTANCE

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -272,17 +272,9 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     long numOfPartitionWithTopState = 0;
 
     Set<String> partitions = idealState.getPartitionSet();
-    int replica;
-    try {
-      replica = Integer.valueOf(idealState.getReplicas());
-    } catch (NumberFormatException e) {
-      _logger.info("Unspecified replica count for {}, skip updating the ResourceMonitor Mbean: {}", _resourceName,
-          idealState.getReplicas());
-      return;
-    } catch (Exception ex) {
-      _logger.warn("Failed to get replica count for {}, cannot update the ResourceMonitor Mbean.", _resourceName);
-      return;
-    }
+
+    // returns -1 when replica is set to ANY_LIVEINSTANCE.
+    int replica = idealState.getReplicaCount(-1);
 
     int minActiveReplica = idealState.getMinActiveReplicas();
     minActiveReplica = (minActiveReplica >= 0) ? minActiveReplica : replica;


### PR DESCRIPTION
### Issues
Fixes #2803

### Description

The metric "MissingTopState" is not being calculated (hence not reported) as an exception is thrown prior to metric calculation in the [ResourceMonitor](https://github.com/linkedin/helix/blob/c480eac018932214886aaf55f3c28107d46e84b0/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java#L279).



Whenever the replica is set to ANY_LIVEINSTANCE, we encounter a NumberFormatException and return (as we try to get the replica count as Integer) before calculating rest of the metrics which includes the _numNonTopStatePartitions.

### Tests
```

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Helix 1.3.2-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  1.557 s]
[INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  0.326 s]
[INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [  0.450 s]
[INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [  0.399 s]
[INFO] Apache Helix :: Helix Common ....................... SUCCESS [  0.303 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [  0.402 s]
[INFO] Apache Helix :: Admin Webapp ....................... SUCCESS [  0.884 s]
[INFO] Apache Helix :: Restful Interface .................. SUCCESS [  1.112 s]
[INFO] Apache Helix :: Distributed Lock ................... SUCCESS [  0.241 s]
[INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  0.260 s]
[INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.045 s]
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  0.299 s]
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  0.250 s]
[INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  0.198 s]
[INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  0.225 s]
[INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  0.186 s]
[INFO] Apache Helix :: View Aggregator .................... SUCCESS [  0.210 s]
[INFO] Apache Helix :: Meta Client ........................ SUCCESS [  0.234 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  13.400 s
[INFO] Finished at: 2024-05-30T10:30:40-07:00
[INFO] ------------------------------------------------------------------------
```

 mvn test -o -Dtest=TestResourceMonitor -pl=helix-core  

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.638 s - in org.apache.helix.monitoring.mbeans.TestResourceMonitor
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] Analyzed bundle 'Apache Helix :: Core' with 950 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:14 min
[INFO] Finished at: 2024-05-30T10:30:21-07:00
[INFO] ------------------------------------------------------------------------
```


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
