### PR TITLE
Fix waged instance capacity npe on new resource

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -516,6 +516,14 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
   }
 
   /**
+   * Clears the WAGED algorithm specific instance capacity provider and resource weight provider.
+   */
+  public void clearWagedCapacityProviders() {
+    _wagedInstanceCapacity = null;
+    _wagedPartitionWeightProvider = null;
+  }
+
+  /**
    * Check and reduce the capacity of an instance for a resource partition
    * @param instance - the instance to check
    * @param resourceName - the resource name

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -364,10 +364,6 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
         .filter(entry -> WagedValidationUtil.isWagedEnabled(cache.getIdealState(entry.getKey())))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-    if (wagedEnabledResourceMap.isEmpty()) {
-      return;
-    }
-
     // Phase 1: Rebuild Always
     WagedInstanceCapacity capacityProvider = new WagedInstanceCapacity(cache);
     WagedResourceWeightsProvider weightProvider = new WagedResourceWeightsProvider(cache);
@@ -385,7 +381,7 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
    */
   static boolean skipCapacityCalculation(ResourceControllerDataProvider cache, Map<String, Resource> resourceMap,
       ClusterEvent event) {
-    if (resourceMap == null || resourceMap.isEmpty()) {
+    if (resourceMap == null) {
       return true;
     }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -359,7 +359,7 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
       // Ensure instance capacity is null if there are no resources. This prevents using a stale map when all resources
       // are removed and then a new resource is added.
       if (resourceMap == null || resourceMap.isEmpty()) {
-        cache.setWagedCapacityProviders(null, null);
+        cache.clearWagedCapacityProviders();
       }
       return;
     }
@@ -371,7 +371,7 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
 
     // Ensure instance capacity is null if there are no WAGED enabled instances
     if (wagedEnabledResourceMap.isEmpty()) {
-      cache.setWagedCapacityProviders(null, null);
+      cache.clearWagedCapacityProviders();
       return;
     }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/TestWagedNPE.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestWagedNPE.java
@@ -1,0 +1,124 @@
+package org.apache.helix.integration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.ResourceConfig;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestWagedNPE extends ZkTestBase  {
+
+  public static String CLUSTER_NAME = TestHelper.getTestClassName() + "_cluster";
+  public static int PARTICIPANT_COUNT = 10;
+  public static List<MockParticipantManager> _participants = new ArrayList<>();
+  public static ClusterControllerManager _controller;
+  public static ConfigAccessor _configAccessor;
+
+  @BeforeClass
+  public void beforeClass() {
+    System.out.println("Start test " + TestHelper.getTestClassName());
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < PARTICIPANT_COUNT; i++) {
+      addParticipant("localhost_" + i);
+    }
+
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    _configAccessor = new ConfigAccessor(_gZkClient);
+    ClusterConfig clusterConfig =  _configAccessor.getClusterConfig(CLUSTER_NAME);
+    String testCapacityKey = "TestCapacityKey";
+    clusterConfig.setInstanceCapacityKeys(Collections.singletonList(testCapacityKey));
+    clusterConfig.setDefaultInstanceCapacityMap(Collections.singletonMap(testCapacityKey, 100));
+    clusterConfig.setDefaultPartitionWeightMap(Collections.singletonMap(testCapacityKey, 1));
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+  }
+
+  @Test
+  public void testNPE() throws Exception {
+    String firstDB = "firstDB";
+    int numPartition = 10;
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, firstDB, numPartition, "LeaderStandby",
+        IdealState.RebalanceMode.FULL_AUTO.name(), null);
+
+    IdealState idealStateOne =
+        _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, firstDB);
+    idealStateOne.setMinActiveReplicas(2);
+    idealStateOne.setRebalancerClassName(WagedRebalancer.class.getName());
+    _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, firstDB, idealStateOne);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, firstDB, 3);
+
+    BestPossibleExternalViewVerifier verifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+            .setResources(Collections.singleton(firstDB))
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
+
+    Assert.assertTrue(verifier.verifyByPolling());
+
+    // drop resource
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, firstDB);
+
+    // add instance
+    MockParticipantManager participantToAdd = addParticipant("instance_to_add");
+     verifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+            .setResources(new HashSet<>(_gSetupTool.getClusterManagementTool().getResourcesInCluster(CLUSTER_NAME)))
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
+    Assert.assertTrue(verifier.verifyByPolling());
+
+    // add resource again
+    String secondDb = "secondDB";
+    _configAccessor.setResourceConfig(CLUSTER_NAME, secondDb, new ResourceConfig(secondDb));
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, secondDb, numPartition, "LeaderStandby",
+        IdealState.RebalanceMode.FULL_AUTO.name(), null);
+    IdealState idealStateTwo =
+        _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, secondDb);
+    idealStateTwo.setMinActiveReplicas(2);
+    idealStateTwo.setRebalancerClassName(WagedRebalancer.class.getName());
+    _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, secondDb, idealStateTwo);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, secondDb, 3);
+
+
+    verifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+            .setResources(Collections.singleton(secondDb))
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
+    Assert.assertTrue(verifier.verifyByPolling());
+  }
+
+  public MockParticipantManager addParticipant(String instanceName) {
+    _gSetupTool.addInstanceToCluster(CLUSTER_NAME, instanceName);
+    MockParticipantManager participant = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+    participant.syncStart();
+    _participants.add(participant);
+    return participant;
+  }
+
+  public void dropParticipant(String instanceName) {
+    MockParticipantManager participantToDrop = _participants.stream()
+        .filter(p -> p.getInstanceName().equals(instanceName)).findFirst().get();
+    dropParticipant(participantToDrop);
+
+  }
+
+  public void dropParticipant(MockParticipantManager participantToDrop) {
+    participantToDrop.syncStop();
+    _gSetupTool.getClusterManagementTool().dropInstance(CLUSTER_NAME,
+        _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, participantToDrop.getInstanceName()));
+    _participants.remove(participantToDrop);
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
NPE occurs for first WAGED resource in cluster after previous WAGED resources have been removed
#2891 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Full description of the NPE can be found in the issue #2891. Here is a brief summary:
1. `_instanceCapacityMap` is calculated with WAGED resources in cluster
2. If you remove all WAGED resources, the previous `_instanceCapacityMap` is still present. This is only recalculated under certain conditions
3. If you add a new WAGED resource, the `_instanceCapacityMap` is not recalculated before it is used. This stale `_instanceCapacityMap` can lead to an NPE

This PR addresses the above issue by ensuring the `_instanceCapacityMap` is null whenever there are no WAGED resources in the cluster. This leads to the map being recalculated before it is used when a new WAGED resource is added.

### Tests
- [x] The following tests are written for this issue:
New test class: `TestWagedNPE`

- The following is the result of the "mvn test" command on the appropriate module:
```
$ mvn test -o -Dtest=TestWagedNPE -pl=helix-core

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.836 s - in org.apache.helix.integration.TestWagedNPE
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  35.815 s
[INFO] Finished at: 2024-11-25T10:09:46-08:00
[INFO] ------------------------------------------------------------------------

```

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
