### PR TITLE
Fix unstable tests of TestPartitionAssignmentAPI and TestPerInstanceAccessor

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPartitionAssignmentAPI.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPartitionAssignmentAPI.java
@@ -103,8 +103,6 @@ public class TestPartitionAssignmentAPI extends AbstractTestClass {
         .setResources(new HashSet<>(_resources))
         .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
 
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-
     // Add and start instances to cluster
     for (int i = 0; i < DEFAULT_INSTANCE_COUNT; i++) {
       String instanceName = INSTANCE_NAME_PREFIX + (INSTANCE_START_PORT + i);
@@ -119,6 +117,7 @@ public class TestPartitionAssignmentAPI extends AbstractTestClass {
       _participants.add(participant);
     }
 
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
     System.out.println("End setup:" + TestHelper.getTestMethodName());
   }
 
@@ -126,11 +125,8 @@ public class TestPartitionAssignmentAPI extends AbstractTestClass {
   public void afterTest() throws Exception {
     System.out.println("Start teardown:" + TestHelper.getTestMethodName());
 
-    // Drop all resources
-    for (String resource : _resources) {
-      _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, resource);
-    }
-    _resources.clear();
+    // Stop controller
+    _controller.syncStop();
 
     // Stop and remove all instances
     for (MockParticipantManager participant : _participants) {
@@ -143,8 +139,11 @@ public class TestPartitionAssignmentAPI extends AbstractTestClass {
     }
     _participants.clear();
 
-    // Stop controller
-    _controller.syncStop();
+    // Drop all resources
+    for (String resource : _resources) {
+      _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, resource);
+    }
+    _resources.clear();
 
     // Drop cluster
     _gSetupTool.deleteCluster(CLUSTER_NAME);
@@ -442,6 +441,7 @@ public class TestPartitionAssignmentAPI extends AbstractTestClass {
     MockParticipantManager toAddParticipant = createParticipant(toAddInstanceName);
     toAddParticipant.syncStart();
 
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
     // Choose participant to simulate killing in API call
     MockParticipantManager participantToKill = _participants.get(0);
 


### PR DESCRIPTION



### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

resolve #2839 #2838 #2836 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

1. Make sure use the semiauto cluster for PerInstanceAccessor test and clean up the logic when it completes.
2. Make the poll and clean up logic in the right order to avoid leaderless race condition between tests.
### Tests

- [ ] The following tests are written for this issue:


- The following is the result of the "mvn test" command on the appropriate module:


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
