### PR TITLE
Create a custom ContainerManager for purging the TTL based znodes

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBaseDataAccessor.java
@@ -243,7 +243,7 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
   }
 
   @Test
-  public void testSyncCreateWithTTL() {
+  public void testSyncCreateWithTTL() throws InterruptedException {
     System.setProperty("zookeeper.extendedTypesEnabled", "true");
     String className = TestHelper.getTestClassName();
     String methodName = TestHelper.getTestMethodName();
@@ -271,6 +271,10 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     Assert.assertNotNull(getRecord);
     Assert.assertEquals(getRecord.getSimpleFields().size(), 0);
 
+    // Check if the TTL znode expires or not.
+    advanceFakeElapsedTime(2000);
+    _containerManager.checkContainers();
+    Assert.assertFalse(accessor.exists(path, 0));
     System.clearProperty("zookeeper.extendedTypesEnabled");
     System.out.println("END " + testName + " at " + new Date(System.currentTimeMillis()));
   }
@@ -300,7 +304,6 @@ public class TestZkBaseDataAccessor extends ZkUnitTestBase {
     getRecord = _gZkClient.readData(path);
     Assert.assertNotNull(getRecord);
     Assert.assertEquals(getRecord.getSimpleFields().size(), 0);
-
     System.clearProperty("zookeeper.extendedTypesEnabled");
     System.out.println("END " + testName + " at " + new Date(System.currentTimeMillis()));
   }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkServer.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkServer.java
@@ -150,4 +150,13 @@ public class ZkServer {
     public ZkClient getZkClient() {
         return _zkClient;
     }
+
+    /**
+     * Get the ZooKeeper server instance.
+     * @return The ZooKeeper server instance
+     */
+    public ZooKeeperServer getZooKeeperServer() {
+        return _zk;
+    }
+
 }

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestBase.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestBase.java
@@ -22,9 +22,11 @@ package org.apache.helix.zookeeper.impl;
 import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
 import java.util.Map;
-
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
@@ -32,6 +34,10 @@ import org.apache.commons.io.FileUtils;
 import org.apache.helix.zookeeper.constant.TestConstants;
 import org.apache.helix.zookeeper.zkclient.IDefaultNameSpace;
 import org.apache.helix.zookeeper.zkclient.ZkServer;
+import org.apache.zookeeper.server.ContainerManager;
+import org.apache.zookeeper.server.DataNode;
+import org.apache.zookeeper.server.RequestProcessor;
+import org.apache.zookeeper.server.ZooKeeperServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -60,7 +66,17 @@ public class ZkTestBase {
    */
   // The following maps hold ZK connect string as keys
   protected static final Map<String, ZkServer> _zkServerMap = new ConcurrentHashMap<>();
+  protected static final Map<ZkServer, ContainerManager> _zkServerContainerManagerMap = new ConcurrentHashMap<>();
+  protected static AtomicLong _fakeElapsed = new AtomicLong(0);
   protected static int _numZk = 1; // Initial value
+
+  /**
+   * Advances the fake elapsed time used by the ContainerManager
+   * @param additionalTime time to add in milliseconds
+   */
+  public static void advanceFakeElapsedTime(long additionalTime) {
+    _fakeElapsed.addAndGet(additionalTime);
+  }
 
   @BeforeSuite
   public void beforeSuite() throws IOException {
@@ -91,6 +107,9 @@ public class ZkTestBase {
       }
     }
 
+    // Shut down ContainerManagers
+    _zkServerContainerManagerMap.values().forEach(ContainerManager::stop);
+    
     // Shut down all ZkServers
     _zkServerMap.values().forEach(ZkServer::shutdown);
   }
@@ -115,6 +134,35 @@ public class ZkTestBase {
     for (int i = 0; i < _numZk; i++) {
       String zkAddress = ZK_PREFIX + (ZK_START_PORT + i);
       _zkServerMap.computeIfAbsent(zkAddress, ZkTestBase::startZkServer);
+      _zkServerContainerManagerMap.computeIfAbsent(_zkServerMap.get(zkAddress), ZkTestBase::createContainerManager);
+    }
+  }
+
+  /**
+   * Creates a ContainerManager with custom elapsed time functionality for a ZkServer
+   */
+  private static ContainerManager createContainerManager(ZkServer zkServer) {
+    try {
+      ZooKeeperServer zooKeeperServer = zkServer.getZooKeeperServer();
+
+      Field firstProcessorField = ZooKeeperServer.class.getDeclaredField("firstProcessor");
+      firstProcessorField.setAccessible(true);
+      RequestProcessor firstProcessor = (RequestProcessor) firstProcessorField.get(zooKeeperServer);
+
+      // Create a ContainerManager with a custom elapsed time logic
+      return new ContainerManager(
+          zooKeeperServer.getZKDatabase(),
+          firstProcessor,
+          100, // Check interval in ms
+          100  // Max containers to check per interval
+      ) {
+        @Override
+        protected long getElapsed(DataNode node) {
+          return _fakeElapsed.get();
+        }
+      };
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException("Failed to access firstProcessor field in ZooKeeperServer", e);
     }
   }
 

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestFederatedZkClient.java
@@ -38,11 +38,13 @@ import org.apache.helix.zookeeper.constant.RoutingSystemPropertyKeys;
 import org.apache.helix.zookeeper.constant.TestConstants;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
+import org.apache.helix.zookeeper.impl.ZkTestBase;
 import org.apache.helix.zookeeper.routing.RoutingDataManager;
 import org.apache.helix.zookeeper.zkclient.IZkStateListener;
 import org.apache.helix.zookeeper.zkclient.exception.ZkBadVersionException;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.server.ContainerManager;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -184,7 +186,7 @@ public class TestFederatedZkClient extends RealmAwareZkClientTestBase {
    * Test creating a sequential TTL node.
    */
   @Test(dependsOnMethods = "testRealmAwareZkClientCreateContainer")
-  public void testRealmAwareZkClientCreateSequentialWithTTL() {
+  public void testRealmAwareZkClientCreateSequentialWithTTL() throws InterruptedException {
     System.setProperty("zookeeper.extendedTypesEnabled", "true");
     // Create a dummy ZNRecord
     ZNRecord znRecord = new ZNRecord("DummyRecord");
@@ -199,6 +201,12 @@ public class TestFederatedZkClient extends RealmAwareZkClientTestBase {
     Assert.assertEquals(znRecord.getSimpleField("Dummy"),
         retrievedRecord.getSimpleField("Dummy"));
 
+    // Check if the TTL znode expires or not.
+    advanceFakeElapsedTime(2000);
+    ContainerManager containerManager = _zkServerContainerManagerMap.get(_zkServerMap.get(ZkTestBase.ZK_ADDR));
+    containerManager.checkContainers();
+    Assert.assertFalse(_realmAwareZkClient.exists(childPath));
+
     // Clean up
     _realmAwareZkClient.deleteRecursively(TEST_VALID_PATH);
     System.clearProperty("zookeeper.extendedTypesEnabled");
@@ -208,7 +216,7 @@ public class TestFederatedZkClient extends RealmAwareZkClientTestBase {
    * Test creating a TTL node.
    */
   @Test(dependsOnMethods = "testRealmAwareZkClientCreateSequentialWithTTL")
-  public void testRealmAwareZkClientCreateWithTTL() {
+  public void testRealmAwareZkClientCreateWithTTL() throws InterruptedException {
     System.setProperty("zookeeper.extendedTypesEnabled", "true");
     // Create a dummy ZNRecord
     ZNRecord znRecord = new ZNRecord("DummyRecord");
@@ -225,6 +233,12 @@ public class TestFederatedZkClient extends RealmAwareZkClientTestBase {
     ZNRecord retrievedRecord = _realmAwareZkClient.readData(childPath);
     Assert.assertEquals(znRecord.getSimpleField("Dummy"),
         retrievedRecord.getSimpleField("Dummy"));
+
+    // Check if the TTL znode expires or not.
+    advanceFakeElapsedTime(2000);
+    ContainerManager containerManager = _zkServerContainerManagerMap.get(_zkServerMap.get(ZkTestBase.ZK_ADDR));
+    containerManager.checkContainers();
+    Assert.assertFalse(_realmAwareZkClient.exists(childPath));
 
     // Clean up
     _realmAwareZkClient.deleteRecursively(TEST_VALID_PATH);

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/client/TestRawZkClient.java
@@ -66,6 +66,7 @@ import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
+import org.apache.zookeeper.server.ContainerManager;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
@@ -115,7 +116,7 @@ public class TestRawZkClient extends ZkTestBase {
   }
 
   @Test
-  void testCreatePersistentWithTTL() {
+  void testCreatePersistentWithTTL() throws InterruptedException {
     // Enable extended types and create a ZkClient
     System.setProperty("zookeeper.extendedTypesEnabled", "true");
     ZkClient zkClient = new ZkClient(ZkTestBase.ZK_ADDR);
@@ -145,6 +146,12 @@ public class TestRawZkClient extends ZkTestBase {
     zkClient.createPersistentWithTTL(path, true, ttl);
     AssertJUnit.assertTrue(zkClient.exists(path));
 
+    // Check if the TTL znode expires or not.
+    advanceFakeElapsedTime(2000);
+    ContainerManager containerManager = _zkServerContainerManagerMap.get(_zkServerMap.get(ZkTestBase.ZK_ADDR));
+    containerManager.checkContainers();
+    AssertJUnit.assertFalse(zkClient.exists(path));
+
     // Clean up
     zkClient.deleteRecursively(parentPath);
     zkClient.close();
@@ -152,7 +159,7 @@ public class TestRawZkClient extends ZkTestBase {
   }
 
   @Test
-  void testCreatePersistentSequentialWithTTL() {
+  void testCreatePersistentSequentialWithTTL() throws InterruptedException {
     // Enable extended types and create a ZkClient
     System.setProperty("zookeeper.extendedTypesEnabled", "true");
     ZkClient zkClient = new ZkClient(ZkTestBase.ZK_ADDR);
@@ -177,6 +184,12 @@ public class TestRawZkClient extends ZkTestBase {
     AssertJUnit.assertTrue(zkClient.exists(path + "0000000000"));
     ZNRecord retrievedRecord = zkClient.readData(path + "0000000000");
     AssertJUnit.assertEquals(value, retrievedRecord.getSimpleField(key));
+
+    // Check if the TTL znode expires or not.
+    advanceFakeElapsedTime(2000);
+    ContainerManager containerManager = _zkServerContainerManagerMap.get(_zkServerMap.get(ZkTestBase.ZK_ADDR));
+    containerManager.checkContainers();
+    AssertJUnit.assertFalse(zkClient.exists(path));
 
     // Clean up
     zkClient.deleteRecursively(parentPath);


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)
This PR fixes #3036 TTL Znode doesn't expire in Test envs

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
The issue is related to ZooKeeper's TTL (Time-To-Live) node functionality and specifically how it behaves in the embedded ZooKeeper environment used in tests.

In a normal ZooKeeper deployment, a background ContainerManager thread runs periodically to clean up expired TTL nodes. However, in the embedded ZooKeeper used for testing, this background thread doesn't appear to be functioning properly. The ContainerManager is designed to run on a configurable schedule (default is 60 seconds), but in the test environment, this cleanup process doesn't happen.

The way we solve it is by creating a custom ContainerManager and using a fakeElapsedTimer.

### Tests

- [ ] The following tests are written for this issue:
No new tests, but old tests modified.

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
