### PR TITLE
Fix BestPossibleExternalViewVerifier for WAGED resource

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -276,13 +277,12 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
 
       // Filter resources if requested
       if (_resources != null && !_resources.isEmpty()) {
-        // Find waged-enabled resources among the requested resources
-        Set<String> requestedWagedResources = _resources.stream().filter(
-                resourceEntry -> WagedValidationUtil.isWagedEnabled(idealStates.get(resourceEntry)))
-            .collect(Collectors.toSet());
+        // Find if there are waged-enabled resources among the requested resources
+        boolean hasRequestedWagedResources = _resources.stream().anyMatch(
+            resourceEntry -> WagedValidationUtil.isWagedEnabled(idealStates.get(resourceEntry)));
         Set<String> resourcesToRetain = new HashSet<>(_resources);
 
-        if (!requestedWagedResources.isEmpty()) {
+        if (hasRequestedWagedResources) {
           // If waged-enabled resources are found, retain all the waged-enabled resources and the
           // user requested resources.
           resourcesToRetain.addAll(idealStates.keySet().stream().filter(

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/BestPossibleExternalViewVerifier.java
@@ -276,24 +276,22 @@ public class BestPossibleExternalViewVerifier extends ZkHelixClusterVerifier {
 
       // Filter resources if requested
       if (_resources != null && !_resources.isEmpty()) {
-        Set<String> wagedResource = _resources.stream().filter(
+        // Find waged-enabled resources among the requested resources
+        Set<String> requestedWagedResources = _resources.stream().filter(
                 resourceEntry -> WagedValidationUtil.isWagedEnabled(idealStates.get(resourceEntry)))
             .collect(Collectors.toSet());
-        if (wagedResource.isEmpty()) {
-          // If no waged-enabled resources are found, retain only the provided resources
-          idealStates.keySet().retainAll(_resources);
-          extViews.keySet().retainAll(_resources);
-        } else {
+        Set<String> resourcesToRetain = new HashSet<>(_resources);
+
+        if (!requestedWagedResources.isEmpty()) {
           // If waged-enabled resources are found, retain all the waged-enabled resources and the
           // user requested resources.
-          Set<String> resourcesToRetain = idealStates.keySet().stream().filter(
+          resourcesToRetain.addAll(idealStates.keySet().stream().filter(
                   resourceEntry -> WagedValidationUtil.isWagedEnabled(idealStates.get(resourceEntry)))
-              .collect(Collectors.toSet());
-          resourcesToRetain.addAll(_resources);
-
-          idealStates.keySet().retainAll(resourcesToRetain);
-          extViews.keySet().retainAll(resourcesToRetain);
+              .collect(Collectors.toSet()));
         }
+
+        idealStates.keySet().retainAll(resourcesToRetain);
+        extViews.keySet().retainAll(resourcesToRetain);
       }
 
       // if externalView is not empty and idealState doesn't exist


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
#2938 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Fix the bug where BestPossibleExternalViewVerifier fails to accurately verify WAGED resources. If the user has requested the WAGED resources, the verifier should run against the resources of whole cluster. We can achieve it by `_resources.clear()`.

### Tests

- [X] The following tests are written for this issue:

The current test should be enough to capture this.

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
