### PR TITLE
Support Stoppable Check for Non-Topology-Aware Clusters

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/client/CustomRestClientImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/client/CustomRestClientImpl.java
@@ -132,8 +132,15 @@ class CustomRestClientImpl implements CustomRestClient {
     if (instances != null && !instances.isEmpty()) {
       payLoads.put("instances", instances);
     }
-    if (toBeStoppedInstances != null && !toBeStoppedInstances.isEmpty()) {
-      payLoads.put("to_be_stopped_instances", toBeStoppedInstances);
+    // Before sending the request, make sure the toBeStoppedInstances has no overlap with instances
+    Set<String> remainingToBeStoppedInstances = toBeStoppedInstances;
+    if (instances != null && toBeStoppedInstances != null) {
+      remainingToBeStoppedInstances =
+          toBeStoppedInstances.stream().filter(ins -> !instances.contains(ins))
+              .collect(Collectors.toSet());
+    }
+    if (remainingToBeStoppedInstances != null && !remainingToBeStoppedInstances.isEmpty()) {
+      payLoads.put("to_be_stopped_instances", remainingToBeStoppedInstances);
     }
     if (clusterId != null) {
       payLoads.put("cluster_id", clusterId);

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/StoppableInstancesSelector.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/StoppableInstancesSelector.java
@@ -86,8 +86,7 @@ public class StoppableInstancesSelector {
         result.putArray(InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name());
     ObjectNode failedStoppableInstances = result.putObject(
         InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
-    Set<String> toBeStoppedInstancesSet = new HashSet<>(toBeStoppedInstances);
-    findToBeStoppedInstances(toBeStoppedInstancesSet);
+    Set<String> toBeStoppedInstancesSet = findToBeStoppedInstances(toBeStoppedInstances);
 
     List<String> zoneBasedInstance =
         getZoneBasedInstances(instances, _clusterTopology.toZoneMapping());
@@ -118,8 +117,7 @@ public class StoppableInstancesSelector {
         result.putArray(InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name());
     ObjectNode failedStoppableInstances = result.putObject(
         InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
-    Set<String> toBeStoppedInstancesSet = new HashSet<>(toBeStoppedInstances);
-    findToBeStoppedInstances(toBeStoppedInstancesSet);
+    Set<String> toBeStoppedInstancesSet = findToBeStoppedInstances(toBeStoppedInstances);
 
     Map<String, Set<String>> zoneMapping = _clusterTopology.toZoneMapping();
     for (String zone : _orderOfZone) {
@@ -156,8 +154,7 @@ public class StoppableInstancesSelector {
         result.putArray(InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name());
     ObjectNode failedStoppableInstances = result.putObject(
         InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
-    Set<String> toBeStoppedInstancesSet = new HashSet<>(toBeStoppedInstances);
-    findToBeStoppedInstances(toBeStoppedInstancesSet);
+    Set<String> toBeStoppedInstancesSet = findToBeStoppedInstances(toBeStoppedInstances);
 
     // Because zone order calculation is omitted, we must verify each instance's existence
     // to ensure we only process valid instances before performing stoppable check.
@@ -294,11 +291,12 @@ public class StoppableInstancesSelector {
 
   /**
    * Collect instances within the cluster where the instance operation is set to EVACUATE, SWAP_IN, or UNKNOWN.
-   * And add them into the given toBeStoppedInstances set.
+   * And return them as a set.
    *
-   * @param toBeStoppedInstances A set of instances we presume to be stopped.
+   * @param toBeStoppedInstances A list of instances we presume to be stopped.
    */
-  private void findToBeStoppedInstances(Set<String> toBeStoppedInstances) {
+  private Set<String> findToBeStoppedInstances(List<String> toBeStoppedInstances) {
+    Set<String> toBeStoppedInstancesSet = new HashSet<>(toBeStoppedInstances);
     Set<String> allInstances = _clusterTopology.getAllInstances();
     for (String instance : allInstances) {
       PropertyKey.Builder propertyKeyBuilder = _dataAccessor.keyBuilder();
@@ -308,9 +306,10 @@ public class StoppableInstancesSelector {
       if (operation == InstanceConstants.InstanceOperation.EVACUATE
           || operation == InstanceConstants.InstanceOperation.SWAP_IN
           || operation == InstanceConstants.InstanceOperation.UNKNOWN) {
-        toBeStoppedInstances.add(instance);
+        toBeStoppedInstancesSet.add(instance);
       }
     }
+    return toBeStoppedInstancesSet;
   }
 
   public static class StoppableInstancesSelectorBuilder {

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/StoppableInstancesSelector.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/StoppableInstancesSelector.java
@@ -136,6 +136,40 @@ public class StoppableInstancesSelector {
     return result;
   }
 
+  /**
+   * Evaluates and collects stoppable instances without respecting the zone order.
+   * The method iterates through instances, performing stoppable checks, and records reasons for
+   * non-stoppability.
+   *
+   * @param instances A list of instance to be evaluated.
+   * @param toBeStoppedInstances A list of instances presumed to be already stopped
+   * @return An ObjectNode containing:
+   *         - 'stoppableNode': List of instances that can be stopped.
+   *         - 'instance_not_stoppable_with_reasons': A map with the instance name as the key and
+   *         a list of reasons for non-stoppability as the value.
+   * @throws IOException
+   */
+  public ObjectNode getStoppableInstancesWithoutTopology(List<String> instances,
+      List<String> toBeStoppedInstances) throws IOException {
+    ObjectNode result = JsonNodeFactory.instance.objectNode();
+    ArrayNode stoppableInstances =
+        result.putArray(InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name());
+    ObjectNode failedStoppableInstances = result.putObject(
+        InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
+    Set<String> toBeStoppedInstancesSet = new HashSet<>(toBeStoppedInstances);
+    collectEvacuatingInstances(toBeStoppedInstancesSet);
+
+    // Because zone order calculation is omitted, we must verify each instance's existence
+    // to ensure we only process valid instances before performing stoppable check.
+    Set<String> nonExistingInstances = processNonexistentInstances(instances, failedStoppableInstances);
+    List<String> instancesToCheck = new ArrayList<>(instances);
+    instancesToCheck.removeAll(nonExistingInstances);
+    populateStoppableInstances(instancesToCheck, toBeStoppedInstancesSet, stoppableInstances,
+        failedStoppableInstances);
+
+    return result;
+  }
+
   private void populateStoppableInstances(List<String> instances, Set<String> toBeStoppedInstances,
       ArrayNode stoppableInstances, ObjectNode failedStoppableInstances) throws IOException {
     Map<String, StoppableCheck> instancesStoppableChecks =
@@ -159,7 +193,7 @@ public class StoppableInstancesSelector {
     }
   }
 
-  private void processNonexistentInstances(List<String> instances, ObjectNode failedStoppableInstances) {
+  private Set<String> processNonexistentInstances(List<String> instances, ObjectNode failedStoppableInstances) {
     // Adding following logic to check whether instances exist or not. An instance exist could be
     // checking following scenario:
     // 1. Instance got dropped. (InstanceConfig is gone.)
@@ -174,6 +208,7 @@ public class StoppableInstancesSelector {
       ArrayNode failedReasonsNode = failedStoppableInstances.putArray(nonSelectedInstance);
       failedReasonsNode.add(JsonNodeFactory.instance.textNode(INSTANCE_NOT_EXIST));
     }
+    return nonSelectedInstances;
   }
 
   /**

--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/StoppableInstancesSelector.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/StoppableInstancesSelector.java
@@ -293,8 +293,8 @@ public class StoppableInstancesSelector {
   }
 
   /**
-   * Collect instances marked for evacuation, swap, or unkown in the current topology and add
-   * them into the given set
+   * Collect instances within the cluster where the instance operation is set to EVACUATE, SWAP_IN, or UNKNOWN.
+   * And add them into the given toBeStoppedInstances set.
    *
    * @param toBeStoppedInstances A set of instances we presume to be stopped.
    */

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/ClusterService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/ClusterService.java
@@ -41,4 +41,11 @@ public interface ClusterService {
    * @return
    */
   ClusterInfo getClusterInfo(String clusterId);
+
+  /**
+   * Check if the cluster is topology aware
+   * @param clusterId
+   * @return
+   */
+  boolean isClusterTopologyAware(String clusterId);
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/ClusterServiceImpl.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/ClusterServiceImpl.java
@@ -25,10 +25,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import io.netty.util.internal.StringUtil;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.PropertyKey;
+import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.rest.server.json.cluster.ClusterInfo;
@@ -101,5 +103,12 @@ public class ClusterServiceImpl implements ClusterService {
         .idealStates(_dataAccessor.getChildNames(keyBuilder.idealStates()))
         .instances(_dataAccessor.getChildNames(keyBuilder.instances()))
         .liveInstances(_dataAccessor.getChildNames(keyBuilder.liveInstances())).build();
+  }
+
+  @Override
+  public boolean isClusterTopologyAware(String clusterId) {
+    ClusterConfig config = _configAccessor.getClusterConfig(clusterId);
+    return config.isTopologyAwareEnabled() && !StringUtil.isNullOrEmpty(config.getFaultZoneType())
+        && !StringUtil.isNullOrEmpty(config.getTopology());
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/client/TestCustomRestClient.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/client/TestCustomRestClient.java
@@ -37,14 +37,18 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 import org.junit.Assert;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class TestCustomRestClient {
@@ -233,5 +237,40 @@ public class TestCustomRestClient {
     Assert.assertTrue(Arrays.stream(instances).allMatch(clusterHealth::containsKey));
     Assert.assertTrue(Arrays.stream(healthyInstances).allMatch(instance -> clusterHealth.get(instance).isEmpty()));
     Assert.assertTrue(Arrays.stream(nonStoppableInstances).noneMatch(instance -> clusterHealth.get(instance).isEmpty()));
+  }
+
+  @Test(description = "Test if the aggregated stoppable check request has the correct format when there"
+      + "are duplicate instances in the instances list and the toBeStoppedInstances list.")
+  public void testAggregatedCheckRemoveDuplicateInstances()
+      throws IOException {
+    String clusterId = "cluster1";
+
+    MockCustomRestClient customRestClient = new MockCustomRestClient(_httpClient);
+    HttpResponse httpResponse = mock(HttpResponse.class);
+    StatusLine statusLine = mock(StatusLine.class);
+
+    when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(_httpClient.execute(any(HttpPost.class))).thenReturn(httpResponse);
+
+    customRestClient.getAggregatedStoppableCheck(HTTP_LOCALHOST,
+        ImmutableList.of("n1", "n2"),
+        ImmutableSet.of("n1"), clusterId, Collections.emptyMap());
+
+    // Make sure that the duplicate instances are removed from the toBeStoppedInstances list
+    ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    verify(_httpClient).execute(argThat(x -> {
+      String request = null;
+      try {
+        request = EntityUtils.toString(((HttpPost) x).getEntity());
+        JsonNode node = OBJECT_MAPPER.readTree(request);
+        String instancesInRequest = node.get("instances").toString();
+        Assert.assertEquals(instancesInRequest, "[\"n1\",\"n2\"]");
+        Assert.assertNull(node.get("to_be_stopped_instances"));
+        return true;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }));
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
@@ -132,6 +132,7 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
   protected static BaseDataAccessor<ZNRecord> _baseAccessorTestNS;
   protected static final String STOPPABLE_CLUSTER = "StoppableTestCluster";
   protected static final String STOPPABLE_CLUSTER2 = "StoppableTestCluster2";
+  protected static final String STOPPABLE_CLUSTER3 = "StoppableTestCluster3";
   protected static final String TASK_TEST_CLUSTER = "TaskTestCluster";
   protected static final List<String> STOPPABLE_INSTANCES =
       Arrays.asList("instance0", "instance1", "instance2", "instance3", "instance4", "instance5");
@@ -343,6 +344,7 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
     }
     preSetupForParallelInstancesStoppableTest(STOPPABLE_CLUSTER, STOPPABLE_INSTANCES);
     preSetupForCrosszoneParallelInstancesStoppableTest(STOPPABLE_CLUSTER2, STOPPABLE_INSTANCES2);
+    preSetupForNonTopoAwareInstancesStoppableTest(STOPPABLE_CLUSTER3, STOPPABLE_INSTANCES2);
   }
 
   protected Set<String> createInstances(String cluster, int numInstances) {
@@ -671,6 +673,62 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
       if (++curZoneCount >= perZoneInstancesCount) {
         curZoneCount = 0;
         zoneId++;
+      }
+      instanceConfigs.add(instanceConfig);
+    }
+
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      _gSetupTool.getClusterManagementTool().addInstance(clusterName, instanceConfig);
+    }
+
+    // Start participant
+    startInstances(clusterName, new TreeSet<>(instances), instances.size());
+    createResources(clusterName, 1, 2, 3);
+    _clusterControllerManagers.add(startController(clusterName));
+
+    // Make sure that cluster config exists
+    boolean isClusterConfigExist = TestHelper.verify(() -> {
+      ClusterConfig stoppableClusterConfig;
+      try {
+        stoppableClusterConfig = _configAccessor.getClusterConfig(clusterName);
+      } catch (Exception e) {
+        return false;
+      }
+      return (stoppableClusterConfig != null);
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(isClusterConfigExist);
+    // Make sure that instance config exists for the instance0 to instance5
+    for (String instance: instances) {
+      boolean isinstanceConfigExist = TestHelper.verify(() -> {
+        InstanceConfig instanceConfig;
+        try {
+          instanceConfig = _configAccessor.getInstanceConfig(clusterName, instance);
+        } catch (Exception e) {
+          return false;
+        }
+        return (instanceConfig != null);
+      }, TestHelper.WAIT_DURATION);
+      Assert.assertTrue(isinstanceConfigExist);
+    }
+    _clusters.add(clusterName);
+    _workflowMap.put(clusterName, createWorkflows(clusterName, 3));
+  }
+
+  private void preSetupForNonTopoAwareInstancesStoppableTest(String clusterName,
+      List<String> instances) throws Exception {
+    _gSetupTool.addCluster(clusterName, true);
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(clusterName);
+    clusterConfig.setFaultZoneType("helixZoneId");
+    clusterConfig.setPersistIntermediateAssignment(true);
+    _configAccessor.setClusterConfig(clusterName, clusterConfig);
+    // Create instance configs that do not include the domain field
+    List<InstanceConfig> instanceConfigs = new ArrayList<>();
+    int perZoneInstancesCount = 3;
+    int curZoneCount = 0;
+    for (int i = 0; i < instances.size(); i++) {
+      InstanceConfig instanceConfig = new InstanceConfig(instances.get(i));
+      if (++curZoneCount >= perZoneInstancesCount) {
+        curZoneCount = 0;
       }
       instanceConfigs.add(instanceConfig);
     }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/AbstractTestClass.java
@@ -604,6 +604,8 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
     _gSetupTool.addCluster(clusterName, true);
     ClusterConfig clusterConfig = _configAccessor.getClusterConfig(clusterName);
     clusterConfig.setFaultZoneType("helixZoneId");
+    clusterConfig.setTopologyAwareEnabled(true);
+    clusterConfig.setTopology("/helixZoneId/instance");
     clusterConfig.setPersistIntermediateAssignment(true);
     _configAccessor.setClusterConfig(clusterName, clusterConfig);
     // Create instance configs
@@ -661,6 +663,8 @@ public class AbstractTestClass extends JerseyTestNg.ContainerPerClassTest {
     _gSetupTool.addCluster(clusterName, true);
     ClusterConfig clusterConfig = _configAccessor.getClusterConfig(clusterName);
     clusterConfig.setFaultZoneType("helixZoneId");
+    clusterConfig.setTopologyAwareEnabled(true);
+    clusterConfig.setTopology("/helixZoneId/instance");
     clusterConfig.setPersistIntermediateAssignment(true);
     _configAccessor.setClusterConfig(clusterName, clusterConfig);
     // Create instance configs

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -642,7 +642,7 @@ public class TestInstancesAccessor extends AbstractTestClass {
     String content = String.format(
         "{\"%s\":\"%s\",\"%s\":[\"%s\",\"%s\",\"%s\",\"%s\", \"%s\", \"%s\", \"%s\",\"%s\", \"%s\", \"%s\"], \"%s\":[\"%s\", \"%s\"]}",
         InstancesAccessor.InstancesProperties.selection_base.name(),
-        InstancesAccessor.InstanceHealthSelectionBase.non_topo_based.name(),
+        InstancesAccessor.InstanceHealthSelectionBase.non_zone_based.name(),
         InstancesAccessor.InstancesProperties.instances.name(), "instance1", "instance3",
         "instance6", "instance9", "instance10", "instance11", "instance12", "instance13",
         "instance14", "invalidInstance",
@@ -657,7 +657,7 @@ public class TestInstancesAccessor extends AbstractTestClass {
     String instance1 = "instance1";
     InstanceConfig instanceConfig1 =
         _configAccessor.getInstanceConfig(STOPPABLE_CLUSTER3, instance1);
-    instanceConfig1.setInstanceOperation(InstanceConstants.InstanceOperation.EVACUATE);
+    instanceConfig1.setInstanceOperation(InstanceConstants.InstanceOperation.SWAP_IN);
     _configAccessor.setInstanceConfig(STOPPABLE_CLUSTER3, instance1, instanceConfig1);
 
     // It takes time to reflect the changes.
@@ -718,6 +718,49 @@ public class TestInstancesAccessor extends AbstractTestClass {
         .isBodyReturnExpected(true)
         .expectedReturnStatusCode(Response.Status.BAD_REQUEST.getStatusCode())
         .post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
+
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(description = "Test zone selection base with instance that don't have topology set in the config",
+   dependsOnMethods = "testNonTopoAwareStoppableCheckWithException")
+  public void testZoneSelectionBaseWithInstanceThatDontHaveTopologySet() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+
+    // STOPPABLE_CLUSTER3 is a cluster is non topology aware cluster
+    String content = String.format(
+        "{\"%s\":\"%s\",\"%s\":[\"%s\",\"%s\",\"%s\",\"%s\", \"%s\", \"%s\", \"%s\",\"%s\", \"%s\", \"%s\"], \"%s\":[\"%s\", \"%s\"]}",
+        InstancesAccessor.InstancesProperties.selection_base.name(),
+        InstancesAccessor.InstanceHealthSelectionBase.cross_zone_based.name(),
+        InstancesAccessor.InstancesProperties.instances.name(), "instance1", "instance3",
+        "instance6", "instance9", "instance10", "instance11", "instance12", "instance13",
+        "instance14", "invalidInstance",
+        InstancesAccessor.InstancesProperties.skip_stoppable_check_list.name(), "INSTANCE_NOT_ENABLED", "INSTANCE_NOT_STABLE");
+
+    String instance1 = "instance1";
+    InstanceConfig instanceConfig1 =
+        _configAccessor.getInstanceConfig(STOPPABLE_CLUSTER2, instance1);
+    String domain = instanceConfig1.getDomainAsString();
+    instanceConfig1.setDomain("FALSE_DOMAIN");
+    _configAccessor.setInstanceConfig(STOPPABLE_CLUSTER2, instance1, instanceConfig1);
+
+    // It takes time to reflect the changes.
+    BestPossibleExternalViewVerifier verifier =
+        new BestPossibleExternalViewVerifier.Builder(STOPPABLE_CLUSTER3).setZkAddr(ZK_ADDR).build();
+    Assert.assertTrue(verifier.verifyByPolling());
+
+    // Making the REST Call to cross zone stoppable check while the cluster has no topology aware
+    // setup. The call should return an error.
+    Response response = new JerseyUriRequestBuilder(
+        "clusters/{}/instances?command=stoppable&skipHealthCheckCategories=CUSTOM_INSTANCE_CHECK,CUSTOM_PARTITION_CHECK").format(
+            STOPPABLE_CLUSTER3)
+        .isBodyReturnExpected(true)
+        .expectedReturnStatusCode(Response.Status.BAD_REQUEST.getStatusCode())
+        .post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
+
+    // Restore the changes on instance 1
+    instanceConfig1.setDomain(domain);
+    _configAccessor.setInstanceConfig(STOPPABLE_CLUSTER3, instance1, instanceConfig1);
 
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -30,6 +30,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -630,6 +631,94 @@ public class TestInstancesAccessor extends AbstractTestClass {
     _configAccessor.setInstanceConfig(STOPPABLE_CLUSTER2, instance0, instanceConfig);
     instanceConfig1.setInstanceOperation(InstanceConstants.InstanceOperation.ENABLE);
     _configAccessor.setInstanceConfig(STOPPABLE_CLUSTER2, instance1, instanceConfig1);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testSkipClusterLevelHealthCheck")
+  public void testNonTopoAwareStoppableCheck() throws JsonProcessingException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+
+    // STOPPABLE_CLUSTER3 is a cluster is non topology aware cluster
+    String content = String.format(
+        "{\"%s\":\"%s\",\"%s\":[\"%s\",\"%s\",\"%s\",\"%s\", \"%s\", \"%s\", \"%s\",\"%s\", \"%s\", \"%s\"], \"%s\":[\"%s\", \"%s\"]}",
+        InstancesAccessor.InstancesProperties.selection_base.name(),
+        InstancesAccessor.InstanceHealthSelectionBase.non_topo_based.name(),
+        InstancesAccessor.InstancesProperties.instances.name(), "instance1", "instance3",
+        "instance6", "instance9", "instance10", "instance11", "instance12", "instance13",
+        "instance14", "invalidInstance",
+        InstancesAccessor.InstancesProperties.skip_stoppable_check_list.name(), "INSTANCE_NOT_ENABLED", "INSTANCE_NOT_STABLE");
+
+    // Change instance config of instance1 & instance0 to be evacuating
+    String instance0 = "instance0";
+    InstanceConfig instanceConfig =
+        _configAccessor.getInstanceConfig(STOPPABLE_CLUSTER3, instance0);
+    instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.EVACUATE);
+    _configAccessor.setInstanceConfig(STOPPABLE_CLUSTER3, instance0, instanceConfig);
+    String instance1 = "instance1";
+    InstanceConfig instanceConfig1 =
+        _configAccessor.getInstanceConfig(STOPPABLE_CLUSTER3, instance1);
+    instanceConfig1.setInstanceOperation(InstanceConstants.InstanceOperation.EVACUATE);
+    _configAccessor.setInstanceConfig(STOPPABLE_CLUSTER3, instance1, instanceConfig1);
+
+    // It takes time to reflect the changes.
+    BestPossibleExternalViewVerifier verifier =
+        new BestPossibleExternalViewVerifier.Builder(STOPPABLE_CLUSTER3).setZkAddr(ZK_ADDR).build();
+    Assert.assertTrue(verifier.verifyByPolling());
+
+    Response response = new JerseyUriRequestBuilder(
+        "clusters/{}/instances?command=stoppable&skipHealthCheckCategories=CUSTOM_INSTANCE_CHECK,CUSTOM_PARTITION_CHECK").format(
+        STOPPABLE_CLUSTER3).post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
+    JsonNode jsonNode = OBJECT_MAPPER.readTree(response.readEntity(String.class));
+
+    Set<String> stoppableSet = getStringSet(jsonNode,
+        InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name());
+    Assert.assertTrue(stoppableSet.contains("instance12") && stoppableSet.contains("instance3")
+        && stoppableSet.contains("instance10"));
+
+    JsonNode nonStoppableInstances = jsonNode.get(
+        InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
+    Assert.assertEquals(getStringSet(nonStoppableInstances, "instance13"),
+        ImmutableSet.of("HELIX:MIN_ACTIVE_REPLICA_CHECK_FAILED"));
+    Assert.assertEquals(getStringSet(nonStoppableInstances, "instance14"),
+        ImmutableSet.of("HELIX:MIN_ACTIVE_REPLICA_CHECK_FAILED"));
+    Assert.assertEquals(getStringSet(nonStoppableInstances, "invalidInstance"),
+        ImmutableSet.of("HELIX:INSTANCE_NOT_EXIST"));
+    instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.ENABLE);
+    _configAccessor.setInstanceConfig(STOPPABLE_CLUSTER3, instance0, instanceConfig);
+    instanceConfig1.setInstanceOperation(InstanceConstants.InstanceOperation.ENABLE);
+    _configAccessor.setInstanceConfig(STOPPABLE_CLUSTER3, instance1, instanceConfig1);
+
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testSkipClusterLevelHealthCheck")
+  public void testNonTopoAwareStoppableCheckWithException() throws JsonProcessingException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+
+    // STOPPABLE_CLUSTER3 is a cluster is non topology aware cluster
+    String content = String.format(
+        "{\"%s\":\"%s\",\"%s\":[\"%s\",\"%s\",\"%s\",\"%s\", \"%s\", \"%s\", \"%s\",\"%s\", \"%s\", \"%s\"], \"%s\":[\"%s\", \"%s\"]}",
+        InstancesAccessor.InstancesProperties.selection_base.name(),
+        InstancesAccessor.InstanceHealthSelectionBase.cross_zone_based.name(),
+        InstancesAccessor.InstancesProperties.instances.name(), "instance1", "instance3",
+        "instance6", "instance9", "instance10", "instance11", "instance12", "instance13",
+        "instance14", "invalidInstance",
+        InstancesAccessor.InstancesProperties.skip_stoppable_check_list.name(), "INSTANCE_NOT_ENABLED", "INSTANCE_NOT_STABLE");
+
+    // It takes time to reflect the changes.
+    BestPossibleExternalViewVerifier verifier =
+        new BestPossibleExternalViewVerifier.Builder(STOPPABLE_CLUSTER3).setZkAddr(ZK_ADDR).build();
+    Assert.assertTrue(verifier.verifyByPolling());
+
+    // Making the REST Call to cross zone stoppable check while the cluster has no topology aware
+    // setup. The call should return an error.
+    Response response = new JerseyUriRequestBuilder(
+        "clusters/{}/instances?command=stoppable&skipHealthCheckCategories=CUSTOM_INSTANCE_CHECK,CUSTOM_PARTITION_CHECK").format(
+        STOPPABLE_CLUSTER3)
+        .isBodyReturnExpected(true)
+        .expectedReturnStatusCode(Response.Status.BAD_REQUEST.getStatusCode())
+        .post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
+
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestClusterService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestClusterService.java
@@ -96,6 +96,30 @@ public class TestClusterService {
     Assert.assertEquals(clusterTopology.getClusterId(), TEST_CLUSTER);
   }
 
+  @Test
+  public void testCheckTopologyAware() {
+    Mock mock = new Mock();
+    Assert.assertFalse(mock.clusterService.isClusterTopologyAware(TEST_CLUSTER));
+
+    ClusterConfig config = new ClusterConfig(TEST_CLUSTER);
+    config.setTopology("/zone");
+    when(mock.configAccessor.getClusterConfig(TEST_CLUSTER)).thenReturn(config);
+    Assert.assertFalse(mock.clusterService.isClusterTopologyAware(TEST_CLUSTER));
+
+    config = new ClusterConfig(TEST_CLUSTER);
+    config.setFaultZoneType("zone");
+    config.setTopology("/zone");
+    when(mock.configAccessor.getClusterConfig(TEST_CLUSTER)).thenReturn(config);
+    Assert.assertFalse(mock.clusterService.isClusterTopologyAware(TEST_CLUSTER));
+
+    config = new ClusterConfig(TEST_CLUSTER);
+    config.setFaultZoneType("zone");
+    config.setTopology("/zone");
+    config.setTopologyAwareEnabled(true);
+    when(mock.configAccessor.getClusterConfig(TEST_CLUSTER)).thenReturn(config);
+    Assert.assertTrue(mock.clusterService.isClusterTopologyAware(TEST_CLUSTER));
+  }
+
   private final class Mock {
     private HelixDataAccessor dataAccessor = mock(HelixDataAccessor.class);
     private ConfigAccessor configAccessor = mock(ConfigAccessor.class);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
#2893

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
* Add a new selection base: NON_TOPO_BASED. In this scenario, the order of the zone will not be respected and all instances will be performed stoppable check at once. Additionally, this change supports the stoppable check for non-topo aware clusters.

### Tests

- [X] The following tests are written for this issue:
` mvn test -Dtest=TestInstancesAccessor,TestMaintenanceManagementService,TestInstanceValidationUtilInRest,TestPerInstanceAccessor,TestCustomRestClient,TestClusterService -pl helix-rest && mvn test -Dtest=TestInstanceValidationUtil -pl helix-core`


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
