### PR TITLE
Change stoppable to perform min active check sequentially in mz

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/HealthCheck.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/HealthCheck.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
+import java.util.stream.Collectors;
 
 
 public enum HealthCheck {
@@ -62,9 +63,12 @@ public enum HealthCheck {
   MIN_ACTIVE_REPLICA_CHECK_FAILED;
 
   /**
-   * Pre-defined list of checks to test if an instance can be stopped at runtime
+   * Pre-defined list of checks to test if an instance can be stopped at runtime. Excludes MIN_ACTIVE_REPLICA_CHECK as
+   * that is performed separately.
    */
-  public static List<HealthCheck> STOPPABLE_CHECK_LIST = Arrays.asList(HealthCheck.values());
+  public static List<HealthCheck> STOPPABLE_CHECK_LIST = Arrays.stream(HealthCheck.values())
+      .filter(healthCheck -> healthCheck != HealthCheck.MIN_ACTIVE_REPLICA_CHECK_FAILED)
+      .collect(Collectors.toList());
   /**
    * Pre-defined list of checks to test if an instance is in healthy running state
    */

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/HealthCheck.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/HealthCheck.java
@@ -55,11 +55,14 @@ public enum HealthCheck {
   /**
    * Check if instance has error partitions
    */
-  HAS_ERROR_PARTITION;
-
+  HAS_ERROR_PARTITION,
   /**
-   * Pre-defined list of checks to test if an instance can be stopped at runtime. Excludes MIN_ACTIVE_REPLICA_CHECK as
-   * that is performed separately.
+   * Check if all resources hosted on the instance can still meet the min active replica
+   * constraint if this instance is shutdown
+   */
+  MIN_ACTIVE_REPLICA_CHECK_FAILED;
+  /**
+   * Pre-defined list of checks to test if an instance can be stopped at runtime.
    */
   public static List<HealthCheck> STOPPABLE_CHECK_LIST = Arrays.asList(HealthCheck.values());
 
@@ -69,10 +72,4 @@ public enum HealthCheck {
   public static List<HealthCheck> STARTED_AND_HEALTH_CHECK_LIST = ImmutableList
       .of(INVALID_CONFIG, INSTANCE_NOT_ALIVE, INSTANCE_NOT_ENABLED, INSTANCE_NOT_STABLE,
           EMPTY_RESOURCE_ASSIGNMENT);
-
-  /**
-   * Check if all resources hosted on the instance can still meet the min active replica
-   * constraint if this instance is shutdown
-   */
-  public static String MIN_ACTIVE_REPLICA_CHECK_FAILED = "MIN_ACTIVE_REPLICA_CHECK_FAILED";
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/HealthCheck.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/HealthCheck.java
@@ -55,24 +55,24 @@ public enum HealthCheck {
   /**
    * Check if instance has error partitions
    */
-  HAS_ERROR_PARTITION,
-  /**
-   * Check if all resources hosted on the instance can still meet the min active replica
-   * constraint if this instance is shutdown
-   */
-  MIN_ACTIVE_REPLICA_CHECK_FAILED;
+  HAS_ERROR_PARTITION;
 
   /**
    * Pre-defined list of checks to test if an instance can be stopped at runtime. Excludes MIN_ACTIVE_REPLICA_CHECK as
    * that is performed separately.
    */
-  public static List<HealthCheck> STOPPABLE_CHECK_LIST = Arrays.stream(HealthCheck.values())
-      .filter(healthCheck -> healthCheck != HealthCheck.MIN_ACTIVE_REPLICA_CHECK_FAILED)
-      .collect(Collectors.toList());
+  public static List<HealthCheck> STOPPABLE_CHECK_LIST = Arrays.asList(HealthCheck.values());
+
   /**
    * Pre-defined list of checks to test if an instance is in healthy running state
    */
   public static List<HealthCheck> STARTED_AND_HEALTH_CHECK_LIST = ImmutableList
       .of(INVALID_CONFIG, INSTANCE_NOT_ALIVE, INSTANCE_NOT_ENABLED, INSTANCE_NOT_STABLE,
           EMPTY_RESOURCE_ASSIGNMENT);
+
+  /**
+   * Check if all resources hosted on the instance can still meet the min active replica
+   * constraint if this instance is shutdown
+   */
+  public static String MIN_ACTIVE_REPLICA_CHECK_FAILED = "MIN_ACTIVE_REPLICA_CHECK_FAILED";
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/HealthCheck.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/HealthCheck.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import java.util.stream.Collectors;
 
 
 public enum HealthCheck {
@@ -65,7 +64,6 @@ public enum HealthCheck {
    * Pre-defined list of checks to test if an instance can be stopped at runtime.
    */
   public static List<HealthCheck> STOPPABLE_CHECK_LIST = Arrays.asList(HealthCheck.values());
-
   /**
    * Pre-defined list of checks to test if an instance is in healthy running state
    */

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
@@ -472,9 +472,15 @@ public class MaintenanceManagementService {
   private List<String> batchHelixInstanceStoppableCheck(String clusterId,
       Collection<String> instances, Map<String, StoppableCheck> finalStoppableChecks,
       Set<String> toBeStoppedInstances) {
+
+    // Perform all but min_active replicas check in parallel
     Map<String, Future<StoppableCheck>> helixInstanceChecks = instances.stream().collect(
         Collectors.toMap(Function.identity(), instance -> POOL.submit(
             () -> performHelixOwnInstanceCheck(clusterId, instance, toBeStoppedInstances))));
+
+    // Perform min_active replicas check sequentially
+    addInstanceMinActiveReplicaCheck(helixInstanceChecks, toBeStoppedInstances);
+
     // finalStoppableChecks contains instances that does not pass this health check
     return filterInstancesForNextCheck(helixInstanceChecks, finalStoppableChecks);
   }
@@ -787,10 +793,6 @@ public class MaintenanceManagementService {
           healthStatus.put(HealthCheck.EMPTY_RESOURCE_ASSIGNMENT.name(),
               InstanceValidationUtil.isResourceAssigned(_dataAccessor, instanceName));
           break;
-        case MIN_ACTIVE_REPLICA_CHECK_FAILED:
-          healthStatus.put(HealthCheck.MIN_ACTIVE_REPLICA_CHECK_FAILED.name(),
-              InstanceValidationUtil.siblingNodesActiveReplicaCheck(_dataAccessor, instanceName, toBeStoppedInstances));
-          break;
         default:
           LOG.error("Unsupported health check: {}", healthCheck);
           break;
@@ -798,6 +800,35 @@ public class MaintenanceManagementService {
     }
 
     return healthStatus;
+  }
+
+  // Adds the result of the min_active replica check for each stoppable check passed in futureStoppableCheckByInstance
+  private void addInstanceMinActiveReplicaCheck(Map<String, Future<StoppableCheck>> futureStoppableCheckByInstance,
+      Set<String> toBeStoppedInstances) {
+    Set<String> possibleToStopInstances = new HashSet<>(toBeStoppedInstances);
+
+    for (Map.Entry<String, Future<StoppableCheck>> entry : futureStoppableCheckByInstance.entrySet()) {
+      try {
+        String instanceName = entry.getKey();
+        StoppableCheck stoppableCheck = entry.getValue().get();
+
+        // Check if min active will be violated and add to stoppableCheck. If instance still stoppable,
+        // add to possibleToStopInstances
+        boolean minActiveCheckResult = InstanceValidationUtil.siblingNodesActiveReplicaCheck(_dataAccessor,
+            instanceName, possibleToStopInstances);
+        stoppableCheck.add(new StoppableCheck(Collections.singletonMap(HealthCheck.MIN_ACTIVE_REPLICA_CHECK_FAILED.name(),
+            minActiveCheckResult), StoppableCheck.Category.HELIX_OWN_CHECK));
+        if (stoppableCheck.isStoppable()) {
+          possibleToStopInstances.add(instanceName);
+        }
+
+      } catch (Exception e) {
+        String errorMessage = String.format("Failed to get StoppableChecks in parallel. Instances: %s",
+            futureStoppableCheckByInstance.values());
+        LOG.error(errorMessage, e);
+        throw new HelixException(errorMessage);
+      }
+    }
   }
 
   public static class MaintenanceManagementServiceBuilder {

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/MaintenanceManagementService.java
@@ -816,7 +816,7 @@ public class MaintenanceManagementService {
         // add to possibleToStopInstances
         boolean minActiveCheckResult = InstanceValidationUtil.siblingNodesActiveReplicaCheck(_dataAccessor,
             instanceName, possibleToStopInstances);
-        stoppableCheck.add(new StoppableCheck(Collections.singletonMap(HealthCheck.MIN_ACTIVE_REPLICA_CHECK_FAILED.name(),
+        stoppableCheck.add(new StoppableCheck(Collections.singletonMap(HealthCheck.MIN_ACTIVE_REPLICA_CHECK_FAILED,
             minActiveCheckResult), StoppableCheck.Category.HELIX_OWN_CHECK));
         if (stoppableCheck.isStoppable()) {
           possibleToStopInstances.add(instanceName);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -314,7 +314,7 @@ public class InstancesAccessor extends AbstractHelixResource {
       stoppableInstancesSelector.calculateOrderOfZone(instances, random);
       ObjectNode result;
       // TODO: Add support for clusters that do not have topology set up.
-      // Issue #2893: https://github.com/apache/helix/pull/2886
+      // Issue #2893: https://github.com/apache/helix/issues/2893
       switch (selectionBase) {
         case zone_based:
           result = stoppableInstancesSelector.getStoppableInstancesInSingleZone(instances, toBeStoppedInstances);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -313,6 +313,8 @@ public class InstancesAccessor extends AbstractHelixResource {
               .build();
       stoppableInstancesSelector.calculateOrderOfZone(instances, random);
       ObjectNode result;
+      // TODO: Add support for clusters that do not have topology set up.
+      // Issue #2893: https://github.com/apache/helix/pull/2886
       switch (selectionBase) {
         case zone_based:
           result = stoppableInstancesSelector.getStoppableInstancesInSingleZone(instances, toBeStoppedInstances);

--- a/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
@@ -83,6 +83,7 @@ public class TestMaintenanceManagementService {
     RESTConfig restConfig = new RESTConfig("restConfig");
     restConfig.set(RESTConfig.SimpleFields.CUSTOMIZED_HEALTH_URL, "http://*:123/path");
     when(_configAccessor.getRESTConfig(TEST_CLUSTER)).thenReturn(restConfig);
+    when(_dataAccessorWrapper.keyBuilder()).thenReturn(new PropertyKey.Builder(TEST_CLUSTER));
   }
 
   class MockMaintenanceManagementService extends MaintenanceManagementService {
@@ -124,7 +125,7 @@ public class TestMaintenanceManagementService {
     Map<String, Boolean> failedCheck = ImmutableMap.of("FailCheck", false);
     MockMaintenanceManagementService service =
         new MockMaintenanceManagementService(_dataAccessorWrapper, _configAccessor,
-            _customRestClient, false, false, HelixRestNamespace.DEFAULT_NAMESPACE_NAME) {
+            _customRestClient, false, false, null, HelixRestNamespace.DEFAULT_NAMESPACE_NAME) {
           @Override
           protected Map<String, Boolean> getInstanceHealthStatus(String clusterId,
               String instanceName, List<HealthCheck> healthChecks, Set<String> toBeStoppedInstances) {
@@ -144,7 +145,7 @@ public class TestMaintenanceManagementService {
   public void testGetInstanceStoppableCheckWhenCustomInstanceCheckFail() throws IOException {
     MockMaintenanceManagementService service =
         new MockMaintenanceManagementService(_dataAccessorWrapper, _configAccessor,
-            _customRestClient, false, false, HelixRestNamespace.DEFAULT_NAMESPACE_NAME) {
+            _customRestClient, false, false, null, HelixRestNamespace.DEFAULT_NAMESPACE_NAME) {
           @Override
           protected Map<String, Boolean> getInstanceHealthStatus(String clusterId,
               String instanceName, List<HealthCheck> healthChecks, Set<String> toBeStoppedInstances) {
@@ -243,7 +244,7 @@ public class TestMaintenanceManagementService {
   public void testGetInstanceStoppableCheckConnectionRefused() throws IOException {
     MockMaintenanceManagementService service =
         new MockMaintenanceManagementService(_dataAccessorWrapper, _configAccessor,
-            _customRestClient, false, false, HelixRestNamespace.DEFAULT_NAMESPACE_NAME) {
+            _customRestClient, false, false, null, HelixRestNamespace.DEFAULT_NAMESPACE_NAME) {
           @Override
           protected Map<String, Boolean> getInstanceHealthStatus(String clusterId,
               String instanceName, List<HealthCheck> healthChecks, Set<String> toBeStoppedInstances) {

--- a/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestMaintenanceManagementService.java
@@ -129,6 +129,9 @@ public class TestMaintenanceManagementService {
           @Override
           protected Map<String, Boolean> getInstanceHealthStatus(String clusterId,
               String instanceName, List<HealthCheck> healthChecks, Set<String> toBeStoppedInstances) {
+            if (Collections.singletonList(HealthCheck.MIN_ACTIVE_REPLICA_CHECK_FAILED).equals(healthChecks)) {
+              return Collections.emptyMap();
+            }
             return failedCheck;
           }
         };
@@ -367,6 +370,9 @@ public class TestMaintenanceManagementService {
           @Override
           protected Map<String, Boolean> getInstanceHealthStatus(String clusterId,
               String instanceName, List<HealthCheck> healthChecks, Set<String> toBeStoppedInstances) {
+            if (Collections.singletonList(HealthCheck.MIN_ACTIVE_REPLICA_CHECK_FAILED).equals(healthChecks)) {
+              return Collections.emptyMap();
+            }
             return instanceHealthFailedCheck;
           }
         };

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.helix.TestHelper;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.rest.server.resources.helix.InstancesAccessor;
 import org.apache.helix.rest.server.util.JerseyUriRequestBuilder;
@@ -288,6 +289,10 @@ public class TestInstancesAccessor extends AbstractTestClass {
         ImmutableSet.of("HELIX:MIN_ACTIVE_REPLICA_CHECK_FAILED"));
     Assert.assertEquals(getStringSet(nonStoppableInstances, "invalidInstance"),
         ImmutableSet.of("HELIX:INSTANCE_NOT_EXIST"));
+    instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.ENABLE);
+    _configAccessor.setInstanceConfig(STOPPABLE_CLUSTER2, instance0, instanceConfig);
+    instanceConfig1.setInstanceOperation(InstanceConstants.InstanceOperation.ENABLE);
+    _configAccessor.setInstanceConfig(STOPPABLE_CLUSTER2, instance1, instanceConfig1);
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
@@ -516,6 +521,59 @@ public class TestInstancesAccessor extends AbstractTestClass {
     // in ClusterConfig
     node.iterator().forEachRemaining(child -> Assert.assertTrue(child.booleanValue()));
 
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testValidateWeightForAllInstances")
+  public void testMultipleReplicasInSameMZ() throws Exception {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    // Create SemiAuto DB so that we can control assignment
+    String testDb = TestHelper.getTestMethodName() + "_resource";
+    _gSetupTool.getClusterManagementTool().addResource(STOPPABLE_CLUSTER2, testDb, 3, "MasterSlave",
+        IdealState.RebalanceMode.SEMI_AUTO.toString());
+    _gSetupTool.getClusterManagementTool().rebalance(STOPPABLE_CLUSTER2, testDb, 3);
+
+    // Manually set ideal state to have the 3 replcias assigned to 3 instances all in the same zone
+    List<String> preferenceList = Arrays.asList("instance0", "instance1", "instance2");
+    IdealState is = _gSetupTool.getClusterManagementTool().getResourceIdealState(STOPPABLE_CLUSTER2, testDb);
+    for (String p : is.getPartitionSet()) {
+      is.setPreferenceList(p, preferenceList);
+    }
+    is.setMinActiveReplicas(2);
+    _gSetupTool.getClusterManagementTool().setResourceIdealState(STOPPABLE_CLUSTER2, testDb, is);
+
+    // Wait for assignments to take place
+    BestPossibleExternalViewVerifier verifier =
+        new BestPossibleExternalViewVerifier.Builder(STOPPABLE_CLUSTER2).setZkAddr(ZK_ADDR).build();
+    Assert.assertTrue(verifier.verifyByPolling());
+
+    // Run stoppable check against the 3 instances where SemiAuto DB was assigned
+    String content =
+        String.format("{\"%s\":\"%s\",\"%s\":[\"%s\",\"%s\",\"%s\"]}",
+            InstancesAccessor.InstancesProperties.selection_base.name(),
+            InstancesAccessor.InstanceHealthSelectionBase.zone_based.name(),
+            InstancesAccessor.InstancesProperties.instances.name(), "instance0", "instance1",
+            "instance2");
+    Response response =
+        new JerseyUriRequestBuilder("clusters/{}/instances?command=stoppable&skipHealthCheckCategories=CUSTOM_INSTANCE_CHECK,CUSTOM_PARTITION_CHECK").format(
+            STOPPABLE_CLUSTER2).post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
+    JsonNode jsonNode = OBJECT_MAPPER.readTree(response.readEntity(String.class));
+
+    // Resource has 3 replicas with min_active of 2
+    // First instance should be stoppable as min_active still satisfied
+    Set<String> stoppableSet = getStringSet(jsonNode,
+        InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name());
+    Assert.assertTrue(Collections.singleton("instance0").equals(stoppableSet));
+
+    // Next 2 instances should fail stoppable due to MIN_ACTIVE_REPLICA_CHECK_FAILED
+    JsonNode nonStoppableInstances = jsonNode.get(
+        InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
+    Assert.assertFalse(getStringSet(nonStoppableInstances, "instance0")
+        .contains("HELIX:MIN_ACTIVE_REPLICA_CHECK_FAILED"));
+    Assert.assertTrue(getStringSet(nonStoppableInstances, "instance1")
+        .contains("HELIX:MIN_ACTIVE_REPLICA_CHECK_FAILED"));
+    Assert.assertTrue(getStringSet(nonStoppableInstances, "instance2")
+        .contains("HELIX:MIN_ACTIVE_REPLICA_CHECK_FAILED"));
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

#2885 
Helix stoppable does not account for multiple replicas in the same fault zone. This can occur during instance operations such as swap but also as a result of the issue linked above. 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently, the batch stoppable check parallelizes the performHelixOwnInstanceCheck, which includes the min active replica check. This parallelization works on the assumption that a single partition will not have more than 2 replicas hosted in 1 fault zone. This assumption is not fully correct as n+1 transitions can result in 2 replicas in the same fault zone, as well instance operations such as SWAP. 

The parallelization of the other helix health checks can be kept to not lose out on that optimization. The min active check can then be done sequentially for each instance. 

There is a potential for optimizing the min active replica check. Currently it is done per instance and reads the externalView and idealStates for each resource from ZK. It could be optimized to read the EVs and IS's once and use those for all instances the check is being ran on. However, I did not want to complicate this first draft of the PR with that refactoring. 


### Tests

- [x] The following tests are written for this issue:

TestInstancesAccessor.java#testMultipleReplicasInSameMZ

- The following is the result of the "mvn test" command on the appropriate module:

```
$ mvn test -o -Dtest=TestPerInstanceAccessor,TestInstancesAccessor,TestMaintenanceManagementService -pl=helix-rest

[INFO] Results:
[INFO] 
[INFO] Tests run: 45, Failures: 0, Errors: 0, Skipped: 0
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:31 min
[INFO] Finished at: 2024-08-15T20:43:09-07:00
[INFO] ------------------------------------------------------------------------

```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

Not a significant incompatibility, but the STOPPABLE_CHECK_LIST no longer contains the min_active_replica check as it is done separately. 

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
