### PR TITLE
Add TTL support for compressedBucketWrite fn

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -432,7 +432,7 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
    * ttl is only used when creating new znode, hence if znode is already created with a ttl, further
    * update operations will not update the znode ttl even if ttl is provided in the options
    */
-  public AccessResult doUpdate(String path, DataUpdater<T> updater, int options, long ttl) {
+  AccessResult doUpdate(String path, DataUpdater<T> updater, int options, long ttl) {
     AccessResult result = new AccessResult();
     CreateMode mode = AccessOption.getMode(options);
     if (mode == null) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -428,6 +428,9 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
 
   /**
    * sync update with ttl
+   *
+   * ttl is only used when creating new znode, hence if znode is already created with a ttl, further
+   * update operations will not update the znode ttl even if ttl is provided in the options
    */
   public AccessResult doUpdate(String path, DataUpdater<T> updater, int options, long ttl) {
     AccessResult result = new AccessResult();
@@ -1003,6 +1006,9 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
 
   /**
    * async set with ttl, give up on error other than NoNode
+   *
+   * ttl is only used when creating new znode, hence if znode is already created with a ttl, further
+   * set operations will not update the znode ttl even if ttl is provided in the options
    */
   boolean[] set(List<String> paths, List<T> records, List<List<String>> pathsCreated,
       List<Stat> stats, int options, long ttl) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBaseDataAccessor.java
@@ -419,12 +419,15 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
     return result._retCode == RetCode.OK;
   }
 
+  /**
+   * sync update
+   */
   public AccessResult doUpdate(String path, DataUpdater<T> updater, int options) {
     return doUpdate(path, updater, options, ZkClient.TTL_NOT_SET);
   }
 
   /**
-   * sync update
+   * sync update with ttl
    */
   public AccessResult doUpdate(String path, DataUpdater<T> updater, int options, long ttl) {
     AccessResult result = new AccessResult();
@@ -983,17 +986,23 @@ public class ZkBaseDataAccessor<T> implements BaseDataAccessor<T> {
     return set(paths, records, null, null, options);
   }
 
+  /**
+  * async setChildren with TTL
+   */
   public boolean[] setChildren(List<String> paths, List<T> records, int options, long ttl) {
     return set(paths, records, null, null, options, ttl);
   }
 
+  /**
+   * async set, give up on error other than NoNode
+   */
   boolean[] set(List<String> paths, List<T> records, List<List<String>> pathsCreated,
       List<Stat> stats, int options) {
     return set(paths, records, pathsCreated, stats, options, ZkClient.TTL_NOT_SET);
   }
 
   /**
-   * async set, give up on error other than NoNode
+   * async set with ttl, give up on error other than NoNode
    */
   boolean[] set(List<String> paths, List<T> records, List<List<String>> pathsCreated,
       List<Stat> stats, int options, long ttl) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
@@ -356,7 +356,7 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
     close();
   }
 
-  int getAccessOption(long znodeTTLms) {
+  static int getAccessOption(long znodeTTLms) {
     if(znodeTTLms > 0) {
       return AccessOption.PERSISTENT_WITH_TTL;
     } else {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
@@ -19,7 +19,6 @@ package org.apache.helix.manager.zk;
  * under the License.
  */
 
-import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
@@ -117,11 +117,7 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
     _versionTTLms = versionTTLms;
     _usesExternalZkClient = usesExternalZkClient;
     _znodeTTLms = znodeTTLms;
-    if(_znodeTTLms > 0) {
-      _accessOption = AccessOption.PERSISTENT_WITH_TTL;
-    } else {
-      _accessOption = AccessOption.PERSISTENT;
-    }
+    _accessOption = getAccessOption(znodeTTLms);
   }
 
   /**
@@ -131,17 +127,6 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
   public ZkBucketDataAccessor(String zkAddr) {
     this(zkAddr, DEFAULT_BUCKET_SIZE, DEFAULT_VERSION_TTL);
   }
-
-  @VisibleForTesting
-  void setZnodeTTLms(long znodeTTLms) {
-    _znodeTTLms = znodeTTLms;
-  }
-
-  @VisibleForTesting
-  void setAccessOption(int accessOption) {
-    _accessOption = accessOption;
-  }
-
 
   private static RealmAwareZkClient createRealmAwareZkClient(String zkAddr) {
     RealmAwareZkClient zkClient;
@@ -370,6 +355,14 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
   public void finalize() {
     _zkBaseDataAccessor.close();
     close();
+  }
+
+  int getAccessOption(long znodeTTLms) {
+    if(znodeTTLms > 0) {
+      return AccessOption.PERSISTENT_WITH_TTL;
+    } else {
+      return AccessOption.PERSISTENT;
+    }
   }
 
   private synchronized void scheduleStaleVersionGC(String rootPath) {

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -159,6 +159,10 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     System.out.println("END " + testName + " at " + new Date(System.currentTimeMillis()));
   }
 
+  /**
+   *  Test to ensure async setChildren fn with ttl configured works as expected. Test verifies general setChildren functionality
+   *  and also verifies if the znodes created are configured with correct TTL.
+   */
   @Test
   public void testAsyncSetChildrenWithTTL() {
     System.setProperty("zookeeper.extendedTypesEnabled", "true");
@@ -457,6 +461,10 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     System.out.println("END " + testName + " at " + new Date(System.currentTimeMillis()));
   }
 
+  /**
+   * Test to ensure sync doUpdate fn with ttl configured works as expected. Test verifies general doUpdate functionality
+   * and also verifies if znode created are configured with correct TTL.
+   */
   @Test
   public void testSyncDoUpdateWithTTL() {
     System.setProperty("zookeeper.extendedTypesEnabled", "true");
@@ -472,6 +480,7 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     ZkBaseDataAccessor<ZNRecord> accessor = Mockito.spy(new ZkBaseDataAccessor<ZNRecord>(_gZkClient));
 
     AccessResult result = accessor.doUpdate(path, new ZNRecordUpdater(record), AccessOption.PERSISTENT_WITH_TTL);
+    // Fails as ttl is not provided when AccessOption.PERSISTENT_WITH_TTL is used
     Assert.assertEquals(result._retCode, RetCode.ERROR);
 
     result = accessor.doUpdate(path, new ZNRecordUpdater(record), AccessOption.PERSISTENT_WITH_TTL, ttl);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -238,7 +238,7 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
     ttl = -100L;  // Example of a negative TTL
     result = _bucketDataAccessor.getAccessOption(ttl);
     Assert.assertEquals(AccessOption.PERSISTENT, result,
-        "Expected PERSISTENT for zero znodeTTLms");
+        "Expected PERSISTENT for negative znodeTTLms");
   }
 
   private HelixProperty createLargeHelixProperty(String name, int numEntries) {

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -60,7 +60,7 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
   private final ZNRecord record = new ZNRecord(NAME_KEY);
 
   private HelixZkClient _zkClient;
-  private ZkBucketDataAccessor _bucketDataAccessor;
+  private BucketDataAccessor _bucketDataAccessor;
   private BaseDataAccessor<byte[]> _zkBaseDataAccessor;
   private BucketDataAccessor _fastGCBucketDataAccessor;
 
@@ -226,17 +226,17 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
   @Test
   public void testGetAccessOption() {
     long ttl = 1000L;  // Example of a positive TTL
-    int result = _bucketDataAccessor.getAccessOption(ttl);
+    int result = ZkBucketDataAccessor.getAccessOption(ttl);
     Assert.assertEquals(AccessOption.PERSISTENT_WITH_TTL, result,
         "Expected PERSISTENT_WITH_TTL for positive znodeTTLms");
 
     ttl = 0L;  // Example of a zero TTL
-    result = _bucketDataAccessor.getAccessOption(ttl);
+    result = ZkBucketDataAccessor.getAccessOption(ttl);
     Assert.assertEquals(AccessOption.PERSISTENT, result,
         "Expected PERSISTENT for zero znodeTTLms");
 
     ttl = -100L;  // Example of a negative TTL
-    result = _bucketDataAccessor.getAccessOption(ttl);
+    result = ZkBucketDataAccessor.getAccessOption(ttl);
     Assert.assertEquals(AccessOption.PERSISTENT, result,
         "Expected PERSISTENT for negative znodeTTLms");
   }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -61,7 +61,7 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
 
   private HelixZkClient _zkClient;
   private ZkBucketDataAccessor _bucketDataAccessor;
-  private ZkBaseDataAccessor<byte[]> _zkBaseDataAccessor;
+  private BaseDataAccessor<byte[]> _zkBaseDataAccessor;
   private BucketDataAccessor _fastGCBucketDataAccessor;
 
   @BeforeClass


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

This PR enables to initialize ZkBucketDataAccessor class with option to configure TTL on znodes created. To support the same, underlying base ZkBaseDataAccessor class methods are modified to accept ttl as a param. 

- Added ability to initialized ZkBucketDataAccessor with TTL configured
- If TTL enabled, for zk operations ZkBucketDataAccessor will use PERSISTENT_WITH_TTL accessoption. 
- Updated ZkBaseDataAccessor class to accept ttl as a param in doUpdate(), setChildren() methods. 

### Tests

- Unit test added for changes made to ZkBaseDataAccessor class
- Unit test added for changes made to ZkBucketDataAccessor class

### Changes that Break Backward Compatibility (Optional)

This shouldn't break existing func. 

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
