### PR TITLE
Helix fails to connect with Kerberos enabled ZK

### DIFF
--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientKerberos.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientKerberos.java
@@ -1,0 +1,171 @@
+package org.apache.helix.zookeeper.zkclient;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+
+import org.apache.helix.zookeeper.impl.ZkTestBase;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
+import org.apache.helix.zookeeper.zkclient.serialize.SerializableSerializer;
+import org.apache.zookeeper.client.ZKClientConfig;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Integration tests for Kerberos authentication detection in ZkClient
+ */
+public class TestZkClientKerberos extends ZkTestBase {
+  
+  private ZkClient _zkClient;
+  private Configuration _originalJaasConfig;
+
+  @BeforeMethod
+  public void setUp() {
+    // Save original JAAS configuration
+    _originalJaasConfig = Configuration.getConfiguration();
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    // Restore original JAAS configuration
+    if (_originalJaasConfig != null) {
+      Configuration.setConfiguration(_originalJaasConfig);
+    }
+    
+    if (_zkClient != null && !_zkClient.isClosed()) {
+      _zkClient.close();
+    }
+  }
+
+  /**
+   * Test isKerberosAuthEnabled returns false when SASL is disabled
+   */
+  @Test
+  public void testIsKerberosAuthEnabled_WhenSaslDisabled() throws Exception {
+    // Create ZkClient with SASL disabled (default configuration)
+    ZkClient.Builder builder = new ZkClient.Builder();
+    builder.setZkServer(ZkTestBase.ZK_ADDR)
+        .setMonitorRootPathOnly(false);
+    _zkClient = builder.build();
+    _zkClient.setZkSerializer(new BasicZkSerializer(new SerializableSerializer()));
+    
+    // Use reflection to call private isKerberosAuthEnabled method
+    boolean result = invokeIsKerberosAuthEnabled(_zkClient);
+    
+    // Verify
+    Assert.assertFalse(result, "isKerberosAuthEnabled should return false when SASL is disabled");
+  }
+
+  /**
+   * Test isKerberosAuthEnabled returns false when SASL is enabled but without Kerberos
+   */
+  @Test
+  public void testIsKerberosAuthEnabled_WhenSaslEnabledWithoutKerberos() throws Exception {
+    // Setup JAAS configuration with non-Kerberos module
+    Configuration jaasConfig = new Configuration() {
+      @Override
+      public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+        if (ZKClientConfig.LOGIN_CONTEXT_NAME_KEY_DEFAULT.equals(name)) {
+          return new AppConfigurationEntry[] {
+              new AppConfigurationEntry(
+                  "com.example.PlainLoginModule",
+                  AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                  new HashMap<>()
+              )
+          };
+        }
+        return null;
+      }
+    };
+    Configuration.setConfiguration(jaasConfig);
+    
+    // Enable SASL via system property
+    System.setProperty("zookeeper.sasl.client", "true");
+    
+    try {
+      // Create ZkClient
+      ZkClient.Builder builder = new ZkClient.Builder();
+      builder.setZkServer(ZkTestBase.ZK_ADDR)
+          .setMonitorRootPathOnly(false);
+      _zkClient = builder.build();
+      _zkClient.setZkSerializer(new BasicZkSerializer(new SerializableSerializer()));
+      
+      // Use reflection to call private isKerberosAuthEnabled method
+      boolean result = invokeIsKerberosAuthEnabled(_zkClient);
+      
+      // Verify
+      Assert.assertFalse(result, "isKerberosAuthEnabled should return false when Kerberos is not configured");
+    } finally {
+      System.clearProperty("zookeeper.sasl.client");
+    }
+  }
+
+
+  /**
+   * Test isKerberosAuthEnabled returns false when JAAS configuration is null
+   */
+  @Test
+  public void testIsKerberosAuthEnabled_WhenJaasConfigNull() throws Exception {
+    // Setup JAAS configuration that returns null
+    Configuration jaasConfig = new Configuration() {
+      @Override
+      public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+        return null;
+      }
+    };
+    Configuration.setConfiguration(jaasConfig);
+    
+    // Enable SASL via system property
+    System.setProperty("zookeeper.sasl.client", "true");
+    
+    try {
+      // Create ZkClient
+      ZkClient.Builder builder = new ZkClient.Builder();
+      builder.setZkServer(ZkTestBase.ZK_ADDR)
+          .setMonitorRootPathOnly(false);
+      _zkClient = builder.build();
+      _zkClient.setZkSerializer(new BasicZkSerializer(new SerializableSerializer()));
+      
+      // Use reflection to call private isKerberosAuthEnabled method
+      boolean result = invokeIsKerberosAuthEnabled(_zkClient);
+      
+      // Verify
+      Assert.assertFalse(result, "isKerberosAuthEnabled should return false when JAAS config is null");
+    } finally {
+      System.clearProperty("zookeeper.sasl.client");
+    }
+  }
+
+  /**
+   * Use reflection to invoke private isKerberosAuthEnabled method
+   */
+  private boolean invokeIsKerberosAuthEnabled(ZkClient zkClient) throws Exception {
+    // The method is in the base class org.apache.helix.zookeeper.zkclient.ZkClient
+    Method method = org.apache.helix.zookeeper.zkclient.ZkClient.class.getDeclaredMethod("isKerberosAuthEnabled");
+    method.setAccessible(true);
+    return (Boolean) method.invoke(zkClient);
+  }
+}


