### PR TITLE
Fixing the flaky topology migration check and ConstrainBasedAlgorith replicaHash computation

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -22,7 +22,6 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,7 +30,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.controller.rebalancer.waged.RebalanceAlgorithm;
@@ -224,7 +222,7 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
       // group tag to calculate the hash code because topology changes to a single instance group tag
       // should be isolated from other instance group tags. Assignable replica ordering changes only
       // change when the topology of the instance group tag changes.
-      _replicaHash = Objects.hash(replica.toString(), clusterModel.getAssignableNodesForInstanceTag(replica.getResourceInstanceGroupTag()));
+      _replicaHash = Objects.hash(replica.toString(), clusterModel.getAssignableNodesForInstanceGroupTag(replica.getResourceInstanceGroupTag()));
       computeScore(overallClusterRemainingCapacityMap);
     }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -218,7 +218,13 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
           .containsKey(replica.getResourceName());
       _isInBaselineAssignment =
           clusterModel.getContext().getBaselineAssignment().containsKey(replica.getResourceName());
-      _replicaHash = Objects.hash(replica.toString(), clusterModel.getAssignableLogicalIds());
+
+      // _replicaHash is used to randomize the replicas order so that the same replicas are not
+      // always moved in each rebalance. We only use instances which satisfy the replica's instance
+      // group tag to calculate the hash code because topology changes to a single instance group tag
+      // should be isolated from other instance group tags. Assignable replica ordering changes only
+      // change when the topology of the instance group tag changes.
+      _replicaHash = Objects.hash(replica.toString(), clusterModel.getAssignableNodesForInstanceTag(replica.getResourceInstanceGroupTag()));
       computeScore(overallClusterRemainingCapacityMap);
     }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModel.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModel.java
