### PR TITLE
Fix intellji formatter to wrap on Enum type per line

### DIFF
--- a/helix-style-intellij.xml
+++ b/helix-style-intellij.xml
@@ -131,7 +131,7 @@
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
     <option name="VARIABLE_ANNOTATION_WRAP" value="2" />
-    <option name="ENUM_CONSTANTS_WRAP" value="5" />
+    <option name="ENUM_CONSTANTS_WRAP" value="2" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true" />
     <indentOptions>
       <option name="INDENT_SIZE" value="2" />


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:

fixes #1991 

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Fix intellji formatter to wrap on Enum type per line
### Tests

- [ ] The following tests are written for this issue:


- The following is the result of the "mvn test" command on the appropriate module:

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
