### PR TITLE
Fix config for metaclient

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionClient.java
@@ -97,7 +97,13 @@ public class LeaderElectionClient implements AutoCloseable {
     LOG.info("Creating MetaClient for LeaderElectionClient");
     if (MetaClientConfig.StoreType.ZOOKEEPER.equals(metaClientConfig.getStoreType())) {
       ZkMetaClientConfig zkMetaClientConfig = new ZkMetaClientConfig.ZkMetaClientConfigBuilder().setConnectionAddress(
-          metaClientConfig.getConnectionAddress()).setZkSerializer((new LeaderInfoSerializer())).build();
+              metaClientConfig.getConnectionAddress())
+          .setZkSerializer((new LeaderInfoSerializer()))
+          .setSessionTimeoutInMillis(metaClientConfig.getSessionTimeoutInMillis())
+          .setMetaClientReconnectPolicy(metaClientConfig.getMetaClientReconnectPolicy())
+          .setConnectionInitTimeoutInMillis(metaClientConfig.getConnectionInitTimeoutInMillis())
+          .setAuthEnabled(metaClientConfig.isAuthEnabled())
+          .build();
       _metaClient = new ZkMetaClientFactory().getMetaClient(zkMetaClientConfig);
       _metaClient.connect();
       _metaClient.subscribeStateChanges(_connectStateListener);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2808 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Config for leader election client should cover all params in metaclient config.

### Tests

- [X] The following tests are written for this issue:
Verified manually using break point. Session timeout is buried in native ZK connection object, cant compare without modifying the ZkConnection class. 

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
