### PR TITLE
Refactor and fix puppy for metaclient

### DIFF
--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/CreatePuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/CreatePuppy.java
@@ -29,10 +29,9 @@ import java.util.Random;
 public class CreatePuppy extends AbstractPuppy {
 
   private final Random _random;
-  private final String _parentPath = "/test";
 
-  public CreatePuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec) {
-    super(metaclient, puppySpec);
+  public CreatePuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec, String parentPath) {
+    super(metaclient, puppySpec, parentPath);
     _random = new Random();
   }
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/DeletePuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/DeletePuppy.java
@@ -28,11 +28,12 @@ import java.util.Random;
 public class DeletePuppy extends AbstractPuppy {
 
   private final Random _random;
-  private final String _parentPath = "/test";
+  private final String _parentPath;
 
-  public DeletePuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec) {
-    super(metaclient, puppySpec);
+  public DeletePuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec, String parentPath) {
+    super(metaclient, puppySpec, parentPath);
     _random = new Random();
+    _parentPath = parentPath;
   }
 
   @Override

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/GetPuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/GetPuppy.java
@@ -31,8 +31,8 @@ public class GetPuppy extends AbstractPuppy {
   private final Random _random;
   private final String _parentPath = "/test";
 
-  public GetPuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec) {
-    super(metaclient, puppySpec);
+  public GetPuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec, String parentPath) {
+    super(metaclient, puppySpec, parentPath);
     _random = new Random();
   }
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/SetPuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/SetPuppy.java
@@ -31,8 +31,8 @@ public class SetPuppy extends AbstractPuppy {
   private final Random _random;
   private final String _parentPath = "/test";
 
-  public SetPuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec) {
-    super(metaclient, puppySpec);
+  public SetPuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec, String parentPath) {
+    super(metaclient, puppySpec, parentPath);
     _random = new Random();
   }
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/TestMultiThreadStressZKClient.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/TestMultiThreadStressZKClient.java
@@ -35,6 +35,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.helix.metaclient.impl.zk.TestUtil.*;
+
+
 public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
 
   private ZkMetaClient<String> _zkMetaClient;
@@ -50,12 +53,13 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
 
   @Test
   public void testCreatePuppy() {
-    _zkMetaClient.create(zkParentKey, "test");
+    String testPath = zkParentKey + getTestMethodName();
+    _zkMetaClient.create(testPath, "test");
 
     PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
-    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
-    CreatePuppy createPuppy2 = new CreatePuppy(_zkMetaClient, puppySpec);
-    CreatePuppy createPuppy3 = new CreatePuppy(_zkMetaClient, puppySpec);
+    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec, testPath);
+    CreatePuppy createPuppy2 = new CreatePuppy(_zkMetaClient, puppySpec, testPath);
+    CreatePuppy createPuppy3 = new CreatePuppy(_zkMetaClient, puppySpec, testPath);
 
     PuppyManager puppyManager = new PuppyManager();
     puppyManager.addPuppy(createPuppy);
@@ -67,17 +71,18 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     assertNoExceptions(puppyManager, null);
 
     // cleanup
-    _zkMetaClient.recursiveDelete(zkParentKey);
-    Assert.assertEquals(_zkMetaClient.countDirectChildren(zkParentKey), 0);
+    _zkMetaClient.recursiveDelete(testPath);
+    Assert.assertEquals(_zkMetaClient.countDirectChildren(testPath), 0);
   }
 
-  @Test
+  @Test(dependsOnMethods = "testCreatePuppy")
   public void testDeletePuppy() {
-    _zkMetaClient.create(zkParentKey, "test");
+    String testPath = zkParentKey + getTestMethodName();
+    _zkMetaClient.create(testPath, "test");
 
     PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
-    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
-    DeletePuppy deletePuppy = new DeletePuppy(_zkMetaClient, puppySpec);
+    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec, testPath);
+    DeletePuppy deletePuppy = new DeletePuppy(_zkMetaClient, puppySpec, testPath);
 
     PuppyManager puppyManager = new PuppyManager();
     puppyManager.addPuppy(createPuppy);
