### PR TITLE
[apache/helix] -- Enable JDK 1.8 (backward) compatibility for dependent modules of meta-client and helix-core

### DIFF
--- a/helix-common/pom.xml
+++ b/helix-common/pom.xml
@@ -91,6 +91,54 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.12.1</version>
+        <executions>
+          <execution>
+            <id>JDK 8</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}_jdk8</outputDirectory>
+              <release>8</release>
+              <fork>true</fork>
+            </configuration>
+          </execution>
+          <execution>
+            <id>JDK 11</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>11</release>
+              <fork>true</fork>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>default-package-jdk11</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classesDirectory>${project.build.outputDirectory}_jdk8</classesDirectory>
+              <classifier>jdk8</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptors>

--- a/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
+++ b/helix-common/src/main/java/org/apache/helix/constants/InstanceConstants.java
@@ -2,6 +2,8 @@ package org.apache.helix.constants;
 
 import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
+
 public class InstanceConstants {
   public static final String INSTANCE_NOT_DISABLED = "INSTANCE_NOT_DISABLED";
 
@@ -9,7 +11,7 @@ public class InstanceConstants {
    * The set contains the InstanceOperations that are allowed to be assigned replicas by the rebalancer.
    */
   public static final Set<InstanceOperation> ASSIGNABLE_INSTANCE_OPERATIONS =
-      Set.of(InstanceOperation.ENABLE, InstanceOperation.DISABLE);
+      ImmutableSet.of(InstanceOperation.ENABLE, InstanceOperation.DISABLE);
 
 
   /**
@@ -18,14 +20,14 @@ public class InstanceConstants {
    * TODO: Remove this when the deprecated HELIX_ENABLED is removed.
    */
   public static final Set<InstanceOperation> INSTANCE_DISABLED_OVERRIDABLE_OPERATIONS =
-      Set.of(InstanceOperation.ENABLE, InstanceOperation.DISABLE, InstanceOperation.EVACUATE);
+      ImmutableSet.of(InstanceOperation.ENABLE, InstanceOperation.DISABLE, InstanceOperation.EVACUATE);
 
 
   /**
    * The set of InstanceOperations that are not allowed to be populated in the RoutingTableProvider.
    */
   public static final Set<InstanceOperation> UNSERVABLE_INSTANCE_OPERATIONS =
-      Set.of(InstanceOperation.SWAP_IN, InstanceOperation.UNKNOWN);
+      ImmutableSet.of(InstanceOperation.SWAP_IN, InstanceOperation.UNKNOWN);
 
   public enum InstanceDisabledType {
     CLOUD_EVENT,

--- a/metadata-store-directory-common/pom.xml
+++ b/metadata-store-directory-common/pom.xml
@@ -115,6 +115,54 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.12.1</version>
+        <executions>
+          <execution>
+            <id>JDK 8</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}_jdk8</outputDirectory>
+              <release>8</release>
+              <fork>true</fork>
+            </configuration>
+          </execution>
+          <execution>
+            <id>JDK 11</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>11</release>
+              <fork>true</fork>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>default-package-jdk11</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classesDirectory>${project.build.outputDirectory}_jdk8</classesDirectory>
+              <classifier>jdk8</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptors>

--- a/metrics-common/pom.xml
+++ b/metrics-common/pom.xml
@@ -86,6 +86,54 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.12.1</version>
+        <executions>
+          <execution>
+            <id>JDK 8</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}_jdk8</outputDirectory>
+              <release>8</release>
+              <fork>true</fork>
+            </configuration>
+          </execution>
+          <execution>
+            <id>JDK 11</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>11</release>
+              <fork>true</fork>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>default-package-jdk11</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classesDirectory>${project.build.outputDirectory}_jdk8</classesDirectory>
+              <classifier>jdk8</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptors>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -135,6 +135,54 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.12.1</version>
+        <executions>
+          <execution>
+            <id>JDK 8</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}_jdk8</outputDirectory>
+              <release>8</release>
+              <fork>true</fork>
+            </configuration>
+          </execution>
+          <execution>
+            <id>JDK 11</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>11</release>
+              <fork>true</fork>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>default-package-jdk11</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classesDirectory>${project.build.outputDirectory}_jdk8</classesDirectory>
+              <classifier>jdk8</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptors>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes https://github.com/apache/helix/issues/2779

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
We have some consumers which are still running their (open-source) systems on JRE-8, hence they are not able to run helix libraries compiled with JDK11+. We would like to provide a backward compatible support to our consumers where they also have an option to use JDK-8 compiled helix-core jar, if they have such a requirement. By default we will generate JDK-11 jars and JDK-8 jars using a classifier.
```
<major.minor.patch> will use JDK11 (default)
<major.minor.patch> classifier say jdk8 , will use JDK8
```

In this PR, we are enabling the the full sub-tree of the `helix-core` and `meta-client` modules. This includes:
- helix-common
- zookeeper-api
- metadata-store-directory-common
- metrics-common

### Tests

- [x] The following tests are written for this issue:

```
[INFO] --- install:2.5.2:install (default-install) @ helix-common ---
...
[INFO] Installing /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-common/target/helix-common-1.3.2-SNAPSHOT-jdk8.jar to /Users/hkandwal/.m2/repository/org/apache/helix/helix-common/1.3.2-SNAPSHOT/helix-common-1.3.2-SNAPSHOT-jdk8.jar
```
```
[INFO] --- install:2.5.2:install (default-install) @ zookeeper-api ---
...
[INFO] Installing /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/zookeeper-api/target/zookeeper-api-1.3.2-SNAPSHOT-jdk8.jar to /Users/hkandwal/.m2/repository/org/apache/helix/zookeeper-api/1.3.2-SNAPSHOT/zookeeper-api-1.3.2-SNAPSHOT-jdk8.jar
```

```
[INFO] 
[INFO] --- install:2.5.2:install (default-install) @ metadata-store-directory-common ---
...
/Users/hkandwal/.m2/repository/org/apache/helix/metadata-store-directory-common/1.3.2-SNAPSHOT/metadata-store-directory-common-1.3.2-SNAPSHOT-jdk8.jar
```

```
[INFO] --- install:2.5.2:install (default-install) @ metrics-common ---
...
[INFO] Installing /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/metrics-common/target/metrics-common-1.3.2-SNAPSHOT-jdk8.jar to /Users/hkandwal/.m2/repository/org/apache/helix/metrics-common/1.3.2-SNAPSHOT/metrics-common-1.3.2-SNAPSHOT-jdk8.jar
```

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
