### PR TITLE
Prevent controller from dropping replicas when best possible fails to calculate assignment

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageGenerationPhase.java
@@ -152,8 +152,12 @@ public class MessageGenerationPhase extends AbstractBaseStage {
       // resourceStateMap. This instance may not have had been dropped by the rebalance strategy.
       // This check is required to ensure that the instances removed from the ideal state stateMap
       // are properly dropped.
+      // This should only solve for instance operation case where the instance is removed from the statemap but there
+      // are still valid assignments in the mapping. We should not consider case where there is no mapping at all for
+      // the resource, which can occur on a rebalance failure. If the resource has been removed, the BP will
+      // contain the DROPPED states
       for (String instance : currentStateMap.keySet()) {
-        if (!instanceStateMap.containsKey(instance)) {
+        if (!instanceStateMap.isEmpty() && !instanceStateMap.containsKey(instance)) {
           instanceStateMap.put(instance, HelixDefinedState.DROPPED.name());
         }
       }

--- a/helix-core/src/test/java/org/apache/helix/integration/TestPreserveAssignmentsOnRebalanceFailure.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestPreserveAssignmentsOnRebalanceFailure.java
@@ -1,14 +1,11 @@
 package org.apache.helix.integration;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
-import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -36,6 +33,7 @@ public class TestPreserveAssignmentsOnRebalanceFailure extends ZkTestBase {
     _gSetupTool.addCluster(CLUSTER_NAME, true);
     for (int i = 0; i < PARTICIPANT_COUNT; i++) {
       String instanceName = "localhost_" + i;
+      addParticipant(CLUSTER_NAME, instanceName);
       InstanceConfig instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, instanceName);
       instanceConfig.setDomain("zone=zone" + i);
       _configAccessor.setInstanceConfig(CLUSTER_NAME, instanceName, instanceConfig);

--- a/helix-core/src/test/java/org/apache/helix/integration/TestPreserveAssignmentsOnRebalanceFailure.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestPreserveAssignmentsOnRebalanceFailure.java
@@ -1,0 +1,100 @@
+package org.apache.helix.integration;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.apache.helix.tools.ClusterVerifiers.StrictMatchExternalViewVerifier;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestPreserveAssignmentsOnRebalanceFailure extends ZkTestBase {
+
+  private final String CLUSTER_NAME = TestHelper.getTestClassName() + "_cluster";
+  public final int PARTICIPANT_COUNT = 3;
+  private ClusterControllerManager _controller;
+  private ConfigAccessor _configAccessor;
+  private StrictMatchExternalViewVerifier _externalViewVerifier;
+  private BestPossibleExternalViewVerifier _bestPossibleVerifier;
+
+  @BeforeClass
+  public void setup() {
+    System.out.println("Start test " + TestHelper.getTestClassName());
+    _configAccessor = new ConfigAccessor(_gZkClient);
+    _gSetupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < PARTICIPANT_COUNT; i++) {
+      String instanceName = "localhost_" + i;
+      InstanceConfig instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, instanceName);
+      instanceConfig.setDomain("zone=zone" + i);
+      _configAccessor.setInstanceConfig(CLUSTER_NAME, instanceName, instanceConfig);
+    }
+
+    // Enable topology aware rebalance and set expcted topology
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setFaultZoneType("zone");
+    clusterConfig.setTopology("/zone");
+    clusterConfig.setTopologyAwareEnabled(true);
+    clusterConfig.setPersistBestPossibleAssignment(true);
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    _externalViewVerifier = new StrictMatchExternalViewVerifier.Builder(CLUSTER_NAME).setZkAddr(ZK_ADDR)
+            .setDeactivatedNodeAwareness(true)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    _bestPossibleVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
+            .setZkAddr(ZK_ADDR)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+  }
+
+  // This test verifies that when a mapping cannot be generated for a resource (failureResources in
+  // BestPossibleStateCalcStage), the replicas are not dropped
+  @Test
+  public void testPreserveAssignmentsOnRebalanceFailure() {
+    System.out.println("Start test: " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName());
+
+    // Create a CRUSHED resource
+    int numPartition = 3;
+    String firstDB = "firstDB";
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, firstDB, numPartition, "LeaderStandby",
+        IdealState.RebalanceMode.FULL_AUTO.name(), CrushEdRebalanceStrategy.class.getName());
+    IdealState idealStateOne =
+        _gSetupTool.getClusterManagementTool().getResourceIdealState(CLUSTER_NAME, firstDB);
+    idealStateOne.setMinActiveReplicas(2);
+    idealStateOne.setRebalancerClassName(DelayedAutoRebalancer.class.getName());
+    _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, firstDB, idealStateOne);
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, firstDB, 3);
+
+    // Wait for cluster to converge and take a snapshot of the ExternalView
+    Assert.assertTrue(_bestPossibleVerifier.verifyByPolling());
+    ExternalView oldEV = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, firstDB);
+
+    // Add an instance with no domain set to the cluster, this will cause the topology aware assignment to fail
+    String badInstance = "bad_instance";
+    _gSetupTool.addInstanceToCluster(CLUSTER_NAME, badInstance);
+
+    // Assert EV = IS
+    Assert.assertTrue(_externalViewVerifier.verifyByPolling());
+
+    // Check that the new EV (after bad instance added) is the same as the old EV (before bad instance added)
+    ExternalView newEV = _gSetupTool.getClusterManagementTool().getResourceExternalView(CLUSTER_NAME, firstDB);
+    Assert.assertEquals(oldEV, newEV);
+    System.out.println("End test: " + TestHelper.getTestClassName() + "." + TestHelper.getTestMethodName());
+  }
+}


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

fixes #3018

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Change behavior in message generation when state exists in current state map but not in the best possible state only when the best possible state map actually contains a mapping for the partition. This is to prevent the case where the best possible state map does not contain a mapping for a resource because calculation failed (failureResources in BestPossibleStateCalcStage). More information can be seen in the issue #3018 

### Tests

- [ ] The following tests are written for this issue:

TestPreserveAssignmentsOnRebalanceFailure
TestRebalancePipeline.testNoMessagesSentOnNoResourceMapping


- The following is the result of the "mvn test" command on the appropriate module:
```
$ mvn test -o -Dtest=TestPreserveAssignmentsOnRebalanceFailure,TestRebalancePipeline -pl=helix-core

[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:17 min
[INFO] Finished at: 2025-05-05T17:27:50+05:30
[INFO] ------------------------------------------------------------------------

```


### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:
N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