@@ -88,17 +93,18 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     assertNoExceptions(puppyManager, null);
 
     // cleanup
-    _zkMetaClient.recursiveDelete(zkParentKey);
-    Assert.assertEquals(_zkMetaClient.countDirectChildren(zkParentKey), 0);
+    _zkMetaClient.recursiveDelete(testPath);
+    Assert.assertEquals(_zkMetaClient.countDirectChildren(testPath), 0);
   }
 
-  @Test
+  @Test(dependsOnMethods = "testDeletePuppy")
   public void testGetPuppy() {
-    _zkMetaClient.create(zkParentKey, "test");
+    String testPath = zkParentKey + getTestMethodName();
+    _zkMetaClient.create(testPath, "test");
 
     PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
-    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
-    GetPuppy getPuppy = new GetPuppy(_zkMetaClient, puppySpec);
+    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec, testPath);
+    GetPuppy getPuppy = new GetPuppy(_zkMetaClient, puppySpec, testPath);
 
     PuppyManager puppyManager = new PuppyManager();
     puppyManager.addPuppy(createPuppy);
@@ -109,17 +115,18 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     assertNoExceptions(puppyManager, null);
 
     // cleanup
-    _zkMetaClient.recursiveDelete(zkParentKey);
-    Assert.assertEquals(_zkMetaClient.countDirectChildren(zkParentKey), 0);
+    _zkMetaClient.recursiveDelete(testPath);
+    Assert.assertEquals(_zkMetaClient.countDirectChildren(testPath), 0);
   }
 
-  @Test
+  @Test(dependsOnMethods = "testGetPuppy")
   public void testSetPuppy() {
-    _zkMetaClient.create(zkParentKey, "test");
+    String testPath = zkParentKey + getTestMethodName();
+    _zkMetaClient.create(testPath, "test");
 
     PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
-    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
-    SetPuppy setPuppy = new SetPuppy(_zkMetaClient, puppySpec);
+    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec, testPath);
+    SetPuppy setPuppy = new SetPuppy(_zkMetaClient, puppySpec, testPath);
 
     PuppyManager puppyManager = new PuppyManager();
     puppyManager.addPuppy(createPuppy);
@@ -130,17 +137,18 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     assertNoExceptions(puppyManager, null);
 
     // cleanup
-    _zkMetaClient.recursiveDelete(zkParentKey);
-    Assert.assertEquals(_zkMetaClient.countDirectChildren(zkParentKey), 0);
+    _zkMetaClient.recursiveDelete(testPath);
+    Assert.assertEquals(_zkMetaClient.countDirectChildren(testPath), 0);
   }
 
-  @Test
+  @Test(dependsOnMethods = "testSetPuppy")
   public void testUpdatePuppy() {
-    _zkMetaClient.create(zkParentKey, "test");
+    String testPath = zkParentKey + getTestMethodName();
+    _zkMetaClient.create(testPath, "test");
 
     PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
-    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
-    UpdatePuppy updatePuppy = new UpdatePuppy(_zkMetaClient, puppySpec);
+    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec, testPath);
+    UpdatePuppy updatePuppy = new UpdatePuppy(_zkMetaClient, puppySpec, testPath);
 
     PuppyManager puppyManager = new PuppyManager();
     puppyManager.addPuppy(createPuppy);
@@ -151,20 +159,21 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     assertNoExceptions(puppyManager, null);
 
     // cleanup
-    _zkMetaClient.recursiveDelete(zkParentKey);
-    Assert.assertEquals(_zkMetaClient.countDirectChildren(zkParentKey), 0);
+    _zkMetaClient.recursiveDelete(testPath);
+    Assert.assertEquals(_zkMetaClient.countDirectChildren(testPath), 0);
   }
 
