### PR TITLE
Change partitionAssignment API to handle ANY_LIVEINSTANCE

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterDataCache.java
@@ -159,22 +159,11 @@ public class ClusterDataCache extends ResourceControllerDataProvider {
     Map<String, IdealState> idealStateMap = _idealStateCache.getIdealStateMap();
 
     if (idealStateMap.containsKey(resourceName)) {
-      String replicasStr = idealStateMap.get(resourceName).getReplicas();
+      int replicasStr = idealStateMap.get(resourceName).getReplicaCount(_liveInstanceMap.size());
 
-      if (replicasStr != null) {
-        if (replicasStr.equals(IdealState.IdealStateConstants.ANY_LIVEINSTANCE.toString())) {
-          replicas = _liveInstanceMap.size();
-        } else {
-          try {
-            replicas = Integer.parseInt(replicasStr);
-          } catch (Exception e) {
-            LogUtil.logError(LOG, _eventId, "invalid replicas string: " + replicasStr + " for "
-                + (_isTaskCache ? "TASK" : "DEFAULT") + "pipeline");
-          }
-        }
-      } else {
-        LogUtil.logError(LOG, _eventId, "idealState for resource: " + resourceName
-            + " does NOT have replicas for " + (_isTaskCache ? "TASK" : "DEFAULT") + "pipeline");
+      if (replicasStr == 0) {
+        LogUtil.logError(LOG, _eventId,
+            "idealState for resource: " + resourceName + " does NOT have replicas for " + (_isTaskCache ? "TASK" : "DEFAULT") + "pipeline");
       }
     }
     return replicas;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -2484,7 +2484,11 @@ public class ZKHelixAdmin implements HelixAdmin {
     setResourceIdealState(clusterName, idealState.getResourceName(), idealState);
 
     // 4. rebalance the resource
-    rebalance(clusterName, idealState.getResourceName(), Integer.parseInt(idealState.getReplicas()),
+    HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, _baseDataAccessor);
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    List<String> liveNodes = accessor.getChildNames(keyBuilder.liveInstances());
+
+    rebalance(clusterName, idealState.getResourceName(), idealState.getReplicaCount(liveNodes.size()),
         idealState.getResourceName(), idealState.getInstanceGroupTag());
 
     return true;

--- a/helix-core/src/main/java/org/apache/helix/model/IdealState.java
+++ b/helix-core/src/main/java/org/apache/helix/model/IdealState.java
@@ -554,8 +554,9 @@ public class IdealState extends HelixProperty {
   }
 
   /**
-   * Get the number of replicas for each partition of this resource.
-   * @return String value of the replica count, can be ANY_LIVEINSTANCE string
+   * Get the number of replicas for each partition of this resource. Return value can be "ANY_LIVEINSTANCE", use
+   * {@link #getReplicaCount(int)} to prevent NumberFormatException when parsing string for int. 
+   * @return String value of the replica count,
    */
   public String getReplicas() {
     // HACK: if replica doesn't exists, use the length of the first list field

--- a/helix-core/src/main/java/org/apache/helix/model/IdealState.java
+++ b/helix-core/src/main/java/org/apache/helix/model/IdealState.java
@@ -554,8 +554,8 @@ public class IdealState extends HelixProperty {
   }
 
   /**
-   * Get the number of replicas for each partition of this resource
-   * @return number of replicas (as a string)
+   * Get the number of replicas for each partition of this resource.
+   * @return String value of the replica count, can be ANY_LIVEINSTANCE string
    */
   public String getReplicas() {
     // HACK: if replica doesn't exists, use the length of the first list field

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -394,7 +394,7 @@ public final class HelixUtil {
         RebalanceStrategy.class.cast(loadClass(HelixUtil.class, strategyClassName).newInstance());
 
     strategy.init(idealState.getResourceName(), partitions, stateModelDefinition
-            .getStateCountMap(liveInstances.size(), Integer.parseInt(idealState.getReplicas())),
+            .getStateCountMap(liveInstances.size(), idealState.getReplicaCount(liveInstances.size())),
         idealState.getMaxPartitionsPerInstance());
 
     // Remove all disabled instances so that Helix will not consider them live.


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

#2816 
partitionAssignment fails to calculate when there is FULL_AUTO resource that has `ANY_LIVEINSTANCE` for replica count.

### Description
partitionAssignment fails due to `Integer.parseInt(idealState.getReplicas())` in the `getIdealAssignmentForFullAuto` method. `idealState.getReplicas()` returns `"ANY_LIVEINSTANCE"` which then fails to be parsed to an int.

This change switches to the getReplicaCount() method which takes a default value if the replica count is ANY_LIVEINSTANCE. 

### Tests

- [ ] The following tests are written for this issue:

Added a resource that utilizes ANY_LIVEINSTANCE into the testComputePartitionAssignmentMaintenanceMode test method. Without the changes to getReplicas()

- The following is the result of the "mvn test" command on the appropriate module:
$ mvn test -o -Dtest=TestPartitionAssignmentAPI.java -pl=helix-rest

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 147.587 s - in org.apache.helix.rest.server.TestPartitionAssignmentAPI
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-rest ---
[INFO] Loading execution data file /Users/gspencer/Desktop/git-repos/helix/helix-rest/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Restful Interface' with 95 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:34 min
[INFO] Finished at: 2024-06-26T16:23:02-07:00
[INFO] ------------------------------------------------------------------------

```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

Change to the return value of getReplicas when called on a resource with ANY_LIVEINSTANCE as its replica count. 


### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
