### PR TITLE
Fix flaky testDisableErrorLogByDefault

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StatusUpdateUtil.java
@@ -19,6 +19,7 @@ package org.apache.helix.util;
  * under the License.
  */
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.DateFormat;
@@ -56,8 +57,16 @@ import org.slf4j.LoggerFactory;
 public class StatusUpdateUtil {
   static Logger _logger = LoggerFactory.getLogger(StatusUpdateUtil.class);
 
-  public static final boolean ERROR_LOG_TO_ZK_ENABLED =
+  private static boolean ERROR_LOG_TO_ZK_ENABLED =
       Boolean.getBoolean(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_PERSISTENCY_ENABLED);
+  public static boolean isErrorLogToZkEnabled() {
+    return ERROR_LOG_TO_ZK_ENABLED;
+  }
+
+  @VisibleForTesting
+  public static void setErrorLogToZkEnabled(boolean enabled) {
+    ERROR_LOG_TO_ZK_ENABLED = enabled;
+  }
 
   public static class Transition implements Comparable<Transition> {
     private final String _msgID;
@@ -555,9 +564,10 @@ public class StatusUpdateUtil {
    */
   void publishErrorRecord(ZNRecord record, String instanceName, String updateSubPath,
       String updateKey, String sessionId, HelixDataAccessor accessor, boolean isController) {
-    if (!ERROR_LOG_TO_ZK_ENABLED) {
+    if (!isErrorLogToZkEnabled()) {
       return;
     }
+
     Builder keyBuilder = accessor.keyBuilder();
     if (isController) {
       // TODO need to fix: ERRORS_CONTROLLER doesn't have a form of

--- a/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/manager/TestParticipantManager.java
@@ -46,6 +46,7 @@ import org.apache.helix.TestHelper;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.ParticipantHistory;
+import org.apache.helix.util.StatusUpdateUtil;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.ZkTestHelper;
 import org.apache.helix.common.ZkTestBase;
@@ -65,7 +66,6 @@ import org.apache.helix.monitoring.mbeans.ZkClientPathMonitor;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.testng.Assert;
 import org.testng.ITestContext;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
@@ -74,18 +74,9 @@ public class TestParticipantManager extends ZkTestBase {
   private final String _clusterName = TestHelper.getTestClassName();
   private final ExecutorService _executor = Executors.newFixedThreadPool(1);
 
-  static {
-    System.setProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_PERSISTENCY_ENABLED, "true");
-  }
-
   @AfterMethod
   public void afterMethod(Method testMethod, ITestContext testContext) {
     deleteCluster(_clusterName);
-  }
-
-  @AfterClass
-  public void afterClass() {
-    System.clearProperty(SystemPropertyKeys.STATEUPDATEUTIL_ERROR_PERSISTENCY_ENABLED);
   }
 
   @Test
@@ -439,6 +430,7 @@ public class TestParticipantManager extends ZkTestBase {
     String newSessionId = participants[0].getSessionId();
     Assert.assertNotSame(newSessionId, oldSessionId);
 
+    StatusUpdateUtil.setErrorLogToZkEnabled(true);
     // assert interrupt exception error in old session
     String errPath = PropertyPathBuilder.instanceError(_clusterName, "localhost_12918", oldSessionId,
         "TestDB0", "TestDB0_0");


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

https://github.com/apache/helix/issues/2818
testDisableErrorLogByDefault in TestStatusUpdateUtil failing intermittently

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
There are 2 things at play here:
1. TestParticipantManager's static field is setting STATEUPDATEUTIL_ERROR_PERSISTENCY_ENABLED to true. My assumption is that this code is executed early on when the JVM firsts loads these classes. This is why StatusUpdateUtil is pushing error logs to ZK in the first place
2. Setting the static field's variable appears to not successfully propagate the changed value to the loaded class. This is why the logs are pushed to ZK despite using setFinalStatic to change the value to false. At this point I'm not sure why it fails - my very uneducated guess is that the jvm might be doing some optimization by having threads cache the variables and the change is not propagated properly. The observed behavior is that when reading the value of  StatusUpdateUtil.ERROR_LOG_TO_ZK_ENABLED within TestStatusUpdateUtil will show false (set by setFinalStatic call), but the value when read within StatusUpdateUtil's publishErrorRecord will show true (original value). 

I'm not sure this specific approach of having a static method to reassign the static variable is the best practice. Maybe it is better to modify StatusUpdateUtil so that it has a local variable taht can be set by its constructor, or that defaults to the system property value if no value provided. 

### Tests

- [ ] The following tests are written for this issue:

testDisableErrorLogByDefault

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
