### PR TITLE
 Fix incompatibility for customers which implement HelixAdmin and BaseDataAccessor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/BaseDataAccessor.java
@@ -121,7 +121,9 @@ public interface BaseDataAccessor<T> {
    * version
    * @return true if the removal succeeded, false otherwise
    */
-  boolean removeWithExpectedVersion(String path, int options, int expectedVersion);
+  default boolean removeWithExpectedVersion(String path, int options, int expectedVersion) {
+    throw new NotImplementedException("removeWithExpectedVersion is not implemented");
+  }
 
   /**
    * Use it when creating children under a parent node. This will use async api for better

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -316,8 +316,10 @@ public interface HelixAdmin {
    * @param instanceName      The instance name
    * @param instanceOperation The instance operation type
    */
-  void setInstanceOperation(String clusterName, String instanceName,
-      InstanceConstants.InstanceOperation instanceOperation);
+  default void setInstanceOperation(String clusterName, String instanceName,
+      InstanceConstants.InstanceOperation instanceOperation) {
+    throw new UnsupportedOperationException("setInstanceOperation is not implemented.");
+  }
 
   /**
    * Set the instanceOperation of and instance with {@link InstanceConstants.InstanceOperation}.
@@ -327,8 +329,10 @@ public interface HelixAdmin {
    * @param instanceOperation The instance operation type
    * @param reason            The reason for the operation
    */
-  void setInstanceOperation(String clusterName, String instanceName,
-      InstanceConstants.InstanceOperation instanceOperation, String reason);
+  default void setInstanceOperation(String clusterName, String instanceName,
+      InstanceConstants.InstanceOperation instanceOperation, String reason) {
+    throw new UnsupportedOperationException("setInstanceOperation is not implemented.");
+  }
 
   /**
    * Set the instanceOperation of and instance with {@link InstanceConstants.InstanceOperation}.
@@ -340,8 +344,10 @@ public interface HelixAdmin {
    * @param overrideAll       Whether to override all existing instance operations from all other
    *                          instance operations
    */
-  void setInstanceOperation(String clusterName, String instanceName,
-      InstanceConstants.InstanceOperation instanceOperation, String reason, boolean overrideAll);
+  default void setInstanceOperation(String clusterName, String instanceName,
+      InstanceConstants.InstanceOperation instanceOperation, String reason, boolean overrideAll) {
+    throw new UnsupportedOperationException("setInstanceOperation is not implemented.");
+  }
 
   /**
    * Disable or enable a resource
@@ -453,8 +459,10 @@ public interface HelixAdmin {
    * @param resourceName
    * @param partitionNames
    */
-  void setPartitionsToError(String clusterName, String instanceName, String resourceName,
-      List<String> partitionNames);
+  default void setPartitionsToError(String clusterName, String instanceName, String resourceName,
+      List<String> partitionNames) {
+    throw new UnsupportedOperationException("setPartitionsToError is not implemented.");
+  }
 
   /**
    * Reset a list of partitions in error state for an instance
@@ -795,7 +803,9 @@ public interface HelixAdmin {
    * @param instancesNames
    * @return Return true if there is no current state nor pending message on the instance.
    */
-  boolean isEvacuateFinished(String clusterName, String instancesNames);
+  default boolean isEvacuateFinished(String clusterName, String instancesNames) {
+    throw new UnsupportedOperationException("isEvacuateFinished is not implemented.");
+  }
 
   /**
    * Check to see if swapping between two instances can be completed. Either the swapOut or
@@ -804,7 +814,9 @@ public interface HelixAdmin {
    * @param instanceName The instance that is being swapped out or swapped in
    * @return True if the swap is ready to be completed, false otherwise.
    */
-  boolean canCompleteSwap(String clusterName, String instanceName);
+  default boolean canCompleteSwap(String clusterName, String instanceName) {
+    throw new UnsupportedOperationException("canCompleteSwap is not implemented.");
+  }
 
   /**
    * Check to see if swapping between two instances is ready to be completed and complete it if
@@ -816,7 +828,10 @@ public interface HelixAdmin {
    * @return True if the swap is ready to be completed and was completed successfully, false
    * otherwise.
    */
-  boolean completeSwapIfPossible(String clusterName, String instanceName, boolean forceComplete);
+  default boolean completeSwapIfPossible(String clusterName, String instanceName,
+      boolean forceComplete) {
+    throw new UnsupportedOperationException("completeSwapIfPossible is not implemented.");
+  }
 
   /**
    * Return if instance is ready for preparing joining cluster. The instance should have no current state,
@@ -825,5 +840,8 @@ public interface HelixAdmin {
    * @param instancesNames
    * @return true if the instance is ready for preparing joining cluster.
    */
-  boolean isReadyForPreparingJoiningCluster(String clusterName, String instancesNames);
+  default boolean isReadyForPreparingJoiningCluster(String clusterName, String instancesNames) {
+    throw new UnsupportedOperationException(
+        "isReadyForPreparingJoiningCluster is not implemented.");
+  }
 }


### PR DESCRIPTION
### Issues

- [x]  Fix incompatibility for customers which implement HelixAdmin and BaseDataAccessor

### Description

After changing public interfaces, we did not add new default implementations for new methods. This is backwards incompatible. We are adding defaults in this PR that throw not implemented exception.

### Tests
NA

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
