### PR TITLE
Use actions/upload-artifact@v4, v2 was deprecated

### DIFF
--- a/.github/workflows/Helix-CI.yml
+++ b/.github/workflows/Helix-CI.yml
@@ -36,7 +36,7 @@ jobs:
         reporter: java-junit
     - name: Upload Unit Test Results as Artifacts
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: surefire-reports
         path: ./**/target/surefire-reports/

--- a/.github/workflows/Helix-Manual-CI.yml
+++ b/.github/workflows/Helix-Manual-CI.yml
@@ -45,7 +45,7 @@ jobs:
           reporter: java-junit
       - name: Upload unit test results
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: surefire-reports
           path: ./**/target/surefire-reports/


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Helix CI and Manual CI fails due to:
```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```
https://github.com/apache/helix/actions/runs/10811307760

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Uses v4 of upload-artifact action

### Tests
Successfully initiated tests on my personal fork:
- https://github.com/GrantPSpencer/helix/actions/runs/10819711509
- https://github.com/GrantPSpencer/helix/actions/runs/10819712154

Could not run tests on my personal fork prior to merging this change into my master branch, was failing for same reason as Apache Helix CI:
- https://github.com/GrantPSpencer/helix/actions/runs/10819689382
- https://github.com/GrantPSpencer/helix/actions/runs/10819657182

- [x] The following tests are written for this issue:

N/A

- The following is the result of the "mvn test" command on the appropriate module:

N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
