### PR TITLE
Fix new resource causing pipeline NPE when rebalance overwrites required

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java
@@ -38,7 +38,6 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.model.ResourceConfig;
-import org.apache.helix.util.InstanceValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -321,7 +320,8 @@ public class DelayedRebalanceUtil {
     Set<AssignableReplica> toBeAssignedReplicas = new HashSet<>();
 
     for (String resourceName : resources) {
-      ResourceAssignment resourceAssignment = currentAssignment.get(resourceName);
+      ResourceAssignment resourceAssignment = currentAssignment.getOrDefault(resourceName,
+          new ResourceAssignment(resourceName));
       IdealState idealState = clusterData.getIdealState(resourceName);
       String modelDef = idealState.getStateModelDefRef();
       Map<String, Integer> statePriorityMap = clusterData.getStateModelDef(modelDef).getStatePriorityMap();

--- a/helix-core/src/test/java/org/apache/helix/integration/TestAddResourceWhenNodesOffline.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestAddResourceWhenNodesOffline.java
@@ -1,0 +1,140 @@
+package org.apache.helix.integration;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestAddResourceWhenNodesOffline extends ZkTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestForceKillInstance.class);
+  protected final String CLASS_NAME = getShortClassName();
+  protected final String CLUSTER_NAME = CLUSTER_PREFIX + "_" + CLASS_NAME;
+  private static final int NUM_REPLICAS = 3;
+  private static final int NUM_PARTITIONS = 10;
+  private static final int NUM_MIN_ACTIVE_REPLICAS = 2;
+  private static final int NUM_NODES = 5;
+  private BestPossibleExternalViewVerifier _bestPossibleClusterVerifier;
+  private HelixAdmin _admin;
+  private List<MockParticipantManager> _participants = new ArrayList<>();
+  private ClusterControllerManager _controller;
+  private ArrayList<String> _resources = new ArrayList<>();
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    System.out.println("START " + CLASS_NAME + " at " + new Date(System.currentTimeMillis()));
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+    enablePersistIntermediateAssignment(_gZkClient, CLUSTER_NAME, true);
+
+    ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    ClusterConfig clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setRebalanceDelayTime(2000000L);
+    configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    for (int i = 0; i < NUM_NODES; i++) {
+      String instanceName = "localhost_" + i;
+      addParticipant(CLUSTER_NAME, instanceName);
+    }
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    _admin = new ZKHelixAdmin(_gZkClient);
+
+    _bestPossibleClusterVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
+  }
+
+  @Test
+  public void testAddResourceNewCluster() {
+    System.out.println("START " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
+
+    String resourceName = "TestWagedDB";
+    _resources.add(resourceName);
+    createResourceWithWagedRebalance(CLUSTER_NAME, resourceName, "MasterSlave", NUM_PARTITIONS, NUM_REPLICAS,
+        NUM_MIN_ACTIVE_REPLICAS);
+
+    Assert.assertTrue(_bestPossibleClusterVerifier.verify());
+    Assert.assertTrue(isMinActiveSatisfied());
+  }
+
+  @Test (dependsOnMethods = "testAddResourceNewCluster")
+  public void testAddResourceWhenInstancesDisabledWithinWindow() {
+    System.out.println("START " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
+
+    // Disable 2 instances
+    for (int i = 0; i < 2; i++) {
+      _admin.setInstanceOperation(CLUSTER_NAME, _participants.get(i).getInstanceName(),
+          InstanceConstants.InstanceOperation.DISABLE);
+    }
+    Assert.assertTrue(_bestPossibleClusterVerifier.verify());
+    Assert.assertTrue(isMinActiveSatisfied());
+
+    // Add resource
+    String resourceName = "TestWagedDB2";
+    _resources.add(resourceName);
+    createResourceWithWagedRebalance(CLUSTER_NAME, resourceName, "MasterSlave", NUM_PARTITIONS, NUM_REPLICAS,
+        NUM_MIN_ACTIVE_REPLICAS);
+
+    Assert.assertTrue(_bestPossibleClusterVerifier.verify());
+    System.out.println("END " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName() + " at "
+        + new Date(System.currentTimeMillis()));
+  }
+
+  private MockParticipantManager addParticipant(String cluster, String instanceName) {
+    _gSetupTool.addInstanceToCluster(cluster, instanceName);
+    MockParticipantManager toAddParticipant =
+        new MockParticipantManager(ZK_ADDR, cluster, instanceName);
+    _participants.add(toAddParticipant);
+    toAddParticipant.syncStart();
+    return toAddParticipant;
+  }
+
+  private Map<String, ExternalView> getEVs() {
+    Map<String, ExternalView> externalViews = new HashMap<String, ExternalView>();
+    for (String resource : _resources) {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, resource);
+      externalViews.put(resource, ev);
+    }
+    return externalViews;
+  }
+
+  private boolean isMinActiveSatisfied() {
+    Map<String, ExternalView> externalViews = getEVs();
+    for (ExternalView ev : externalViews.values()) {
+      Assert.assertEquals(ev.getPartitionSet().size(), NUM_PARTITIONS);
+      for (String partition : ev.getPartitionSet()) {
+        long activeReplicas = ev.getStateMap(partition).values().stream()
+            .filter(state -> state.equals("SLAVE") || state.equals("MASTER"))
+            .count();
+        if (activeReplicas < NUM_MIN_ACTIVE_REPLICAS) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+}


### PR DESCRIPTION


### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
#2909 

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
Resources that are in the resourceMap but not in the current assignment will return an empty currentAssignment rather than a null object. 

**Code Changes**
* `helix-core/src/main/java/org/apache/helix/controller/rebalancer/util/DelayedRebalanceUtil.java`: Updated `findToBeAssignedReplicasForMinActiveReplica` method to use `getOrDefault` when fetching resource assignments, an empty `ResourceAssignment` is created if one does not exist in the current assignment map. 

* `helix-core/src/test/java/org/apache/helix/integration/TestAddResourceWhenRequireDelayedRebalanceOverwrite.java`: Added a new test class to reproduce the issue linked above.  

### Tests

- [ ] The following tests are written for this issue:

`helix-core/src/test/java/org/apache/helix/integration/TestAddResourceWhenRequireDelayedRebalanceOverwrite.java`

- The following is the result of the "mvn test" command on the appropriate module:
```
mvn test -o -Dtest=TestAddResourceWhenRequireDelayedRebalanceOverwrite -pl=helix-core

[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.072 s - in org.apache.helix.integration.TestAddResourceWhenRequireDelayedRebalanceOverwrite
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  45.780 s
[INFO] Finished at: 2024-09-12T12:12:14-07:00
[INFO] ------------------------------------------------------------------------

```

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
