### PR TITLE
Update bump-up.sh to remove deprecated helix-admin-webapp and helix-front

### DIFF
--- a/bump-up.sh
+++ b/bump-up.sh
@@ -74,12 +74,12 @@ echo "bump up: $current_version -> $new_version"
 update_pom_version "pom.xml" $current_version
 
 for module in "metrics-common" "metadata-store-directory-common" "zookeeper-api" "helix-common" "helix-core" \
-              "helix-admin-webapp" "helix-rest" "helix-lock" "helix-view-aggregator" "helix-agent" "meta-client"; do
+              "helix-rest" "helix-lock" "helix-view-aggregator" "helix-agent" "meta-client"; do
   update_ivy $module
   update_pom_version $module/pom.xml $current_version
 done
 
-for module in recipes/task-execution recipes helix-front \
+for module in recipes/task-execution recipes \
            recipes/distributed-lock-manager recipes/rsync-replicated-file-system \
            recipes/rabbitmq-consumer-group recipes/service-discovery; do
   update_pom_version $module/pom.xml $current_version


### PR DESCRIPTION
### Description

As helix-admin-webapp and helix-front are deprecated, `<parent>`'s version in pom.xml is not consistent with other modules.

For example:
- `helix-admin-webapp/pom.xml`: 1.3.2-SNAPSHOT [link](https://github.com/apache/helix/blob/eda45fc58f4e6fd19a96eb6bcf33f0e7813e0a53/helix-admin-webapp/pom.xml#L21C1-L25C12)
- `pom.xml` and other modules: 1.4.1-SNAPSHOT [link](https://github.com/abhilash1in/helix/blob/add9a5274dbf7f0299a127a81bec0542cf758e60/pom.xml#L32)

As a result, the current version obtained by `bump-up.sh` from `pom.xml` (get_version_from_pom) does not match what's in `helix-admin-webapp`, so the find and replace fails:
```
bump up helix-admin-webapp/pom.xml
Failed to update new version 1.4.1-dev-202407292139 in helix-admin-webapp/pom.xml
```

This PR removes helix-admin-webapp and helix-front from bump-up.sh so that it doesn't fail while attempting to "find and replace" version numbers from these deprecated modules (until they are permanently removed).