### PR TITLE
Controller triggers rebalance pipeline after disconnect to catch missed events

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -794,6 +794,8 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
       return;
     }
 
+    System.out.println("gspencerTest - handling event: " + event.getEventType());
+
     // Event handling happens in a different thread from the onControllerChange processing thread.
     // Thus, there are several possible conditions.
     // 1. Event handled after leadership acquired. So we will have a valid rebalancer for the
@@ -1021,6 +1023,7 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     notifyCaches(changeContext, ChangeType.CURRENT_STATE);
     pushToEventQueues(ClusterEventType.CurrentStateChange, changeContext, Collections
         .<String, Object>singletonMap(AttributeName.instanceName.name(), instanceName));
+    System.out.println("gspencerTest - currentStateChange for instance: " + instanceName);
     logger.info("END: GenericClusterController.onStateChange()");
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -794,8 +794,6 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
       return;
     }
 
-    System.out.println("gspencerTest - handling event: " + event.getEventType());
-
     // Event handling happens in a different thread from the onControllerChange processing thread.
     // Thus, there are several possible conditions.
     // 1. Event handled after leadership acquired. So we will have a valid rebalancer for the
@@ -1023,7 +1021,6 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     notifyCaches(changeContext, ChangeType.CURRENT_STATE);
     pushToEventQueues(ClusterEventType.CurrentStateChange, changeContext, Collections
         .<String, Object>singletonMap(AttributeName.instanceName.name(), instanceName));
-    System.out.println("gspencerTest - currentStateChange for instance: " + instanceName);
     logger.info("END: GenericClusterController.onStateChange()");
   }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixManager.java
@@ -115,7 +115,7 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
   public static final String ALLOW_PARTICIPANT_AUTO_JOIN = "allowParticipantAutoJoin";
   private static final int FLAPPING_TIME_WINDOW = 300000; // Default to 300 sec
   public static final int DEFAULT_MAX_DISCONNECT_THRESHOLD = 600; // Default to be a large number
-  private static final int DEFAULT_WAIT_CONNECTED_TIMEOUT = 10 * 1000;  // wait until connected for up to 10 seconds.
+  private static final int DEFAULT_WAIT_CONNECTED_TIMEOUT = 60 * 1000;  // wait until connected for up to 10 seconds.
 
   protected final String _zkAddress;
   private final String _clusterName;
