### PR TITLE
Fix race condition when reconnect

### DIFF
--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -666,7 +666,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
   }
 
   @VisibleForTesting
-  ZkClient getZkClient() {
+   ZkClient getZkClient() {
     return _zkClient;
   }
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/impl/zk/ZkMetaClient.java
@@ -666,7 +666,7 @@ public class ZkMetaClient<T> implements MetaClientInterface<T>, AutoCloseable {
   }
 
   @VisibleForTesting
-   ZkClient getZkClient() {
+  ZkClient getZkClient() {
     return _zkClient;
   }
 }

--- a/meta-client/src/main/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionClient.java
+++ b/meta-client/src/main/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionClient.java
@@ -38,7 +38,6 @@ import org.apache.helix.metaclient.exception.MetaClientException;
 import org.apache.helix.metaclient.exception.MetaClientNoNodeException;
 import org.apache.helix.metaclient.exception.MetaClientNodeExistsException;
 import org.apache.helix.metaclient.factories.MetaClientConfig;
-import org.apache.helix.metaclient.impl.zk.ZkMetaClient;
 import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientConfig;
 import org.apache.helix.metaclient.impl.zk.factory.ZkMetaClientFactory;
 import org.slf4j.Logger;
@@ -167,6 +166,7 @@ public class LeaderElectionClient implements AutoCloseable {
       // try to create participant info entry, assuming leader election group node is already there
       _metaClient.create(leaderPath + PARTICIPANTS_ENTRY_PARENT + _participant, participantInfo,
           MetaClientInterface.EntryMode.EPHEMERAL);
+      LOG.info("Participant {} joined leader group {}.", _participant, leaderPath);
     } catch (MetaClientNodeExistsException ex) {
       throw new ConcurrentModificationException("Already joined leader election group. ", ex);
     } catch (MetaClientNoNodeException ex) {
@@ -261,6 +261,7 @@ public class LeaderElectionClient implements AutoCloseable {
     // deleting ZNode. So that handler in ReElectListener won't recreate the leader node.
     if (exitLeaderElectionParticipantPool) {
       _leaderGroups.remove(leaderPath + LEADER_ENTRY_KEY);
+      LOG.info("Leaving leader election pool {}.", leaderPath);
       _metaClient.delete(leaderPath + PARTICIPANTS_ENTRY_PARENT + _participant);
     }
     // check if current participant is the leader
@@ -272,12 +273,13 @@ public class LeaderElectionClient implements AutoCloseable {
         List<Op> ops = Arrays.asList(Op.check(key, expectedVersion), Op.delete(key, expectedVersion));
         //Execute transactional support on operations
         List<OpResult> opResults = _metaClient.transactionOP(ops);
+        LOG.info("Try relinquish leader {}.", leaderPath);
         if (opResults.get(0).getType() == ERRORRESULT) {
           if (isLeader(leaderPath)) {
             // Participant re-elected as leader.
             throw new ConcurrentModificationException("Concurrent operation, please retry");
           } else {
-            LOG.info("Someone else is already leader");
+            LOG.info("Someone else is already leader when relinquishing leadership for path {}.", leaderPath);
           }
         }
       }
@@ -366,7 +368,7 @@ public class LeaderElectionClient implements AutoCloseable {
 
   @Override
   public void close() throws Exception {
-
+    LOG.info("Closing leader election client.");
     _metaClient.unsubscribeConnectStateChanges(_connectStateListener);
 
     // exit all previous joined leader election groups
@@ -406,9 +408,11 @@ public class LeaderElectionClient implements AutoCloseable {
     @Override
     public void handleConnectStateChanged(MetaClientInterface.ConnectState prevState,
         MetaClientInterface.ConnectState currentState) throws Exception {
-      if (prevState == MetaClientInterface.ConnectState.EXPIRED
+      LOG.info("Connect state changed from {} to {}", prevState, currentState);
+      if ((prevState == MetaClientInterface.ConnectState.EXPIRED || prevState == MetaClientInterface.ConnectState.CLOSED_BY_CLIENT)
           && currentState == MetaClientInterface.ConnectState.CONNECTED) {
         for (String leaderPath : _participantInfos.keySet()) {
+          LOG.info("Recreate participant node for leaderPath {}.", leaderPath);
           _metaClient.create(leaderPath + PARTICIPANTS_ENTRY_PARENT + _participant, _participantInfos.get(leaderPath),
               MetaClientInterface.EntryMode.EPHEMERAL);
         }
@@ -431,6 +435,7 @@ public class LeaderElectionClient implements AutoCloseable {
       if (tup.left.getLeaderName().equalsIgnoreCase(_participant)) {
         int expectedVersion = tup.right.getVersion();
         try {
+          LOG.info("Try touch leader node for path {}", _leaderGroups);
           _metaClient.set(key, tup.left, expectedVersion);
         } catch (MetaClientNoNodeException ex) {
           LOG.info("leaderPath {} gone when retouch leader node.", key);

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestUtil.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestUtil.java
@@ -185,4 +185,22 @@ public class TestUtil {
     zkClient.process(event);
   }
 
+  /**
+   * Simulate a zk state change by calling {@link ZkClient#process(WatchedEvent)} directly
+   * This need to be done in a separate thread to simulate ZkClient eventThread.
+   */
+  public static void simulateZkStateClosedAndReconnect(ZkMetaClient client) throws InterruptedException {
+    final ZkClient zkClient = client.getZkClient();
+    WatchedEvent event =
+        new WatchedEvent(Watcher.Event.EventType.None, Watcher.Event.KeeperState.Closed,
+            null);
+    zkClient.process(event);
+
+    Thread.sleep(AUTO_RECONNECT_WAIT_TIME_WITHIN);
+
+    event = new WatchedEvent(Watcher.Event.EventType.None, Watcher.Event.KeeperState.SyncConnected,
+        null);
+    zkClient.process(event);
+  }
+
 }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
@@ -25,8 +25,11 @@ public class TestLeaderElection extends ZkMetaClientTestBase {
 
   public static LeaderElectionClient createLeaderElectionClient(String participantName) {
     MetaClientConfig.StoreType storeType = MetaClientConfig.StoreType.ZOOKEEPER;
-    MetaClientConfig config =
-        new MetaClientConfig.MetaClientConfigBuilder<>().setConnectionAddress(ZK_ADDR).setStoreType(storeType).build();
+    MetaClientConfig config = new MetaClientConfig.MetaClientConfigBuilder<>().setConnectionAddress(ZK_ADDR)
+        .setStoreType(storeType)
+        .setSessionTimeoutInMillis(1 * 60 * 1000)
+        .setConnectionInitTimeoutInMillis(1 * 60 * 1000)
+        .build();
     return new LeaderElectionClient(config, participantName);
   }
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/TestLeaderElection.java
@@ -25,11 +25,8 @@ public class TestLeaderElection extends ZkMetaClientTestBase {
 
   public static LeaderElectionClient createLeaderElectionClient(String participantName) {
     MetaClientConfig.StoreType storeType = MetaClientConfig.StoreType.ZOOKEEPER;
-    MetaClientConfig config = new MetaClientConfig.MetaClientConfigBuilder<>().setConnectionAddress(ZK_ADDR)
-        .setStoreType(storeType)
-        .setSessionTimeoutInMillis(1 * 60 * 1000)
-        .setConnectionInitTimeoutInMillis(1 * 60 * 1000)
-        .build();
+    MetaClientConfig config =
+        new MetaClientConfig.MetaClientConfigBuilder<>().setConnectionAddress(ZK_ADDR).setStoreType(storeType).build();
     return new LeaderElectionClient(config, participantName);
   }
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2815

### Description


- [X] Here are some details about my PR, including screenshots of any UI changes:

User reporting that when they make heap dump on an app that uses leader election client for leadership orchestration, the participant ZNode is gone. The node is still the leader.

This is caused by a race condition between Helix ZkClient reconnect and native ZooKeeper client life cycle. 
ZooKeeper client will close the client when expired.
CONNECTED->EXPIRED->CLOSED
In Helix, ZkClient will create a new native ZooKeeper client, and close the old one when the old client has session expired. (code link https://github.com/apache/helix/blob/master/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkConnection.java#L116) 

In most cases, the previous ZooKeeper client is closed by Helix ZkClient after Helix ZkClient switched to a new client. So HelixZkClient will vener receive the "Closed" state event. Helix ZkClient will send out state change event `EXPIRED->CONNECTED`
However, sometimes the client closes it self before Helix ZkClient switched to a new client, thus, Helix ZkClient will receive "Closed" state event.  . Helix ZkClient will send out state change event `EXPIRED->CLOSED->CONNECTED`

### Tests

- [X] The following tests are written for this issue:

Reproduce this issue by adding breakpoint in ZK code. Verified before/after behavior. 

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
