### PR TITLE
Fix flaky test - testDisableErrorLogByDefault

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/util/TestStatusUpdateUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestStatusUpdateUtil.java
@@ -24,13 +24,11 @@ import java.lang.reflect.Modifier;
 
 import org.apache.helix.HelixConstants;
 import org.apache.helix.PropertyPathBuilder;
-import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.messaging.handling.HelixStateTransitionHandler;
 import org.apache.helix.model.Message;
-import org.apache.helix.model.StatusUpdate;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.zkclient.exception.ZkException;
 import org.testng.Assert;
@@ -116,7 +114,7 @@ public class TestStatusUpdateUtil extends ZkTestBase {
       } catch (ZkException zke) {
         return false;
       }
-    }, 10000);
+    }, TestHelper.WAIT_DURATION);
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/util/TestStatusUpdateUtil.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestStatusUpdateUtil.java
@@ -108,11 +108,15 @@ public class TestStatusUpdateUtil extends ZkTestBase {
         .instanceError(clusterName, "localhost_12918", participants[0].getSessionId(), "TestDB",
             "TestDB_0");
 
-    try {
-      ZNRecord error = _gZkClient.readData(errPath);
-    } catch (ZkException zke) {
-      Assert.fail("expecting being able to send error logs to ZK.", zke);
-    }
+    // Verify message exists in ZK
+    TestHelper.verify(() -> {
+      try {
+        _gZkClient.readData(errPath);
+        return true;
+      } catch (ZkException zke) {
+        return false;
+      }
+    }, 10000);
   }
 
   @Test


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

https://github.com/apache/helix/issues/2818
Flaky test currently failing in CI

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Test failing in CI but passes locally. Likely this is due to attempting to read ZK node immediately after calling calling .logError() . If ZK server on CI is slow, the node may not be created yet. We should use verifier instead to retry read and only assert that it is eventually created

### Tests

- [ ] The following tests are written for this issue:

changed to using verifier in: TestStatusUpdateUtil.testEnableErrorLog

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
