### PR TITLE
ZkBucketDataAccessor always complete scheduled GC

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
@@ -23,11 +23,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -81,7 +79,7 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
   private final ZkSerializer _zkSerializer;
   private final RealmAwareZkClient _zkClient;
   private final ZkBaseDataAccessor<byte[]> _zkBaseDataAccessor;
-  private final Map<String, Queue<ScheduledFuture>> _gcTaskFutureQueueMap = new HashMap<>();
+  private final Map<String, ScheduledFuture> _gcTaskFutureMap = new ConcurrentHashMap<>();
   private boolean _usesExternalZkClient = false;
 
   /**
@@ -241,7 +239,7 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
     }
 
     // 5. Update the timer for GC
-    scheduleStaleVersionGC(rootPath, version);
+    scheduleStaleVersionGC(rootPath);
     return true;
   }
 
@@ -257,7 +255,7 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
       throw new HelixException(String.format("Failed to delete the bucket data! Path: %s", path));
     }
     synchronized (this) {
-      _gcTaskFutureQueueMap.remove(path);
+      _gcTaskFutureMap.remove(path);
     }
   }
 
@@ -270,13 +268,7 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
 
   private HelixProperty compressedBucketRead(String path) {
     // 1. Get the version to read
-    byte[] binaryVersionToRead = _zkBaseDataAccessor.get(path + "/" + LAST_SUCCESSFUL_WRITE_KEY,
-        null, AccessOption.PERSISTENT);
-    if (binaryVersionToRead == null) {
-      throw new ZkNoNodeException(
-          String.format("Last successful write ZNode does not exist for path: %s", path));
-    }
-    String versionToRead = new String(binaryVersionToRead);
+    String versionToRead = getLastSuccessfulWriteVersion(path);
 
     // 2. Get the metadata map
     byte[] binaryMetadata = _zkBaseDataAccessor.get(path + "/" + versionToRead + "/" + METADATA_KEY,
@@ -356,28 +348,30 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
     close();
   }
 
-  private synchronized void scheduleStaleVersionGC(String rootPath, long currentVersion) {
-    // Create empty queue for new path
-    if (!_gcTaskFutureQueueMap.containsKey(rootPath)) {
-      _gcTaskFutureQueueMap.put(rootPath, new LinkedList<>());
+  private synchronized void scheduleStaleVersionGC(String rootPath) {
+    // If GC already scheduled, return early
+    if (_gcTaskFutureMap.containsKey(rootPath)) {
+      return;
     }
     // Schedule GC task
-    _gcTaskFutureQueueMap.get(rootPath).add(GC_THREAD.schedule(() -> {
+    _gcTaskFutureMap.put(rootPath, GC_THREAD.schedule(() -> {
           try {
-            deleteStaleVersions(rootPath, currentVersion);
+            _gcTaskFutureMap.remove(rootPath);
+            deleteStaleVersions(rootPath);
           } catch (Exception ex) {
             LOG.error("Failed to delete the stale versions.", ex);
           }
-        }, _versionTTLms, TimeUnit.MILLISECONDS)
-    );
-  }
+        }, _versionTTLms, TimeUnit.MILLISECONDS));
+    }
 
   /**
    * Deletes all stale versions.
    * @param rootPath
-   * @param currentVersion
    */
-  private void deleteStaleVersions(String rootPath, long currentVersion) {
+  private void deleteStaleVersions(String rootPath) {
+    // Get most recent write version
+    String currentVersionStr = getLastSuccessfulWriteVersion(rootPath);
+
     // Get all children names under path
     List<String> children = _zkBaseDataAccessor.getChildNames(rootPath, AccessOption.PERSISTENT);
     if (children == null || children.isEmpty()) {
@@ -385,7 +379,7 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
       return;
     }
     List<String> pathsToDelete =
-        getPathsToDelete(rootPath, filterChildrenNames(children, currentVersion));
+        getPathsToDelete(rootPath, filterChildrenNames(children, Long.parseLong(currentVersionStr)));
     for (String pathToDelete : pathsToDelete) {
       // TODO: Should be batch delete but it doesn't work. It's okay since this runs async
       _zkBaseDataAccessor.remove(pathToDelete, AccessOption.PERSISTENT);
@@ -432,5 +426,15 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
     List<String> pathsToDelete = new ArrayList<>();
     staleVersions.forEach(ver -> pathsToDelete.add(path + "/" + ver));
     return pathsToDelete;
+  }
+
+  private String getLastSuccessfulWriteVersion(String path) {
+    byte[] binaryVersionToRead = _zkBaseDataAccessor.get(path + "/" + LAST_SUCCESSFUL_WRITE_KEY,
+        null, AccessOption.PERSISTENT);
+    if (binaryVersionToRead == null) {
+      throw new ZkNoNodeException(
+          String.format("Last successful write ZNode does not exist for path: %s", path));
+    }
+    return new String(binaryVersionToRead);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
@@ -355,13 +355,13 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
     }
     // Schedule GC task
     _gcTaskFutureMap.put(rootPath, GC_THREAD.schedule(() -> {
-          try {
-            _gcTaskFutureMap.remove(rootPath);
-            deleteStaleVersions(rootPath);
-          } catch (Exception ex) {
-            LOG.error("Failed to delete the stale versions.", ex);
-          }
-        }, _versionTTLms, TimeUnit.MILLISECONDS));
+        try {
+          _gcTaskFutureMap.remove(rootPath);
+          deleteStaleVersions(rootPath);
+        } catch (Exception ex) {
+          LOG.error("Failed to delete the stale versions.", ex);
+        }
+      }, _versionTTLms, TimeUnit.MILLISECONDS));
     }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -221,6 +221,7 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
 
     Assert.assertTrue(children.size() < writeCount,
         "Expecting stale versions to cleaned up. Children were: " + children);
+    System.out.print("Children after GC: " + children);
   }
 
   private HelixProperty createLargeHelixProperty(String name, int numEntries) {

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -50,7 +50,7 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
   private static final String NAME_KEY = TestHelper.getTestClassName();
   private static final String LAST_SUCCESSFUL_WRITE_KEY = "LAST_SUCCESSFUL_WRITE";
   private static final String LAST_WRITE_KEY = "LAST_WRITE";
-  private static final long VERSION_TTL_MS = 5000L;
+  private static final long VERSION_TTL_MS = 1000L;
 
   // Populate list and map fields for content comparison
   private static final List<String> LIST_FIELD = ImmutableList.of("1", "2");


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

https://github.com/apache/helix/issues/2872
When a write occurs, ZkBucketDataAccessor schedules a GC task to execute 60s (default ttl) from when the task was submitted. If there already exists a GC task, [updateGCTimer](https://github.com/apache/helix/blob/2add0c48e648c011740ec419a1b1ef17a5888c97/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java#L357) attempts to cancel it reschedule it for 60s from then.

With this current logic, if the time between subsequent writes is never slower than the ttl (60s), then a GC task will never be executed - the task will constantly be scheduled and then cancelled.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

ZkBucket GC's are no longer rescheduled if another write occurs. 
deleteStaleVersions has been refactored to determine recent version at method execution time (rather than passing currentVersion as a parameter)
This should guarantee that a GC will occur within TTL delay (60) seconds from any write. 

### Tests

- [x] The following tests are written for this issue:

testGCScheduler

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)


### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
