### PR TITLE
Add check for customized resources in isEvacuatedFinished

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -800,11 +800,23 @@ public interface HelixAdmin {
   /**
    * Return if instance operation 'Evacuate' is finished.
    * @param clusterName
-   * @param instancesNames
-   * @return Return true if there is no current state nor pending message on the instance.
+   * @param instancesName
+   * @return Return true if there is no FULL_AUTO or CUSTOMIZED resources in the current state nor
+   * any pending message on the instance.
    */
-  default boolean isEvacuateFinished(String clusterName, String instancesNames) {
+  default boolean isEvacuateFinished(String clusterName, String instancesName) {
     throw new UnsupportedOperationException("isEvacuateFinished is not implemented.");
+  }
+
+  /**
+   * Check to see if instance is drained.
+   * @param clusterName
+   * @param instanceName
+   * @return Return true if there is no FULL_AUTO or CUSTOMIZED resources in the current state nor
+   * any pending message on the instance.
+   */
+  default boolean isInstanceDrained(String clusterName, String instanceName) {
+    throw new UnsupportedOperationException("isInstanceDrained is not implemented.");
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
@@ -24,9 +24,11 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.helix.HelixDefinedState;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
@@ -132,10 +134,13 @@ public class CustomRebalancer extends AbstractRebalancer<ResourceControllerDataP
       boolean notInErrorState = currentStateMap != null
           && !HelixDefinedState.ERROR.toString().equals(currentStateMap.get(instance));
       boolean enabled = !disabledInstancesForPartition.contains(instance) && isResourceEnabled;
-
+      InstanceConfig instanceConfig = cache.getInstanceConfigMap().get(instance);
+      boolean isInstanceEvacuated = instanceConfig != null &&
+          instanceConfig.getInstanceOperation().getOperation() == InstanceConstants.InstanceOperation.EVACUATE;
       // Note: if instance is not live, the mapping for that instance will not show up in
       // BestPossibleMapping (and ExternalView)
-      if (assignableLiveInstancesMap.containsKey(instance) && notInErrorState) {
+      // if instance is evacuated keep the instanceStateMap same as idealStateMap
+      if ((assignableLiveInstancesMap.containsKey(instance) || isInstanceEvacuated) && notInErrorState) {
         if (enabled) {
           instanceStateMap.put(instance, idealStateMap.get(instance));
         } else {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -460,12 +460,17 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   @Override
   public boolean isEvacuateFinished(String clusterName, String instanceName) {
-    if (!instanceHasFullAutoCurrentStateOrMessage(clusterName, instanceName)) {
-      InstanceConfig config = getInstanceConfig(clusterName, instanceName);
-      return config != null && config.getInstanceOperation().getOperation()
-          .equals(InstanceConstants.InstanceOperation.EVACUATE);
+    InstanceConfig config = getInstanceConfig(clusterName, instanceName);
+    if (config == null || config.getInstanceOperation().getOperation() !=
+        InstanceConstants.InstanceOperation.EVACUATE ) {
+      return false;
     }
-    return false;
+    return !instanceHasCurrentStateOrMessage(clusterName, instanceName);
+  }
+
+  @Override
+  public boolean isInstanceDrained(String clusterName, String instanceName) {
+    return !instanceHasCurrentStateOrMessage(clusterName, instanceName);
   }
 
   /**
@@ -721,7 +726,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   @Override
   public boolean isReadyForPreparingJoiningCluster(String clusterName, String instanceName) {
-    if (!instanceHasFullAutoCurrentStateOrMessage(clusterName, instanceName)) {
+    if (!instanceHasCurrentStateOrMessage(clusterName, instanceName)) {
       InstanceConfig config = getInstanceConfig(clusterName, instanceName);
       return config != null && INSTANCE_OPERATION_TO_EXCLUDE_FROM_ASSIGNMENT.contains(
           config.getInstanceOperation().getOperation());
@@ -757,13 +762,14 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   /**
-   * Return true if Instance has any current state or pending message. Otherwise, return false if instance is offline,
+   * Return true if instance has any resource with FULL_AUTO or CUSTOMIZED rebalance mode in current state or
+   * if instance has any pending message. Otherwise, return false if instance is offline,
    * instance has no active session, or if instance is online but has no current state or pending message.
    * @param clusterName
    * @param instanceName
    * @return
    */
-  private boolean instanceHasFullAutoCurrentStateOrMessage(String clusterName,
+  private boolean instanceHasCurrentStateOrMessage(String clusterName,
       String instanceName) {
     HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, _baseDataAccessor);
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
@@ -803,13 +809,14 @@ public class ZKHelixAdmin implements HelixAdmin {
       return true;
     }
 
-    // Get set of FULL_AUTO resources
+    // Get set of FULL_AUTO and CUSTOMIZED resources
     List<IdealState> idealStates = accessor.getChildValues(keyBuilder.idealStates(), true);
-    Set<String> fullAutoResources = idealStates != null ? idealStates.stream()
-        .filter(idealState -> idealState.getRebalanceMode() == RebalanceMode.FULL_AUTO)
+    Set<String> resources = idealStates != null ? idealStates.stream()
+        .filter(idealState -> idealState.getRebalanceMode() == RebalanceMode.FULL_AUTO ||
+            idealState.getRebalanceMode() == RebalanceMode.CUSTOMIZED)
         .map(IdealState::getResourceName).collect(Collectors.toSet()) : Collections.emptySet();
 
-    return currentStates.stream().anyMatch(fullAutoResources::contains);
+    return currentStates.stream().anyMatch(resources::contains);
   }
 
   @Override

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestCustomRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestCustomRebalancer.java
@@ -25,6 +25,7 @@ import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.CustomRebalancer;
 import org.apache.helix.controller.stages.CurrentStateOutput;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.OnlineOfflineSMD;
 import org.apache.helix.model.Partition;
@@ -70,7 +71,7 @@ public class TestCustomRebalancer {
         .thenReturn(ImmutableSet.of(instanceName));
     when(cache.getAssignableLiveInstances())
         .thenReturn(ImmutableMap.of(instanceName, new LiveInstance(instanceName)));
-
+    when(cache.getInstanceConfigMap()).thenReturn(ImmutableMap.of(instanceName, new InstanceConfig(instanceName)));
     CurrentStateOutput currOutput = new CurrentStateOutput();
     ResourceAssignment resourceAssignment =
         customRebalancer.computeBestPossiblePartitionState(cache, idealState, resource, currOutput);

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -578,6 +578,11 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   @Override
+  public boolean isInstanceDrained(String clusterName, String instancesNames) {
+    return false;
+  }
+
+  @Override
   public boolean canCompleteSwap(String clusterName, String instancesNames) {
     return false;
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -90,6 +90,7 @@ public class AbstractResource {
     completeSwapIfPossible,
     onDemandRebalance,
     isEvacuateFinished,
+    isInstanceDrained,
     setPartitionsToError,
     forceKillInstance
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -508,6 +508,16 @@ public class PerInstanceAccessor extends AbstractHelixResource {
             return serverError(e);
           }
           return OK(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of("successful", evacuateFinished)));
+        case isInstanceDrained:
+          boolean instanceDrained;
+          try {
+            instanceDrained = admin.isInstanceDrained(clusterId, instanceName);
+          } catch (HelixException e) {
+            LOG.error(String.format("Encountered error when checking if instance is drained for cluster: "
+                + "{}, instance: {}", clusterId, instanceName), e);
+            return serverError(e);
+          }
+          return OK(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of("successful", instanceDrained)));
         case forceKillInstance:
           boolean instanceForceKilled = admin.forceKillInstance(clusterId, instanceName, reason, instanceOperationSource);
           if (!instanceForceKilled) {

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -580,6 +580,12 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     Assert.assertTrue(evacuateFinishedResult.get("successful"));
 
+    response = new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=isInstanceDrained")
+        .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
+    Map<String, Boolean> instanceDrainedResult = OBJECT_MAPPER.readValue(response.readEntity(String.class), Map.class);
+    Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+    Assert.assertTrue(instanceDrainedResult.get("successful"));
+
     // test isEvacuateFinished on instance with EVACUATE and no currentState
     // Create new instance so no currentState or messages assigned to it
     String test_instance_name = INSTANCE_NAME + "_foo";


### PR DESCRIPTION
### Issues

- [ ] Currently isEvacuateFinished doesn't check if there is any resource with customized rebalance mode in current state. For Pinot usecase this isEvacuateFinished is returning true even when there are resources with customized rebalance mode in current state.

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- This change returns false if the current state contains any resource with rebalance mode full auto or customized
- Because isEvactuateFinished also checks if the instance operations is set to evacaute, added another API in HelixAdmin `isInstanceDrained` to check if the instance doesn't has any resource with rebalance mode full auto or customized in the current state
- Exposed the `isInstanceDrained` check via API
- Added a logic in CustomRebalancer to not update the assigned mapping of instances marked as evacuted. 

(Write a concise description including what, why, how)

### Tests

- [ ] The following tests are written for this issue:

- `TestInstanceOperation.testEvacuateWithCustomizedResource()`
- `TestCustomRebalancer.testDisabledBootstrappingPartitions()` have been adjusted appropriately

- The following is the result of the "mvn test" command on the appropriate module:
```
mvn test -o -Dtest=TestInstanceOperation -pl=helix-core


[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 597.813 s - in org.apache.helix.integration.rebalancer.TestInstanceOperation
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/anubagar/workspace/helix-projects/apache-helix/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 962 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10:11 min
[INFO] Finished at: 2025-04-21T22:23:14+05:30
[INFO] ------------------------------------------------------------------------
```

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
