### PR TITLE
Fix gateway e2e test - set timestamp in second instead of ms

### DIFF
--- a/helix-gateway/src/main/java/org/apache/helix/gateway/service/GatewayServiceManager.java
+++ b/helix-gateway/src/main/java/org/apache/helix/gateway/service/GatewayServiceManager.java
@@ -119,7 +119,7 @@ public class GatewayServiceManager {
    */
   public  Map<String, Map<String, Map<String, String>>> updateCacheWithNewCurrentStateAndGetDiff(String clusterName,
       Map<String, Map<String, Map<String, String>>> newCurrentStateMap) {
-   return  getOrCreateCache(clusterName).updateCacheWithNewCurrentStateAndGetDiff(newCurrentStateMap);
+   return getOrCreateCache(clusterName).updateCacheWithNewCurrentStateAndGetDiff(newCurrentStateMap);
   }
 
   public void updateCurrentState(String clusterName, String instanceName, String resourceId, String shardId, String toState) {

--- a/helix-gateway/src/test/java/org/apache/helix/gateway/integration/TestFilePullChannelE2E.java
+++ b/helix-gateway/src/test/java/org/apache/helix/gateway/integration/TestFilePullChannelE2E.java
@@ -89,7 +89,7 @@ public class TestFilePullChannelE2E extends HelixGatewayTestBase {
       for (int i = 0; i < START_NUM_NODE; i++) {
         csPaths.add(createTempFile(currentStatePath + i, ".txt", ""));
         targetPaths.add(createTempFile(targetStatePath + i, ".txt", ""));
-        String currentTime = String.valueOf(System.currentTimeMillis());
+        String currentTime = String.valueOf(System.currentTimeMillis()/1000);
         String content = "{\"IsAlive\":" + true + ",\"LastUpdateTime\":" + currentTime + "}";
         healthPaths.add(createTempFile("tmphealthCheck" + i, ".txt", content));
       }
@@ -158,15 +158,18 @@ public class TestFilePullChannelE2E extends HelixGatewayTestBase {
     // check no pending messages for partitions
     verifyNoPendingMessages(List.of("instance0", "instance1", "instance2"));
 
-    // change health state to false on one instance
-    String currentTime = String.valueOf(System.currentTimeMillis());
-    String content = "{\"IsAlive\":" + false + ",\"LastUpdateTime\":" + currentTime + "}";
+    // change health state to false on two instances
+    String currentTime = String.valueOf(System.currentTimeMillis()/1000 - 100);
+    String content = "{\"IsAlive\":" + true + ",\"LastUpdateTime\":" + currentTime + "}";
     Files.write(healthPaths.get(0), content.getBytes());
+
+    String content2 = "{\"IsAlive\":" + false + ",\"LastUpdateTime\":" + currentTime + "}";
+    Files.write(healthPaths.get(1), content2.getBytes());
 
     // check live instance for that instance is gone
     Assert.assertTrue(TestHelper.verify(() -> {
       List<String> liveInstance = getLiveInstances();
-      return !liveInstance.contains("instance0") && liveInstance.contains("instance1") && liveInstance.contains(
+      return !liveInstance.contains("instance0") && !liveInstance.contains("instance1") && liveInstance.contains(
           "instance2");
     }, TestHelper.WAIT_DURATION));
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
Fix gateway e2e test - set timestamp in second instead of ms

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
This change fix a minor bug in e2e test - setting timestamp in second instead of ms.

### Tests

- [X] The following tests are written for this issue:
NA

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
