### PR TITLE
Stoppable API skips min_active replica check if instance replica already in unhealthy state

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ParticipantDeregistrationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ParticipantDeregistrationStage.java
@@ -26,14 +26,14 @@ public class ParticipantDeregistrationStage extends AbstractAsyncBaseStage {
   @Override
   public void execute(ClusterEvent event) throws Exception {
     HelixManager manager = event.getAttribute(AttributeName.helixmanager.name());
-    ClusterConfig clusterConfig = manager.getConfigAccessor().getClusterConfig(manager.getClusterName());
+    ResourceControllerDataProvider cache = event.getAttribute(AttributeName.ControllerDataProvider.name());
+    ClusterConfig clusterConfig = cache.getClusterConfig();
     if (clusterConfig == null || !clusterConfig.isParticipantDeregistrationEnabled()) {
       LOG.debug("Cluster config is null or participant deregistration is not enabled. "
           + "Skipping participant deregistration.");
       return;
     }
 
-    ResourceControllerDataProvider cache = event.getAttribute(AttributeName.ControllerDataProvider.name());
     Map<String, Long> offlineTimeMap = cache.getInstanceOfflineTimeMap();
     long deregisterDelay = clusterConfig.getParticipantDeregistrationTimeout();
     long stageStartTime = System.currentTimeMillis();

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
@@ -449,6 +449,11 @@ public class InstanceValidationUtil {
         Map<String, String> stateByInstanceMap = externalView.getStateMap(partition);
         // found the resource hosted on the instance
         if (stateByInstanceMap.containsKey(instanceName)) {
+          // If this node's replica is in unhealthy state, skip the sibling check as removing this replica will not
+          // negatively affect availability.
+          if (unhealthyStates.contains(stateByInstanceMap.get(instanceName))) {
+            continue;
+          }
           int numHealthySiblings = 0;
           for (Map.Entry<String, String> entry : stateByInstanceMap.entrySet()) {
             String siblingInstanceName = entry.getKey();

--- a/helix-core/src/test/java/org/apache/helix/integration/TestWagedNPE.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestWagedNPE.java
@@ -2,13 +2,10 @@ package org.apache.helix.integration;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
-import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
-import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -426,7 +426,7 @@ public class TestInstancesAccessor extends AbstractTestClass {
     JsonNode jsonResult = OBJECT_MAPPER.readTree(response.readEntity(String.class));
     Assert.assertFalse(jsonResult.get("stoppable").asBoolean());
     Assert.assertEquals(getStringSet(jsonResult, "failedChecks"),
-            ImmutableSet.of("HELIX:HAS_DISABLED_PARTITION","HELIX:INSTANCE_NOT_ENABLED","HELIX:INSTANCE_NOT_STABLE","HELIX:MIN_ACTIVE_REPLICA_CHECK_FAILED"));
+            ImmutableSet.of("HELIX:HAS_DISABLED_PARTITION","HELIX:INSTANCE_NOT_ENABLED","HELIX:INSTANCE_NOT_STABLE"));
 
     // Reenable instance0, it should passed the check
     instanceConfig.setInstanceOperation(InstanceConstants.InstanceOperation.ENABLE);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
N/A

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Stoppable check will fail if node has replica in bad state for partition that does not have healthy siblings. 

Example: (replicas = 3, min_active = 2)
Partition 0 : {
   Node A : ERROR,
   Node B: ERROR,
   Node C: ERROR
}

Stoppable will fail on Node A because min active replica check will fail for partition 0 since there are not 2 healthy replicas for this partition. However, stopping this node will not affect the availability of this partition. Therefore, we should skip the min active replica sibling check if the instance replica is already in an unhealthy state. We should only fail for this check if removing this instance will affect the availability of the partition (aka the instance's replica is in a healthy state)

This PR also contains 2 unrelated changes:
1. Removing unused imports in TestWagedNPE
2. Changing ParticipantDeregistrationStage from using the configAccessor (reads from ZK) to using the cached clusterConfig

### Tests

- [x] The following tests are written for this issue:
TestSiblingNodesActiveReplicaCheckSuccessWithReplicaInErrorState in TestInstanceValidationUtil


- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
