### PR TITLE
Add atomic recursive delete to ZK client and use for drop instance

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -273,10 +273,12 @@ public class ZKHelixAdmin implements HelixAdmin {
           "Node " + instanceName + " is still alive for cluster " + clusterName + ", can't drop.");
     }
 
-    dropInstancePathsRecursively(instanceName, instancePath, instanceConfigPath);
+    dropInstancePathsRecursively(clusterName, instanceName);
   }
 
-  private void dropInstancePathsRecursively(String instanceName, String instancePath, String instanceConfigPath) {
+  private void dropInstancePathsRecursively(String clusterName, String instanceName) {
+    String instanceConfigPath = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
+    String instancePath = PropertyPathBuilder.instance(clusterName, instanceName);
     int retryCnt = 0;
     while (true) {
       try {
@@ -328,9 +330,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   private void purgeInstance(String clusterName, String instanceName) {
     logger.info("Purge instance {} from cluster {}.", instanceName, clusterName);
-    String instanceConfigPath = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
-    String instancePath = PropertyPathBuilder.instance(clusterName, instanceName);
-    dropInstancePathsRecursively(instanceName, instancePath, instanceConfigPath);
+    dropInstancePathsRecursively(clusterName, instanceName);
   }
 
   @Override

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -49,7 +49,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
-import org.apache.zookeeper.Op;
 
 public class TestZkBaseDataAccessor extends ZkUnitTestBase {
   // serialize/deserialize integer list to byte array

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -49,6 +49,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+import org.apache.zookeeper.Op;
 
 public class TestZkBaseDataAccessor extends ZkUnitTestBase {
   // serialize/deserialize integer list to byte array

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -237,7 +237,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
         new ZkException("ZkException: failed to delete " + instancePath,
             new KeeperException.NotEmptyException(
                 "NotEmptyException: directory" + instancePath + " is not empty"))))
-        .when(mockZkClient).deleteRecursively(instancePath);
+        .when(mockZkClient).deleteRecursivelyAtomic(Arrays.asList(instancePath, instanceConfigPath));
 
     HelixAdmin helixAdminMock = new ZKHelixAdmin(mockZkClient);
     try {
@@ -1341,5 +1341,30 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
       controller.syncStop();
       _gSetupTool.deleteCluster(clusterName);
     }
+  }
+
+  @Test
+  public void testDropInstanceAtomic() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    int numInstances = 5;
+    final String clusterName = getShortClassName();
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
+    admin.addCluster(clusterName, true);
+    Assert.assertTrue(ZKUtil.isClusterSetup(clusterName, _gZkClient), "Cluster should be setup");
+
+    // Add instances to cluster
+    for (int i = 0; i < numInstances; i++) {
+      admin.addInstance(clusterName, new InstanceConfig("localhost_" + i));
+      // Create dummy message nodes
+      _gZkClient.createPersistent(PropertyPathBuilder.instanceMessage(clusterName, "localhost_" + i, ""+i));
+    }
+    Assert.assertTrue(admin.getInstancesInCluster(clusterName).size() == numInstances, "Instances should be added");
+
+    for (int i = 0; i < 5; i++) {
+      admin.dropInstance(clusterName, new InstanceConfig("localhost_" + i));
+    }
+    Assert.assertTrue(admin.getInstancesInCluster(clusterName).isEmpty(), "Instances should be removed");
+
+    System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -1344,7 +1344,7 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
   }
 
   @Test
-  public void testDropInstanceAtomic() {
+  public void testDropInstance() {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
     int numInstances = 5;
     final String clusterName = getShortClassName();

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -252,6 +252,9 @@ public interface RealmAwareZkClient {
 
   void deleteRecursively(String path);
 
+  void deleteRecursivelyAtomic(String path);
+  void deleteRecursivelyAtomic(List<String> paths);
+
   boolean delete(final String path);
 
   boolean delete(final String path, final int expectedVersion);

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -384,6 +384,20 @@ public class DedicatedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public void deleteRecursivelyAtomic(String path) {
+    checkIfPathContainsShardingKey(path);
+    _rawZkClient.deleteRecursivelyAtomic(path);
+  }
+
+  @Override
+  public void deleteRecursivelyAtomic(List<String> paths) {
+    for (String path : paths) {
+      checkIfPathContainsShardingKey(path);
+    }
+    _rawZkClient.deleteRecursivelyAtomic(paths);
+  }
+
+  @Override
   public boolean delete(String path) {
     return delete(path, -1);
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -413,6 +413,20 @@ public class SharedZkClient implements RealmAwareZkClient {
   }
 
   @Override
+  public void deleteRecursivelyAtomic(String path) {
+    checkIfPathContainsShardingKey(path);
+    _innerSharedZkClient.deleteRecursivelyAtomic(path);
+  }
+
+  @Override
+  public void deleteRecursivelyAtomic(List<String> paths) {
+    for (String path : paths) {
+      checkIfPathContainsShardingKey(path);
+    }
+    _innerSharedZkClient.deleteRecursivelyAtomic(paths);
+  }
+
+  @Override
   public boolean delete(String path) {
     return delete(path, -1);
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java
@@ -1886,7 +1886,6 @@ public class ZkClient implements Watcher {
     return ops;
   }
 
-
   private void processDataOrChildChange(WatchedEvent event, long notificationTime) {
     final String path = event.getPath();
     final boolean pathExists = event.getType() != EventType.NodeDeleted;

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -21,6 +21,7 @@ package org.apache.helix.zookeeper.impl.client;
 
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
@@ -51,6 +52,7 @@ import org.apache.helix.zookeeper.zkclient.ZkConnection;
 import org.apache.helix.zookeeper.zkclient.ZkServer;
 import org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks;
 import org.apache.helix.zookeeper.zkclient.exception.ZkException;
+import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
 import org.apache.helix.zookeeper.zkclient.exception.ZkSessionMismatchedException;
 import org.apache.helix.zookeeper.zkclient.exception.ZkTimeoutException;
 import org.apache.helix.zookeeper.zkclient.metric.ZkClientMonitor;
@@ -1230,5 +1232,54 @@ public class TestRawZkClient extends ZkTestBase {
         zkClient.close();
       }
     }
+  }
+
+  @Test
+  void testDeleteRecursivelyAtomic() {
+    System.out.println("Start test: " + TestHelper.getTestMethodName());
+    String grandParent = "/testDeleteRecursively";
+    String parent = grandParent + "/parent";
+    String child1 = parent + "/child1";
+    String child2 = parent + "/child2";
+    _zkClient.createPersistent(grandParent);
+    _zkClient.createPersistent(parent);
+    _zkClient.createPersistent(child1);
+    _zkClient.createPersistent(child2);
+    Assert.assertTrue(_zkClient.exists(grandParent));
+    Assert.assertFalse(_zkClient.getChildren(parent).isEmpty());
+
+    // Test calling delete on same path twice
+    try {
+      _zkClient.deleteRecursivelyAtomic(Arrays.asList(grandParent, grandParent));
+      Assert.fail("Operation should not succeed when attempting to delete same path twice");
+    } catch (ZkClientException expected) {
+      // Caught expected exception
+    }
+
+    Assert.assertTrue(_zkClient.exists(grandParent));
+    Assert.assertFalse(_zkClient.getChildren(parent).isEmpty());
+
+    // Test calling delete on path that is child of another path in the list
+    try {
+      _zkClient.deleteRecursivelyAtomic(Arrays.asList(grandParent, parent));
+      Assert.fail("Operation should not succeed when attempting to delete same path twice");
+    } catch (ZkClientException expected) {
+      // Caught expected exception
+    }
+
+    Assert.assertTrue(_zkClient.exists(grandParent));
+    Assert.assertFalse(_zkClient.getChildren(parent).isEmpty());
+
+    // Test successfully delete multiple paths. Also that operation succeeds when attempting to delete non-existent path
+    String newNode = "/newNode";
+    _zkClient.createPersistent(newNode);
+    Assert.assertTrue(_zkClient.exists(newNode));
+
+    String nonexistentPath = grandParent + "/nonexistent";
+    Assert.assertFalse(_zkClient.exists(nonexistentPath));
+
+    _zkClient.deleteRecursivelyAtomic(Arrays.asList(grandParent, newNode, nonexistentPath));
+    Assert.assertFalse(_zkClient.exists(grandParent));
+    Assert.assertFalse(_zkClient.exists(newNode));
   }
 }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -1267,6 +1267,11 @@ public class TestRawZkClient extends ZkTestBase {
       // Caught expected exception
     }
 
+    // Test calling delete on single node
+    Assert.assertTrue(_zkClient.exists(child2));
+    _zkClient.deleteRecursivelyAtomic(child2);
+    Assert.assertFalse(_zkClient.exists(child2));
+
     Assert.assertTrue(_zkClient.exists(grandParent));
     Assert.assertFalse(_zkClient.getChildren(parent).isEmpty());
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Feature warranted by discussion from PR #2932 
Discussion here: https://github.com/apache/helix/pull/2932#discussion_r1868312803

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds an ATOMIC recursive delete method and uses it for dropping/purging instances from the cluster. The deleteRecursivelyAtomic method will either fully fail or fully succeed. This will prevent partially deleted instances from entering the cluster into an invalid state. This behaves similarly to the current deleteRecursively method, but with the addition of atomicity. There are two signatures available, one for deleting a single path and its children, and one for deleting multiple paths and all their children. Atomicity across different paths is needed to ensure atomicity of dropping an instance. 

The FederatedZkClient implementation throws an IllegalArgumentException when deleteRecursivelyAtomic is called upon 2 paths that exist in different ZK realms as atomicity cannot be guaranteed across different realms due to their being 2 separate ZKClients and therefore 2 separate calls. 

### Tests

- [ ] The following tests are written for this issue:

testDropInstance in TestZkHelixAdmin.java
testDeleteRecursivelyAtomic in TestRawZkClient.java

- The following is the result of the "mvn test" command on the appropriate module:

Ran manual CI on my personal fork and saw no new failing tests introduced. 

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

N/A


### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