### PR DESCRIPTION

### Issues

- fixes #3101

### Description

Refer #3101 for details on the issue

### Tests
- Verified the changes through unit test cases
- Verified Change through Quickstart sample App
   In the Quickstart sample app, I have enabled Zookeeper Kerberos authentication and verified the fix
   
**Quickstart Output Before Fix**
Creating cluster: HELIX_QUICKSTART
 Adding 2 participants to the cluster
 	 Added participant: localhost_12000
 	 Added participant: localhost_12001
 Configuring StateModel: MyStateModel  with 1 Leader and 1 Standby
 Adding a resource MyResource: with 6 partitions and 2 replicas
 Starting Participants
 ERROR ZKHelixManager zkClient is not connected after waiting 10000ms., clusterName: HELIX_QUICKSTART, zkAddress: sl73tskrapd1044.visa.com:2181
 ERROR ZKHelixManager fail to createClient. retry 1
  org.apache.helix.HelixException: HelixManager is not connected within retry timeout for cluster HELIX_QUICKSTART
 	at org.apache.helix.manager.zk.ZKHelixManager.checkConnected(ZKHelixManager.java:417)
 	at org.apache.helix.manager.zk.ZKHelixManager.getConfigAccessor(ZKHelixManager.java:688)
 	at org.apache.helix.manager.zk.ParticipantManager.<init>(ParticipantManager.java:118)
 	at org.apache.helix.manager.zk.ZKHelixManager.handleNewSessionAsParticipant(ZKHelixManager.java:1441)
 	at org.apache.helix.manager.zk.ZKHelixManager.handleNewSession(ZKHelixManager.java:1391)
 	at org.apache.helix.manager.zk.ZKHelixManager.createClient(ZKHelixManager.java:783)
 	at org.apache.helix.manager.zk.ZKHelixManager.connect(ZKHelixManager.java:818)
 	at org.apache.helix.examples.Quickstart$MyProcess.start(Quickstart.java:247)
 	at org.apache.helix.examples.Quickstart.startNodes(Quickstart.java:146)
 	at org.apache.helix.examples.Quickstart.main(Quickstart.java:164)
 ERROR ZKHelixManager fail to createClient. retry 2
  org.apache.helix.zookeeper.zkclient.exception.ZkTimeoutException: Waiting to be connected to ZK server has timed out.
 	at org.apache.helix.zookeeper.zkclient.ZkClient.waitForEstablishedSession(ZkClient.java:2082)
 	at org.apache.helix.manager.zk.ZKHelixManager.createClient(ZKHelixManager.java:776)
 	at org.apache.helix.manager.zk.ZKHelixManager.connect(ZKHelixManager.java:818)
 	at org.apache.helix.examples.Quickstart$MyProcess.start(Quickstart.java:247)
 	at org.apache.helix.examples.Quickstart.startNodes(Quickstart.java:146)
 	at org.apache.helix.examples.Quickstart.main(Quickstart.java:164)



**Quickstart Output After Fix:**

Creating cluster: HELIX_QUICKSTART
  Adding 2 participants to the cluster
  	 Added participant: localhost_12000
  	 Added participant: localhost_12001
  Configuring StateModel: MyStateModel  with 1 Leader and 1 Standby
  Adding a resource MyResource: with 6 partitions and 2 replicas
  Starting Participants
  	 Started Participant: localhost_12000
  	 Started Participant: localhost_12001
  Starting Helix Controller
  LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12000 transitioning from OFFLINE to STANDBY for MyResource MyResource_1
  LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12000 transitioning from OFFLINE to STANDBY for MyResource MyResource_4
  LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12000 transitioning from OFFLINE to STANDBY for MyResource MyResource_3
  LeaderStandbyStateModel.onBecomeStandbyFromOffline():localhost_12000 transitioning from OFFLINE to STANDBY for MyResource MyResource_5

- [ ] The following tests are written for this issue:

org.apache.helix.zookeeper.impl.client.TestRawZkClient
#testWaitForKeeperStateWithSaslAuthenticated
#testWaitForKeeperStateWithConnectedReadOnly
#testWaitForKeeperStateWithOtherStates
#testWaitForKeeperStateExactMatchStillWorks

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
