### PR TITLE
Improve setInstanceOperation performance

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -211,7 +211,8 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     List<InstanceConfig> matchingLogicalIdInstances =
-        InstanceUtil.findInstancesWithMatchingLogicalId(_configAccessor, clusterName,
+        InstanceUtil.findInstancesWithMatchingLogicalId(_baseDataAccessor, _configAccessor,
+            clusterName,
             instanceConfig);
     if (matchingLogicalIdInstances.size() > 1) {
       throw new HelixException(
@@ -224,7 +225,8 @@ public class ZKHelixAdmin implements HelixAdmin {
     InstanceConstants.InstanceOperation attemptedInstanceOperation =
         instanceConfig.getInstanceOperation().getOperation();
     try {
-      InstanceUtil.validateInstanceOperationTransition(_configAccessor, clusterName, instanceConfig,
+      InstanceUtil.validateInstanceOperationTransition(_baseDataAccessor, _configAccessor,
+          clusterName, instanceConfig,
           InstanceConstants.InstanceOperation.UNKNOWN, attemptedInstanceOperation);
     } catch (HelixException e) {
       instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN);
@@ -616,7 +618,8 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     List<InstanceConfig> swappingInstances =
-        InstanceUtil.findInstancesWithMatchingLogicalId(_configAccessor, clusterName,
+        InstanceUtil.findInstancesWithMatchingLogicalId(_baseDataAccessor, _configAccessor,
+            clusterName,
             instanceConfig);
     if (swappingInstances.size() != 1) {
       logger.warn(
@@ -655,7 +658,8 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     List<InstanceConfig> swappingInstances =
-        InstanceUtil.findInstancesWithMatchingLogicalId(_configAccessor, clusterName,
+        InstanceUtil.findInstancesWithMatchingLogicalId(_baseDataAccessor, _configAccessor,
+            clusterName,
             instanceConfig);
     if (swappingInstances.size() != 1) {
       logger.warn(

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -211,8 +211,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     List<InstanceConfig> matchingLogicalIdInstances =
-        InstanceUtil.findInstancesWithMatchingLogicalId(_baseDataAccessor, _configAccessor,
-            clusterName,
+        InstanceUtil.findInstancesWithMatchingLogicalId(_baseDataAccessor, clusterName,
             instanceConfig);
     if (matchingLogicalIdInstances.size() > 1) {
       throw new HelixException(
@@ -225,8 +224,8 @@ public class ZKHelixAdmin implements HelixAdmin {
     InstanceConstants.InstanceOperation attemptedInstanceOperation =
         instanceConfig.getInstanceOperation().getOperation();
     try {
-      InstanceUtil.validateInstanceOperationTransition(_baseDataAccessor, _configAccessor,
-          clusterName, instanceConfig,
+      InstanceUtil.validateInstanceOperationTransition(_baseDataAccessor, clusterName,
+          instanceConfig,
           InstanceConstants.InstanceOperation.UNKNOWN, attemptedInstanceOperation);
     } catch (HelixException e) {
       instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN);
@@ -618,8 +617,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     List<InstanceConfig> swappingInstances =
-        InstanceUtil.findInstancesWithMatchingLogicalId(_baseDataAccessor, _configAccessor,
-            clusterName,
+        InstanceUtil.findInstancesWithMatchingLogicalId(_baseDataAccessor, clusterName,
             instanceConfig);
     if (swappingInstances.size() != 1) {
       logger.warn(
@@ -658,8 +656,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     }
 
     List<InstanceConfig> swappingInstances =
-        InstanceUtil.findInstancesWithMatchingLogicalId(_baseDataAccessor, _configAccessor,
-            clusterName,
+        InstanceUtil.findInstancesWithMatchingLogicalId(_baseDataAccessor, clusterName,
             instanceConfig);
     if (swappingInstances.size() != 1) {
       logger.warn(

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
@@ -30,7 +30,6 @@ import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
-import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
@@ -217,7 +216,7 @@ public class InstanceUtil {
         helixDataAccessor.getProperty(helixDataAccessor.keyBuilder().clusterConfig());
     String logicalIdKey =
         ClusterTopologyConfig.createFromClusterConfig(clusterConfig).getEndNodeType();
-    
+
     List<InstanceConfig> instanceConfigs =
         helixDataAccessor.getChildValues(helixDataAccessor.keyBuilder().instanceConfigs(), true);
 
@@ -231,14 +230,14 @@ public class InstanceUtil {
   private static List<InstanceConfig> findInstancesWithMatchingLogicalId(
       @Nullable BaseDataAccessor<ZNRecord> baseDataAccessor,
       @Nullable ConfigAccessor configAccessor, String clusterName, InstanceConfig instanceConfig) {
-    if (baseDataAccessor != null) {
-      return findInstancesWithMatchingLogicalId(baseDataAccessor, clusterName, instanceConfig);
-    } else if (configAccessor != null) {
-      return findInstancesWithMatchingLogicalId(configAccessor, clusterName, instanceConfig);
-    } else {
+    if (baseDataAccessor == null && configAccessor == null) {
       throw new HelixException(
           "Both BaseDataAccessor and ConfigAccessor cannot be null at the same time");
     }
+
+    return baseDataAccessor != null ? findInstancesWithMatchingLogicalId(baseDataAccessor,
+        clusterName, instanceConfig)
+        : findInstancesWithMatchingLogicalId(configAccessor, clusterName, instanceConfig);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
@@ -30,6 +30,7 @@ import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
+import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
@@ -212,14 +213,11 @@ public class InstanceUtil {
       InstanceConfig instanceConfig) {
     HelixDataAccessor helixDataAccessor = new ZKHelixDataAccessor(clusterName, baseDataAccessor);
 
-    List<ClusterConfig> clusterConfigs =
-        helixDataAccessor.getChildValues(helixDataAccessor.keyBuilder().clusterConfig(), true);
-    if (clusterConfigs.isEmpty()) {
-      throw new HelixException("Cluster " + clusterName + " does not exist");
-    }
-
+    ClusterConfig clusterConfig =
+        helixDataAccessor.getProperty(helixDataAccessor.keyBuilder().clusterConfig());
     String logicalIdKey =
-        ClusterTopologyConfig.createFromClusterConfig(clusterConfigs.get(0)).getEndNodeType();
+        ClusterTopologyConfig.createFromClusterConfig(clusterConfig).getEndNodeType();
+    
     List<InstanceConfig> instanceConfigs =
         helixDataAccessor.getChildValues(helixDataAccessor.keyBuilder().instanceConfigs(), true);
 

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
@@ -20,23 +20,24 @@ package org.apache.helix.util;
  */
 
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.PropertyPathBuilder;
 import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.model.ClusterTopologyConfig;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.helix.zookeeper.zkclient.DataUpdater;
 
 public class InstanceUtil {
 
@@ -45,27 +46,46 @@ public class InstanceUtil {
   }
 
   // Validators for instance operation transitions
-  private static final Function<List<InstanceConfig>, Boolean> ALWAYS_ALLOWED =
-      (matchingInstances) -> true;
-  private static final Function<List<InstanceConfig>, Boolean> ALL_MATCHES_ARE_UNKNOWN =
-      (matchingInstances) -> matchingInstances.isEmpty() || matchingInstances.stream().allMatch(
-          instance -> instance.getInstanceOperation().getOperation()
-              .equals(InstanceConstants.InstanceOperation.UNKNOWN));
-  private static final Function<List<InstanceConfig>, Boolean> ALL_MATCHES_ARE_UNKNOWN_OR_EVACUATE =
-      (matchingInstances) -> matchingInstances.isEmpty() || matchingInstances.stream().allMatch(
-          instance -> instance.getInstanceOperation().getOperation()
-              .equals(InstanceConstants.InstanceOperation.UNKNOWN)
-              || instance.getInstanceOperation().getOperation()
-              .equals(InstanceConstants.InstanceOperation.EVACUATE));
-  private static final Function<List<InstanceConfig>, Boolean> ANY_MATCH_ENABLE_OR_DISABLE =
-      (matchingInstances) -> !matchingInstances.isEmpty() && matchingInstances.stream().anyMatch(
-          instance -> instance.getInstanceOperation().getOperation()
-              .equals(InstanceConstants.InstanceOperation.ENABLE) || instance.getInstanceOperation()
-              .getOperation().equals(InstanceConstants.InstanceOperation.DISABLE));
+  private static final InstanceOperationValidator ALWAYS_ALLOWED =
+      (baseDataAccessor, configAccessor, clusterName, instanceConfig) -> true;
+  private static final InstanceOperationValidator ALL_MATCHES_ARE_UNKNOWN =
+      (baseDataAccessor, configAccessor, clusterName, instanceConfig) -> {
+        List<InstanceConfig> matchingInstances =
+            baseDataAccessor != null ? findInstancesWithMatchingLogicalId(baseDataAccessor,
+                configAccessor, clusterName, instanceConfig)
+                : findInstancesWithMatchingLogicalId(configAccessor, clusterName, instanceConfig);
+        return matchingInstances.isEmpty() || matchingInstances.stream().allMatch(
+            instance -> instance.getInstanceOperation().getOperation()
+                .equals(InstanceConstants.InstanceOperation.UNKNOWN));
+      };
+  private static final InstanceOperationValidator ALL_MATCHES_ARE_UNKNOWN_OR_EVACUATE =
+      (baseDataAccessor, configAccessor, clusterName, instanceConfig) -> {
+        List<InstanceConfig> matchingInstances =
+            baseDataAccessor != null ? findInstancesWithMatchingLogicalId(baseDataAccessor,
+                configAccessor, clusterName, instanceConfig)
+                : findInstancesWithMatchingLogicalId(configAccessor, clusterName, instanceConfig);
+        return matchingInstances.isEmpty() || matchingInstances.stream().allMatch(instance ->
+            instance.getInstanceOperation().getOperation()
+                .equals(InstanceConstants.InstanceOperation.UNKNOWN)
+                || instance.getInstanceOperation().getOperation()
+                .equals(InstanceConstants.InstanceOperation.EVACUATE));
+      };
+  private static final InstanceOperationValidator ANY_MATCH_ENABLE_OR_DISABLE =
+      (baseDataAccessor, configAccessor, clusterName, instanceConfig) -> {
+        List<InstanceConfig> matchingInstances =
+            baseDataAccessor != null ? findInstancesWithMatchingLogicalId(baseDataAccessor,
+                configAccessor, clusterName, instanceConfig)
+                : findInstancesWithMatchingLogicalId(configAccessor, clusterName, instanceConfig);
+        return !matchingInstances.isEmpty() && matchingInstances.stream().anyMatch(instance ->
+            instance.getInstanceOperation().getOperation()
+                .equals(InstanceConstants.InstanceOperation.ENABLE)
+                || instance.getInstanceOperation().getOperation()
+                .equals(InstanceConstants.InstanceOperation.DISABLE));
+      };
 
   // Validator map for valid instance operation transitions <currentOperation>:<targetOperation>:<validator>
-  private static final ImmutableMap<InstanceConstants.InstanceOperation, ImmutableMap<InstanceConstants.InstanceOperation, Function<List<InstanceConfig>, Boolean>>>
-      validInstanceOperationTransitions =
+  private static final ImmutableMap<InstanceConstants.InstanceOperation, ImmutableMap<InstanceConstants.InstanceOperation, InstanceOperationValidator>>
+      VALID_INSTANCE_OPERATION_TRANSITIONS =
       ImmutableMap.of(InstanceConstants.InstanceOperation.ENABLE,
       // ENABLE and DISABLE can be set to UNKNOWN when matching instance is in SWAP_IN and set to ENABLE in a transaction.
           ImmutableMap.of(InstanceConstants.InstanceOperation.ENABLE, ALWAYS_ALLOWED,
@@ -100,22 +120,47 @@ public class InstanceUtil {
    * @param instanceConfig   The current instance configuration
    * @param currentOperation The current operation
    * @param targetOperation  The target operation
+   * @deprecated Use {@link #validateInstanceOperationTransition(BaseDataAccessor, ConfigAccessor, String, InstanceConfig, InstanceConstants.InstanceOperation, InstanceConstants.InstanceOperation)}
+   *        instead for better performance.
    */
+  @Deprecated
   public static void validateInstanceOperationTransition(ConfigAccessor configAccessor,
       String clusterName, InstanceConfig instanceConfig,
       InstanceConstants.InstanceOperation currentOperation,
       InstanceConstants.InstanceOperation targetOperation) {
-    // Check if the current operation and target operation are in the valid transitions map
-    if (!validInstanceOperationTransitions.containsKey(currentOperation)
-        || !validInstanceOperationTransitions.get(currentOperation).containsKey(targetOperation)) {
+
+    validateInstanceOperationTransition(null, configAccessor, clusterName, instanceConfig,
+        currentOperation, targetOperation);
+  }
+
+  /**
+   * Validates if the transition from the current operation to the target operation is valid.
+   *
+   * @param baseDataAccessor The BaseDataAccessor instance
+   * @param configAccessor   The ConfigAccessor instance
+   * @param clusterName      The cluster name
+   * @param instanceConfig   The current instance configuration
+   * @param currentOperation The current operation
+   * @param targetOperation  The target operation
+   */
+  public static void validateInstanceOperationTransition(
+      BaseDataAccessor<ZNRecord> baseDataAccessor, ConfigAccessor configAccessor,
+      String clusterName, InstanceConfig instanceConfig,
+      InstanceConstants.InstanceOperation currentOperation,
+      InstanceConstants.InstanceOperation targetOperation) {
+
+    ImmutableMap<InstanceConstants.InstanceOperation, InstanceOperationValidator> transitionMap =
+        VALID_INSTANCE_OPERATION_TRANSITIONS.get(currentOperation);
+
+    if (transitionMap == null || !transitionMap.containsKey(targetOperation)) {
       throw new HelixException(
           "Invalid instance operation transition from " + currentOperation + " to "
               + targetOperation);
     }
 
-    // Throw exception if the validation fails
-    if (!validInstanceOperationTransitions.get(currentOperation).get(targetOperation)
-        .apply(findInstancesWithMatchingLogicalId(configAccessor, clusterName, instanceConfig))) {
+    InstanceOperationValidator validator = transitionMap.get(targetOperation);
+    if (validator == null || !validator.validate(baseDataAccessor, configAccessor, clusterName,
+        instanceConfig)) {
       throw new HelixException(
           "Failed validation for instance operation transition from " + currentOperation + " to "
               + targetOperation);
@@ -130,6 +175,7 @@ public class InstanceUtil {
    * @param instanceConfig  The instance configuration to match
    * @return A list of matching instances
    */
+  @Deprecated
   public static List<InstanceConfig> findInstancesWithMatchingLogicalId(
       ConfigAccessor configAccessor, String clusterName, InstanceConfig instanceConfig) {
     String logicalIdKey =
@@ -149,16 +195,42 @@ public class InstanceUtil {
   }
 
   /**
+   * Finds the instances that have a matching logical ID with the given instance.
+   *
+   * @param configAccessor  The ConfigAccessor instance
+   * @param clusterName     The cluster name
+   * @param instanceConfig  The instance configuration to match
+   * @return A list of matching instances
+   */
+  public static List<InstanceConfig> findInstancesWithMatchingLogicalId(
+      BaseDataAccessor<ZNRecord> baseDataAccessor, ConfigAccessor configAccessor,
+      String clusterName, InstanceConfig instanceConfig) {
+    String logicalIdKey =
+        ClusterTopologyConfig.createFromClusterConfig(configAccessor.getClusterConfig(clusterName))
+            .getEndNodeType();
+
+    HelixDataAccessor helixDataAccessor = new ZKHelixDataAccessor(clusterName, baseDataAccessor);
+    List<InstanceConfig> instanceConfigs =
+        helixDataAccessor.getChildValues(helixDataAccessor.keyBuilder().instanceConfigs(), true);
+
+    // Retrieve and filter instances with matching logical ID
+    return instanceConfigs.stream().filter(potentialInstanceConfig ->
+        !potentialInstanceConfig.getInstanceName().equals(instanceConfig.getInstanceName())
+            && potentialInstanceConfig.getLogicalId(logicalIdKey)
+            .equals(instanceConfig.getLogicalId(logicalIdKey))).collect(Collectors.toList());
+  }
+
+  /**
    * Sets the instance operation for the given instance.
    *
    * @param configAccessor      The ConfigAccessor instance
-   * @param baseAccessor        The BaseDataAccessor instance
+   * @param baseDataAccessor    The BaseDataAccessor instance
    * @param clusterName         The cluster name
    * @param instanceName        The instance name
    * @param instanceOperation   The instance operation to set
    */
   public static void setInstanceOperation(ConfigAccessor configAccessor,
-      BaseDataAccessor<ZNRecord> baseAccessor, String clusterName, String instanceName,
+      BaseDataAccessor<ZNRecord> baseDataAccessor, String clusterName, String instanceName,
       InstanceConfig.InstanceOperation instanceOperation) {
     String path = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
 
@@ -170,29 +242,32 @@ public class InstanceUtil {
     }
 
     // Validate the instance operation transition
-    validateInstanceOperationTransition(configAccessor, clusterName, instanceConfig,
+    validateInstanceOperationTransition(baseDataAccessor, configAccessor, clusterName,
+        instanceConfig,
         instanceConfig.getInstanceOperation().getOperation(),
         instanceOperation == null ? InstanceConstants.InstanceOperation.ENABLE
             : instanceOperation.getOperation());
 
     // Update the instance operation
-    boolean succeeded = baseAccessor.update(path, new DataUpdater<ZNRecord>() {
-      @Override
-      public ZNRecord update(ZNRecord currentData) {
-        if (currentData == null) {
-          throw new HelixException("Cluster: " + clusterName + ", instance: " + instanceName
-              + ", participant config is null");
-        }
-
-        InstanceConfig config = new InstanceConfig(currentData);
-        config.setInstanceOperation(instanceOperation);
-        return config.getRecord();
+    boolean succeeded = baseDataAccessor.update(path, currentData -> {
+      if (currentData == null) {
+        throw new HelixException("Cluster: " + clusterName + ", instance: " + instanceName
+            + ", participant config is null");
       }
+
+      InstanceConfig config = new InstanceConfig(currentData);
+      config.setInstanceOperation(instanceOperation);
+      return config.getRecord();
     }, AccessOption.PERSISTENT);
 
     if (!succeeded) {
       throw new HelixException(
           "Failed to update instance operation. Please check if instance is disabled.");
     }
+  }
+
+  private interface InstanceOperationValidator {
+    boolean validate(@Nullable BaseDataAccessor<ZNRecord> baseDataAccessor,
+        ConfigAccessor configAccessor, String clusterName, InstanceConfig instanceConfig);
   }
 }


### PR DESCRIPTION

### Issues

- [x] Currently setInstanceOperation takes a long time because we are unecessarily finding instances with matching logicalIds as well as individually getting all instance configs in the cluster.
 

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

This change will switch to parallel get on all instance configs and avoid calling findInstancesWithMatchingLogicalId for instance operation transitions where this check is not required.

### Tests

Current tests cover this change, as the result/response of these APIs will not change.

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
