### PR TITLE
Synchronize calls to StreamObserver methods

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ParticipantManager.java
@@ -394,7 +394,7 @@ public class ParticipantManager {
           continue;
         }
 
-        // If the the current state is related to tasks, there is no need to carry it over to new session.
+        // If the current state is related to tasks, there is no need to carry it over to new session.
         // Note: this check is not necessary due to TaskCurrentStates, but keep it for backwards compatibility
         if (stateModelDefRef.equals(TaskConstants.STATE_MODEL_NAME)) {
           continue;

--- a/helix-gateway/src/main/java/org/apache/helix/gateway/channel/HelixGatewayServiceGrpcService.java
+++ b/helix-gateway/src/main/java/org/apache/helix/gateway/channel/HelixGatewayServiceGrpcService.java
@@ -124,7 +124,8 @@ public class HelixGatewayServiceGrpcService extends HelixGatewayServiceGrpc.Heli
     _lockRegistry.withLock(instanceName, () -> {
       StreamObserver<ShardChangeRequests> observer = _observerMap.get(instanceName);
 
-      // If observer is null, this means that the connection is already closed.
+      // If observer is null, this means that the connection is already closed and
+      // we should not send a ShardChangeRequest
       if (observer != null) {
         observer.onNext(requests);
       } else {
@@ -160,7 +161,8 @@ public class HelixGatewayServiceGrpcService extends HelixGatewayServiceGrpc.Heli
     _lockRegistry.withLock(instanceName, () -> {
       StreamObserver<ShardChangeRequests> observer = _observerMap.get(instanceName);
 
-      // If observer is null, this means that the connection is already closed.
+      // If observer is null, this means that the connection is already closed and
+      // we should not try and close it again.
       if (observer != null) {
         // Depending on whether the connection is closed with error, send different status
         if (withError) {

--- a/helix-gateway/src/main/java/org/apache/helix/gateway/channel/HelixGatewayServiceGrpcService.java
+++ b/helix-gateway/src/main/java/org/apache/helix/gateway/channel/HelixGatewayServiceGrpcService.java
@@ -120,7 +120,7 @@ public class HelixGatewayServiceGrpcService extends HelixGatewayServiceGrpc.Heli
   @Override
   public void sendStateChangeRequests(String instanceName, ShardChangeRequests requests) {
     StreamObserver<ShardChangeRequests> observer = _observerMap.get(instanceName);
-    if (observer!= null) {
+    if (observer != null) {
       // Synchronize on the observer to ensure no concurrent calls to onNext
       // since onNext is not thread safe
       synchronized (observer) {

--- a/helix-gateway/src/main/java/org/apache/helix/gateway/channel/HelixGatewayServicePollModeChannel.java
+++ b/helix-gateway/src/main/java/org/apache/helix/gateway/channel/HelixGatewayServicePollModeChannel.java
@@ -82,7 +82,7 @@ public class HelixGatewayServicePollModeChannel implements HelixGatewayServiceCh
    * 1. Get the diff of previous and current shard states, and send the state change event to the gateway manager.
    * 2. Compare previous liveness and current liveness, and send the connection event to the gateway manager.
    */
- protected  void fetchUpdates() {
+ protected void fetchUpdates() {
     // 1.  get the shard state change
     Map<String, Map<String, Map<String, Map<String, String>>>> currentShardStates =
         getChangedParticipantsCurrentState(_userCurrentStateFilePath);

--- a/helix-gateway/src/main/java/org/apache/helix/gateway/util/PollChannelUtil.java
+++ b/helix-gateway/src/main/java/org/apache/helix/gateway/util/PollChannelUtil.java
@@ -87,7 +87,7 @@ public class PollChannelUtil {
           new TypeReference<Map<String, Map<String, Map<String, Map<String, String>>>>>() {
           });
     } catch (IOException e) {
-      logger.warn("Failed to read from file: " + filePath);
+      logger.warn("Failed to read from file: " + filePath, e);
       return new HashMap<>();
     }
   }
@@ -107,7 +107,7 @@ public class PollChannelUtil {
       });
       return status.isHealthy() && (System.currentTimeMillis()/1000 - status.getLastUpdatedTime()) < timeoutInSec;
     } catch (IOException e) {
-      logger.warn("Failed to read from file: " + filePath);
+      logger.warn("Failed to read from file: " + filePath, e);
       return false;
     }
   }


### PR DESCRIPTION
### Issues

- [x] After investigation, we were seeing grpc failures related to concurrent invocations of onNext. onNext, onError, and onComplete are not thread safe so we need to synchronize invocations to these.

### Tests

NA

### Changes that Break Backward Compatibility (Optional)

NA

### Documentation (Optional)

NA

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
