### PR TITLE
Add functionality to forcefully kill an instance

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -844,4 +844,14 @@ public interface HelixAdmin {
     throw new UnsupportedOperationException(
         "isReadyForPreparingJoiningCluster is not implemented.");
   }
+
+  /**
+   * Attempt to forcefully kill an instance in the cluster. This will remove the instance's
+   * LIVEINSTANCES znode, causing the controller to treat the instance as offline. The instance
+   * will not receive any state transitions until it rejoins the cluster. If the instance's
+   * current ZK session expires, then it will rejoin the cluster automatically.
+   */
+  default boolean forceKillInstance(String clusterName, String instanceName) {
+    throw new UnsupportedOperationException("forceKillInstance is not implemented.");
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -846,6 +846,9 @@ public interface HelixAdmin {
   }
 
   /**
+   * WARNING: THIS METHOD WILL FORCEFULLY DROP THE NODE FROM THE EXTERNAL VIEW WITHOUT WAITING FOR IT TO PROCESS
+   * ANY DOWNWARD STATE TRANSITIONS. USE WITH CAUTION AS THE NODE WILL KEEP ITS CURRENT STATES LOCALLY AND NOT DOWNWARD
+   * ST UNTIL IT RECONNECTS UNDER A NEW SESSION AND RESETS TO THE INITIALSTATE.
    * Attempt to forcefully kill an instance in the cluster. This will remove the instance's
    * LIVEINSTANCES znode, causing the controller to treat the instance as offline. The instance
    * will not receive any state transitions until it rejoins the cluster. If the instance's

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -854,4 +854,10 @@ public interface HelixAdmin {
   default boolean forceKillInstance(String clusterName, String instanceName) {
     throw new UnsupportedOperationException("forceKillInstance is not implemented.");
   }
+
+  default boolean forceKillInstance(String clusterName, String instanceName, String reason,
+      InstanceConstants.InstanceOperationSource operationSource) {
+    throw new UnsupportedOperationException("forceKillInstance is not implemented.");
+  }
+
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/TestForceKillInstance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestForceKillInstance.java
@@ -1,0 +1,317 @@
+package org.apache.helix.integration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.TestHelper;
+import org.apache.helix.ZkTestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class TestForceKillInstance extends ZkTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(TestForceKillInstance.class);
+  protected final String CLASS_NAME = getShortClassName();
+  protected final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + CLASS_NAME;
+  private static final int NUM_REPLICAS = 3;
+  private static final int NUM_PARTITIONS = 10;
+  private static final int NUM_MIN_ACTIVE_REPLICAS = 2;
+  private static final int NUM_NODES = NUM_REPLICAS;
+  private BestPossibleExternalViewVerifier _bestPossibleClusterVerifier;
+  private HelixAdmin _admin;
+  HelixDataAccessor _dataAccessor;
+  List<MockParticipantManager> _participants = new ArrayList<MockParticipantManager>();
+  List<String> _resources;
+  protected ClusterControllerManager _controller;
+
+
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    System.out.println("START " + CLASS_NAME + " at " + new Date(System.currentTimeMillis()));
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+
+    IdealState crushedResource = createResourceWithWagedRebalance(CLUSTER_NAME, "Test_CRUSHED_Resource",
+        "MasterSlave", NUM_PARTITIONS, NUM_REPLICAS, NUM_MIN_ACTIVE_REPLICAS);
+    IdealState wagedResource = createResourceWithDelayedRebalance(CLUSTER_NAME, "Test_WAGED_Resource",
+        "MasterSlave", NUM_PARTITIONS, NUM_REPLICAS, NUM_MIN_ACTIVE_REPLICAS, 200000, CrushEdRebalanceStrategy.class.getName());
+    _resources = Arrays.asList(crushedResource.getId(), wagedResource.getId());
+    _bestPossibleClusterVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+        .setResources(new HashSet<>(_resources)).setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
+
+    for (int i = 0; i < NUM_NODES; i++) {
+      addParticipant(CLUSTER_NAME, "localhost_" + i);
+    }
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    _admin = new ZKHelixAdmin(_gZkClient);
+  }
+
+  @BeforeMethod
+  public void beforeMethod() {
+    _bestPossibleClusterVerifier.verifyByPolling();
+  }
+
+  @Test
+  public void testForceKillDropsAssignment() {
+    MockParticipantManager instanceToKill = _participants.get(0);
+    String instanceToKillName = instanceToKill.getInstanceName();
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist before force kill");
+
+    // Get assignments on node, assert it has at least one assignemnt
+    Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should have at least one assignment");
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist before force kill");
+
+    // Force kill the instance
+    _admin.forceKillInstance(CLUSTER_NAME, instanceToKillName);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+
+    // ensure no live instance znode and no assignments
+    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should not exist after force kill");
+    Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should not have any assignments");
+
+    // Actually stop the instance, re assert no live instance znode and no assignments
+    instanceToKill.syncStop();
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should not exist after force kill");
+    Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should not have any assignments");
+
+    // Reset state of cluster
+    dropParticipant(CLUSTER_NAME, instanceToKillName);
+    addParticipant(CLUSTER_NAME, instanceToKillName);
+  }
+
+  @Test(dependsOnMethods = "testForceKillDropsAssignment")
+  public void testSessionExpiration() throws Exception {
+    MockParticipantManager instanceToKill = _participants.get(0);
+    String instanceToKillName = instanceToKill.getInstanceName();
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist before force kill");
+
+    // Get assignments on node, assert it has at least one assignemnt
+    Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should have at least one assignment");
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist before force kill");
+
+    // Force kill the instance
+    _admin.forceKillInstance(CLUSTER_NAME, instanceToKillName);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+
+    // Expire the session of the instance, assert live instance znode was recreated but instance does not have assignments
+    ZkTestHelper.expireSession(instanceToKill.getZkClient());
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist after session recreation");
+    Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should not have any assignments");
+
+    // Reset state of cluster
+    dropParticipant(CLUSTER_NAME, instanceToKillName);
+    addParticipant(CLUSTER_NAME, instanceToKillName);
+  }
+
+  @Test(dependsOnMethods = "testSessionExpiration")
+  public void testDisconnectReconnect() {
+    MockParticipantManager instanceToKill = _participants.get(0);
+    String instanceToKillName = instanceToKill.getInstanceName();
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist before force kill");
+
+    // Get assignments on node, assert it has at least one assignemnt
+    Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should have at least one assignment");
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist before force kill");
+
+    // Force kill the instance
+    _admin.forceKillInstance(CLUSTER_NAME, instanceToKillName);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should not exist after force kill");
+
+    // Restart the instance, assert live instance znode recreated but still no assignments
+    // This should behave the same as if session was expired for same zkClient
+    ZkTestHelper.simulateZkStateReconnected(instanceToKill.getZkClient());
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should not recreated if client reconnects within same session");
+    Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should not have any assignments");
+
+    // Reset state of cluster
+    dropParticipant(CLUSTER_NAME, instanceToKillName);
+    addParticipant(CLUSTER_NAME, instanceToKillName);
+  }
+
+  @Test(dependsOnMethods = "testDisconnectReconnect")
+  public void testRemoveUnknownOperationAfterForceKill() {
+    MockParticipantManager instanceToKill = _participants.get(0);
+    String instanceToKillName = instanceToKill.getInstanceName();
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist before force kill");
+
+    // Get assignments on node, assert it has at least one assignemnt
+    Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should have at least one assignment");
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist before force kill");
+
+    // Force kill the instance
+    _admin.forceKillInstance(CLUSTER_NAME, instanceToKillName);
+    _admin.setInstanceOperation(CLUSTER_NAME, instanceToKillName, InstanceConstants.InstanceOperation.ENABLE);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+
+    // ensure no live instance znode and no assignments
+    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should not exist after force kill");
+    Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should not have any assignments");
+
+    // Reset state of cluster
+    dropParticipant(CLUSTER_NAME, instanceToKillName);
+    addParticipant(CLUSTER_NAME, instanceToKillName);
+  }
+
+  @Test(dependsOnMethods = "testRemoveUnknownOperationAfterForceKill")
+  public void testSessionExpirationWithoutUnknownOperation() throws Exception {
+    MockParticipantManager instanceToKill = _participants.get(0);
+    String instanceToKillName = instanceToKill.getInstanceName();
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist before force kill");
+
+    // Get assignments on node, assert it has at least one assignemnt
+    Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should have at least one assignment");
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist before force kill");
+
+    // Force kill the instance
+    _admin.forceKillInstance(CLUSTER_NAME, instanceToKillName);
+    _admin.setInstanceOperation(CLUSTER_NAME, instanceToKillName, InstanceConstants.InstanceOperation.ENABLE);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+
+    // Expire the session of the instance, assert live instance znode was recreated and instance has assignments
+    ZkTestHelper.expireSession(instanceToKill.getZkClient());
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist after session recreation");
+    Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should have assignments");
+
+    // Reset state of cluster
+    dropParticipant(CLUSTER_NAME, instanceToKillName);
+    addParticipant(CLUSTER_NAME, instanceToKillName);
+  }
+
+  @Test(dependsOnMethods = "testSessionExpirationWithoutUnknownOperation")
+  public void testDisconnectReconnectWithoutUnknownOperation() {
+    MockParticipantManager instanceToKill = _participants.get(0);
+    String instanceToKillName = instanceToKill.getInstanceName();
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist before force kill");
+
+    // Get assignments on node, assert it has at least one assignemnt
+    Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should have at least one assignment");
+    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should exist before force kill");
+
+    // Force kill the instance
+    _admin.forceKillInstance(CLUSTER_NAME, instanceToKillName);
+    _admin.setInstanceOperation(CLUSTER_NAME, instanceToKillName, InstanceConstants.InstanceOperation.ENABLE);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should not exist after force kill");
+
+    // Restart the instance, assert live instance znode recreated but still no assignments
+    // This should behave the same as if session was expired for same zkClient
+    ZkTestHelper.simulateZkStateReconnected(instanceToKill.getZkClient());
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+        "Instance znode should not recreated if client reconnects within same session");
+    Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should not have any assignments");
+
+    // Reset state of cluster
+    dropParticipant(CLUSTER_NAME, instanceToKillName);
+    addParticipant(CLUSTER_NAME, instanceToKillName);
+  }
+
+  private MockParticipantManager addParticipant(String cluster, String instanceName) {
+    _gSetupTool.addInstanceToCluster(cluster, instanceName);
+    MockParticipantManager toAddParticipant =
+        new MockParticipantManager(ZK_ADDR, cluster, instanceName);
+    _participants.add(toAddParticipant);
+    toAddParticipant.syncStart();
+    return toAddParticipant;
+  }
+
+    protected void dropParticipant(String cluster, String instanceName) {
+      // find mock participant manager with instanceName and remove it from _mockParticipantManagers.
+      MockParticipantManager toRemoveManager = _participants.stream()
+          .filter(manager -> manager.getInstanceName().equals(instanceName))
+          .findFirst()
+          .orElse(null);
+      if (toRemoveManager != null) {
+        toRemoveManager.syncStop();
+        _participants.remove(toRemoveManager);
+      }
+
+      InstanceConfig instanceConfig = _gSetupTool.getClusterManagementTool().getInstanceConfig(cluster, instanceName);
+      _gSetupTool.getClusterManagementTool().dropInstance(cluster, instanceConfig);
+    }
+
+  private Map<String, ExternalView> getEVs() {
+    Map<String, ExternalView> externalViews = new HashMap<String, ExternalView>();
+    for (String resource : _resources) {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, resource);
+      externalViews.put(resource, ev);
+    }
+    return externalViews;
+  }
+
+  private Map<String, String> getInstanceCurrentStates(String instanceName) {
+    Map<String, String> assignment = new HashMap<>();
+    for (ExternalView ev : getEVs().values()) {
+      for (String partition : ev.getPartitionSet()) {
+        Map<String, String> stateMap = ev.getStateMap(partition);
+        if (stateMap.containsKey(instanceName)) {
+          assignment.put(partition, stateMap.get(instanceName));
+        }
+      }
+    }
+    return assignment;
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/TestForceKillInstance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestForceKillInstance.java
@@ -50,6 +50,7 @@ public class TestForceKillInstance extends ZkTestBase {
   private static final int NUM_MIN_ACTIVE_REPLICAS = 2;
   private static final int NUM_NODES = 3;
   private BestPossibleExternalViewVerifier _bestPossibleClusterVerifier;
+  private ZkHelixClusterVerifier _clusterVerifier;
   private HelixAdmin _admin;
   private HelixDataAccessor _dataAccessor;
   private List<MockParticipantManager> _participants = new ArrayList<>();

--- a/helix-core/src/test/java/org/apache/helix/integration/TestForceKillInstance.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestForceKillInstance.java
@@ -7,8 +7,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.NotificationContext;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZkTestHelper;
 import org.apache.helix.common.ZkTestBase;
@@ -20,7 +22,17 @@ import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.Message;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.participant.statemachine.StateModel;
+import org.apache.helix.participant.statemachine.StateModelFactory;
+import org.apache.helix.participant.statemachine.StateModelInfo;
+import org.apache.helix.participant.statemachine.Transition;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.apache.helix.tools.ClusterVerifiers.StrictMatchExternalViewVerifier;
+import org.apache.helix.tools.ClusterVerifiers.ZkHelixClusterVerifier;
+import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -36,31 +48,37 @@ public class TestForceKillInstance extends ZkTestBase {
   private static final int NUM_REPLICAS = 3;
   private static final int NUM_PARTITIONS = 10;
   private static final int NUM_MIN_ACTIVE_REPLICAS = 2;
-  private static final int NUM_NODES = NUM_REPLICAS;
+  private static final int NUM_NODES = 3;
   private BestPossibleExternalViewVerifier _bestPossibleClusterVerifier;
   private HelixAdmin _admin;
-  HelixDataAccessor _dataAccessor;
-  List<MockParticipantManager> _participants = new ArrayList<MockParticipantManager>();
-  List<String> _resources;
-  protected ClusterControllerManager _controller;
-
-
+  private HelixDataAccessor _dataAccessor;
+  private List<MockParticipantManager> _participants = new ArrayList<>();
+  private List<String> _resources;
+  private ClusterControllerManager _controller;
+  private Set<String> _downwardSTBlockedInstances = new HashSet<>();
 
   @BeforeClass
   public void beforeClass() throws Exception {
     System.out.println("START " + CLASS_NAME + " at " + new Date(System.currentTimeMillis()));
     _gSetupTool.addCluster(CLUSTER_NAME, true);
+    enablePersistIntermediateAssignment(_gZkClient, CLUSTER_NAME, true);
 
-    IdealState crushedResource = createResourceWithWagedRebalance(CLUSTER_NAME, "Test_CRUSHED_Resource",
+    IdealState wagedResource = createResourceWithWagedRebalance(CLUSTER_NAME, "Test_WAGED_Resource",
         "MasterSlave", NUM_PARTITIONS, NUM_REPLICAS, NUM_MIN_ACTIVE_REPLICAS);
-    IdealState wagedResource = createResourceWithDelayedRebalance(CLUSTER_NAME, "Test_WAGED_Resource",
-        "MasterSlave", NUM_PARTITIONS, NUM_REPLICAS, NUM_MIN_ACTIVE_REPLICAS, 200000, CrushEdRebalanceStrategy.class.getName());
+    IdealState crushedResource = createResourceWithDelayedRebalance(CLUSTER_NAME, "Test_CRUSHED_Resource",
+        "MasterSlave", NUM_PARTITIONS, NUM_REPLICAS, NUM_MIN_ACTIVE_REPLICAS, 0, CrushEdRebalanceStrategy.class.getName());
     _resources = Arrays.asList(crushedResource.getId(), wagedResource.getId());
     _bestPossibleClusterVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
-        .setResources(new HashSet<>(_resources)).setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
+        .setResources(new HashSet<>(_resources)).setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
+    _clusterVerifier = new StrictMatchExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+        .setDeactivatedNodeAwareness(true).setResources(new HashSet<>(_resources))
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
 
     for (int i = 0; i < NUM_NODES; i++) {
-      addParticipant(CLUSTER_NAME, "localhost_" + i);
+      String instanceName = "localhost_" + i;
+      addParticipant(CLUSTER_NAME, instanceName);
     }
 
     // start controller
@@ -69,32 +87,37 @@ public class TestForceKillInstance extends ZkTestBase {
     _controller.syncStart();
 
     _admin = new ZKHelixAdmin(_gZkClient);
+    _dataAccessor = _controller.getHelixDataAccessor();
   }
 
   @BeforeMethod
   public void beforeMethod() {
     _bestPossibleClusterVerifier.verifyByPolling();
+    _downwardSTBlockedInstances.clear();
   }
 
   @Test
   public void testForceKillDropsAssignment() {
+    System.out.println("START " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
     MockParticipantManager instanceToKill = _participants.get(0);
     String instanceToKillName = instanceToKill.getInstanceName();
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist before force kill");
 
     // Get assignments on node, assert it has at least one assignemnt
     Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should have at least one assignment");
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist before force kill");
 
     // Force kill the instance
     _admin.forceKillInstance(CLUSTER_NAME, instanceToKillName);
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
 
+
     // ensure no live instance znode and no assignments
-    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertFalse(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should not exist after force kill");
     Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should not have any assignments");
@@ -102,7 +125,7 @@ public class TestForceKillInstance extends ZkTestBase {
     // Actually stop the instance, re assert no live instance znode and no assignments
     instanceToKill.syncStop();
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertFalse(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should not exist after force kill");
     Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should not have any assignments");
@@ -110,19 +133,23 @@ public class TestForceKillInstance extends ZkTestBase {
     // Reset state of cluster
     dropParticipant(CLUSTER_NAME, instanceToKillName);
     addParticipant(CLUSTER_NAME, instanceToKillName);
+    System.out.println("END " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
   }
 
   @Test(dependsOnMethods = "testForceKillDropsAssignment")
   public void testSessionExpiration() throws Exception {
+    System.out.println("START " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
     MockParticipantManager instanceToKill = _participants.get(0);
     String instanceToKillName = instanceToKill.getInstanceName();
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist before force kill");
 
     // Get assignments on node, assert it has at least one assignemnt
     Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should have at least one assignment");
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist before force kill");
 
     // Force kill the instance
@@ -132,7 +159,7 @@ public class TestForceKillInstance extends ZkTestBase {
     // Expire the session of the instance, assert live instance znode was recreated but instance does not have assignments
     ZkTestHelper.expireSession(instanceToKill.getZkClient());
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist after session recreation");
     Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should not have any assignments");
@@ -140,32 +167,36 @@ public class TestForceKillInstance extends ZkTestBase {
     // Reset state of cluster
     dropParticipant(CLUSTER_NAME, instanceToKillName);
     addParticipant(CLUSTER_NAME, instanceToKillName);
+    System.out.println("END " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
   }
 
   @Test(dependsOnMethods = "testSessionExpiration")
   public void testDisconnectReconnect() {
+    System.out.println("START " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
     MockParticipantManager instanceToKill = _participants.get(0);
     String instanceToKillName = instanceToKill.getInstanceName();
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist before force kill");
 
     // Get assignments on node, assert it has at least one assignemnt
     Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should have at least one assignment");
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist before force kill");
 
     // Force kill the instance
     _admin.forceKillInstance(CLUSTER_NAME, instanceToKillName);
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertFalse(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should not exist after force kill");
 
     // Restart the instance, assert live instance znode recreated but still no assignments
     // This should behave the same as if session was expired for same zkClient
     ZkTestHelper.simulateZkStateReconnected(instanceToKill.getZkClient());
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertFalse(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should not recreated if client reconnects within same session");
     Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should not have any assignments");
@@ -173,19 +204,23 @@ public class TestForceKillInstance extends ZkTestBase {
     // Reset state of cluster
     dropParticipant(CLUSTER_NAME, instanceToKillName);
     addParticipant(CLUSTER_NAME, instanceToKillName);
+    System.out.println("END " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
   }
 
   @Test(dependsOnMethods = "testDisconnectReconnect")
   public void testRemoveUnknownOperationAfterForceKill() {
+    System.out.println("START " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
     MockParticipantManager instanceToKill = _participants.get(0);
     String instanceToKillName = instanceToKill.getInstanceName();
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist before force kill");
 
     // Get assignments on node, assert it has at least one assignemnt
     Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should have at least one assignment");
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist before force kill");
 
     // Force kill the instance
@@ -194,7 +229,7 @@ public class TestForceKillInstance extends ZkTestBase {
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
 
     // ensure no live instance znode and no assignments
-    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertFalse(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should not exist after force kill");
     Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should not have any assignments");
@@ -202,19 +237,23 @@ public class TestForceKillInstance extends ZkTestBase {
     // Reset state of cluster
     dropParticipant(CLUSTER_NAME, instanceToKillName);
     addParticipant(CLUSTER_NAME, instanceToKillName);
+    System.out.println("END " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
   }
 
   @Test(dependsOnMethods = "testRemoveUnknownOperationAfterForceKill")
   public void testSessionExpirationWithoutUnknownOperation() throws Exception {
+    System.out.println("START " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
     MockParticipantManager instanceToKill = _participants.get(0);
     String instanceToKillName = instanceToKill.getInstanceName();
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist before force kill");
 
     // Get assignments on node, assert it has at least one assignemnt
     Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should have at least one assignment");
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist before force kill");
 
     // Force kill the instance
@@ -225,7 +264,7 @@ public class TestForceKillInstance extends ZkTestBase {
     // Expire the session of the instance, assert live instance znode was recreated and instance has assignments
     ZkTestHelper.expireSession(instanceToKill.getZkClient());
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist after session recreation");
     Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should have assignments");
@@ -233,33 +272,37 @@ public class TestForceKillInstance extends ZkTestBase {
     // Reset state of cluster
     dropParticipant(CLUSTER_NAME, instanceToKillName);
     addParticipant(CLUSTER_NAME, instanceToKillName);
+    System.out.println("END " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
   }
 
   @Test(dependsOnMethods = "testSessionExpirationWithoutUnknownOperation")
   public void testDisconnectReconnectWithoutUnknownOperation() {
+    System.out.println("START " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
     MockParticipantManager instanceToKill = _participants.get(0);
     String instanceToKillName = instanceToKill.getInstanceName();
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist before force kill");
 
     // Get assignments on node, assert it has at least one assignemnt
     Assert.assertFalse(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should have at least one assignment");
-    Assert.assertTrue(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should exist before force kill");
 
     // Force kill the instance
     _admin.forceKillInstance(CLUSTER_NAME, instanceToKillName);
     _admin.setInstanceOperation(CLUSTER_NAME, instanceToKillName, InstanceConstants.InstanceOperation.ENABLE);
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertFalse(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should not exist after force kill");
 
     // Restart the instance, assert live instance znode recreated but still no assignments
     // This should behave the same as if session was expired for same zkClient
     ZkTestHelper.simulateZkStateReconnected(instanceToKill.getZkClient());
     Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
-    Assert.assertFalse(_gZkClient.exists("/" + CLUSTER_NAME + "/LIVEINSTANCES/" + instanceToKillName),
+    Assert.assertFalse(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
         "Instance znode should not recreated if client reconnects within same session");
     Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
         "Instance should not have any assignments");
@@ -267,16 +310,123 @@ public class TestForceKillInstance extends ZkTestBase {
     // Reset state of cluster
     dropParticipant(CLUSTER_NAME, instanceToKillName);
     addParticipant(CLUSTER_NAME, instanceToKillName);
+    System.out.println("END " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
   }
 
-  private MockParticipantManager addParticipant(String cluster, String instanceName) {
-    _gSetupTool.addInstanceToCluster(cluster, instanceName);
-    MockParticipantManager toAddParticipant =
-        new MockParticipantManager(ZK_ADDR, cluster, instanceName);
-    _participants.add(toAddParticipant);
-    toAddParticipant.syncStart();
-    return toAddParticipant;
+  @Test(dependsOnMethods = "testDisconnectReconnectWithoutUnknownOperation")
+  public void testLiveInstanceZNodeImmediatelyRecreated() {
+    System.out.println("START " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
+    MockParticipantManager instanceToKill = _participants.get(0);
+    String instanceToKillName = instanceToKill.getInstanceName();
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
+        "Instance znode should exist before force kill");
+
+    LiveInstance liveInstance = _dataAccessor.getProperty(_dataAccessor.keyBuilder().liveInstance(instanceToKillName));
+    LiveInstanceZnodeListener listener = new LiveInstanceZnodeListener(_dataAccessor, liveInstance);
+    _gZkClient.subscribeDataChanges(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath(), listener, true);
+
+    // Force kill the instance
+    _admin.forceKillInstance(CLUSTER_NAME, instanceToKillName);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
+        "Instance znode should exist because of listener");
+    Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should not have any assignments");
+
+    // Manually remove the live instance znode that was created by the listener
+    _gZkClient.unsubscribeDataChanges(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath(), listener);
+    _dataAccessor.removeProperty(_dataAccessor.keyBuilder().liveInstance(instanceToKillName));
+
+    // Reset state of cluster
+    dropParticipant(CLUSTER_NAME, instanceToKillName);
+    addParticipant(CLUSTER_NAME, instanceToKillName);
+    System.out.println("END " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
   }
+
+  // Test to confirm that the custom state model factory is correctly blocking downward state transitions
+  @Test(dependsOnMethods = "testLiveInstanceZNodeImmediatelyRecreated")
+  public void testDownwardStateTransitionsBlocked() throws Exception {
+    System.out.println("START " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
+    MockParticipantManager instanceToKill = _participants.get(0);
+    String instanceToKillName = instanceToKill.getInstanceName();
+
+    // Block downward ST and get assignments on node, assert it has at least one assignment
+    _downwardSTBlockedInstances.add(instanceToKillName);
+    Map<String, String> assignments = getInstanceCurrentStates(instanceToKillName);
+    Assert.assertFalse(assignments.isEmpty(), "Instance should have at least one assignment");
+
+    // Manually set instance operation to unknown, this should block topstate handoff
+    _admin.setInstanceOperation(CLUSTER_NAME, instanceToKillName, InstanceConstants.InstanceOperation.UNKNOWN);
+    Thread.sleep(1000); // Wait for downward ST to be sent
+    Assert.assertEquals(getInstanceCurrentStates(instanceToKillName).size(), assignments.size(),
+        "Instance should not have lost any assignments");
+    Assert.assertFalse(_dataAccessor.getChildNames(_dataAccessor.keyBuilder().messages(instanceToKillName)).isEmpty(),
+        "Instance should have pending ST messages");
+
+    // Remove block on downward ST so instance can drop assignments
+    _downwardSTBlockedInstances.remove(instanceToKillName);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should not have any assignments");
+
+    // Reset state of cluster
+    dropParticipant(CLUSTER_NAME, instanceToKillName);
+    addParticipant(CLUSTER_NAME, instanceToKillName);
+    System.out.println("END " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
+  }
+
+  // Recreate scenario where node is not capable of processing downward state transitions, so setting unknown operation
+  // will not have any effect on external view. Only removing of live instance (force kill) will drop assignments
+  @Test(dependsOnMethods = "testDownwardStateTransitionsBlocked")
+  public void testForceKillWithBlockedDownwardStateTransition() throws Exception {
+    System.out.println("START " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
+    MockParticipantManager instanceToKill = _participants.get(0);
+    String instanceToKillName = instanceToKill.getInstanceName();
+    Assert.assertTrue(_gZkClient.exists(_dataAccessor.keyBuilder().liveInstance(instanceToKillName).getPath()),
+        "Instance znode should exist before force kill");
+
+    // Block downward ST and get assignments on node, assert it has at least one assignemnt
+    _downwardSTBlockedInstances.add(instanceToKillName);
+    Map<String, String> assignments = getInstanceCurrentStates(instanceToKillName);
+    Assert.assertFalse(assignments.isEmpty(), "Instance should have at least one assignment");
+
+    // Manually set instance operation to unknown, this should block topstate handoff
+    _admin.setInstanceOperation(CLUSTER_NAME, instanceToKillName, InstanceConstants.InstanceOperation.UNKNOWN);
+    Thread.sleep(1000); // Wait for downward ST to be sent
+    Assert.assertEquals(getInstanceCurrentStates(instanceToKillName).size(), assignments.size(),
+        "Instance should not have lost any assignments");
+    Assert.assertFalse(_dataAccessor.getChildNames(_dataAccessor.keyBuilder().messages(instanceToKillName)).isEmpty(),
+        "Instance should have pending ST messages");
+
+    _admin.forceKillInstance(CLUSTER_NAME, instanceToKillName);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(getInstanceCurrentStates(instanceToKillName).isEmpty(),
+        "Instance should not have any assignments");
+
+    // Reset state of cluster
+    dropParticipant(CLUSTER_NAME, instanceToKillName);
+    addParticipant(CLUSTER_NAME, instanceToKillName);
+    System.out.println("END " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
+  }
+
+    private MockParticipantManager addParticipant(String cluster, String instanceName) {
+      _gSetupTool.addInstanceToCluster(cluster, instanceName);
+      MockParticipantManager toAddParticipant =
+          new MockParticipantManager(ZK_ADDR, cluster, instanceName);
+      StateMachineEngine stateMachine = toAddParticipant.getStateMachineEngine();
+      stateMachine.registerStateModelFactory("MasterSlave",
+          new TestBlockDownwardStateTransitionModelFactory(instanceName));
+      _participants.add(toAddParticipant);
+      toAddParticipant.syncStart();
+      return toAddParticipant;
+    }
 
     protected void dropParticipant(String cluster, String instanceName) {
       // find mock participant manager with instanceName and remove it from _mockParticipantManagers.
@@ -313,5 +463,87 @@ public class TestForceKillInstance extends ZkTestBase {
       }
     }
     return assignment;
+  }
+
+  private class LiveInstanceZnodeListener implements IZkDataListener {
+    private final HelixDataAccessor _helixDataAccessor;
+    private final LiveInstance _liveInstance;
+
+    public LiveInstanceZnodeListener(HelixDataAccessor helixDataAccessor, LiveInstance liveInstance) {
+      this._helixDataAccessor = helixDataAccessor;
+      this._liveInstance = liveInstance;
+    }
+
+    @Override
+    public void handleDataChange(String dataPath, Object data) throws Exception {
+      //no-op
+    }
+
+    @Override
+    public void handleDataDeleted(String dataPath) throws Exception {
+      System.out.println("LIVEINSTANCE znode deleted. Recreating...");
+      _helixDataAccessor.setProperty(_helixDataAccessor.keyBuilder().liveInstance(_liveInstance.getInstanceName()), _liveInstance);
+    }
+  }
+
+  // Statemodel factory that loops endlessly on downward state transitions if instance is in blocked set. This is used
+  // to mimic scenario where node is being sent downward ST's but is not processing them, so topstate handoff cannot occur
+  public class TestBlockDownwardStateTransitionModelFactory extends StateModelFactory<TestBlockDownwardStateTransitionStateModel> {
+
+    private final String _instanceName;
+    public TestBlockDownwardStateTransitionModelFactory(String instanceName) {
+      _instanceName = instanceName;
+    }
+
+    @Override
+    public TestBlockDownwardStateTransitionStateModel createNewStateModel(String resourceName, String partitionKey) {
+      return new TestBlockDownwardStateTransitionStateModel(_instanceName);
+    }
+  }
+
+  @StateModelInfo(initialState = "OFFLINE", states = {"MASTER", "SLAVE", "ERROR"})
+  public class TestBlockDownwardStateTransitionStateModel extends StateModel {
+    private final String _instanceName;
+
+    public TestBlockDownwardStateTransitionStateModel(String instanceName) {
+      _instanceName = instanceName;
+    }
+
+    @Transition(to = "MASTER", from = "SLAVE")
+    public void onBecomeMasterFromSlave(Message message, NotificationContext context) {
+      LOG.info("Become MASTER from SLAVE");
+    }
+
+    @Transition(to = "SLAVE", from = "OFFLINE")
+    public void onBecomeSlaveFromOffline(Message message, NotificationContext context) {
+      LOG.info("Become SLAVE from OFFLINE");
+    }
+
+    @Transition(to = "SLAVE", from = "MASTER")
+    public void onBecomeSlaveFromMaster(Message message, NotificationContext context) {
+      loopWhileBlocked();
+      LOG.info("Become SLAVE from MASTER");
+    }
+
+    @Transition(to = "OFFLINE", from = "SLAVE")
+    public void onBecomeOfflineFromSlave(Message message, NotificationContext context) {
+      loopWhileBlocked();
+      LOG.info("Become OFFLINE from SLAVE");
+    }
+
+    @Transition(to = "DROPPED", from = "OFFLINE")
+    public void onBecomeDroppedFromOffline(Message message, NotificationContext context) {
+      LOG.info("Become DROPPED from OFFLINE");
+    }
+
+    private void loopWhileBlocked() {
+      while (_downwardSTBlockedInstances.contains(_instanceName)) {
+        try {
+          Thread.sleep(1000);
+        } catch (InterruptedException e) {
+          // no op, continue loop
+        }
+      }
+    }
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -68,7 +68,7 @@ import org.testng.annotations.Test;
 
 
 public class TestInstanceOperation extends ZkTestBase {
-  private static final Logger LOG = LoggerFactory.getLogger(TestHelper.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TestInstanceOperation.class);
   public static final int TIMEOUT = 10000;
   private final int ZONE_COUNT = 4;
   protected final int START_NUM_NODE = 10;

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -90,7 +90,8 @@ public class AbstractResource {
     completeSwapIfPossible,
     onDemandRebalance,
     isEvacuateFinished,
-    setPartitionsToError
+    setPartitionsToError,
+    forceKillInstance
   }
 
   @Context

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -511,7 +511,8 @@ public class PerInstanceAccessor extends AbstractHelixResource {
         case forceKillInstance:
           boolean instanceForceKilled = admin.forceKillInstance(clusterId, instanceName, reason, instanceOperationSource);
           if (!instanceForceKilled) {
-            return serverError("Failed to forcefully kill instance: " + instanceName);
+            return serverError("Failed to forcefully kill instance: " + instanceName +
+                ". Possible that instance was already stopped.");
           }
           return OK(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of("successful", instanceForceKilled)));
         default:

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -45,7 +45,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
-import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
@@ -510,23 +509,15 @@ public class PerInstanceAccessor extends AbstractHelixResource {
           }
           return OK(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of("successful", evacuateFinished)));
         case forceKillInstance:
-          // set instance to unknown
-          InstanceUtil.setInstanceOperation(new ConfigAccessor(getRealmAwareZkClient()),
-              new ZkBaseDataAccessor<>(getRealmAwareZkClient()), clusterId, instanceName,
-              new InstanceConfig.InstanceOperation.Builder().setOperation(InstanceConstants.InstanceOperation.UNKNOWN)
-                  .setReason(reason).setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
-          // delete liveInstanceZnode
-          boolean instanceForceKilled = admin.forceKillInstance(clusterId, instanceName);
+          boolean instanceForceKilled = admin.forceKillInstance(clusterId, instanceName, reason, instanceOperationSource);
           if (!instanceForceKilled) {
-            return serverError("Failed to kill instance: " + instanceName);
+            return serverError("Failed to forcefully kill instance: " + instanceName);
           }
           return OK(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of("successful", instanceForceKilled)));
         default:
           LOG.error("Unsupported command :" + command);
           return badRequest("Unsupported command :" + command);
       }
-
-
     } catch (Exception e) {
       LOG.error("Failed in updating instance : " + instanceName, e);
       return badRequest(e.getMessage());

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
@@ -336,10 +336,9 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
       _configAccessor.setClusterConfig(cluster, clusterConfig);
       createResourceConfigs(cluster, 8);
       _workflowMap.put(cluster, createWorkflows(cluster, 3));
-      Set<String> resources = createResources(cluster, 8, MIN_ACTIVE_REPLICA, NUM_REPLICA);
+      createResources(cluster, 8, MIN_ACTIVE_REPLICA, NUM_REPLICA);
       _instancesMap.put(cluster, instances);
       _liveInstancesMap.put(cluster, liveInstances);
-      _resourcesMap.put(cluster, resources);
       _clusterControllerManagers.add(startController(cluster));
     }
     preSetupForParallelInstancesStoppableTest(STOPPABLE_CLUSTER, STOPPABLE_INSTANCES);
@@ -356,20 +355,60 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
     return instances;
   }
 
-  protected Set<String> createResources(String cluster, int numResources, int minActiveReplica,
+  protected void addParticipant(String cluster, String instanceName) {
+    // Create instance
+    _gSetupTool.addInstanceToCluster(cluster, instanceName);
+    _instancesMap.get(cluster).add(instanceName);
+
+    // Start participant
+    MockParticipantManager participant = new MockParticipantManager(ZK_ADDR, cluster, instanceName);
+    Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
+    taskFactoryReg.put(MockTask.TASK_COMMAND, MockTask::new);
+    StateMachineEngine stateMachineEngine = participant.getStateMachineEngine();
+
+    stateMachineEngine.registerStateModelFactory("Task",
+        new TaskStateModelFactory(participant, taskFactoryReg));
+    participant.syncStart();
+    _mockParticipantManagers.add(participant);
+    _liveInstancesMap.get(cluster).add(instanceName);
+  }
+
+  protected void dropParticipant(String cluster, String instanceName) {
+    // find mock participant manager with instanceName and remove it from _mockParticipantManagers.
+    MockParticipantManager toRemoveManager = _mockParticipantManagers.stream()
+        .filter(manager -> manager.getInstanceName().equals(instanceName)).findFirst().orElse(null);
+    if (toRemoveManager != null) {
+      toRemoveManager.syncStop();
+      _mockParticipantManagers.remove(toRemoveManager);
+    }
+
+    InstanceConfig instanceConfig = _gSetupTool.getClusterManagementTool().getInstanceConfig(cluster, instanceName);
+    _gSetupTool.getClusterManagementTool().dropInstance(cluster, instanceConfig);
+    _instancesMap.get(cluster).remove(instanceName);
+    _liveInstancesMap.get(cluster).remove(instanceName);
+  }
+
+  protected void createResources(String cluster, int numResources, int minActiveReplica,
       int replicationFactor) {
-    Set<String> resources = new HashSet<>();
     for (int i = 0; i < numResources; i++) {
       String resource = cluster + "_db_" + i;
-      _gSetupTool.addResourceToCluster(cluster, resource, NUM_PARTITIONS, "MasterSlave");
-      IdealState idealState =
-          _gSetupTool.getClusterManagementTool().getResourceIdealState(cluster, resource);
-      idealState.setMinActiveReplicas(minActiveReplica);
-      _gSetupTool.getClusterManagementTool().setResourceIdealState(cluster, resource, idealState);
-      _gSetupTool.rebalanceStorageCluster(cluster, resource, replicationFactor);
-      resources.add(resource);
+      addResource(cluster, resource, NUM_PARTITIONS, "OnlineOffline", minActiveReplica,
+          replicationFactor);
     }
-    return resources;
+  }
+
+  protected void addResource(String cluster, String resource, int numPartitions, String stateModel,
+      int minActiveReplica, int replicationFactor) {
+    _gSetupTool.addResourceToCluster(cluster, resource, numPartitions, stateModel);
+    IdealState idealState =
+        _gSetupTool.getClusterManagementTool().getResourceIdealState(cluster, resource);
+    idealState.setMinActiveReplicas(minActiveReplica);
+    _gSetupTool.getClusterManagementTool().setResourceIdealState(cluster, resource, idealState);
+    _gSetupTool.rebalanceStorageCluster(cluster, resource, replicationFactor);
+    if (!_resourcesMap.containsKey(cluster)) {
+      _resourcesMap.put(cluster, new HashSet<>());
+    }
+    _resourcesMap.get(cluster).add(resource);
   }
 
   protected Set<String> createResourceConfigs(String cluster, int numResources) {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
@@ -323,7 +323,7 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
   }
 
   protected void setupHelixResources() throws Exception {
-    _clusters = createClusters(5);
+    _clusters = createClusters(6);
     _gSetupTool.addCluster(_superCluster, true);
     _gSetupTool.addCluster(TASK_TEST_CLUSTER, true);
     _clusters.add(_superCluster);
@@ -392,7 +392,7 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
       int replicationFactor) {
     for (int i = 0; i < numResources; i++) {
       String resource = cluster + "_db_" + i;
-      addResource(cluster, resource, NUM_PARTITIONS, "OnlineOffline", minActiveReplica,
+      addResource(cluster, resource, NUM_PARTITIONS, "MasterSlave", minActiveReplica,
           replicationFactor);
     }
   }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -45,7 +45,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class TestInstancesAccessor extends AbstractTestClass {
-  private final static String CLUSTER_NAME = "TestCluster_4";
+  private final static String CLUSTER_NAME = "TestCluster_5";
 
   @DataProvider
   public Object[][] generatePayloadCrossZoneStoppableCheckWithZoneOrder() {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPartitionAssignmentAPI.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPartitionAssignmentAPI.java
@@ -59,7 +59,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class TestPartitionAssignmentAPI extends AbstractTestClass {
-  private static final Logger LOG = LoggerFactory.getLogger(TestHelper.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TestPartitionAssignmentAPI.class);
 
   private static final int REPLICAS = 3;
   private static final int MIN_ACTIVE_REPLICAS = 2;


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

N/A - New feature to forcefully kill an instance

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds a new feature, a HelixAdmin and Helix-rest API command to forcefully kill an instance. This is achieved by marking the instance's operation as UNKNOWN and then deleting the LIVEINSTANCE znode. This feature is intended for use in a scenario where the participant is in an unrecoverable state but is keeping an active connection with ZK. Marking the node as UNKNOWN will remove it from calculations and subsequently deleting the LIVEINSTANCE znode will cause the controller to consider it as OFFLINE. This skips the requirement that the node must process the downward state transition for topstate handoff to occur. 

My current findings indicate that the LIVEINSTANCE znode will only be recreated on ZK session establishment, which occurs on initial connection and after session expiration. 

#### The following code changes were made:

* `helix-core/src/main/java/org/apache/helix/HelixAdmin.java`: Added `forceKillInstance` method to the HelixAdmin interface.
* `helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java`: Implemented the `forceKillInstance` method in the ZKHelixAdmin class.
* `helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java`: Added forceKillInstance command to the to the REST API updateInstance endpoint. Called via:
```
https://<helix-rest-url>/namespaces/<namespace>/clusters/<cluster>/instances/<instance>?command=forceKillInstance
```

Also includes miscellaneous changes:
* `helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java` Corrected the logger class reference.
* `helix-rest/src/test/java/org/apache/helix/rest/server/TestPartitionAssignmentAPI.java`: Corrected the logger class reference.
* `helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java`: Refactored resource creation logic. Added addParticipant and dropParticipant methods. Also added another test cluster to isolate `testPerInstanceAccessor` and `testInstancesAccessor`
* `helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java`: Now using isolated test cluster

### Tests

- [ ] The following tests are written for this issue:

* `helix-core/src/test/java/org/apache/helix/integration/TestForceKillInstance.java` for HelixAdmin API
```
$ mvn test -o -Dtest=TestForceKillInstance -pl=helix-core

[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 41.027 s - in org.apache.helix.integration.TestForceKillInstance
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:16 min
[INFO] Finished at: 2024-09-03T11:37:35-07:00
[INFO] ------------------------------------------------------------------------

```

* `testForceKillInstance` in `helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java` for Helix-Rest API
```
$ mvn test -o -Dtest=TestInstancesAccessor -pl=helix-rest  

[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 86.395 s - in org.apache.helix.rest.server.TestInstancesAccessor
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:40 min
[INFO] Finished at: 2024-09-03T11:35:04-07:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
N/A


### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)

