### PR TITLE
Fix endless creation of best possible nodes

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentMetadataStore.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.util.stream.Collectors;
 import org.apache.helix.BucketDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixProperty;
@@ -133,11 +134,15 @@ public class AssignmentMetadataStore {
    * @param globalBaseline
    */
   public synchronized void persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
+    // Create defensive copy so that the in-memory assignment is not modified after it is persisted
+    Map<String, ResourceAssignment> baselineCopy = globalBaseline.entrySet().stream().collect(
+        Collectors.toMap(Map.Entry::getKey,
+            entry -> new ResourceAssignment(entry.getValue().getRecord())));
     // write to metadata store
-    persistAssignmentToMetadataStore(globalBaseline, _baselinePath, BASELINE_KEY);
+    persistAssignmentToMetadataStore(baselineCopy, _baselinePath, BASELINE_KEY);
     // write to memory
     getBaseline().clear();
-    getBaseline().putAll(globalBaseline);
+    getBaseline().putAll(baselineCopy);
   }
 
   /**
@@ -146,11 +151,15 @@ public class AssignmentMetadataStore {
    * @param bestPossibleAssignment
    */
   public synchronized void persistBestPossibleAssignment(Map<String, ResourceAssignment> bestPossibleAssignment) {
+    // Create defensive copy so that the in-memory assignment is not modified after it is persisted
+    Map<String, ResourceAssignment> bestPossibleAssignmentCopy = bestPossibleAssignment.entrySet().stream().collect(
+        Collectors.toMap(Map.Entry::getKey,
+            entry -> new ResourceAssignment(entry.getValue().getRecord())));
     // write to metadata store
-    persistAssignmentToMetadataStore(bestPossibleAssignment, _bestPossiblePath, BEST_POSSIBLE_KEY);
+    persistAssignmentToMetadataStore(bestPossibleAssignmentCopy, _bestPossiblePath, BEST_POSSIBLE_KEY);
     // write to memory
     getBestPossibleAssignment().clear();
-    getBestPossibleAssignment().putAll(bestPossibleAssignment);
+    getBestPossibleAssignment().putAll(bestPossibleAssignmentCopy);
     _bestPossibleVersion++;
     _lastPersistedBestPossibleVersion = _bestPossibleVersion;
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/TestEndlessBestPossibleNodes.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestEndlessBestPossibleNodes.java
@@ -1,0 +1,96 @@
+package org.apache.helix.integration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestEndlessBestPossibleNodes extends ZkTestBase  {
+
+  public static String CLUSTER_NAME = TestHelper.getTestClassName() + "_cluster";
+  public static int PARTICIPANT_COUNT = 12;
+  public static List<MockParticipantManager> _participants = new ArrayList<>();
+  public static ClusterControllerManager _controller;
+  public static ConfigAccessor _configAccessor;
+
+  @BeforeClass
+  public void beforeClass() {
+    System.out.println("Start test " + TestHelper.getTestClassName());
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < PARTICIPANT_COUNT; i++) {
+      addParticipant("localhost_" + i);
+    }
+
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    _configAccessor = new ConfigAccessor(_gZkClient);
+    ClusterConfig clusterConfig =  _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setInstanceCapacityKeys(Collections.singletonList("partcount"));
+    clusterConfig.setDefaultInstanceCapacityMap(Collections.singletonMap("partcount", 10000));
+    clusterConfig.setDefaultPartitionWeightMap(Collections.singletonMap("partcount", 1));
+    clusterConfig.setDelayRebalaceEnabled(true);
+    clusterConfig.setRebalanceDelayTime(57600000);
+    clusterConfig.setPersistBestPossibleAssignment(true);
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+  }
+
+  // This test was constructed to capture the bug described in issue 2971
+  // https://github.com/apache/helix/issues/2971
+  @Test
+  public void testEndlessBestPossibleNodes() throws Exception {
+    int numPartition = 10;
+    BestPossibleExternalViewVerifier verifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
+
+    // Create 1 WAGED Resource
+    String firstDB = "InPlaceMigrationTestDB3";
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, firstDB, numPartition, "LeaderStandby",
+        IdealState.RebalanceMode.FULL_AUTO.name(), null);
+    IdealState idealStateOne =
+        _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, firstDB);
+    idealStateOne.setMinActiveReplicas(2);
+    idealStateOne.setRebalancerClassName(WagedRebalancer.class.getName());
+    _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, firstDB, idealStateOne);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, firstDB, 3);
+    Assert.assertTrue(verifier.verifyByPolling());
+
+    // Disable instances so delay rebalance overwrite is required due to min active
+    for (int i = 0; i < PARTICIPANT_COUNT/2; i++) {
+      _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, _participants.get(i).getInstanceName(), false);
+    }
+
+    // Add new instance to cause partial rebalance to calculate a new best possible
+    addParticipant("newInstance_0");
+
+    // Sleep to let pipeline run and ZK writes occur
+    Thread.sleep(5000);
+
+    // There should only be 2 best possibles created (children will be 0, 1, LAST_WRITE, and LAST_SUCCESSFUL_WRITE)
+    int childCount = _gZkClient.getChildren("/" + CLUSTER_NAME + "/ASSIGNMENT_METADATA/BEST_POSSIBLE").size();
+    Assert.assertTrue(childCount > 0);
+    Assert.assertTrue(childCount < 5, "Child count was " + childCount);
+  }
+
+  public MockParticipantManager addParticipant(String instanceName) {
+    _gSetupTool.addInstanceToCluster(CLUSTER_NAME, instanceName);
+    MockParticipantManager participant = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+    participant.syncStart();
+    _participants.add(participant);
+    return participant;
+  }
+}


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
#2971

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
Controller endlessly creates best possible nodes under certain circumstances due handle`handleDelayedRebalanceMinActiveReplica` modifying the same underlying ResourceAssignments that are used for the in memory bestPossibleAssignment

This PR changes `AssignmentMetadataStore`'s methods `persistBaseline` and `persistBestPossibleAssignment` to create a copy of the underlying `ResourceAssignment` objects before persisting them to the store's in-memory map. This allows the object passed to these methods to be safely modified afterwards without affecting the cached bestPossible. 

There are specific circumstances to trigger this behavior:
1. Cluster is in state to require delyRebalance overwrites (nodes are disabled within delay window and partitions are violating minActiveReplica count)
2. Change cluster so that partialRebalance will calculate a new assignment (adding or removing instances)

PartialRebalance will async calculate a new best possible and increment the `_bestPossibleVersion` and schedule an onDemandPipeline run. In emergencyRebalance(...) of the next pipeline, the bestPossibleAssignment (object A) will be persisted as `_bestPossibleVersion` != `_lastPersistedBestPossibleVersion`. The values of the new best possible are stored in our in-memory bestPossibleAssignment map (object B). While object A and B are different, their values map to the same objects. We then pass object A to `handleDelayedRebalanceMinActiveReplica` which modifies the values of object A, also modifying the values of object B. This causes partialRebalance to believe it has calculated a different assignment, so it triggers a new pipeline run which will repeat the above behavior ad infinitum.  

### Tests

- [ ] The following tests are written for this issue:

TestEndlessBestPossibleNodes
This test will fail on master, but pass on this branch

```
$ mvn test -o -Dtest=TestEndlessBestPossibleNodes -pl=helix-core 

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.512 s - in org.apache.helix.integration.TestEndlessBestPossibleNodes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  53.849 s
[INFO] Finished at: 2024-11-26T15:52:41-08:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
