### PR TITLE
Add cluster config update validation

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -1281,23 +1281,26 @@ public class ClusterAccessor extends AbstractHelixResource {
 
     // Only validate the topology related settings if the topology aware is enabled.
     if (updatedConfig.isTopologyAwareEnabled()) {
+      if (updatedConfig.getTopology() == null || updatedConfig.getFaultZoneType() == null) {
+        throw new IllegalArgumentException(
+            "Topology and fault zone type must be set when topology aware is enabled.");
+      }
+
       boolean isTopologyAwareChanged =
           !oldConfig.isTopologyAwareEnabled() && updatedConfig.isTopologyAwareEnabled();
       boolean isTopologyPathChanged =
-          (oldConfig.getTopology() == null && newClusterConfig.getTopology() != null) || (
-              oldConfig.getTopology() != null && !oldConfig.getTopology()
-                  .equals(updatedConfig.getTopology()));
+          oldConfig.getTopology() == null || (oldConfig.getTopology() != null
+              && !oldConfig.getTopology().equals(updatedConfig.getTopology()));
       boolean isFaultZoneTypeChanged =
-          (oldConfig.getFaultZoneType() == null && newClusterConfig.getFaultZoneType() != null) || (
-              oldConfig.getFaultZoneType() != null && !oldConfig.getFaultZoneType()
-                  .equals(updatedConfig.getFaultZoneType()));
+          oldConfig.getFaultZoneType() == null || (oldConfig.getFaultZoneType() != null
+              && !oldConfig.getFaultZoneType().equals(updatedConfig.getFaultZoneType()));
 
       if (isTopologyAwareChanged || isTopologyPathChanged || isFaultZoneTypeChanged) {
         HelixDataAccessor dataAccessor = getDataAccssor(clusterName);
         PropertyKey.Builder keyBuilder = dataAccessor.keyBuilder();
         List<InstanceConfig> instanceConfigs = dataAccessor.getChildValues(keyBuilder.instanceConfigs(), true);
         for (InstanceConfig instanceConfig : instanceConfigs) {
-          instanceConfig.validateTopologySettingInInstanceConfig(newClusterConfig,
+          instanceConfig.validateTopologySettingInInstanceConfig(updatedConfig,
               instanceConfig.getInstanceName());
         }
       }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -60,6 +60,7 @@ import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ControllerHistory;
 import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.HelixConfigScope;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.MaintenanceSignal;
 import org.apache.helix.model.Message;
@@ -708,9 +709,11 @@ public class ClusterAccessor extends AbstractHelixResource {
     try {
       switch (command) {
         case update:
+          validateClusterConfigChange(clusterId, configAccessor, config, command);
           configAccessor.updateClusterConfig(clusterId, config);
           break;
         case delete: {
+          validateClusterConfigChange(clusterId, configAccessor, config, command);
           HelixConfigScope clusterScope =
               new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER)
                   .forCluster(clusterId).build();
@@ -1247,5 +1250,48 @@ public class ClusterAccessor extends AbstractHelixResource {
 
   private AclRegister getAclRegister() {
     return (AclRegister) _application.getProperties().get(ContextPropertyKeys.ACL_REGISTER.name());
+  }
+
+  /**
+   * Validates the changes to the cluster configuration.
+   *
+   * Specifically checks changes related to topology settings. If topology settings are updated,
+   * ensures all instance configurations align with the new cluster configuration.
+   *
+   * @param clusterName Name of the cluster to validate.
+   * @param configAccessor Accessor to retrieve and update cluster configurations.
+   * @param newClusterConfig The new cluster configuration to validate against.
+   * @param command Type of command triggering this validation (e.g., update, delete).
+   */
+  private void validateClusterConfigChange(String clusterName, ConfigAccessor configAccessor,
+      ClusterConfig newClusterConfig, Command command) {
+    ClusterConfig oldConfig = configAccessor.getClusterConfig(clusterName);
+    ClusterConfig updatedConfig = configAccessor.getClusterConfig(clusterName);
+
+    if (command == Command.delete) {
+      // Since the topology related setting is only in the simple field, we don't need to validate
+      // other fields.
+      for (Map.Entry<String, String> entry : newClusterConfig.getRecord().getSimpleFields()
+          .entrySet()) {
+        updatedConfig.getRecord().getSimpleFields().remove(entry.getKey());
+      }
+    } else {
+      updatedConfig.getRecord().update(newClusterConfig.getRecord());
+    }
+
+    boolean isTopologySettingChanged =
+        (!oldConfig.isTopologyAwareEnabled() && updatedConfig.isTopologyAwareEnabled())
+            || (oldConfig.getTopology() != null && !oldConfig.getTopology().equals(updatedConfig.getTopology()))
+            || (oldConfig.getFaultZoneType() != null && !oldConfig.getFaultZoneType().equals(updatedConfig.getFaultZoneType()));
+
+    if (updatedConfig.isTopologyAwareEnabled() && isTopologySettingChanged) {
+      HelixDataAccessor dataAccessor = getDataAccssor(clusterName);
+      PropertyKey.Builder keyBuilder = dataAccessor.keyBuilder();
+      List<InstanceConfig> instanceConfigs = dataAccessor.getChildValues(keyBuilder.instanceConfigs(), true);
+      for (InstanceConfig instanceConfig : instanceConfigs) {
+        instanceConfig.validateTopologySettingInInstanceConfig(newClusterConfig,
+            instanceConfig.getInstanceName());
+      }
+    }
   }
 }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -122,6 +122,33 @@ public class TestClusterAccessor extends AbstractTestClass {
       updateClusterConfigFromRest(cluster, newConfig, Command.update);
     }
 
+    // Update the topology path string to NULL. This request should go through since the
+    // topology aware is not enabled.
+    {
+      ClusterConfig newConfig = new ClusterConfig(config.getRecord());
+      newConfig.setTopology(null);
+      newConfig.setFaultZoneType(null);
+      newConfig.setTopologyAwareEnabled(false);
+      updateClusterConfigFromRest(cluster, newConfig, Command.update);
+    }
+
+    // Now update the config while keeping the topology path and fault zone unchanged (it's still NULL)
+    {
+      ClusterConfig newConfig = new ClusterConfig(config.getClusterName());
+      newConfig.setTopologyAwareEnabled(true);
+      _auditLogger.clearupLogs();
+      Entity entity = Entity.entity(OBJECT_MAPPER.writeValueAsString(newConfig.getRecord()),
+          MediaType.APPLICATION_JSON_TYPE);
+      post("clusters/" + cluster + "/configs", ImmutableMap.of("command", Command.update.name()),
+          entity, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+
+      validateAuditLogSize(1);
+      AuditLog auditLog = _auditLogger.getAuditLogs().get(0);
+      Assert.assertEquals(auditLog.getHttpMethod(), HTTPMethods.POST.name());
+      Assert.assertEquals(auditLog.getRequestPath(), "clusters/" + cluster + "/configs");
+      Assert.assertEquals(auditLog.getExceptions().size(), 1);
+    }
+
     // Restore the cluster config
     updateClusterConfigFromRest(cluster, config, Command.update);
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -90,6 +90,45 @@ public class TestClusterAccessor extends AbstractTestClass {
   }
 
   @Test
+  public void testValidateClusterConfigChange() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String cluster = "TestCluster_1";
+    ClusterConfig config = getClusterConfigFromRest(cluster);
+
+    // Enable the topology aware setting while the instance config does not have the DOMAIN info
+    {
+      ClusterConfig newConfig = new ClusterConfig(config.getRecord());
+      newConfig.setTopologyAwareEnabled(true);
+      _auditLogger.clearupLogs();
+      Entity entity = Entity.entity(OBJECT_MAPPER.writeValueAsString(newConfig.getRecord()),
+          MediaType.APPLICATION_JSON_TYPE);
+      post("clusters/" + cluster + "/configs", ImmutableMap.of("command", Command.update.name()),
+          entity, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+
+      validateAuditLogSize(1);
+      AuditLog auditLog = _auditLogger.getAuditLogs().get(0);
+      Assert.assertEquals(auditLog.getHttpMethod(), HTTPMethods.POST.name());
+      Assert.assertEquals(auditLog.getRequestPath(), "clusters/" + cluster + "/configs");
+      Assert.assertEquals(auditLog.getExceptions().size(), 1);
+    }
+
+    // Since the topology aware is not enabled, changing the cluster config should not fail even
+    // if the instance config does not have the DOMAIN info
+    {
+      ClusterConfig newConfig = new ClusterConfig(config.getRecord());
+      newConfig.setFaultZoneType("TestZoneId");
+      newConfig.setTopology("/TestZoneId/instance");
+      newConfig.setTopologyAwareEnabled(false);
+      updateClusterConfigFromRest(cluster, newConfig, Command.update);
+    }
+
+    // Restore the cluster config
+    updateClusterConfigFromRest(cluster, config, Command.update);
+
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test(dependsOnMethods = "testValidateClusterConfigChange")
   public void testGetClusters() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
 


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
#3025 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Adding the sanity checks for the cluster topology changes. When the user enables the topology aware, this change will loop through the instances' config to see if each instance has the correctly setup the `DOMAIN` info. If not, throw an exception. The check for changes of `TOPOLOGY` string and `FAULT_ZONE_TYPE` will only issued if topologyAware is enabled.

### Tests

- [X] The following tests are written for this issue:
`mvn clean install -Dmaven.test.skip.exec=true &&  mvn test -Dtest=TestClusterAccessor -pl helix-rest`


- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
