### PR TITLE
Fix virtual topology string computation

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ClusterTopologyConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterTopologyConfig.java
@@ -23,7 +23,6 @@ import java.util.LinkedHashMap;
 import org.apache.helix.HelixException;
 import org.apache.helix.controller.rebalancer.topology.Topology;
 
-
 public class ClusterTopologyConfig {
   private static final String DEFAULT_DOMAIN_PREFIX = "Helix_default_";
   private static final String TOPOLOGY_SPLITTER = "/";
@@ -81,6 +80,26 @@ public class ClusterTopologyConfig {
       }
     }
     return new ClusterTopologyConfig(true, endNodeType, faultZoneType, topologyKeyDefaultValue);
+  }
+
+  /**
+   * Replace the fault zone in the given topology string with the new fault zone.
+   *
+   * @param topologyString the topology string to be modified
+   * @param newFaultZone the new fault zone to be set
+   * @return the modified topology string
+   */
+  public String replaceFaultZoneInTopologyString(String topologyString, String newFaultZone) {
+    if (topologyString == null || topologyString.isEmpty()) {
+      throw new IllegalArgumentException("Topology string cannot be null or empty");
+    }
+    String[] newTopologyString = topologyString.split(TOPOLOGY_SPLITTER);
+    for (int i = 0; i < newTopologyString.length; i++) {
+      if (newTopologyString[i].equals(_faultZoneType)) {
+        newTopologyString[i] = newFaultZone;
+      }
+    }
+    return String.join(TOPOLOGY_SPLITTER, newTopologyString);
   }
 
   public boolean isTopologyAwareEnabled() {

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterTopologyConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterTopologyConfig.java
@@ -82,26 +82,6 @@ public class ClusterTopologyConfig {
     return new ClusterTopologyConfig(true, endNodeType, faultZoneType, topologyKeyDefaultValue);
   }
 
-  /**
-   * Replace the fault zone in the given topology string with the new fault zone.
-   *
-   * @param topologyString the topology string to be modified
-   * @param newFaultZone the new fault zone to be set
-   * @return the modified topology string
-   */
-  public String replaceFaultZoneInTopologyString(String topologyString, String newFaultZone) {
-    if (topologyString == null || topologyString.isEmpty()) {
-      throw new IllegalArgumentException("Topology string cannot be null or empty");
-    }
-    String[] newTopologyString = topologyString.split(TOPOLOGY_SPLITTER);
-    for (int i = 0; i < newTopologyString.length; i++) {
-      if (newTopologyString[i].equals(_faultZoneType)) {
-        newTopologyString[i] = newFaultZone;
-      }
-    }
-    return String.join(TOPOLOGY_SPLITTER, newTopologyString);
-  }
-
   public boolean isTopologyAwareEnabled() {
     return _topologyAwareEnabled;
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/VirtualTopologyGroupService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/VirtualTopologyGroupService.java
@@ -47,6 +47,7 @@ import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.helix.cloud.constants.VirtualTopologyGroupConstants.PATH_NAME_SPLITTER;
 import static org.apache.helix.util.VirtualTopologyUtil.computeVirtualFaultZoneTypeKey;
 
 /**
@@ -200,13 +201,31 @@ public class VirtualTopologyGroupService {
     LOG.info("Successfully update instance and cluster config for {}", clusterName);
   }
 
+  /**
+   * Compute the virtual topology string based on the cluster config by replacing the old fault zone
+   * with the new virtual topology fault zone key.
+   *
+   * @param clusterConfig cluster config for the cluster.
+   * @return the updated virtual topology string.
+   */
   @VisibleForTesting
   static String computeVirtualTopologyString(ClusterConfig clusterConfig) {
     ClusterTopologyConfig clusterTopologyConfig =
         ClusterTopologyConfig.createFromClusterConfig(clusterConfig);
     String topologyString = clusterConfig.getTopology();
-    return clusterTopologyConfig.replaceFaultZoneInTopologyString(topologyString,
-        computeVirtualFaultZoneTypeKey(clusterConfig.getFaultZoneType()));
+
+    if (topologyString == null || topologyString.isEmpty()) {
+      throw new IllegalArgumentException("Topology string cannot be null or empty");
+    }
+
+    String newFaultZone = computeVirtualFaultZoneTypeKey(clusterConfig.getFaultZoneType());
+    String[] newTopologyString = topologyString.split(PATH_NAME_SPLITTER);
+    for (int i = 0; i < newTopologyString.length; i++) {
+      if (newTopologyString[i].equals(clusterTopologyConfig.getFaultZoneType())) {
+        newTopologyString[i] = newFaultZone;
+      }
+    }
+    return String.join(PATH_NAME_SPLITTER, newTopologyString);
   }
 
   /**

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/service/VirtualTopologyGroupService.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/service/VirtualTopologyGroupService.java
@@ -202,10 +202,11 @@ public class VirtualTopologyGroupService {
 
   @VisibleForTesting
   static String computeVirtualTopologyString(ClusterConfig clusterConfig) {
-    ClusterTopologyConfig clusterTopologyConfig = ClusterTopologyConfig.createFromClusterConfig(clusterConfig);
-    String endNodeType = clusterTopologyConfig.getEndNodeType();
-    String[] splits = new String[] {"", computeVirtualFaultZoneTypeKey(clusterConfig.getFaultZoneType()), endNodeType};
-    return String.join(VirtualTopologyGroupConstants.PATH_NAME_SPLITTER, splits);
+    ClusterTopologyConfig clusterTopologyConfig =
+        ClusterTopologyConfig.createFromClusterConfig(clusterConfig);
+    String topologyString = clusterConfig.getTopology();
+    return clusterTopologyConfig.replaceFaultZoneInTopologyString(topologyString,
+        computeVirtualFaultZoneTypeKey(clusterConfig.getFaultZoneType()));
   }
 
   /**

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestVirtualTopologyGroupService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestVirtualTopologyGroupService.java
@@ -188,6 +188,16 @@ public class TestVirtualTopologyGroupService {
         "/zone_virtualZone/instance");
   }
 
+  @Test
+  public void testVirtualTopologyStringMulti() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    testConfig.setTopologyAwareEnabled(true);
+    testConfig.setTopology("/testZone/instance/appInstance");
+    testConfig.setFaultZoneType("testZone");
+    Assert.assertEquals(VirtualTopologyGroupService.computeVirtualTopologyString(testConfig),
+        "/testZone_virtualZone/instance/appInstance");
+  }
+
   private static ClusterTopology prepareClusterTopology() {
     List<ClusterTopology.Zone> zones = ImmutableList.of(
         new ClusterTopology.Zone("zone0", ImmutableList.of(

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestVirtualTopologyGroupService.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/service/TestVirtualTopologyGroupService.java
@@ -196,6 +196,13 @@ public class TestVirtualTopologyGroupService {
     testConfig.setFaultZoneType("testZone");
     Assert.assertEquals(VirtualTopologyGroupService.computeVirtualTopologyString(testConfig),
         "/testZone_virtualZone/instance/appInstance");
+
+    testConfig = new ClusterConfig("testingName");
+    testConfig.setTopologyAwareEnabled(true);
+    testConfig.setTopology("/testZone/instance/appInstance/endNodeType");
+    testConfig.setFaultZoneType("instance");
+    Assert.assertEquals(VirtualTopologyGroupService.computeVirtualTopologyString(testConfig),
+        "/testZone/instance_virtualZone/appInstance/endNodeType");
   }
 
   private static ClusterTopology prepareClusterTopology() {


### PR DESCRIPTION
### Issues

- [X] My PR addresses the following Helix issues and references them in the PR description:
#3030 

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Fix the problem where the virtual topology string doesn't carry over the correct topology after updating the cluster config

### Tests

- [X] The following tests are written for this issue:
Added a new test case: `testVirtualTopologyStringMulti`

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
