### PR TITLE
Fix flaky test - testExists in TestZookeeperAccessor

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestZooKeeperAccessor.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.ws.rs.core.Response;
 
 import org.apache.helix.AccessOption;
+import org.apache.helix.TestHelper;
 import org.apache.helix.manager.zk.ZKUtil;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.rest.server.util.JerseyUriRequestBuilder;
@@ -67,7 +68,7 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
   @Test
   public void testExists()
       throws IOException {
-    String path = "/path";
+    String path = "/" + TestHelper.getTestMethodName();
     Assert.assertFalse(_testBaseDataAccessor.exists(path, AccessOption.PERSISTENT));
     Map<String, Boolean> result;
     String data = new JerseyUriRequestBuilder("zookeeper{}?command=exists").format(path)
@@ -95,7 +96,7 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
   @Test
   public void testGetData()
       throws IOException {
-    String path = "/path";
+    String path = "/" + TestHelper.getTestMethodName();
     String content = "testGetData";
 
     Assert.assertFalse(_testBaseDataAccessor.exists(path, AccessOption.PERSISTENT));
@@ -140,18 +141,18 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
   @Test
   public void testGetChildren()
       throws IOException {
-    String path = "/path";
+    String parentPath = "/" + TestHelper.getTestMethodName();
     String childrenKey = "/children";
     int numChildren = 20;
 
     // Create a ZNode and its children
     for (int i = 0; i < numChildren; i++) {
-      _testBaseDataAccessor.create(path + childrenKey, null, AccessOption.PERSISTENT_SEQUENTIAL);
+      _testBaseDataAccessor.create(parentPath + childrenKey, null, AccessOption.PERSISTENT_SEQUENTIAL);
     }
 
     // Verify
     String getChildrenKey = "getChildren";
-    String data = new JerseyUriRequestBuilder("zookeeper{}?command=getChildren").format(path)
+    String data = new JerseyUriRequestBuilder("zookeeper{}?command=getChildren").format(parentPath)
         .isBodyReturnExpected(true).get(this);
     Map<String, List<String>> result = OBJECT_MAPPER.readValue(data, HashMap.class);
     Assert.assertTrue(result.containsKey(getChildrenKey));
@@ -163,12 +164,12 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
     });
 
     // Clean up
-    _testBaseDataAccessor.remove(path, AccessOption.PERSISTENT);
+    _testBaseDataAccessor.remove(parentPath, AccessOption.PERSISTENT);
   }
 
   @Test
   public void testGetStat() throws IOException {
-    String path = "/path/getStat";
+    String path = "/" + TestHelper.getTestMethodName();
 
     // Make sure it returns a NOT FOUND if there is no ZNode
     String data = new JerseyUriRequestBuilder("zookeeper{}?command=getStat").format(path)
@@ -194,8 +195,8 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
 
   @Test
   public void testDelete() {
-    String path = "/path";
-    String deletePath = path + "/delete";
+    String parentPath = "/" + TestHelper.getTestMethodName();
+    String deletePath = parentPath + "/delete";
 
     try {
       // 1. Create a persistent node. Delete shall fail.
@@ -215,7 +216,7 @@ public class TestZooKeeperAccessor extends AbstractTestClass {
       Assert.assertFalse(_testBaseDataAccessor.exists(deletePath, AccessOption.PERSISTENT));
     } finally {
       // Clean up
-      _testBaseDataAccessor.remove(path, AccessOption.PERSISTENT);
+      _testBaseDataAccessor.remove(parentPath, AccessOption.PERSISTENT);
     }
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
#2929 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Refactor to isolate test paths. If test method run order varies between runners, my assumption is that `testGetStat` is culprit because it creates 2 nodes when it calls create on: "/path/getStat" (/path and /path/getStat), but it only deletes node when it calls remove on: "/path/getStat" (/path/getStat), leaving the "/path" node behind. 

### Tests

- [X] The following tests are written for this issue:
N/A
Triggered multiple CI runs on my personal fork, will update PR once they are done. 

- The following is the result of the "mvn test" command on the appropriate module:

```
$ mvn test -o -Dtest=TestZooKeeperAccessor -pl=helix-rest

[INFO] Results:
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:28 min
[INFO] Finished at: 2024-09-30T16:22:11-07:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