-  @Test
+  @Test(dependsOnMethods = "testUpdatePuppy")
   public void testCrudPuppies() {
-    _zkMetaClient.create(zkParentKey, "test");
+    String testPath = zkParentKey + getTestMethodName();
+    _zkMetaClient.create(testPath, "test");
 
     PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
-    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
-    GetPuppy getPuppy = new GetPuppy(_zkMetaClient, puppySpec);
-    DeletePuppy deletePuppy = new DeletePuppy(_zkMetaClient, puppySpec);
-    SetPuppy setPuppy = new SetPuppy(_zkMetaClient, puppySpec);
-    UpdatePuppy updatePuppy = new UpdatePuppy(_zkMetaClient, puppySpec);
+    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec, testPath);
+    GetPuppy getPuppy = new GetPuppy(_zkMetaClient, puppySpec, testPath);
+    DeletePuppy deletePuppy = new DeletePuppy(_zkMetaClient, puppySpec, testPath);
+    SetPuppy setPuppy = new SetPuppy(_zkMetaClient, puppySpec, testPath);
+    UpdatePuppy updatePuppy = new UpdatePuppy(_zkMetaClient, puppySpec, testPath);
 
     PuppyManager puppyManager = new PuppyManager();
     puppyManager.addPuppy(createPuppy);
@@ -178,24 +187,25 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     assertNoExceptions(puppyManager, null);
 
     // cleanup
-    _zkMetaClient.recursiveDelete(zkParentKey);
-    Assert.assertEquals(_zkMetaClient.countDirectChildren(zkParentKey), 0);
+    _zkMetaClient.recursiveDelete(testPath);
+    Assert.assertEquals(_zkMetaClient.countDirectChildren(testPath), 0);
   }
 
-
-  @Test
+  @Test(dependsOnMethods = "testCrudPuppies")
   public void testBasicParentListenerPuppy() {
-    _zkMetaClient.create(zkParentKey, "test");
+    String testPath = zkParentKey + getTestMethodName();
+    _zkMetaClient.create(testPath, "test");
     AtomicInteger globalChildChangeCounter = new AtomicInteger();
     ChildChangeListener childChangeListener = (changedPath, changeType) -> {
       globalChildChangeCounter.addAndGet(1);
-      System.out.println("-------------- Child change detected: " + changeType + " at path: " + changedPath + ". Number of total changes: " + globalChildChangeCounter.get());
+      System.out.println("-------------- Child change detected: " + changeType + " at path: " + changedPath
+          + ". Number of total changes: " + globalChildChangeCounter.get());
     };
 
-    _zkMetaClient.subscribeChildChanges(zkParentKey, childChangeListener, false);
+    _zkMetaClient.subscribeChildChanges(testPath, childChangeListener, false);
 
     PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
-    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
+    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec, testPath);
 
     PuppyManager puppyManager = new PuppyManager();
     puppyManager.addPuppy(createPuppy);
@@ -205,28 +215,31 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     assertNoExceptions(puppyManager, globalChildChangeCounter);
 
     // cleanup
-    _zkMetaClient.unsubscribeChildChanges(zkParentKey, childChangeListener);
-    _zkMetaClient.recursiveDelete(zkParentKey);
-    Assert.assertEquals(_zkMetaClient.countDirectChildren(zkParentKey), 0);
+    _zkMetaClient.unsubscribeChildChanges(testPath, childChangeListener);
+    _zkMetaClient.recursiveDelete(testPath);
+    Assert.assertEquals(_zkMetaClient.countDirectChildren(testPath), 0);
   }
 