@@ -406,12 +406,14 @@ public class ZKHelixManager implements HelixManager, IZkStateListener {
 
     boolean isConnected = isConnected();
     if (!isConnected && timeout > 0) {
+      System.out.println("gspencerTest - warning not connected");
       LOG.warn("zkClient to " + getZkConnectionInfo() + " is not connected, wait for "
           + _waitForConnectedTimeout + "ms.");
       isConnected = _zkclient.waitUntilConnected(_waitForConnectedTimeout, TimeUnit.MILLISECONDS);
     }
 
     if (!isConnected) {
+      System.out.println("gspencerTest - error not connected");
       LOG.error("zkClient is not connected after waiting " + timeout + "ms."
           + ", clusterName: " + _clusterName + ", zkAddress: " + getZkConnectionInfo());
       throw new HelixException(

--- a/helix-core/src/test/java/org/apache/helix/integration/TestMissedEventAfterReconnect.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestMissedEventAfterReconnect.java
@@ -26,11 +26,12 @@ import org.testng.annotations.Test;
 
 public class TestMissedEventAfterReconnect extends ZkTestBase  {
 
-  public static String CLUSTER_NAME = TestHelper.getTestClassName() + "_cluster";
-  public static int PARTICIPANT_COUNT = 10;
-  public static List<MockParticipantManager> _participants = new ArrayList<>();
-  public static ClusterControllerManager _controller;
-  public static ConfigAccessor _configAccessor;
+  protected static String CLUSTER_NAME = TestHelper.getTestClassName() + "_cluster";
+  protected static int PARTICIPANT_COUNT = 10;
+  protected List<MockParticipantManager> _participants = new ArrayList<>();
+  protected ClusterControllerManager _controller;
+  protected ConfigAccessor _configAccessor;
+  protected static int HELIX_MANAGER_TIMEOUT = 11 * 1000; //11 seconds
 
   @BeforeClass
   public void beforeClass() {
@@ -82,10 +83,10 @@ public class TestMissedEventAfterReconnect extends ZkTestBase  {
     helixManagerZkClient.process(event);
 
     System.out.println("Killing participant 0");
-    _participants.get(0).syncStop();
+    participantToKill.syncStop();
 
     System.out.println("Sleeping for timeout");
-    Thread.sleep(60000);
+    Thread.sleep(HELIX_MANAGER_TIMEOUT);
 
     System.out.println("Reconnecting");
     //reconnect
@@ -99,6 +100,9 @@ public class TestMissedEventAfterReconnect extends ZkTestBase  {
 
     System.out.println("Killing participant 1");
     _participants.get(1).syncStop();
+    Assert.assertTrue(verifier.verifyByPolling());
+    Assert.assertFalse(hasAssignment(participantToKill.getInstanceName()), "Should not have assignments after reconnect");
+    Assert.assertFalse(hasAssignment(_participants.get(1).getInstanceName()), "Should have assignments after reconnect");
 
     System.out.println("end test");
   }

--- a/helix-core/src/test/java/org/apache/helix/integration/TestMissedEventAfterReconnect.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestMissedEventAfterReconnect.java
@@ -1,0 +1,143 @@
+package org.apache.helix.integration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.apache.helix.zookeeper.zkclient.ZkClient;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestMissedEventAfterReconnect extends ZkTestBase  {
+
+  public static String CLUSTER_NAME = TestHelper.getTestClassName() + "_cluster";
+  public static int PARTICIPANT_COUNT = 10;
+  public static List<MockParticipantManager> _participants = new ArrayList<>();
+  public static ClusterControllerManager _controller;
+  public static ConfigAccessor _configAccessor;
+
+  @BeforeClass
+  public void beforeClass() {
+    System.out.println("Start test " + TestHelper.getTestClassName());
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < PARTICIPANT_COUNT; i++) {
+      addParticipant("localhost_" + i);
+    }
+
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    _configAccessor = new ConfigAccessor(_gZkClient);
+    ClusterConfig clusterConfig =  _configAccessor.getClusterConfig(CLUSTER_NAME);
+    String testCapacityKey = "TestCapacityKey";
+    clusterConfig.setInstanceCapacityKeys(Collections.singletonList(testCapacityKey));
+    clusterConfig.setDefaultInstanceCapacityMap(Collections.singletonMap(testCapacityKey, 100));
+    clusterConfig.setDefaultPartitionWeightMap(Collections.singletonMap(testCapacityKey, 1));
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+  }
+
+  @Test
+  public void testControllerDisconnectedDuringEvent() throws Exception {
+    System.out.println("Start test");
+    String firstDB = "firstDB";
+    int numPartition = 10;
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, firstDB, numPartition, "LeaderStandby",
+        IdealState.RebalanceMode.FULL_AUTO.name(), null);
+
+    IdealState idealStateOne =
+        _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, firstDB);
+    idealStateOne.setMinActiveReplicas(2);
+    idealStateOne.setRebalancerClassName(WagedRebalancer.class.getName());
+    _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, firstDB, idealStateOne);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, firstDB, 3);
+
+    BestPossibleExternalViewVerifier verifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME).build();
+
+    Assert.assertTrue(verifier.verifyByPolling());
+    MockParticipantManager participantToKill = _participants.get(0);
+
+    //disconnect
+    System.out.println("Disconnecting");
+    ZkClient helixManagerZkClient = (ZkClient) _controller.getZkClient();
+    WatchedEvent event = new WatchedEvent(Watcher.Event.EventType.None, Watcher.Event.KeeperState.Disconnected, null);
+    helixManagerZkClient.process(event);
+
+    System.out.println("Killing participant 0");
+    _participants.get(0).syncStop();
+
+    System.out.println("Sleeping for timeout");
+    Thread.sleep(60000);
+
+    System.out.println("Reconnecting");
+    //reconnect
+    event = new WatchedEvent(Watcher.Event.EventType.None, Watcher.Event.KeeperState.SyncConnected, null);
+    helixManagerZkClient.process(event);
+
+
+    Assert.assertTrue(verifier.verifyByPolling());
+    Assert.assertFalse(hasAssignment(participantToKill.getInstanceName()), "Should not have assignments after reconnect");
+    Assert.assertTrue(hasAssignment(_participants.get(1).getInstanceName()), "Should have assignments after reconnect");
+
+    System.out.println("Killing participant 1");
+    _participants.get(1).syncStop();
+
+    System.out.println("end test");
+  }
+
+  private boolean hasAssignment(String instanceName) {
+    for (ExternalView ev : getEVs().values()) {
+      for (String partition : ev.getPartitionSet()) {
+        Map<String, String> stateMap = ev.getStateMap(partition);
+        if (stateMap.containsKey(instanceName)) {
+          System.out.println("Found assignment for " + instanceName + " with partition " + partition);
+          return true;
+        }
+      }
+    }
+    System.out.println("No assignment for " + instanceName);
+    return false;
+  }
+
+  private Map<String, ExternalView> getEVs() {
+    Map<String, ExternalView> externalViews = new HashMap<String, ExternalView>();
+    for (String db : _gSetupTool.getClusterManagementTool().getResourcesInCluster(CLUSTER_NAME)) {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, db);
+      externalViews.put(db, ev);
+    }
+    return externalViews;
+  }
+
+  public MockParticipantManager addParticipant(String instanceName) {
+    _gSetupTool.addInstanceToCluster(CLUSTER_NAME, instanceName);
+    MockParticipantManager participant = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+    participant.syncStart();
+    _participants.add(participant);
+    return participant;
+  }
+
+  public void dropParticipant(MockParticipantManager participantToDrop) {
+    participantToDrop.syncStop();
+    _gSetupTool.getClusterManagementTool().dropInstance(CLUSTER_NAME,
+        _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, participantToDrop.getInstanceName()));
+    _participants.remove(participantToDrop);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/TestMissedEventAfterReconnect.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestMissedEventAfterReconnect.java
@@ -2,6 +2,7 @@ package org.apache.helix.integration;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +57,7 @@ public class TestMissedEventAfterReconnect extends ZkTestBase  {
 
   @Test
   public void testControllerDisconnectedDuringEvent() throws Exception {
-    System.out.println("Start test");
+    System.out.println("Start testControllerDisconnectedDuringEvent at " + new Date(System.currentTimeMillis()));
     String firstDB = "firstDB";
     int numPartition = 10;
     _gSetupTool.addResourceToCluster(CLUSTER_NAME, firstDB, numPartition, "LeaderStandby",
@@ -95,16 +96,11 @@ public class TestMissedEventAfterReconnect extends ZkTestBase  {
 
 
     Assert.assertTrue(verifier.verifyByPolling());
+    Assert.assertFalse(_gZkClient.exists(_controller.getHelixDataAccessor().keyBuilder()
+            .liveInstance(participantToKill.getInstanceName()).getPath()), "Instance should be offline from ZK View");
     Assert.assertFalse(hasAssignment(participantToKill.getInstanceName()), "Should not have assignments after reconnect");
     Assert.assertTrue(hasAssignment(_participants.get(1).getInstanceName()), "Should have assignments after reconnect");
-
-    System.out.println("Killing participant 1");
-    _participants.get(1).syncStop();
-    Assert.assertTrue(verifier.verifyByPolling());
-    Assert.assertFalse(hasAssignment(participantToKill.getInstanceName()), "Should not have assignments after reconnect");
-    Assert.assertFalse(hasAssignment(_participants.get(1).getInstanceName()), "Should have assignments after reconnect");
-
-    System.out.println("end test");
+    System.out.println("End testControllerDisconnectedDuringEvent at " + new Date(System.currentTimeMillis()));
   }
 
   private boolean hasAssignment(String instanceName) {


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
#3005

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
Please see #3005 for more information on possible missed event bug. This PR adds a test case to capture the bug and a possible solution where the the manager triggers an onDemand rebalance if it is the lead controller. I'm not certain this is the best approach, but my progress on this has stalled and I figured I should open this issue up to open source discussion

### Tests

- [ ] The following tests are written for this issue:

TestMissedEventAfterReconnect

- The following is the result of the "mvn test" command on the appropriate module:

```
mvn test -o -Dtest=TestMissedEventAfterReconnect -pl=helix-core


[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  54.036 s
[INFO] Finished at: 2025-02-13T12:06:32-08:00
[INFO] ------------------------------------------------------------------------

```

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
