### PR TITLE
[TEST PR] Prevent DROPPED messages when mapping cannot be computed

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -152,8 +152,12 @@ public class MessageGenerationPhase extends AbstractBaseStage {
       // resourceStateMap. This instance may not have had been dropped by the rebalance strategy.
       // This check is required to ensure that the instances removed from the ideal state stateMap
       // are properly dropped.
+      // This should only solve for instance operation case where the instance is removed from the statemap but there
+      // are still valid assignments in the mapping. We should not consider case where there is no mapping at all for
+      // the resource, which can occur on a rebalance failure. If the resource has been removed, the BP will
+      // contain the DROPPED states
       for (String instance : currentStateMap.keySet()) {
-        if (!instanceStateMap.containsKey(instance)) {
+        if (!instanceStateMap.isEmpty() && !instanceStateMap.containsKey(instance)) {
           instanceStateMap.put(instance, HelixDefinedState.DROPPED.name());
         }
       }


### PR DESCRIPTION
### Issues

only drop replicas from resources when there is no entry in stapmap for them if the statemap is not empty - this handles the instance operation cases but does not kick in when there is on mapping computed at all (rebalance failures)


