### PR TITLE
Only build property key path on construction

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/PropertyKey.java
+++ b/helix-core/src/main/java/org/apache/helix/PropertyKey.java
@@ -86,6 +86,7 @@ public class PropertyKey {
   public PropertyType _type;
   private final String[] _params;
   Class<? extends HelixProperty> _typeClazz;
+  private String _path;
 
   // if type is CONFIGS, set configScope; otherwise null
   ConfigScopeProperty _configScope;
@@ -110,15 +111,18 @@ public class PropertyKey {
    */
   public PropertyKey(PropertyType type, ConfigScopeProperty configScope,
       Class<? extends HelixProperty> typeClazz, String... params) {
-    _type = type;
     if (params == null || params.length == 0 || Arrays.asList(params).contains(null)) {
       throw new IllegalArgumentException("params cannot be null");
     }
 
+    _type = type;
     _params = params;
     _typeClazz = typeClazz;
-
     _configScope = configScope;
+    _path = PropertyPathBuilder.getPath(_type, _params[0], Arrays.copyOfRange(_params, 1, _params.length));
+    if (_path == null) {
+      LOG.error("Invalid property key with type: {} subKeys: {}", _type, Arrays.toString(_params));
+    }
   }
 
   @Override
@@ -165,13 +169,7 @@ public class PropertyKey {
    * @return absolute path to the property
    */
   public String getPath() {
-    String clusterName = _params[0];
-    String[] subKeys = Arrays.copyOfRange(_params, 1, _params.length);
-    String path = PropertyPathBuilder.getPath(_type, clusterName, subKeys);
-    if (path == null) {
-      LOG.error("Invalid property key with type:" + _type + "subKeys:" + Arrays.toString(_params));
-    }
-    return path;
+    return _path;
   }
 
   /**


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Performance improvement

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Currently, PropertyKey path is built on every call to PropertyKey.getPath() and performs regex match. This can be expensive and redundant as when we add a listener, we loop through the existing handlers and call propertyKey.getPath() for every handler that exists. The performance hit will be most noticeable in clusters with a large instance count. 

Technically, this will make it so that PropertyKey.getPath() will no longer update after instantiation if the underlying PropertyPathBuilder's templateMap is updated. However, I did not find this being done anywhere in the code so in effect there should be no change

Flame graph from 5 minute CPU profile taken during controller transiting to LEADER for clusters with thousands of instances. 

![Screenshot 2025-05-12 at 8 29 49 AM](https://github.com/user-attachments/assets/d2d8ede7-247e-4139-8452-f8a7b5a267b0)


![Screenshot 2025-05-12 at 8 30 04 AM](https://github.com/user-attachments/assets/017d2643-a320-45dd-a992-b7e05030b2a1)



### Tests

- [ ] The following tests are written for this issue:

None

- The following is the result of the "mvn test" command on the appropriate module:

N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)