### PR TITLE
Move existing assignments usage calculation to pre-process stage

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -52,7 +52,6 @@ import org.apache.helix.model.CustomizedView;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
-import org.apache.helix.model.Message;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -595,23 +594,21 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
     }
     for (String resourceName : resourceNameSet) {
       // Process current state mapping
-      for (Map.Entry<Partition, Map<String, String>> entry : currentStateOutput.getCurrentStateMap(
-          resourceName).entrySet()) {
-        for (String instanceName : entry.getValue().keySet()) {
-          CapacityNode node = simpleCapacityMap.get(instanceName);
-          if (node != null) {
-            node.canAdd(resourceName, entry.getKey().getPartitionName());
-          }
-        }
-      }
+      populateCapacityNodeUsageFromStateMap(resourceName, simpleCapacityMap,
+          currentStateOutput.getCurrentStateMap(resourceName));
       // Process pending state mapping
-      for (Map.Entry<Partition, Map<String, Message>> entry : currentStateOutput.getPendingMessageMap(
-          resourceName).entrySet()) {
-        for (String instanceName : entry.getValue().keySet()) {
-          CapacityNode node = simpleCapacityMap.get(instanceName);
-          if (node != null) {
-            node.canAdd(resourceName, entry.getKey().getPartitionName());
-          }
+      populateCapacityNodeUsageFromStateMap(resourceName, simpleCapacityMap,
+          currentStateOutput.getPendingMessageMap(resourceName));
+    }
+  }
+
+  private <T> void populateCapacityNodeUsageFromStateMap(String resourceName,
+      Map<String, CapacityNode> simpleCapacityMap, Map<Partition, Map<String, T>> stateMap) {
+    for (Map.Entry<Partition, Map<String, T>> entry : stateMap.entrySet()) {
+      for (String instanceName : entry.getValue().keySet()) {
+        CapacityNode node = simpleCapacityMap.get(instanceName);
+        if (node != null) {
+          node.canAdd(resourceName, entry.getKey().getPartitionName());
         }
       }
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -134,6 +134,14 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
 
       handleResourceCapacityCalculation(event, (ResourceControllerDataProvider) cache, currentStateOutput);
     }
+
+    // Populate the capacity for simple CapacityNode
+    if (cache.getClusterConfig().getGlobalMaxPartitionAllowedPerInstance() != -1
+        && cache instanceof ResourceControllerDataProvider) {
+      final ResourceControllerDataProvider dataProvider = (ResourceControllerDataProvider) cache;
+      dataProvider.populateSimpleCapacitySetUsage(resourceToRebalance.keySet(),
+          currentStateExcludingUnknown);
+    }
   }
 
   // update all pending messages to CurrentStateOutput.

--- a/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
@@ -19,7 +19,6 @@ package org.apache.helix.common;
  * under the License.
  */
 
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
@@ -33,6 +32,7 @@ import java.util.logging.Level;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
+import com.google.common.base.Preconditions;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
@@ -50,6 +50,7 @@ import org.apache.helix.controller.pipeline.AbstractAsyncBaseStage;
 import org.apache.helix.controller.pipeline.Pipeline;
 import org.apache.helix.controller.pipeline.Stage;
 import org.apache.helix.controller.pipeline.StageContext;
+import org.apache.helix.controller.rebalancer.ConditionBasedRebalancer;
 import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
 import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
@@ -365,6 +366,14 @@ public class ZkTestBase {
     configAccessor.setClusterConfig(clusterName, clusterConfig);
   }
 
+  protected void setGlobalMaxPartitionAllowedPerInstanceInCluster(HelixZkClient zkClient,
+      String clusterName, int maxPartitionAllowed) {
+    ConfigAccessor configAccessor = new ConfigAccessor(zkClient);
+    ClusterConfig clusterConfig = configAccessor.getClusterConfig(clusterName);
+    clusterConfig.setGlobalMaxPartitionAllowedPerInstance(maxPartitionAllowed);
+    configAccessor.setClusterConfig(clusterName, clusterConfig);
+  }
+
   protected IdealState createResourceWithDelayedRebalance(String clusterName, String db,
       String stateModel, int numPartition, int replica, int minActiveReplica, long delay) {
     return createResourceWithDelayedRebalance(clusterName, db, stateModel, numPartition, replica,
@@ -382,6 +391,13 @@ public class ZkTestBase {
       String stateModel, int numPartition, int replica, int minActiveReplica) {
     return createResource(clusterName, db, stateModel, numPartition, replica, minActiveReplica,
         -1, WagedRebalancer.class.getName(), null);
+  }
+
+  protected IdealState createResourceWithConditionBasedRebalance(String clusterName, String db,
+      String stateModel, int numPartition, int replica, int minActiveReplica,
+      String rebalanceStrategy) {
+    return createResource(clusterName, db, stateModel, numPartition, replica, minActiveReplica, -1,
+        ConditionBasedRebalancer.class.getName(), rebalanceStrategy);
   }
 
   private IdealState createResource(String clusterName, String db, String stateModel,

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestStickyRebalanceStrategy.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestStickyRebalanceStrategy.java
@@ -1,0 +1,353 @@
+package org.apache.helix.integration.rebalancer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.strategy.StickyRebalanceStrategy;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TestStickyRebalanceStrategy extends ZkTestBase {
+  static final int NUM_NODE = 18;
+  static final int ADDITIONAL_NUM_NODE = 2;
+  protected static final int START_PORT = 12918;
+  protected static final int PARTITIONS = 2;
+  protected static final int REPLICAS = 3;
+  protected final String CLASS_NAME = getShortClassName();
+  protected final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + CLASS_NAME;
+
+  protected ClusterControllerManager _controller;
+  protected List<MockParticipantManager> _participants = new ArrayList<>();
+  protected List<MockParticipantManager> _additionalParticipants = new ArrayList<>();
+  protected int _minActiveReplica = 0;
+  protected ZkHelixClusterVerifier _clusterVerifier;
+  protected List<String> _testDBs = new ArrayList<>();
+  protected ConfigAccessor _configAccessor;
+  protected String[] TestStateModels =
+      {BuiltInStateModelDefinitions.MasterSlave.name(), BuiltInStateModelDefinitions.LeaderStandby.name(), BuiltInStateModelDefinitions.OnlineOffline.name()};
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    System.out.println("START " + CLASS_NAME + " at " + new Date(System.currentTimeMillis()));
+
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+
+    for (int i = 0; i < NUM_NODE; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      _gSetupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+
+      // start dummy participants
+      MockParticipantManager participant =
+          new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, storageNodeName);
+      participant.syncStart();
+      _participants.add(participant);
+    }
+
+    for (int i = NUM_NODE; i < NUM_NODE + ADDITIONAL_NUM_NODE; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      _gSetupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+
+      MockParticipantManager participant =
+          new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, storageNodeName);
+      _additionalParticipants.add(participant);
+    }
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    _clusterVerifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
+
+    enablePersistBestPossibleAssignment(_gZkClient, CLUSTER_NAME, true);
+  }
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    if (_clusterVerifier != null) {
+      _clusterVerifier.close();
+    }
+    /*
+      shutdown order: 1) disconnect the controller 2) disconnect participants
+     */
+    _controller.syncStop();
+    for (MockParticipantManager participant : _participants) {
+      participant.syncStop();
+    }
+    deleteCluster(CLUSTER_NAME);
+    System.out.println("END " + CLASS_NAME + " at " + new Date(System.currentTimeMillis()));
+  }
+
+  @BeforeMethod
+  public void beforeTest() {
+    // Restart any participants that has been disconnected from last test
+    for (int i = 0; i < _participants.size(); i++) {
+      if (!_participants.get(i).isConnected()) {
+        _participants.set(i, new MockParticipantManager(ZK_ADDR, CLUSTER_NAME,
+            _participants.get(i).getInstanceName()));
+        _participants.get(i).syncStart();
+      }
+    }
+
+    // Stop any additional participants that has been added from last test
+    for (MockParticipantManager additionalParticipant : _additionalParticipants) {
+      if (additionalParticipant.isConnected()) {
+        additionalParticipant.syncStop();
+      }
+    }
+  }
+
+  @AfterMethod
+  public void afterTest() throws InterruptedException {
+    // delete all DBs create in last test
+    for (String db : _testDBs) {
+      _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, db);
+    }
+    _testDBs.clear();
+    _clusterVerifier.verifyByPolling();
+  }
+
+  @Test
+  public void testFirstTimeAssignmentWithNoInitialLiveNodes() throws Exception {
+    setGlobalMaxPartitionAllowedPerInstanceInCluster(_gZkClient, CLUSTER_NAME, 1);
+    // Shut down all the nodes
+    for (int i = 0; i < NUM_NODE; i++) {
+      _participants.get(i).syncStop();
+    }
+    // Create resource
+    Map<String, ExternalView> externalViewsBefore = createTestDBs();
+    // Start all the nodes
+    for (int i = 0; i < NUM_NODE; i++) {
+      _participants.set(i, new MockParticipantManager(ZK_ADDR, CLUSTER_NAME,
+          _participants.get(i).getInstanceName()));
+      _participants.get(i).syncStart();
+    }
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    Map<String, ExternalView> externalViewsAfter = new HashMap<>();
+    for (String db : _testDBs) {
+      ExternalView ev =
+          _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
+      externalViewsAfter.put(db, ev);
+    }
+    validateAllPartitionAssigned(externalViewsAfter);
+  }
+
+  @Test
+  public void testNoPartitionMovementWithNewInstanceAdd() throws Exception {
+    setGlobalMaxPartitionAllowedPerInstanceInCluster(_gZkClient, CLUSTER_NAME, 1);
+    Map<String, ExternalView> externalViewsBefore = createTestDBs();
+
+    // Start more new instances
+    for (int i = 0; i < _additionalParticipants.size(); i++) {
+      _additionalParticipants.set(i, new MockParticipantManager(ZK_ADDR, CLUSTER_NAME,
+          _additionalParticipants.get(i).getInstanceName()));
+      _additionalParticipants.get(i).syncStart();
+    }
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    // All partition assignment should remain the same
+    for (String db : _testDBs) {
+      ExternalView ev =
+          _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
+      IdealState is =
+          _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
+      validateNoPartitionMove(is, externalViewsBefore.get(db), ev);
+    }
+  }
+
+  @Test
+  public void testNoPartitionMovementWithInstanceDown() throws Exception {
+    setGlobalMaxPartitionAllowedPerInstanceInCluster(_gZkClient, CLUSTER_NAME, 1);
+    Map<String, ExternalView> externalViewsBefore = createTestDBs();
+
+    // Shut down 2 instances
+    _participants.get(0).syncStop();
+    _participants.get(_participants.size() - 1).syncStop();
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    // No movement for previous remaining assignment
+    Map<String, ExternalView> externalViewsAfter = new HashMap<>();
+    Map<String, IdealState> idealStates = new HashMap<>();
+    for (String db : _testDBs) {
+      ExternalView ev =
+          _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
+      IdealState is =
+          _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
+      externalViewsAfter.put(db, ev);
+      idealStates.put(db, is);
+    }
+    validateNoPartitionMoveWithDiffCount(idealStates, externalViewsBefore, externalViewsAfter, 2);
+  }
+
+  @Test
+  public void testFirstTimeAssignmentWithStackingPlacement() throws Exception {
+    setGlobalMaxPartitionAllowedPerInstanceInCluster(_gZkClient, CLUSTER_NAME, 2);
+    Map<String, ExternalView> externalViewsBefore = createTestDBs();
+    validateAllPartitionAssigned(externalViewsBefore);
+  }
+
+  @Test
+  public void testNoPartitionMovementWithNewInstanceAddWithStackingPlacement() throws Exception {
+    setGlobalMaxPartitionAllowedPerInstanceInCluster(_gZkClient, CLUSTER_NAME, 2);
+    Map<String, ExternalView> externalViewsBefore = createTestDBs();
+
+    // Start more new instances
+    for (int i = 0; i < _additionalParticipants.size(); i++) {
+      _additionalParticipants.set(i, new MockParticipantManager(ZK_ADDR, CLUSTER_NAME,
+          _additionalParticipants.get(i).getInstanceName()));
+      _additionalParticipants.get(i).syncStart();
+    }
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    // All partition assignment should remain the same
+    for (String db : _testDBs) {
+      ExternalView ev =
+          _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
+      IdealState is =
+          _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
+      validateNoPartitionMove(is, externalViewsBefore.get(db), ev);
+    }
+  }
+
+  @Test
+  public void testNoPartitionMovementWithInstanceDownWithStackingPlacement() throws Exception {
+    setGlobalMaxPartitionAllowedPerInstanceInCluster(_gZkClient, CLUSTER_NAME, 2);
+    // Shut down half of the nodes given we allow stacking placement
+    for (int i = 0; i < NUM_NODE / 2; i++) {
+      _participants.get(i).syncStop();
+    }
+    Map<String, ExternalView> externalViewsBefore = createTestDBs();
+
+    // Shut down 2 instances
+    _participants.get(_participants.size() - 1).syncStop();
+    _participants.get(_participants.size() - 2).syncStop();
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    // No movement for previous remaining assignment
+    Map<String, ExternalView> externalViewsAfter = new HashMap<>();
+    Map<String, IdealState> idealStates = new HashMap<>();
+    for (String db : _testDBs) {
+      ExternalView ev =
+          _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
+      IdealState is =
+          _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, db);
+      externalViewsAfter.put(db, ev);
+      idealStates.put(db, is);
+    }
+    validateNoPartitionMoveWithDiffCount(idealStates, externalViewsBefore, externalViewsAfter, 4);
+  }
+
+  // create test DBs, wait it converged and return externalviews
+  protected Map<String, ExternalView> createTestDBs() throws InterruptedException {
+    Map<String, ExternalView> externalViews = new HashMap<String, ExternalView>();
+    int i = 0;
+    for (String stateModel : TestStateModels) {
+      String db = "Test-DB-" + i++;
+      createResourceWithConditionBasedRebalance(CLUSTER_NAME, db, stateModel, PARTITIONS, REPLICAS,
+          _minActiveReplica, StickyRebalanceStrategy.class.getName());
+      _testDBs.add(db);
+    }
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    for (String db : _testDBs) {
+      ExternalView ev =
+          _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
+      externalViews.put(db, ev);
+    }
+    return externalViews;
+  }
+
+  protected void validateNoPartitionMove(IdealState is, ExternalView evBefore,
+      ExternalView evAfter) {
+    for (String partition : is.getPartitionSet()) {
+      Map<String, String> assignmentsBefore = evBefore.getRecord().getMapField(partition);
+      Map<String, String> assignmentsAfter = evAfter.getRecord().getMapField(partition);
+
+      Set<String> instancesBefore = new HashSet<>(assignmentsBefore.keySet());
+      Set<String> instancesAfter = new HashSet<>(assignmentsAfter.keySet());
+
+      Assert.assertEquals(instancesBefore, instancesAfter,
+          String.format("%s has been moved to new instances, before: %s, after: %s", partition,
+              assignmentsBefore, assignmentsAfter));
+    }
+  }
+
+  protected void validateNoPartitionMoveWithDiffCount(Map<String, IdealState> idealStates,
+      Map<String, ExternalView> externalViewsBefore, Map<String, ExternalView> externalViewsAfter,
+      int diffCount) {
+    for (Map.Entry<String, IdealState> entry : idealStates.entrySet()) {
+      String resourceName = entry.getKey();
+      IdealState is = entry.getValue();
+      for (String partition : is.getPartitionSet()) {
+        Map<String, String> assignmentsBefore =
+            externalViewsBefore.get(resourceName).getRecord().getMapField(partition);
+        Map<String, String> assignmentsAfter =
+            externalViewsAfter.get(resourceName).getRecord().getMapField(partition);
+
+        Set<String> instancesBefore = new HashSet<>(assignmentsBefore.keySet());
+        Set<String> instancesAfter = new HashSet<>(assignmentsAfter.keySet());
+
+        if (instancesBefore.size() == instancesAfter.size()) {
+          Assert.assertEquals(instancesBefore, instancesAfter,
+              String.format("%s has been moved to new instances, before: %s, after: %s", partition,
+                  assignmentsBefore, assignmentsAfter));
+        } else {
+          Assert.assertTrue(instancesBefore.containsAll(instancesAfter),
+              String.format("%s has been moved to new instances, before: %s, after: %s", partition,
+                  assignmentsBefore, assignmentsAfter));
+          diffCount = diffCount - (instancesBefore.size() - instancesAfter.size());
+        }
+      }
+    }
+    Assert.assertEquals(diffCount, 0,
+        String.format("Partition movement detected, before: %s, after: %s", externalViewsBefore,
+            externalViewsAfter));
+  }
+
+  private void validateAllPartitionAssigned(Map<String, ExternalView> externalViewsBefore) {
+    for (ExternalView ev : externalViewsBefore.values()) {
+      Map<String, Map<String, String>> assignments = ev.getRecord().getMapFields();
+      Assert.assertNotNull(assignments);
+      Assert.assertEquals(assignments.size(), PARTITIONS);
+      for (Map<String, String> assignmentMap : assignments.values()) {
+        Assert.assertEquals(assignmentMap.keySet().size(), REPLICAS);
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

resolves #2822

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

One of the key steps of sticky rebalance strategy is to populate the previous node usage based on current mapping. Previous we do this in rebalance stage where we don't have the node usage info from global view. e.g. if the nodeA has resource1, then in rebalance stage of resource2, we don't have this info anymore. This PR moves the existing assignments usage calculation to pre-process stage where we will have the global view for all resources.

Will add one more test in following PR when https://github.com/apache/helix/pull/2889 is merged from master to this feature branch.

### Tests

- [x] The following tests are written for this issue:

`helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestStickyRebalanceStrategy.java`

- The following is the result of the "mvn test" command on the appropriate module:

```
mvn test -o -Dtest=TestStickyRebalanceStrategy -pl=helix-core
...
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 61.9 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/tmu/projects/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 961 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
...
mvn test -o -Dtest=TestStickyRebalanceWithGlobalPerInstancePartitionLimit -pl=helix-core
...
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.285 s - in org.apache.helix.integration.rebalancer.TestStickyRebalanceWithGlobalPerInstancePartitionLimit
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/tmu/projects/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 961 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