-  @Test
+  @Test(dependsOnMethods = "testBasicParentListenerPuppy")
   public void testComplexParentListenerPuppy() {
-    _zkMetaClient.create(zkParentKey, "test");
+    String testPath = zkParentKey + getTestMethodName();
+    _zkMetaClient.create(testPath, "test");
     // Global counter for all child changes
     AtomicInteger globalChildChangeCounter = new AtomicInteger();
     ChildChangeListener childChangeListener = (changedPath, changeType) -> {
       globalChildChangeCounter.addAndGet(1);
-      System.out.println("-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: " + globalChildChangeCounter.get());
+      System.out.println(
+          "-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: "
+              + globalChildChangeCounter.get());
     };
-    _zkMetaClient.subscribeChildChanges(zkParentKey, childChangeListener, false);
+    _zkMetaClient.subscribeChildChanges(testPath, childChangeListener, false);
 
     PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 5);
-    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
-    GetPuppy getPuppy = new GetPuppy(_zkMetaClient, puppySpec);
-    DeletePuppy deletePuppy = new DeletePuppy(_zkMetaClient, puppySpec);
-    SetPuppy setPuppy = new SetPuppy(_zkMetaClient, puppySpec);
-    UpdatePuppy updatePuppy = new UpdatePuppy(_zkMetaClient, puppySpec);
+    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec, testPath);
+    GetPuppy getPuppy = new GetPuppy(_zkMetaClient, puppySpec, testPath);
+    DeletePuppy deletePuppy = new DeletePuppy(_zkMetaClient, puppySpec, testPath);
+    SetPuppy setPuppy = new SetPuppy(_zkMetaClient, puppySpec, testPath);
+    UpdatePuppy updatePuppy = new UpdatePuppy(_zkMetaClient, puppySpec, testPath);
 
     PuppyManager puppyManager = new PuppyManager();
     puppyManager.addPuppy(createPuppy);
@@ -240,23 +253,23 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     assertNoExceptions(puppyManager, globalChildChangeCounter);
 
     // cleanup
-    _zkMetaClient.recursiveDelete(zkParentKey);
-    Assert.assertEquals(_zkMetaClient.countDirectChildren(zkParentKey), 0);
-    _zkMetaClient.unsubscribeChildChanges(zkParentKey, childChangeListener);
-    _zkMetaClient.delete(zkParentKey);
+    _zkMetaClient.recursiveDelete(testPath);
+    Assert.assertEquals(_zkMetaClient.countDirectChildren(testPath), 0);
+    _zkMetaClient.unsubscribeChildChanges(testPath, childChangeListener);
+    _zkMetaClient.delete(testPath);
   }
 
-
-  @Test
+  @Test(dependsOnMethods = "testComplexParentListenerPuppy")
   public void testChildListenerPuppy() {
-    _zkMetaClient.create(zkParentKey, "test");
+    String testPath = zkParentKey + getTestMethodName();
+    _zkMetaClient.create(testPath, "test");
     // Setting num diff paths to 3 until we find a better way of scaling listeners.
     PuppySpec puppySpec = new PuppySpec(PuppyMode.REPEAT, 0.2f, new ExecDelay(5000, 0.1f), 3);
-    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec);
-    GetPuppy getPuppy = new GetPuppy(_zkMetaClient, puppySpec);
-    DeletePuppy deletePuppy = new DeletePuppy(_zkMetaClient, puppySpec);
-    SetPuppy setPuppy = new SetPuppy(_zkMetaClient, puppySpec);
-    UpdatePuppy updatePuppy = new UpdatePuppy(_zkMetaClient, puppySpec);
+    CreatePuppy createPuppy = new CreatePuppy(_zkMetaClient, puppySpec, testPath);
+    GetPuppy getPuppy = new GetPuppy(_zkMetaClient, puppySpec, testPath);
+    DeletePuppy deletePuppy = new DeletePuppy(_zkMetaClient, puppySpec, testPath);
+    SetPuppy setPuppy = new SetPuppy(_zkMetaClient, puppySpec, testPath);
+    UpdatePuppy updatePuppy = new UpdatePuppy(_zkMetaClient, puppySpec, testPath);
 
     PuppyManager puppyManager = new PuppyManager();
     puppyManager.addPuppy(createPuppy);
@@ -264,29 +277,39 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     puppyManager.addPuppy(deletePuppy);
     puppyManager.addPuppy(setPuppy);
     puppyManager.addPuppy(updatePuppy);