@@ -97,7 +97,7 @@ public class ClusterModel {
    * @param instanceTag The instance tag.
    * @return The set of assignable logical IDs.
    */
-  public Set<String> getAssignableNodesForInstanceTag(String instanceTag) {
+  public Set<String> getAssignableNodesForInstanceGroupTag(String instanceTag) {
     if (instanceTag == null) {
       return getAssignableLogicalIds();
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModel.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModel.java
@@ -20,6 +20,8 @@ package org.apache.helix.controller.rebalancer.waged.model;
  */
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -38,6 +40,7 @@ public class ClusterModel {
   private final Map<String, Map<String, AssignableReplica>> _assignableReplicaIndex;
   private final Map<String, AssignableNode> _assignableNodeMap;
   private final Set<String> _assignableNodeLogicalIds;
+  private final Map<String, Set<String>> _assignableLogicalIdsByInstanceTag;
 
   /**
    * @param clusterContext         The initialized cluster context.
@@ -64,6 +67,15 @@ public class ClusterModel {
     _assignableNodeLogicalIds =
         assignableNodes.parallelStream().map(AssignableNode::getLogicalId)
             .collect(Collectors.toSet());
+
+    // Index all the instances by their instance tags
+    _assignableLogicalIdsByInstanceTag = new HashMap<>();
+    assignableNodes.forEach(node -> {
+      node.getInstanceTags().forEach(tag -> {
+        _assignableLogicalIdsByInstanceTag.computeIfAbsent(tag, key -> new HashSet<>())
+            .add(node.getLogicalId());
+      });
+    });
   }
 
   public ClusterContext getContext() {
@@ -76,6 +88,20 @@ public class ClusterModel {
 
   public Set<String> getAssignableLogicalIds() {
     return _assignableNodeLogicalIds;
+  }
+
+  /**
+   * Get the assignable nodes for the given instance tag.
+   * If the instance tag is null, return all the assignable nodes.
+   *
+   * @param instanceTag The instance tag.
+   * @return The set of assignable logical IDs.
+   */
+  public Set<String> getAssignableNodesForInstanceTag(String instanceTag) {
+    if (instanceTag == null) {
+      return getAssignableLogicalIds();
+    }
+    return _assignableLogicalIdsByInstanceTag.getOrDefault(instanceTag, getAssignableLogicalIds());
   }
 
   public Map<String, Set<AssignableReplica>> getAssignableReplicaMap() {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -232,7 +232,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
                 cache.getStateModelDef(resourceMap.get(resourceName).getStateModelDefRef()),
                 stateMap, swapInToSwapOutInstancePairs.get(swapInInstance), swapInInstance, resourceName,
                 partition.getPartitionName(), cache);
-            if (stateMap != null) {
+            if (selectedState != null) {
               bestPossibleStateOutput.setState(resourceName, partition, swapInInstance,
                   selectedState);
             }


### PR DESCRIPTION
### Issues

- [x] fixes https://github.com/apache/helix/issues/2945
- [x] Fix ConstrainBasedAlgorithm global shuffling when only updating on instance tag groups DOMAIN
- [x] Fix a incorrect condition in swap impl to avoid adding state value of null to stateMap of bestPossibleAssignment

### Description

Fixing the flaky topology migration check which should isolate shuffling to a single instance tag. After investigation, a fix was needed for ContraintBasedAlgorithm to compute the replica hash using only the assignable instances for a given instance tag. This is to ensure that cluster topology changes to instances with specific tags only affects resources with those tags.

### Tests

- [x] TestTopologyMigration

```
 ./scripts/runSingleTest.sh TestTopologyMigration#testTopologyMigrationByResourceGroup                       
Running test on TestTopologyMigration#testTopologyMigrationByResourceGroup in component helix-core for -1 times.
======================================================================
Attempt 1 TestTopologyMigration#testTopologyMigrationByResourceGroup
======================================================================
Start zookeeper at localhost:2183 in thread main
START TestTopologyMigration at Thu Jan 16 17:07:36 PST 2025
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12926 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12927 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_2
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12925 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_7
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12923 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_5
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12927 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12924 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_5
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12919 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12927 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12920 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_7
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12921 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12918 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_5
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12928 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_4
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12922 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_9
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12929 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12926 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_0
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12918 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_4
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12924 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_0
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12921 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_0
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12920 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_0
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12919 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_0
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12923 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_9
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12922 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_7
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12918 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12921 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_3
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12924 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_4
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12924 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_7
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12929 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_4
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12929 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_3
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12919 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12919 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_4
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12929 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_5
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12922 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_2
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12927 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_3
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12925 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_0
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12921 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_7
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12923 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_2
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12928 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12918 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_9
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12919 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_3
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12925 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12920 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_4
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12929 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_1
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12928 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12920 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12924 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12918 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12922 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12926 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_2
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12923 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12926 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12925 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_1
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12926 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_7
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12928 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_5
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12928 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_2
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12927 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_1
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12922 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_5
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12923 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_3
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12921 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_2
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12925 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_3
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12918 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12923 transitioning from STANDBY to LEADER for TestDB0 TestDB0_3
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12929 transitioning from STANDBY to LEADER for TestDB1 TestDB1_4
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12926 transitioning from STANDBY to LEADER for TestDB1 TestDB1_7
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12922 transitioning from STANDBY to LEADER for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12918 transitioning from STANDBY to LEADER for TestDB0 TestDB0_9
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12921 transitioning from STANDBY to LEADER for TestDB0 TestDB0_2
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12919 transitioning from STANDBY to LEADER for TestDB0 TestDB0_4
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12927 transitioning from STANDBY to LEADER for TestDB1 TestDB1_3
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12924 transitioning from STANDBY to LEADER for TestDB1 TestDB1_5
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12926 transitioning from STANDBY to LEADER for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12928 transitioning from STANDBY to LEADER for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12920 transitioning from STANDBY to LEADER for TestDB0 TestDB0_7
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12919 transitioning from STANDBY to LEADER for TestDB0 TestDB0_0
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12924 transitioning from STANDBY to LEADER for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12920 transitioning from STANDBY to LEADER for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12918 transitioning from STANDBY to LEADER for TestDB0 TestDB0_5
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12921 transitioning from STANDBY to LEADER for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12927 transitioning from STANDBY to LEADER for TestDB1 TestDB1_2
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12925 transitioning from STANDBY to LEADER for TestDB1 TestDB1_1
LeaderStandbyStateModel.onBecomeLeaderFromStandby():localhost_12925 transitioning from STANDBY to LEADER for TestDB1 TestDB1_0
Capturing initial external views
Setting MM to true
Setting MM to false
Begin resource group migration for: TestDB1
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12927 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12929 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12925 transitioning from OFFLINE to STANDBY for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12925 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12927 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12929 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12929 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12925 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12927 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_6
Begin resource group migration for: TestDB0
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12920 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12923 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12919 transitioning from OFFLINE to STANDBY for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12918 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12919 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12923 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12923 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12918 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12919 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12926 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_0
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12926 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_2
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12927 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_1
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12926 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12926 transitioning from LEADER to STANDBY for TestDB1 TestDB1_7
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12927 transitioning from LEADER to STANDBY for TestDB1 TestDB1_3
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12926 transitioning from LEADER to STANDBY for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12927 transitioning from LEADER to STANDBY for TestDB1 TestDB1_2
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12927 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12927 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12928 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_2
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12928 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_5
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12928 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_4
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12928 transitioning from LEADER to STANDBY for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12924 transitioning from LEADER to STANDBY for TestDB1 TestDB1_5
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12925 transitioning from LEADER to STANDBY for TestDB1 TestDB1_1
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12924 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_0
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12924 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_4
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12928 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12924 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_7
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12924 transitioning from LEADER to STANDBY for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12925 transitioning from LEADER to STANDBY for TestDB1 TestDB1_0
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12925 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_3
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12925 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_7
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12929 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_1
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12925 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12929 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_3
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12929 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_5
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12929 transitioning from LEADER to STANDBY for TestDB1 TestDB1_4
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12929 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12928 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_2
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12928 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_5
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12928 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_4
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12928 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12928 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12921 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_7
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12918 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12919 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12919 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_3
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12918 transitioning from LEADER to STANDBY for TestDB0 TestDB0_9
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12924 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_0
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12921 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_3
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12924 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_5
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12920 transitioning from LEADER to STANDBY for TestDB0 TestDB0_7
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12922 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_7
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12923 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_9
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12926 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_0
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12923 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12922 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_9
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12920 transitioning from LEADER to STANDBY for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12924 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_4
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12921 transitioning from LEADER to STANDBY for TestDB0 TestDB0_2
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12918 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12919 transitioning from LEADER to STANDBY for TestDB0 TestDB0_4
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12924 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_7
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12920 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_4
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12921 transitioning from LEADER to STANDBY for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12918 transitioning from LEADER to STANDBY for TestDB0 TestDB0_5
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12922 transitioning from LEADER to STANDBY for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12926 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_2
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12923 transitioning from LEADER to STANDBY for TestDB0 TestDB0_3
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12923 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_2
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12922 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_2
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12920 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12924 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12921 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_0
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12918 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_4
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12919 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12920 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_0
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12922 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_5
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12923 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_5
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12926 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_7
LeaderStandbyStateModel.onBecomeStandbyFromLeader():localhost_12919 transitioning from LEADER to STANDBY for TestDB0 TestDB0_0
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12926 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12926 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12929 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_1
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12925 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_1
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12929 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_3
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12929 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_5
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12925 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_0
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12929 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_4
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12927 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_1
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12927 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_3
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12925 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_3
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12927 transitioning from STANDBY to OFFLINE for TestDB1 TestDB1_2
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12929 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12927 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12925 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_7
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12927 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12925 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12924 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_6
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12928 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_9
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12924 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_5
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12925 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_1
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12929 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_4
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12926 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_7
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12922 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_7
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12925 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_0
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12922 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_9
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12918 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12922 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12918 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_9
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12926 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_8
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12918 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12918 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_5
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12922 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_2
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12922 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_5
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12918 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_4
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12923 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_9
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12927 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_3
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12921 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_7
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12923 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12927 transitioning from OFFLINE to DROPPED for TestDB1 TestDB1_2
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12919 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12923 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_3
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12921 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_3
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12923 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_2
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12919 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_3
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12923 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_5
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12921 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_2
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12919 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_4
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12921 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12921 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_0
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12919 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12919 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_0
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12920 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_7
LeaderStandbyStateModel.onBecomeOfflineFromStandby():localhost_12920 transitioning from STANDBY to OFFLINE for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12920 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_4
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12920 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12920 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_0
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12919 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_4
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12921 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_2
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12922 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_8
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12923 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_3
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12921 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_1
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12919 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_0
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12920 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_7
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12920 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_6
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12918 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_9
LeaderStandbyStateModel.onBecomeDroppedFromOffline():localhost_12918 transitioning from OFFLINE to DROPPED for TestDB0 TestDB0_5
AfterClass: TestTopologyMigration called.
Shut down zookeeper at port 2183 in thread main

```

### Changes that Break Backward Compatibility (Optional)

- Assignment may change for existing clusters using INSTANCE_GROUP_TAG with tiebreaker replica scores

### Documentation (Optional)

NA

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
