### PR TITLE
[apache/helix] -- Added cache refresh trigger after cleaning up of a workflow.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowDispatcher.java
@@ -525,6 +525,8 @@ public class WorkflowDispatcher extends AbstractTaskDispatcher {
         // clean all the contexts even if Configs and IdealStates are exists. Then all the workflows
         // and jobs will rescheduled again.
         removeContexts(workflow, jobs, _clusterDataCache.getTaskDataCache());
+        // Request for full-data refresh to re-fetch workflow resource configs.
+        _clusterDataCache.requireFullRefresh();
       }
     } else {
       LOG.info(

--- a/helix-core/src/main/java/org/apache/helix/task/WorkflowDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/WorkflowDispatcher.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.TimeZone;
 
 import com.google.common.collect.Lists;
+import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixProperty;
@@ -77,6 +78,8 @@ public class WorkflowDispatcher extends AbstractTaskDispatcher {
       LOG.debug("Workflow is marked as deleted {} cleaning up the workflow context.", workflow);
       updateInflightJobs(workflow, workflowCtx, currentStateOutput, bestPossibleOutput);
       cleanupWorkflow(workflow);
+      // Request for complete resource config refresh, when a workflow is explicitly marked as DELETED.
+      _clusterDataCache.notifyDataChange(HelixConstants.ChangeType.RESOURCE_CONFIG);
       return;
     }
 
@@ -525,8 +528,6 @@ public class WorkflowDispatcher extends AbstractTaskDispatcher {
         // clean all the contexts even if Configs and IdealStates are exists. Then all the workflows
         // and jobs will rescheduled again.
         removeContexts(workflow, jobs, _clusterDataCache.getTaskDataCache());
-        // Request for full-data refresh to re-fetch workflow resource configs.
-        _clusterDataCache.requireFullRefresh();
       }
     } else {
       LOG.info(


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes #2957

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

> When a Workflow is marked as deleted (TargetState.DELETE) via TaskDriver.delete API, then in the workflow is deleted by the pipeline in the next run. With deletion, the entries from ZK is deleted and the TaskDataCache is also updated. However, the other entries are still present in ResourceConfig (Base) cache. Usually, the next event which is in the pipeline is the ResourceConfigChange Event, which takes care of the resourceConfig cache update, but in case of a very busy cluster, other change event might be earlier in the pipeline than ResourceConfigChange event. Now, the ResourceConfig cache is updated selectively and not always so the ResourceConfig cache keeps the deleted workflow entries, and when the Workflow (TaskDataCache) is prepared, these (previously deleted) workflow entries comes back in again. This causes, same workflows to be deleted multiple times. (Until we see the ResourceConfigChange or OnDemandRebalance event).

> In Busy Cluster, the resourceConfig cache can take time to be eventually consistent and this causes duplicate deletes of the same workflow.

- [x] Impact
> Some customers delete and re-create workflow with same name and this behavior causes the recently deleted workflow to be deleted again (unexpectedly).

### Tests

- [x] The following tests are written for this issue:
org.apache.helix.integration.task.TestDeleteWorkflow#testDeleteWorkflowAndRecreate

- The following is the result of the "mvn test" command on the appropriate module:
```console
mvn test -Dtest=TestDeleteWorkflow -pl=helix-core 

[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 30.505 s - in org.apache.helix.integration.task.TestDeleteWorkflow
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 957 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  48.378 s
[INFO] Finished at: 2024-11-03T15:10:56-08:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
