### PR TITLE
Fix partition assignment npe

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -950,6 +950,10 @@ public class BaseControllerDataProvider implements ControlContextProvider {
     return _stateModelDefinitionCache.getPropertyMap();
   }
 
+  public void setStateModelDefMap(Map<String, StateModelDefinition> stateModelDefMap) {
+    _stateModelDefinitionCache.setPropertyMap(stateModelDefMap);
+  }
+
   /**
    * Provides the idealstate for a given resource
    * @param resourceName

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -383,6 +383,7 @@ public final class HelixUtil {
       instanceConfigMap.put(instanceConfig.getInstanceName(), instanceConfig);
     }
 
+    // TODO: Consider full cache refresh to prevent needing to manually set necessary fields
     StateModelDefinition stateModelDefinition =
         BuiltInStateModelDefinitions.valueOf(idealState.getStateModelDefRef())
             .getStateModelDefinition();

--- a/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/HelixUtil.java
@@ -382,13 +382,15 @@ public final class HelixUtil {
       allNodes.add(instanceConfig.getInstanceName());
       instanceConfigMap.put(instanceConfig.getInstanceName(), instanceConfig);
     }
-    ResourceControllerDataProvider cache = new ResourceControllerDataProvider();
-    cache.setClusterConfig(clusterConfig);
-    cache.setInstanceConfigMap(instanceConfigMap);
 
     StateModelDefinition stateModelDefinition =
         BuiltInStateModelDefinitions.valueOf(idealState.getStateModelDefRef())
             .getStateModelDefinition();
+    ResourceControllerDataProvider cache = new ResourceControllerDataProvider(clusterConfig.getClusterName());
+    cache.setClusterConfig(clusterConfig);
+    cache.setInstanceConfigMap(instanceConfigMap);
+    cache.setIdealStates(Collections.singletonList(idealState));
+    cache.setStateModelDefMap(Collections.singletonMap(stateModelDefinition.getId(), stateModelDefinition));
 
     RebalanceStrategy strategy =
         RebalanceStrategy.class.cast(loadClass(HelixUtil.class, strategyClassName).newInstance());


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Failing tests in CI:
#2901
#2902


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

From #2877 , autoRebalanceStrategy now reads the idealState and StateModelDefinition from the cache. This causes an NPE when computing the potential assignment. `getIdealAssignmentForFullAuto` instantiates a cache (`ResourceControllerDataProvider`) and only instantiates the necessary values. I'm assuming this was done as an optimization and to avoid a full cache refresh. My change adds the other necessary fields to the cache for the calculation to complete. It's also possible to fully reresh the cache, but I believe this would require changing public constructors in order to pass the accessor down to the relevant method.

Here is the NPE trace:
```
1271778 [qtp462777594-3583] ERROR org.apache.helix.rest.server.resources.helix.ResourceAssignmentOptimizerAccessor [] - Failed to compute partition assignment
java.lang.NullPointerException: null
	at org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy.calculateExpectedReplicaCount(AutoRebalanceStrategy.java:643) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy.computePartitionAssignment(AutoRebalanceStrategy.java:111) ~[classes/:?]
	at org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy.computePartitionAssignment(AutoRebalanceStrategy.java:44) ~[classes/:?]
	at org.apache.helix.util.HelixUtil.getIdealAssignmentForFullAuto(HelixUtil.java:409) ~[classes/:?]
	at org.apache.helix.rest.server.resources.helix.ResourceAssignmentOptimizerAccessor.computeOptimalAssignmentForResources(ResourceAssignmentOptimizerAccessor.java:287) ~[classes/:?]
	at org.apache.helix.rest.server.resources.helix.ResourceAssignmentOptimizerAccessor.computePotentialAssignment(ResourceAssignmentOptimizerAccessor.java:147) ~[classes/:?]
```


Code changes:
* `helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java`: Added a new method `setStateModelDefMap` to allow manually setting the cache's state model definition map. 
* `helix-core/src/main/java/org/apache/helix/util/HelixUtil.java`: Modified the initialization of `ResourceControllerDataProvider` to include setting the state model definition map and ideal states, which are now necesasry fields

### Tests

- [ ] The following tests are written for this issue:

N/A

- The following is the result of the "mvn test" command on the appropriate module:
Test passes on this branch:
```
$ mvn test -o -Dtest=TestResourceAssignmentOptimizerAccessor,TestPartitionAssignmentAPI -pl=helix-rest

[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 164.565 s - in TestSuite
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:52 min
[INFO] Finished at: 2024-09-05T15:46:33-07:00
[INFO] ------------------------------------------------------------------------

```

Test will fail on current master:
```
$ mvn test -o -Dtest=TestResourceAssignmentOptimizerAccessor,TestPartitionAssignmentAPI -pl=helix-rest

Failed run
[ERROR] Tests run: 6, Failures: 2, Errors: 0, Skipped: 2, Time elapsed: 158.233 s <<< FAILURE! - in TestSuite
[ERROR] testComputePartitionAssignment(org.apache.helix.rest.server.TestResourceAssignmentOptimizerAccessor)  Time elapsed: 0.496 s  <<< FAILURE!
java.lang.AssertionError: expected:<200> but was:<400>
        at org.apache.helix.rest.server.TestResourceAssignmentOptimizerAccessor.testComputePartitionAssignment(TestResourceAssignmentOptimizerAccessor.java:111)

[ERROR] testComputePartitionAssignmentMaintenanceMode(org.apache.helix.rest.server.TestPartitionAssignmentAPI)  Time elapsed: 19.54 s  <<< FAILURE!
java.lang.AssertionError: expected:<200> but was:<400>
        at org.apache.helix.rest.server.TestPartitionAssignmentAPI.testComputePartitionAssignmentMaintenanceMode(TestPartitionAssignmentAPI.java:453)

```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
