### PR TITLE
Fix helix-rest memory leak

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/client/CustomRestClientImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/client/CustomRestClientImpl.java
@@ -202,6 +202,7 @@ class CustomRestClientImpl implements CustomRestClient {
             LOG.warn("Received 302 but no Location header is present, stopping retries.");
             break;  // Break out if there is no valid redirect location
           }
+          EntityUtils.consume(response.getEntity());
         } else {
           LOG.warn("Received non-200 and non-302 status code: {}, payloads: {}", status, payloads);
           return response;  // Return response without retry

--- a/helix-rest/src/main/java/org/apache/helix/rest/client/CustomRestClientImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/client/CustomRestClientImpl.java
@@ -202,7 +202,7 @@ class CustomRestClientImpl implements CustomRestClient {
             LOG.warn("Received 302 but no Location header is present, stopping retries.");
             break;  // Break out if there is no valid redirect location
           }
-          EntityUtils.consume(response.getEntity());
+          EntityUtils.consumeQuietly(response.getEntity());
         } else {
           LOG.warn("Received non-200 and non-302 status code: {}, payloads: {}", status, payloads);
           return response;  // Return response without retry

--- a/helix-rest/src/test/java/org/apache/helix/rest/client/TestCustomRestClient.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/client/TestCustomRestClient.java
@@ -175,7 +175,6 @@ public class TestCustomRestClient {
   @Test (description = "Validate if the post request has memory leak or no")
   public void testMultiplePost() throws IOException {
     // a popular echo server that echos all the inputs
-    // TODO: add a mock rest server
     final String echoServer = "https://httpbin.org/redirect-to?url=http://httpbin.org/post";
     HttpClientBuilder httpClientBuilder = HttpClients.custom()
         .evictExpiredConnections()

--- a/helix-rest/src/test/java/org/apache/helix/rest/client/TestCustomRestClient.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/client/TestCustomRestClient.java
@@ -36,7 +36,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -186,7 +185,7 @@ public class TestCustomRestClient {
     CustomRestClientImpl customRestClient = new CustomRestClientImpl(httpClient);
     HttpResponse response;
 
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 5; i++) {
       response = customRestClient.post(echoServer, Collections.emptyMap());
       if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
         JsonNode json = customRestClient.getJsonObject(response);


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
- #2959 

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Fix the memory leak by consuming the entity before 

### Tests

- [X] The following tests are written for this issue:
- `mvn test -Dtest=TestCustomRestClient -pl helix-rest`

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