+
+    String childTestPath0 = testPath + "/0";
+    String childTestPath1 = testPath + "/1";
+    String childTestPath2 = testPath + "/2";
 
     // Create a child listener for each child defined in number diff paths in puppyspec.
     // TODO: Make this a parameter for a loop.
     AtomicInteger childChangeCounter0 = new AtomicInteger();
     ChildChangeListener childChangeListener0 = (changedPath, changeType) -> {
       childChangeCounter0.addAndGet(1);
-      System.out.println("-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: " + childChangeCounter0.get());
+      System.out.println(
+          "-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: "
+              + childChangeCounter0.get());
     };
-    _zkMetaClient.subscribeChildChanges("/test/0", childChangeListener0, false);
+    _zkMetaClient.subscribeChildChanges(childTestPath0, childChangeListener0, false);
 
     AtomicInteger childChangeCounter1 = new AtomicInteger();
     ChildChangeListener childChangeListener1 = (changedPath, changeType) -> {
       childChangeCounter1.addAndGet(1);
-      System.out.println("-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: " + childChangeCounter1.get());
+      System.out.println(
+          "-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: "
+              + childChangeCounter1.get());
     };
-    _zkMetaClient.subscribeChildChanges("/test/1", childChangeListener1, false);
+    _zkMetaClient.subscribeChildChanges(childTestPath1, childChangeListener1, false);
 
     AtomicInteger childChangeCounter2 = new AtomicInteger();
     ChildChangeListener childChangeListener2 = (changedPath, changeType) -> {
       childChangeCounter2.addAndGet(1);
-      System.out.println("-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: " + childChangeCounter2.get());
+      System.out.println(
+          "-------------- Child change detected: " + changeType + " at path: " + changedPath + " number of changes: "
+              + childChangeCounter2.get());
     };
-    _zkMetaClient.subscribeChildChanges("/test/2", childChangeListener2, false);
+    _zkMetaClient.subscribeChildChanges(childTestPath2, childChangeListener2, false);
 
     puppyManager.start(TIMEOUT);
 
@@ -314,11 +337,11 @@ public class TestMultiThreadStressZKClient extends ZkMetaClientTestBase {
     Assert.assertEquals(childChangeCounter2.get(), mergedEventChangeCounterMap.getOrDefault("2", 0).intValue());
 
     // cleanup
-    _zkMetaClient.unsubscribeChildChanges("/test/0", childChangeListener0);
-    _zkMetaClient.unsubscribeChildChanges("/test/1", childChangeListener1);
-    _zkMetaClient.unsubscribeChildChanges("/test/2", childChangeListener2);
-    _zkMetaClient.recursiveDelete(zkParentKey);
-    Assert.assertEquals(_zkMetaClient.countDirectChildren(zkParentKey), 0);
+    _zkMetaClient.unsubscribeChildChanges(childTestPath0, childChangeListener0);
+    _zkMetaClient.unsubscribeChildChanges(childTestPath1, childChangeListener1);
+    _zkMetaClient.unsubscribeChildChanges(childTestPath2, childChangeListener2);
+    _zkMetaClient.recursiveDelete(testPath);
+    Assert.assertEquals(_zkMetaClient.countDirectChildren(testPath), 0);
   }
 
   private void assertNoExceptions(PuppyManager puppyManager, AtomicInteger globalChangeCounter) {

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/UpdatePuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestMultiThreadStressTest/UpdatePuppy.java
@@ -29,10 +29,9 @@ import java.util.Random;
 public class UpdatePuppy extends AbstractPuppy {
 
   private final Random _random;
-  private final String _parentPath = "/test";
 
-  public UpdatePuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec) {
-    super(metaclient, puppySpec);
+  public UpdatePuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec, String parentPath) {
+    super(metaclient, puppySpec, parentPath);
     _random = new Random();
   }
 

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestUtil.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestUtil.java
@@ -203,4 +203,12 @@ public class TestUtil {
     zkClient.process(event);
   }
 
+  /**
+   * return the name of the calling test method
+   */
+  public static String getTestMethodName() {
+    StackTraceElement[] calls = Thread.currentThread().getStackTrace();
+    return calls[2].getMethodName();
+  }
+
 }

