### PR TITLE
Improve assignmentMetadataStore thread safety 

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentManager.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentManager.java
@@ -55,7 +55,7 @@ class AssignmentManager {
     if (assignmentMetadataStore != null) {
       try {
         _stateReadLatency.startMeasuringLatency();
-        currentBaseline = new HashMap<>(assignmentMetadataStore.getBaseline());
+        currentBaseline = assignmentMetadataStore.getBaseline();
         _stateReadLatency.endMeasuringLatency();
       } catch (Exception ex) {
         throw new HelixRebalanceException(
@@ -88,10 +88,7 @@ class AssignmentManager {
     if (assignmentMetadataStore != null) {
       try {
         _stateReadLatency.startMeasuringLatency();
-        currentBestAssignment =
-            assignmentMetadataStore.getBestPossibleAssignment().entrySet().stream().collect(
-                Collectors.toMap(Map.Entry::getKey,
-                    entry -> new ResourceAssignment(entry.getValue().getRecord())));
+        currentBestAssignment = assignmentMetadataStore.getBestPossibleAssignment();
         ;
         _stateReadLatency.endMeasuringLatency();
       } catch (Exception ex) {

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/MockAssignmentMetadataStore.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/MockAssignmentMetadataStore.java
@@ -19,7 +19,7 @@ package org.apache.helix.controller.rebalancer.waged;
  * under the License.
  */
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.helix.BucketDataAccessor;
@@ -36,7 +36,7 @@ public class MockAssignmentMetadataStore extends AssignmentMetadataStore {
   }
 
   public Map<String, ResourceAssignment> getBaseline() {
-    return _globalBaseline == null ? Collections.emptyMap() : _globalBaseline;
+    return _globalBaseline == null ? new HashMap<>() : _globalBaseline;
   }
 
   public void persistBaseline(Map<String, ResourceAssignment> globalBaseline) {
@@ -44,7 +44,7 @@ public class MockAssignmentMetadataStore extends AssignmentMetadataStore {
   }
 
   public Map<String, ResourceAssignment> getBestPossibleAssignment() {
-    return _bestPossibleAssignment == null ? Collections.emptyMap() : _bestPossibleAssignment;
+    return _bestPossibleAssignment == null ? new HashMap<>() : _bestPossibleAssignment;
   }
 
   public void persistBestPossibleAssignment(


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
ConcurrentModification errors can occur during waged rebalance due to async thread modifying the best possible while the main thread is iterating over it

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR refactors how we access and store the best possible and baseline assignments.

Get - returns a deep copy, assignment can now be safely modified without affecting the cache 
Set - creates a deep copy prior to storing - the passed in assignment can be safely modified without affecting the cache

The above changes are aimed at preventing unintended modification of the underlying ResourceAssignments

When a new assignment is persisted, we no longer clear the previous map and add the new map's value, but just point 
_globalBaseline or _bestPossibleAssignment at the new map. This change is intended to isolate threads so they cannot modify the underlying structure that another thread is pointing at. 


Stack trace of concurrentModification exception that can occur:

```
2025/03/24 20:00:06.938 ERROR [BestPossibleStateCalcStage] [HelixController-pipeline-default-CLUSTER_NAME-(39f24f68_DEFAULT)] [helix] [] Event 39f24f68_DEFAULT : Failed to calculate the new Ideal States using the rebalancer WagedRebalancer due to INVALID_REBALANCER_STATUS
org.apache.helix.HelixRebalanceException: Failed to get the current best possible assignment because of unexpected error. Failure Type: INVALID_REBALANCER_STATUS
        at org.apache.helix.controller.rebalancer.waged.AssignmentManager.getBestPossibleAssignment(AssignmentManager.java:98) ~[org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.emergencyRebalance(WagedRebalancer.java:456) ~[org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.computeBestPossibleAssignment(WagedRebalancer.java:339) ~[org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.computeBestPossibleStates(WagedRebalancer.java:316) ~[org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.rebalancer.waged.WagedRebalancer.computeNewIdealStates(WagedRebalancer.java:248) ~[org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.stages.BestPossibleStateCalcStage.computeResourceBestPossibleStateWithWagedRebalancer(BestPossibleStateCalcStage.java:445) [org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]         at org.apache.helix.controller.stages.BestPossibleStateCalcStage.compute(BestPossibleStateCalcStage.java:289) [org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.stages.BestPossibleStateCalcStage.process(BestPossibleStateCalcStage.java:94) [org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.pipeline.Pipeline.handle(Pipeline.java:75) [org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.GenericHelixController.handleEvent(GenericHelixController.java:905) [org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        at org.apache.helix.controller.GenericHelixController$ClusterEventProcessor.run(GenericHelixController.java:1556) [org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
Caused by: java.util.ConcurrentModificationException
        at java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1855) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
        at org.apache.helix.controller.rebalancer.waged.AssignmentManager.getBestPossibleAssignment(AssignmentManager.java:92) ~[org.apache.helix.helix-core-1.4.3-dev-202502211050.jar:1.4.3-dev-202502211050]
        ... 10 more
```

### Tests

- [ ] The following tests are written for this issue:
No new tests were added

- The following is the result of the "mvn test" command on the appropriate module:

```
$ mvn test -o -Dtest=TestWagedRebalancer -pl=helix-core

[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.02 s - in org.apache.helix.controller.rebalancer.waged.TestWagedRebalancer
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  19.526 s
[INFO] Finished at: 2025-04-15T12:26:57-07:00
[INFO] ------------------------------------------------------------------------

```


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)