### PR TITLE
Fix dropping error state partition for customized resource

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
@@ -129,13 +129,11 @@ public class CustomRebalancer extends AbstractRebalancer<ResourceControllerDataP
 
     Map<String, LiveInstance> assignableLiveInstancesMap = cache.getAssignableLiveInstances();
     for (String instance : idealStateMap.keySet()) {
-      boolean notInErrorState = currentStateMap != null
-          && !HelixDefinedState.ERROR.toString().equals(currentStateMap.get(instance));
       boolean enabled = !disabledInstancesForPartition.contains(instance) && isResourceEnabled;
 
       // Note: if instance is not live, the mapping for that instance will not show up in
       // BestPossibleMapping (and ExternalView)
-      if (assignableLiveInstancesMap.containsKey(instance) && notInErrorState) {
+      if (assignableLiveInstancesMap.containsKey(instance)){
         if (enabled) {
           instanceStateMap.put(instance, idealStateMap.get(instance));
         } else {

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestCustomizedIdealStateRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestCustomizedIdealStateRebalancer.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Lists;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.PropertyKey.Builder;
-import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
@@ -49,7 +48,6 @@ import org.testng.annotations.Test;
 
 public class TestCustomizedIdealStateRebalancer extends ZkStandAloneCMTestBase {
   String db2 = TEST_DB + "2";
-  String db3 = TEST_DB + "3";
   static boolean testRebalancerCreated = false;
   static boolean testRebalancerInvoked = false;
 
@@ -99,45 +97,6 @@ public class TestCustomizedIdealStateRebalancer extends ZkStandAloneCMTestBase {
     HelixDataAccessor accessor =
         new ZKHelixDataAccessor(CLUSTER_NAME, new ZkBaseDataAccessor<ZNRecord>(_gZkClient));
     Builder keyBuilder = accessor.keyBuilder();
-    ExternalView ev = accessor.getProperty(keyBuilder.externalView(db2));
-    Assert.assertEquals(ev.getPartitionSet().size(), 60);
-    for (String partition : ev.getPartitionSet()) {
-      Assert.assertEquals(ev.getStateMap(partition).size(), 1);
-    }
-    IdealState is = accessor.getProperty(keyBuilder.idealStates(db2));
-    for (String partition : is.getPartitionSet()) {
-      Assert.assertEquals(is.getPreferenceList(partition).size(), 0);
-      Assert.assertEquals(is.getInstanceStateMap(partition).size(), 0);
-    }
-    Assert.assertTrue(testRebalancerCreated);
-    Assert.assertTrue(testRebalancerInvoked);
-  }
-
-  @Test
-  public void testCustomizedIdealStateRebalancer2() throws InterruptedException {
-    IdealState idealState =
-        _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, TEST_DB);
-    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
-    ZkBaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<ZNRecord>(_gZkClient);
-    HelixDataAccessor accessor =
-        new ZKHelixDataAccessor(CLUSTER_NAME, new ZkBaseDataAccessor<ZNRecord>(_gZkClient));
-    Builder keyBuilder = accessor.keyBuilder();
-    accessor.setProperty(keyBuilder.idealStates(TEST_DB), idealState);
-
-    // stop  one participant , no longer in liveinstance;
-    _participants[0].syncStop();
-
-    // enable that participant
-    MockParticipantManager participant =
-        new MockParticipantManager(ZK_ADDR, _participants[0].getClusterName(),
-            _participants[0].getInstanceName());
-    participant.syncStart();
-
-    boolean result =
-        ClusterStateVerifier.verifyByZkCallback(new ExternalViewBalancedVerifier(_gZkClient, CLUSTER_NAME, db2));
-    Assert.assertTrue(result);
-    Thread.sleep(1000);
-
     ExternalView ev = accessor.getProperty(keyBuilder.externalView(db2));
     Assert.assertEquals(ev.getPartitionSet().size(), 60);
     for (String partition : ev.getPartitionSet()) {


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
#3014

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Fix dropping error state partition for customized resource

### Tests

- [X] The following tests are written for this issue:

testErrorReplicaPersist

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
