### PR TITLE
Fix flaky test - testMultipleWrites

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -142,13 +142,8 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
           List<String> children = _zkBaseDataAccessor.getChildNames(path, AccessOption.PERSISTENT);
           return children.size() == 3 && children.containsAll(ImmutableList
               .of(LAST_SUCCESSFUL_WRITE_KEY, LAST_WRITE_KEY, new Long(lastSuccessfulWriteVer).toString()));
-        }, VERSION_TTL_MS * 2));
+        }, TestHelper.WAIT_DURATION));
 
-        // Wait one more TTL to ensure that the GC has been done.
-        Thread.sleep(VERSION_TTL_MS);
-        List<String> children = _zkBaseDataAccessor.getChildNames(path, AccessOption.PERSISTENT);
-        Assert.assertTrue(children.size() == 3 && children.containsAll(ImmutableList
-            .of(LAST_SUCCESSFUL_WRITE_KEY, LAST_WRITE_KEY, new Long(lastSuccessfulWriteVer).toString())));
       }
     } finally {
       for (int j = 0; j < pathCount; j++) {


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
#2925 

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
Current test logic has strict assertion that GC should occur within 2*TTL of making the write calls. I believe the flakiness is due to this assertion being too strict and causes the test to fail when the CI's ZK server is overloaded and responses are slowed. The gc occurs on a separate thread so it may be delayed compared to the main test thread. 

This change increases the test timeout to 60s as the test should be isolated from the performance of the ZK server. 
This change also removes a redundant assertion


### Tests

- [ ] The following tests are written for this issue:

testMultipleWrites

Ran this change vs master on my personal fork, test frequently occurred on master but not on this branch

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
