### PR TITLE
Fix flaky test getAllInstances - clean up added instances

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -597,6 +597,9 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     Assert.assertTrue(evacuateFinishedResult.get("successful"));
 
+    // Remove instance created for evacuate test
+    delete("clusters/" + CLUSTER_NAME + "/instances/" + test_instance_name, Response.Status.OK.getStatusCode());
+
     // test setPartitionsToError
     List<String> partitionsToSetToError = Arrays.asList(CLUSTER_NAME + dbName + "7");
 


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

https://github.com/apache/helix/issues/2836
testGetAllInstances flaky in CI

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Test failing due to comparison of in memory instance map vs response from getAllInstances. getAllInstances "instances" value is built from the instance configs in the cluster. 
testInstancesAccessor and testPerInstanceAccessor both modify the same cluster - `TestCluster_4`
updateInstance in testPerInstanceAccessor adds an instance config but does not remove it. This may lead to the failure in testGetAllInstances because the cluster has an instance config added but the in memory map of _instancesMap does not have an instance added as well

Looking at the logs of previously failed runs vs successful runs. Successful runs have testInstancesAcessor run before testPerInstanceAccessor. Failed runs are the reverse

### Tests

- [ ] The following tests are written for this issue:

N/A

- The following is the result of the "mvn test" command on the appropriate module:
```
$ mvn test -o -pl=helix-rest
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  05:40 min
[INFO] Finished at: 2024-08-08T21:19:20-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
