### PR TITLE
#2965 Atomic ZNode creation on node registration

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -19,7 +19,6 @@ package org.apache.helix.manager.zk;
  * under the License.
  */
 
-import com.google.common.collect.ImmutableMap;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -107,9 +106,11 @@ import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.apache.helix.zookeeper.zkclient.NetworkUtil;
 import org.apache.helix.zookeeper.zkclient.exception.ZkException;
 import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
+import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Op;
 import org.apache.zookeeper.OpResult;
+import org.apache.zookeeper.ZooDefs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -238,17 +239,30 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     ZKUtil.createChildren(_zkClient, instanceConfigsPath, instanceConfig.getRecord());
 
-    _zkClient.createPersistent(PropertyPathBuilder.instanceMessage(clusterName, nodeId), true);
-    _zkClient.createPersistent(PropertyPathBuilder.instanceCurrentState(clusterName, nodeId), true);
-    _zkClient
-        .createPersistent(PropertyPathBuilder.instanceTaskCurrentState(clusterName, nodeId), true);
-    _zkClient.createPersistent(PropertyPathBuilder.instanceCustomizedState(clusterName, nodeId), true);
-    _zkClient.createPersistent(PropertyPathBuilder.instanceError(clusterName, nodeId), true);
-    _zkClient.createPersistent(PropertyPathBuilder.instanceStatusUpdate(clusterName, nodeId), true);
-    _zkClient.createPersistent(PropertyPathBuilder.instanceHistory(clusterName, nodeId), true);
+    // if those nodes are not created atomically, then having two nodes registering almost exactly
+    // at the same time could be problematic, because one node would not able to check for already
+    // existing instance with matching logical ID (see
+    // InstanceUtil.findInstancesWithMatchingLogicalId call above, where finding an incomplete
+    // "INSTANCE" node is a killer)
+    final List<Op> ops = Arrays.asList(
+        createPersistentNodeOp(PropertyPathBuilder.instance(clusterName, nodeId)),
+        createPersistentNodeOp(PropertyPathBuilder.instanceMessage(clusterName, nodeId)),
+        createPersistentNodeOp(PropertyPathBuilder.instanceCurrentState(clusterName, nodeId)),
+        createPersistentNodeOp(PropertyPathBuilder.instanceTaskCurrentState(clusterName, nodeId)),
+        createPersistentNodeOp(PropertyPathBuilder.instanceCustomizedState(clusterName, nodeId)),
+        createPersistentNodeOp(PropertyPathBuilder.instanceError(clusterName, nodeId)),
+        createPersistentNodeOp(PropertyPathBuilder.instanceStatusUpdate(clusterName, nodeId)),
+        createPersistentNodeOp(PropertyPathBuilder.instanceHistory(clusterName, nodeId))
+    );
+    _zkClient.multi(ops);
+
     HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, _baseDataAccessor);
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
     accessor.setProperty(keyBuilder.participantHistory(nodeId), new ParticipantHistory(nodeId));
+  }
+
+  private static Op createPersistentNodeOp(String path) {
+    return Op.create(path, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
   }
 
   @Override


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #2965

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

If two nodes try to register at about the same time in the cluster, there may be a race condition while effectively adding the instances to the cluster description in zookeeper (the second one seeing an incomplete node hierarchy and later on refusing to accept tasks). Having an atomic creation of those nodes in zookeeper should prevent that.

### Tests

- [x] The following tests are written for this issue:

No additional tests.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
