### PR TITLE
Add jdk8 support for helix-lock module

### DIFF
--- a/helix-common/pom.xml
+++ b/helix-common/pom.xml
@@ -125,7 +125,7 @@
         <version>3.3.0</version>
         <executions>
           <execution>
-            <id>default-package-jdk11</id>
+            <id>default-package-jdk8</id>
             <phase>package</phase>
             <goals>
               <goal>jar</goal>

--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -215,7 +215,7 @@
         <version>3.3.0</version>
         <executions>
           <execution>
-            <id>default-package-jdk11</id>
+            <id>default-package-jdk8</id>
             <phase>package</phase>
             <goals>
               <goal>jar</goal>

--- a/helix-lock/pom.xml
+++ b/helix-lock/pom.xml
@@ -82,6 +82,54 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.12.1</version>
+        <executions>
+          <execution>
+            <id>JDK 8</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}_jdk8</outputDirectory>
+              <release>8</release>
+              <fork>true</fork>
+            </configuration>
+          </execution>
+          <execution>
+            <id>JDK 11</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>11</release>
+              <fork>true</fork>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>default-package-jdk11</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classesDirectory>${project.build.outputDirectory}_jdk8</classesDirectory>
+              <classifier>jdk8</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptors>

--- a/helix-lock/pom.xml
+++ b/helix-lock/pom.xml
@@ -116,7 +116,7 @@
         <version>3.3.0</version>
         <executions>
           <execution>
-            <id>default-package-jdk11</id>
+            <id>default-package-jdk8</id>
             <phase>package</phase>
             <goals>
               <goal>jar</goal>

--- a/meta-client/pom.xml
+++ b/meta-client/pom.xml
@@ -125,7 +125,7 @@ under the License.
         <version>3.3.0</version>
         <executions>
           <execution>
-            <id>default-package-jdk11</id>
+            <id>default-package-jdk8</id>
             <phase>package</phase>
             <goals>
               <goal>jar</goal>

--- a/metadata-store-directory-common/pom.xml
+++ b/metadata-store-directory-common/pom.xml
@@ -149,7 +149,7 @@
         <version>3.3.0</version>
         <executions>
           <execution>
-            <id>default-package-jdk11</id>
+            <id>default-package-jdk8</id>
             <phase>package</phase>
             <goals>
               <goal>jar</goal>

--- a/metrics-common/pom.xml
+++ b/metrics-common/pom.xml
@@ -120,7 +120,7 @@
         <version>3.3.0</version>
         <executions>
           <execution>
-            <id>default-package-jdk11</id>
+            <id>default-package-jdk8</id>
             <phase>package</phase>
             <goals>
               <goal>jar</goal>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -169,7 +169,7 @@
         <version>3.3.0</version>
         <executions>
           <execution>
-            <id>default-package-jdk11</id>
+            <id>default-package-jdk8</id>
             <phase>package</phase>
             <goals>
               <goal>jar</goal>


### PR DESCRIPTION
### Issues

- [x] Add jdk8 support for helix-lock module
- [x] Rename jar packaging execution ids to match jdk8 and fix typos from past changes

### Description

- [x]  We currently do not support helix-lock jdk8. Some projects that require jdk8 helix-core also have a dependency on helix-lock.

### Tests

```
➜  helix git:(zpinto/add_jdk8_helix_lock) mvn clean install -Dmaven.test.skip.exec=true
...
[INFO] --- jar:3.3.0:jar (default-package-jdk8) @ helix-lock ---
[INFO] Building jar: /Users/zapinto/Documents/git2/zpinto/helix/helix-lock/target/helix-lock-1.4.3-SNAPSHOT-jdk8.jar
...
[INFO] 
[INFO] --- bundle:5.1.4:install (default-install) @ meta-client ---
[INFO] Installing org/apache/helix/meta-client/1.4.3-SNAPSHOT/meta-client-1.4.3-SNAPSHOT.jar
[INFO] Installing org/apache/helix/meta-client/1.4.3-SNAPSHOT/meta-client-1.4.3-SNAPSHOT-jdk8.jar
[INFO] Writing OBR metadata
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Helix 1.4.3-SNAPSHOT:
[INFO] 
[INFO] Apache Helix ....................................... SUCCESS [  0.795 s]
[INFO] Apache Helix :: Metrics Common ..................... SUCCESS [  1.989 s]
[INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [  1.609 s]
[INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [  3.681 s]
[INFO] Apache Helix :: Helix Common ....................... SUCCESS [  1.313 s]
[INFO] Apache Helix :: Core ............................... SUCCESS [ 17.335 s]
[INFO] Apache Helix :: Restful Interface .................. SUCCESS [  2.350 s]
[INFO] Apache Helix :: Distributed Lock ................... SUCCESS [  1.520 s]
[INFO] Apache Helix :: HelixAgent ......................... SUCCESS [  0.496 s]
[INFO] Apache Helix :: Recipes ............................ SUCCESS [  0.009 s]
[INFO] Apache Helix :: Recipes :: Rabbitmq Consumer Group . SUCCESS [  0.347 s]
[INFO] Apache Helix :: Recipes :: Rsync Replicated File Store SUCCESS [  0.404 s]
[INFO] Apache Helix :: Recipes :: distributed lock manager  SUCCESS [  0.310 s]
[INFO] Apache Helix :: Recipes :: distributed task execution SUCCESS [  0.321 s]
[INFO] Apache Helix :: Recipes :: service discovery ....... SUCCESS [  0.337 s]
[INFO] Apache Helix :: View Aggregator .................... SUCCESS [  0.550 s]
[INFO] Apache Helix :: Meta Client ........................ SUCCESS [  2.557 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  36.316 s
[INFO] Finished at: 2025-01-09T21:05:51-08:00
[INFO] ------------------------------------------------------------------------
```

### Changes that Break Backward Compatibility (Optional)

NA

### Documentation (Optional)

NA

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