--- a/meta-client/src/test/java/org/apache/helix/metaclient/puppy/AbstractPuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/puppy/AbstractPuppy.java
@@ -32,11 +32,13 @@ public abstract class AbstractPuppy implements Runnable {
   protected PuppySpec _puppySpec;
   public final HashMap<String, Integer> _eventChangeCounterMap;
   public int _unhandledErrorCounter;
+  protected final String _parentPath ;
 
-  public AbstractPuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec) {
+  public AbstractPuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec, String parentPath) {
     _metaclient = metaclient;
     _puppySpec = puppySpec;
     _eventChangeCounterMap = new HashMap<>();
+    _parentPath = parentPath;
   }
 
   /**

--- a/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionPuppy.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/recipes/leaderelection/LeaderElectionPuppy.java
@@ -35,14 +35,9 @@ public class LeaderElectionPuppy extends AbstractPuppy {
   private final Random _random;
   LeaderElectionClient _leaderElectionClient;
 
-  public LeaderElectionPuppy(MetaClientInterface<String> metaclient, PuppySpec puppySpec) {
-    super(metaclient, puppySpec);
-    _random = new Random();
-  }
-
   public LeaderElectionPuppy(LeaderElectionClient leaderElectionClient, PuppySpec puppySpec, String leaderGroup,
       String participant) {
-    super(leaderElectionClient.getMetaClient(), puppySpec);
+    super(leaderElectionClient.getMetaClient(), puppySpec, leaderGroup);
     _leaderElectionClient = leaderElectionClient;
     _leaderGroup = leaderGroup;
     _random = new Random();


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

#2864 #2863  #2862  #2861 #2860  #2859

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

error message we get from CI run:
```
2024-07-30T21:43:05.0343689Z [ERROR] testDeletePuppy(org.apache.helix.metaclient.impl.zk.TestMultiThreadStressTest.TestMultiThreadStressZKClient)  Time elapsed: 0.001 s  <<< FAILURE!
2024-07-30T21:43:05.0346465Z org.apache.helix.metaclient.exception.MetaClientNodeExistsException: org.apache.helix.zookeeper.zkclient.exception.ZkNodeExistsException: org.apache.zookeeper.KeeperException$NodeExistsException: KeeperErrorCode = NodeExists for /test
2024-07-30T21:43:05.0349365Z 	at org.apache.helix.metaclient.impl.zk.TestMultiThreadStressTest.TestMultiThreadStressZKClient.testDeletePuppy(TestMultiThreadStressZKClient.java:76)
2024-07-30T21:43:05.0351768Z Caused by: org.apache.helix.zookeeper.zkclient.exception.ZkNodeExistsException: org.apache.zookeeper.KeeperException$NodeExistsException: KeeperErrorCode = NodeExists for /test
2024-07-30T21:43:05.0354329Z 	at org.apache.helix.metaclient.impl.zk.TestMultiThreadStressTest.TestMultiThreadStressZKClient.testDeletePuppy(TestMultiThreadStressZKClient.java:76)
2024-07-30T21:43:05.0356414Z Caused by: org.apache.zookeeper.KeeperException$NodeExistsException: KeeperErrorCode = NodeExists for /test
2024-07-30T21:43:05.0359278Z 	at org.apache.helix.metaclient.impl.zk.TestMultiThreadStressTest.TestMultiThreadStressZKClient.testDeletePuppy(TestMultiThreadStressZKClient.java:76)
```

Refactor and fix puppy for metaclient - isolate tests by using different ZK pathes.

### Tests

- [x] The following tests are written for this issue:

NA

- The following is the result of the "mvn test" command on the appropriate module:


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
