### PR TITLE
Move creating live instance after carryover current state

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -156,11 +156,11 @@ public class ParticipantManager {
     // This will help to prevent controller from sending any message prematurely.
     // Live instance creation also checks if the expected session is valid or not. Live instance
     // should not be created by an expired zk session.
-    createLiveInstance();
     if (shouldCarryOver()) {
       carryOverPreviousCurrentState(_dataAccessor, _instanceName, _sessionId,
           _manager.getStateMachineEngine(), true);
     }
+    createLiveInstance();
     removePreviousTaskCurrentStates();
 
     /**


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

resolves #2822

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When implementing the stickiness assignment strategy, noticed a race condition: for some cases in the cache in `CurrentStateComputationStage`, the number of live instances doesn't match with the number of instances in current state. See screenshots:
<img width="539" alt="Screenshot 2024-08-23 at 9 19 41 AM" src="https://github.com/user-attachments/assets/0cee95ff-5198-4bac-9ea6-58255e5cd4e9">
<img width="426" alt="Screenshot 2024-08-23 at 9 19 27 AM" src="https://github.com/user-attachments/assets/91bf6ecf-e0bc-4a39-8426-81764229fa21">

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

```
INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestAssignableNode.testIncompleteInstanceCapacity » Test 
The exception was th...
[ERROR]   TestDelayedAutoRebalanceWithDisabledInstance.testMinimalActiveReplicaMaintainWithOneOffline:159 expected:<true> but was:<false>
[ERROR]   TestInstanceOperation.testSwapEvacuateAdd:1075->verifier:1637 expected:<true> but was:<false>
[ERROR]   TestJobTimeoutTaskNotStarted.testTaskNotStarted:154 » Helix Workflow timeoutWo...
[ERROR]   TestTaskCurrentStateNull.testCurrentStateNull:118 » Helix Workflow testCurrent...
[ERROR]   TestTaskRebalancerStopResume.stopDeleteJobAndResumeNamedQueue:247 » Helix Work...
[INFO] 
[ERROR] Tests run: 1427, Failures: 6, Errors: 0, Skipped: 11
```

The following tests passed after rerun individually:
```
mvn test -o -Dtest=TestDelayedAutoRebalanceWithDisabledInstance -pl=helix-core
mvn test -o -Dtest=TestInstanceOperation -pl=helix-core
mvn test -o -Dtest=TestJobTimeoutTaskNotStarted -pl=helix-core
mvn test -o -Dtest=TestTaskCurrentStateNull -pl=helix-core
mvn test -o -Dtest=TestTaskRebalancerStopResume -pl=helix-core
```

This unit test is trying to compare the map values as string which is not stable
```
mvn test -o -Dtest=TestAssignableNode -pl=helix-core
...
[ERROR] Tests run: 7, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.286 s <<< FAILURE! - in org.apache.helix.controller.rebalancer.waged.model.TestAssignableNode
[ERROR] testIncompleteInstanceCapacity(org.apache.helix.controller.rebalancer.waged.model.TestAssignableNode)  Time elapsed: 0.004 s  <<< FAILURE!
org.testng.TestException: 

The exception was thrown with the wrong message: expected "The required capacity keys: \[item2, item1, item3, AdditionalCapacityKey\] are not fully configured in the instance: testInstanceId, capacity map: \{item2=40, item1=20, item3=30\}." but got "The required capacity keys: [item2, item1, item3, AdditionalCapacityKey] are not fully configured in the instance: testInstanceId, capacity map: {item3=30, item2=40, item1=20}."
	at org.apache.helix.controller.rebalancer.waged.model.TestAssignableNode.testIncompleteInstanceCapacity(TestAssignableNode.java:300)
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
