### PR TITLE
Add default get value for task partition map to prevent NPE

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/WorkflowControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/WorkflowControllerDataProvider.java
@@ -189,7 +189,7 @@ public class WorkflowControllerDataProvider extends BaseControllerDataProvider {
       Map<String, Integer> partitionMap) {
     for (String participant : additionPartitionMap.keySet()) {
       partitionMap.put(participant,
-          partitionMap.get(participant) + additionPartitionMap.get(participant));
+          partitionMap.getOrDefault(participant, 0) + additionPartitionMap.getOrDefault(participant, 0));
     }
   }
 


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
#3079 

NPE occurring due to null value returned from partitionMap, likely from a disabled instance having task current state causing mismatch in map keys. Current logic makes assumption that `additionPartitionMap.keySet()` == `partitionMap.keySet()`


### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Change map.get to .getOrDefault to prevent NPEs


```
"message": Exception while executing TASK pipeline for cluster <cluster_name_here>. Will not continue to next pipeline,
"exceptionChain": [
	{
		"index": 0,
		"message": "Cannot invoke \"java.lang.Integer.intValue()\" because the return value of \"java.util.Map.get(Object)\" is null",
		"stackTrace": [
			{
				"index": 0,
				"call": "fillActiveTaskCount",
				"columnNumber": null,
				"fileName": "WorkflowControllerDataProvider.java",
				"lineNumber": 192,
				"nativeMethod": false,
				"source": "org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider"
			},
			{
				"index": 1,
				"call": "resetActiveTaskCount",
				"columnNumber": null,
				"fileName": "WorkflowControllerDataProvider.java",
				"lineNumber": 178,
				"nativeMethod": false,
				"source": "org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider"
			},
			{
				"index": 2,
				"call": "process",
				"columnNumber": null,
				"fileName": "TaskSchedulingStage.java",
				"lineNumber": 81,
				"nativeMethod": false,
				"source": "org.apache.helix.controller.stages.task.TaskSchedulingStage"
			},
			{
				"index": 3,
				"call": "handle",
				"columnNumber": null,
				"fileName": "Pipeline.java",
				"lineNumber": 75,
				"nativeMethod": false,
				"source": "org.apache.helix.controller.pipeline.Pipeline"
			},
			{
				"index": 4,
				"call": "handleEvent",
				"columnNumber": null,
				"fileName": "GenericHelixController.java",
				"lineNumber": 905,
				"nativeMethod": false,
				"source": "org.apache.helix.controller.GenericHelixController"
			},
			{
				"index": 5,
				"call": "run",
				"columnNumber": null,
				"fileName": "GenericHelixController.java",
				"lineNumber": 1556,
				"nativeMethod": false,
				"source": "org.apache.helix.controller.GenericHelixController$ClusterEventProcessor"
			}
		],
		"type": "java.lang.NullPointerException"
	}
],
"level": ERROR,
```

### Tests

N/A

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
