### PR TITLE
Pin netty_codec to higher version to address vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -540,6 +540,11 @@
         <artifactId>mockito-core</artifactId>
         <version>3.12.4</version>
       </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec</artifactId>
+        <version>4.1.68.Final</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
### Issues

- [x] Pin netty_codec to higher version to address vulnerability

### Description

Fix vulnerability:
```
The Bzip2 decompression decoder function doesn't allow setting size restrictions on the decompressed output data (which affects the allocation size used during decompression).


All users of Bzip2Decoder are affected. The malicious input can trigger an OOME and so a DoS attack
```

### Tests

NA

### Changes that Break Backward Compatibility (Optional)

NA

### Documentation (Optional)

NA

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
