### PR TITLE
Add percentage-based offline instance thresholds for maintenance mode

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -358,41 +358,54 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
   // if yes, auto enable maintenance mode, and use the maintenance rebalancer for this pipeline.
   private boolean validateInstancesUnableToAcceptOnlineReplicasLimit(final ResourceControllerDataProvider cache,
       final HelixManager manager) {
-    int maxInstancesUnableToAcceptOnlineReplicas =
-        cache.getClusterConfig().getMaxOfflineInstancesAllowed();
-    if (maxInstancesUnableToAcceptOnlineReplicas >= 0) {
-      // Instead of only checking the offline instances, we consider how many instances in the cluster
-      // are not assignable and live. This is because some instances may be online but have an unassignable
-      // InstanceOperation such as EVACUATE, and DISABLE. We will exclude SWAP_IN and UNKNOWN instances from
-      // they should not account against the capacity of the cluster.
-      int instancesUnableToAcceptOnlineReplicas = cache.getInstanceConfigMap().entrySet().stream()
-          .filter(instanceEntry -> !InstanceConstants.UNROUTABLE_INSTANCE_OPERATIONS.contains(
-              instanceEntry.getValue().getInstanceOperation().getOperation()))
-          .collect(Collectors.toSet())
-          .size() - cache.getEnabledLiveInstances().size();
-      if (instancesUnableToAcceptOnlineReplicas > maxInstancesUnableToAcceptOnlineReplicas) {
-        String errMsg = String.format(
-            "Instances unable to take ONLINE replicas count %d greater than allowed count %d. Put cluster %s into "
-                + "maintenance mode.", instancesUnableToAcceptOnlineReplicas,
-            maxInstancesUnableToAcceptOnlineReplicas, cache.getClusterName());
-        if (manager != null) {
-          if (manager.getHelixDataAccessor()
-              .getProperty(manager.getHelixDataAccessor().keyBuilder().maintenance()) == null) {
-            manager.getClusterManagmentTool()
-                .autoEnableMaintenanceMode(manager.getClusterName(), true, errMsg,
-                    MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
-            LogUtil.logWarn(logger, _eventId, errMsg);
-          }
-        } else {
-          LogUtil.logError(logger, _eventId, "Failed to put cluster " + cache.getClusterName()
-              + " into maintenance mode, HelixManager is not set!");
+    ClusterConfig clusterConfig = cache.getClusterConfig();
+    int absoluteThreshold = clusterConfig.getMaxOfflineInstancesAllowed();
+    int percentageThreshold = clusterConfig.getMaxOfflineInstancesAllowedPercentage();
+
+    // Early exit if neither threshold is configured
+    if (absoluteThreshold < 0 && percentageThreshold < 0) {
+      return true;
+    }
+
+    // Instead of only checking the offline instances, we consider how many instances in the cluster
+    // are not assignable and live. This is because some instances may be online but have an unassignable
+    // InstanceOperation such as EVACUATE, and DISABLE. We will exclude SWAP_IN and UNKNOWN instances
+    // as they should not account against the capacity of the cluster.
+    int routableInstanceCount = (int) cache.getInstanceConfigMap().entrySet().stream()
+        .filter(instanceEntry -> !InstanceConstants.UNROUTABLE_INSTANCE_OPERATIONS.contains(
+            instanceEntry.getValue().getInstanceOperation().getOperation()))
+        .count();
+    int instancesUnableToAcceptOnlineReplicas =
+        routableInstanceCount - cache.getEnabledLiveInstances().size();
+
+    int effectiveThreshold = ClusterConfig.resolveEffectiveThreshold(
+        absoluteThreshold, percentageThreshold, routableInstanceCount);
+
+    if (effectiveThreshold >= 0
+        && instancesUnableToAcceptOnlineReplicas > effectiveThreshold) {
+      String errMsg = String.format(
+          "Instances unable to take ONLINE replicas count %d greater than effective allowed count %d "
+              + "(absolute=%d, percentage=%d%% of %d routable). Put cluster %s into maintenance mode.",
+          instancesUnableToAcceptOnlineReplicas, effectiveThreshold,
+          absoluteThreshold, percentageThreshold, routableInstanceCount,
+          cache.getClusterName());
+      if (manager != null) {
+        if (manager.getHelixDataAccessor()
+            .getProperty(manager.getHelixDataAccessor().keyBuilder().maintenance()) == null) {
+          manager.getClusterManagmentTool()
+              .autoEnableMaintenanceMode(manager.getClusterName(), true, errMsg,
+                  MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
+          LogUtil.logWarn(logger, _eventId, errMsg);
         }
-
-        // Enable maintenance mode in cache so the maintenance rebalancer is used for this pipeline
-        cache.enableMaintenanceMode();
-
-        return false;
+      } else {
+        LogUtil.logError(logger, _eventId, "Failed to put cluster " + cache.getClusterName()
+            + " into maintenance mode, HelixManager is not set!");
       }
+
+      // Enable maintenance mode in cache so the maintenance rebalancer is used for this pipeline
+      cache.enableMaintenanceMode();
+
+      return false;
     }
     return true;
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MaintenanceRecoveryStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MaintenanceRecoveryStage.java
@@ -24,12 +24,14 @@ import java.util.Map;
 
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.HelixManager;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.LogUtil;
 import org.apache.helix.controller.common.PartitionStateMap;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.pipeline.AbstractAsyncBaseStage;
 import org.apache.helix.controller.pipeline.AsyncWorkerType;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.MaintenanceSignal;
 import org.apache.helix.model.Partition;
@@ -84,18 +86,34 @@ public class MaintenanceRecoveryStage extends AbstractAsyncBaseStage {
     case MAX_OFFLINE_INSTANCES_EXCEEDED:
     case MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS:
       // Check on the number of offline/disabled instances
-      int numOfflineInstancesForAutoExit =
-          cache.getClusterConfig().getNumOfflineInstancesForAutoExit();
-      if (numOfflineInstancesForAutoExit < 0) {
-        return; // Config is not set, no auto-exit
+      ClusterConfig clusterConfig = cache.getClusterConfig();
+      int absoluteExitThreshold = clusterConfig.getNumOfflineInstancesForAutoExit();
+      int percentageExitThreshold = clusterConfig.getNumOfflineInstancesForAutoExitPercentage();
+
+      if (absoluteExitThreshold < 0 && percentageExitThreshold < 0) {
+        return; // Neither config is set, no auto-exit
       }
+
+      // Compute routable instance count for percentage resolution (same filter as entry logic)
+      int routableInstanceCount = (int) cache.getInstanceConfigMap().entrySet().stream()
+          .filter(instanceEntry -> !InstanceConstants.UNROUTABLE_INSTANCE_OPERATIONS.contains(
+              instanceEntry.getValue().getInstanceOperation().getOperation()))
+          .count();
+
       // Get the count of all instances that are either offline or disabled
       int offlineDisabledCount =
           cache.getAssignableInstances().size() - cache.getEnabledLiveInstances().size();
-      shouldExitMaintenance = offlineDisabledCount <= numOfflineInstancesForAutoExit;
+
+      int effectiveExitThreshold = ClusterConfig.resolveEffectiveThreshold(
+          absoluteExitThreshold, percentageExitThreshold, routableInstanceCount);
+
+      shouldExitMaintenance =
+          effectiveExitThreshold >= 0 && offlineDisabledCount <= effectiveExitThreshold;
       reason = String.format(
-          "Auto-exiting maintenance mode for cluster %s; Num. of offline/disabled instances is %d, less than or equal to the exit threshold %d",
-          event.getClusterName(), offlineDisabledCount, numOfflineInstancesForAutoExit);
+          "Auto-exiting maintenance mode for cluster %s; Num. of offline/disabled instances is %d, "
+              + "less than or equal to effective exit threshold %d (absolute=%d, percentage=%d%% of %d routable)",
+          event.getClusterName(), offlineDisabledCount, effectiveExitThreshold,
+          absoluteExitThreshold, percentageExitThreshold, routableInstanceCount);
       break;
     case MAX_PARTITION_PER_INSTANCE_EXCEEDED:
       IntermediateStateOutput intermediateStateOutput =

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -79,6 +79,10 @@ public class ClusterConfig extends HelixProperty {
     //     to make it clear that it includes both offline and non-assignable instances
     MAX_OFFLINE_INSTANCES_ALLOWED,
     NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT, // For auto-exiting maintenance mode
+    // Percentage-based alternatives for maintenance mode thresholds (0-100).
+    // When both absolute and percentage are set, the stricter (lower effective count) wins.
+    MAX_OFFLINE_INSTANCES_ALLOWED_PERCENTAGE,
+    NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT_PERCENTAGE,
 
     TARGET_EXTERNALVIEW_ENABLED,
     @Deprecated // ERROR_OR_RECOVERY_PARTITION_THRESHOLD_FOR_LOAD_BALANCE will take
@@ -590,6 +594,106 @@ public class ClusterConfig extends HelixProperty {
   public int getNumOfflineInstancesForAutoExit() {
     return _record
         .getIntField(ClusterConfigProperty.NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT.name(), -1);
+  }
+
+  /**
+   * Set the max offline instances allowed as a percentage (0-100) of total routable instances.
+   * When both percentage and absolute thresholds are set, the stricter (lower effective count) wins.
+   * -1 disables the percentage-based entry threshold.
+   * @param maxOfflineInstancesAllowedPercentage percentage threshold (0-100) or -1 to disable
+   */
+  public void setMaxOfflineInstancesAllowedPercentage(int maxOfflineInstancesAllowedPercentage) {
+    if (maxOfflineInstancesAllowedPercentage < -1 || maxOfflineInstancesAllowedPercentage > 100) {
+      throw new HelixException(
+          "Max offline instances allowed percentage must be between 0 and 100, or -1 to disable. Got: "
+              + maxOfflineInstancesAllowedPercentage);
+    }
+    _record.setIntField(
+        ClusterConfigProperty.MAX_OFFLINE_INSTANCES_ALLOWED_PERCENTAGE.name(),
+        maxOfflineInstancesAllowedPercentage);
+  }
+
+  /**
+   * Get the max offline instances allowed percentage for the cluster.
+   * @return percentage (0-100) or -1 if not set
+   */
+  public int getMaxOfflineInstancesAllowedPercentage() {
+    return _record.getIntField(
+        ClusterConfigProperty.MAX_OFFLINE_INSTANCES_ALLOWED_PERCENTAGE.name(), -1);
+  }
+
+  /**
+   * Sets the percentage-based offline instances threshold for auto-exit (0-100).
+   * The percentage is computed against total routable instances at runtime.
+   * When both percentage and absolute exit thresholds are set, the stricter (lower) wins.
+   * If a percentage-based entry threshold is also set, exit percentage must be <= entry percentage.
+   * -1 disables the percentage-based auto-exit threshold.
+   * @param autoExitPercentage percentage threshold (0-100) or -1 to disable
+   */
+  public void setNumOfflineInstancesForAutoExitPercentage(int autoExitPercentage)
+      throws HelixException {
+    if (autoExitPercentage < -1 || autoExitPercentage > 100) {
+      throw new HelixException(
+          "Num offline instances for auto exit percentage must be between 0 and 100, or -1 to disable. Got: "
+              + autoExitPercentage);
+    }
+    int entryPercentage = getMaxOfflineInstancesAllowedPercentage();
+    if (entryPercentage >= 0 && autoExitPercentage >= 0) {
+      if (autoExitPercentage > entryPercentage) {
+        throw new HelixException(
+            "Auto-exit percentage threshold must be less than or equal to entry percentage threshold! "
+                + "Exit: " + autoExitPercentage + ", Entry: " + entryPercentage);
+      }
+    }
+    _record.setIntField(
+        ClusterConfigProperty.NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT_PERCENTAGE.name(),
+        autoExitPercentage);
+  }
+
+  /**
+   * Returns the percentage-based offline instances threshold for auto-exit.
+   * @return percentage (0-100) or -1 if not set
+   */
+  public int getNumOfflineInstancesForAutoExitPercentage() {
+    return _record.getIntField(
+        ClusterConfigProperty.NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT_PERCENTAGE.name(), -1);
+  }
+
+  /**
+   * Resolves the effective threshold given an absolute threshold, a percentage threshold,
+   * and a total instance count. The stricter (lower non-negative) value wins.
+   * <ul>
+   *   <li>If both are less than 0 (disabled), returns -1.</li>
+   *   <li>If only one is set (>= 0), that value is used (percentage is converted to count).</li>
+   *   <li>If both are set, the minimum of the two effective counts is returned.</li>
+   * </ul>
+   * Percentage conversion uses integer division (truncation toward zero), which is conservative
+   * for both entry (triggers sooner) and exit (requires more recovery).
+   *
+   * @param absoluteThreshold the absolute count threshold (-1 if not set)
+   * @param percentageThreshold the percentage threshold (0-100, -1 if not set)
+   * @param totalRoutableCount the total routable instance count to compute percentage against
+   * @return the effective threshold count, or -1 if neither is set
+   */
+  public static int resolveEffectiveThreshold(int absoluteThreshold, int percentageThreshold,
+      int totalRoutableCount) {
+    if (absoluteThreshold < 0 && percentageThreshold < 0) {
+      return -1;
+    }
+
+    int effectivePercentage = -1;
+    if (percentageThreshold >= 0) {
+      effectivePercentage =
+          (totalRoutableCount > 0) ? (totalRoutableCount * percentageThreshold / 100) : 0;
+    }
+
+    if (absoluteThreshold < 0) {
+      return effectivePercentage;
+    }
+    if (effectivePercentage < 0) {
+      return absoluteThreshold;
+    }
+    return Math.min(absoluteThreshold, effectivePercentage);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
@@ -431,6 +431,75 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
   }
 
   /**
+   * Test that auto-exit works with percentage-based threshold.
+   * With 3 total instances and exit percentage of 33%, the effective exit threshold is
+   * 3 * 33 / 100 = 0 (integer truncation). So the cluster should auto-exit only when
+   * all instances are back online (0 offline).
+   */
+  @Test(dependsOnMethods = "testMaintenanceHistory")
+  public void testAutoExitMaintenanceModeWithPercentage() throws Exception {
+    // First, exit any existing maintenance mode
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null,
+        null);
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+
+    // Bring all instances back up
+    for (int i = 0; i < _numNodes; i++) {
+      if (!_participants[i].isConnected()) {
+        String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+        _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+        _participants[i].syncStart();
+      }
+    }
+    TestHelper.verify(
+        () -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).size() == _numNodes, 2000L);
+
+    // Set percentage-based config: entry at 30% (of 3 nodes = 0, so >0 triggers), exit at 33%
+    // (of 3 nodes = 0, so exit only when 0 offline)
+    // Use absolute entry threshold of 1 for reliable entry, and percentage-based exit
+    ClusterConfig clusterConfig = _manager.getConfigAccessor().getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setMaxOfflineInstancesAllowed(1);
+    clusterConfig.setNumOfflineInstancesForAutoExit(-1); // Disable absolute exit
+    clusterConfig.setNumOfflineInstancesForAutoExitPercentage(33);
+    _manager.getConfigAccessor().setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    // Kill 2 instances to trigger auto-enter (2 > 1)
+    for (int i = 0; i < 2; i++) {
+      _participants[i].syncStop();
+    }
+    TestHelper.verify(
+        () -> _dataAccessor.getProperty(_keyBuilder.maintenance()) != null, TIMEOUT);
+
+    // Bring up 1 instance (1 still offline). 33% of 3 = 0, so 1 > 0, should NOT auto-exit
+    String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + 0);
+    _participants[0] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+    _participants[0].syncStart();
+    TestHelper.verify(
+        () -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).size() == _numNodes - 1,
+        2000L);
+    // Give some time for the pipeline to run and verify maintenance is NOT exited
+    Thread.sleep(2000);
+    MaintenanceSignal maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(maintenanceSignal, "Cluster should still be in maintenance");
+
+    // Bring up the last instance (0 offline). 0 <= 0, so should auto-exit
+    instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + 1);
+    _participants[1] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+    _participants[1].syncStart();
+    TestHelper.verify(
+        () -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).size() == _numNodes, 2000L);
+
+    // Verify cluster auto-exited maintenance
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, TIMEOUT);
+
+    // Clean up: reset configs
+    clusterConfig = _manager.getConfigAccessor().getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setMaxOfflineInstancesAllowed(-1);
+    clusterConfig.setNumOfflineInstancesForAutoExitPercentage(-1);
+    _manager.getConfigAccessor().setClusterConfig(CLUSTER_NAME, clusterConfig);
+  }
+
+  /**
    * Convert a String representation of a Map into a Map object for verification purposes.
    * @param value
    * @return

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit.java
@@ -196,6 +196,85 @@ public class TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit exten
     checkForRebalanceError(true);
   }
 
+  /**
+   * Test that percentage-based entry threshold works.
+   * With 10 nodes and 40% threshold, the effective limit is 10 * 40 / 100 = 4.
+   * Stopping 4 instances should NOT trigger maintenance (4 is not > 4).
+   * Stopping 5 should trigger it (5 > 4).
+   */
+  @Test(dependsOnMethods = "testWithOfflineInstancesLimit")
+  public void testWithPercentageBasedOfflineLimit() throws Exception {
+    // Restart any stopped instances from previous test
+    for (int i = 0; i < NUM_NODE; i++) {
+      if (!_participants.get(i).isConnected()) {
+        String instanceName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+        MockParticipantManager participant =
+            new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+        participant.syncStart();
+        _participants.set(i, participant);
+      }
+    }
+    // Manually exit maintenance if still in it
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
+    admin.enableMaintenanceMode(CLUSTER_NAME, false);
+
+    ZkHelixClusterVerifier clusterVerifier =
+        new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    Assert.assertTrue(clusterVerifier.verifyByPolling());
+
+    // Set percentage-based threshold: 40% of 10 nodes = 4
+    // Disable absolute threshold so only percentage is used
+    ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    ClusterConfig clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setMaxOfflineInstancesAllowed(-1);
+    clusterConfig.setMaxOfflineInstancesAllowedPercentage(40);
+    clusterConfig.setNumOfflineInstancesForAutoExit(0);
+    configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    MaintenanceSignal maintenanceSignal =
+        _dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
+    Assert.assertNull(maintenanceSignal);
+
+    // Stop 4 instances (exactly at the threshold, should NOT enter maintenance)
+    for (int i = 0; i < 4; i++) {
+      _participants.get(i).syncStop();
+    }
+
+    boolean result = TestHelper.verify(() -> {
+      MaintenanceSignal ms = _dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
+      return ms == null;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result);
+
+    // Stop 5th instance (exceeds threshold, should enter maintenance)
+    _participants.get(4).syncStop();
+
+    result = TestHelper.verify(() -> {
+      MaintenanceSignal ms = _dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
+      return ms != null && ms.getReason() != null;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(result);
+
+    // Clean up: restore absolute threshold, disable percentage
+    clusterConfig = configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setMaxOfflineInstancesAllowed(_maxOfflineInstancesAllowed);
+    clusterConfig.setMaxOfflineInstancesAllowedPercentage(-1);
+    configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    // Re-enable stopped instances
+    for (int i = 0; i < 5; i++) {
+      String instanceName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      MockParticipantManager participant =
+          new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+      participant.syncStart();
+      _participants.set(i, participant);
+    }
+    admin.enableMaintenanceMode(CLUSTER_NAME, false);
+    Assert.assertTrue(clusterVerifier.verifyByPolling());
+  }
+
   @AfterClass
   public void afterClass() throws Exception {
     /*

--- a/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.helix.HelixException;
 import org.apache.helix.controller.rebalancer.constraint.MockAbnormalStateResolver;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.testng.Assert;
@@ -418,6 +419,158 @@ public class TestClusterConfig {
             -1), 10000L);
   }
 
+
+  // --- Percentage-based maintenance mode threshold tests ---
+
+  @Test
+  public void testGetMaxOfflineInstancesAllowedPercentageDefault() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    Assert.assertEquals(testConfig.getMaxOfflineInstancesAllowedPercentage(), -1);
+  }
+
+  @Test
+  public void testSetAndGetMaxOfflineInstancesAllowedPercentage() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    testConfig.setMaxOfflineInstancesAllowedPercentage(25);
+    Assert.assertEquals(testConfig.getMaxOfflineInstancesAllowedPercentage(), 25);
+  }
+
+  @Test
+  public void testSetMaxOfflineInstancesAllowedPercentageBoundaryValues() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    testConfig.setMaxOfflineInstancesAllowedPercentage(0);
+    Assert.assertEquals(testConfig.getMaxOfflineInstancesAllowedPercentage(), 0);
+
+    testConfig.setMaxOfflineInstancesAllowedPercentage(100);
+    Assert.assertEquals(testConfig.getMaxOfflineInstancesAllowedPercentage(), 100);
+
+    testConfig.setMaxOfflineInstancesAllowedPercentage(-1);
+    Assert.assertEquals(testConfig.getMaxOfflineInstancesAllowedPercentage(), -1);
+  }
+
+  @Test(expectedExceptions = HelixException.class)
+  public void testSetMaxOfflineInstancesAllowedPercentageTooHigh() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    testConfig.setMaxOfflineInstancesAllowedPercentage(101);
+  }
+
+  @Test(expectedExceptions = HelixException.class)
+  public void testSetMaxOfflineInstancesAllowedPercentageTooLow() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    testConfig.setMaxOfflineInstancesAllowedPercentage(-2);
+  }
+
+  @Test
+  public void testGetNumOfflineInstancesForAutoExitPercentageDefault() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    Assert.assertEquals(testConfig.getNumOfflineInstancesForAutoExitPercentage(), -1);
+  }
+
+  @Test
+  public void testSetAndGetNumOfflineInstancesForAutoExitPercentage() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    testConfig.setMaxOfflineInstancesAllowedPercentage(30);
+    testConfig.setNumOfflineInstancesForAutoExitPercentage(20);
+    Assert.assertEquals(testConfig.getNumOfflineInstancesForAutoExitPercentage(), 20);
+  }
+
+  @Test(expectedExceptions = HelixException.class)
+  public void testSetAutoExitPercentageExceedsEntryPercentage() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    testConfig.setMaxOfflineInstancesAllowedPercentage(20);
+    testConfig.setNumOfflineInstancesForAutoExitPercentage(30);
+  }
+
+  @Test
+  public void testSetAutoExitPercentageWhenEntryPercentageNotSet() {
+    // When entry percentage is -1, any valid exit percentage should be accepted
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    testConfig.setNumOfflineInstancesForAutoExitPercentage(50);
+    Assert.assertEquals(testConfig.getNumOfflineInstancesForAutoExitPercentage(), 50);
+  }
+
+  @Test(expectedExceptions = HelixException.class)
+  public void testSetAutoExitPercentageTooHigh() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    testConfig.setNumOfflineInstancesForAutoExitPercentage(101);
+  }
+
+  @Test(expectedExceptions = HelixException.class)
+  public void testSetAutoExitPercentageTooLow() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    testConfig.setNumOfflineInstancesForAutoExitPercentage(-2);
+  }
+
+  // --- resolveEffectiveThreshold tests ---
+
+  @Test
+  public void testResolveEffectiveThresholdBothDisabled() {
+    Assert.assertEquals(ClusterConfig.resolveEffectiveThreshold(-1, -1, 100), -1);
+  }
+
+  @Test
+  public void testResolveEffectiveThresholdOnlyAbsolute() {
+    Assert.assertEquals(ClusterConfig.resolveEffectiveThreshold(5, -1, 100), 5);
+  }
+
+  @Test
+  public void testResolveEffectiveThresholdOnlyPercentage() {
+    // 10% of 100 = 10
+    Assert.assertEquals(ClusterConfig.resolveEffectiveThreshold(-1, 10, 100), 10);
+  }
+
+  @Test
+  public void testResolveEffectiveThresholdBothSetAbsoluteStricter() {
+    // absolute=3, percentage=10% of 100 = 10. Stricter is 3.
+    Assert.assertEquals(ClusterConfig.resolveEffectiveThreshold(3, 10, 100), 3);
+  }
+
+  @Test
+  public void testResolveEffectiveThresholdBothSetPercentageStricter() {
+    // absolute=15, percentage=10% of 100 = 10. Stricter is 10.
+    Assert.assertEquals(ClusterConfig.resolveEffectiveThreshold(15, 10, 100), 10);
+  }
+
+  @Test
+  public void testResolveEffectiveThresholdBothEqual() {
+    // absolute=10, percentage=10% of 100 = 10.
+    Assert.assertEquals(ClusterConfig.resolveEffectiveThreshold(10, 10, 100), 10);
+  }
+
+  @Test
+  public void testResolveEffectiveThresholdPercentageRoundsDown() {
+    // 10% of 3 = 0.3, truncated to 0
+    Assert.assertEquals(ClusterConfig.resolveEffectiveThreshold(-1, 10, 3), 0);
+  }
+
+  @Test
+  public void testResolveEffectiveThresholdSmallClusterPercentage() {
+    // 1% of 5 = 0.05, truncated to 0
+    Assert.assertEquals(ClusterConfig.resolveEffectiveThreshold(-1, 1, 5), 0);
+  }
+
+  @Test
+  public void testResolveEffectiveThresholdZeroRoutableCount() {
+    Assert.assertEquals(ClusterConfig.resolveEffectiveThreshold(-1, 50, 0), 0);
+  }
+
+  @Test
+  public void testResolveEffectiveThresholdZeroPercentage() {
+    // 0% of 100 = 0
+    Assert.assertEquals(ClusterConfig.resolveEffectiveThreshold(-1, 0, 100), 0);
+  }
+
+  @Test
+  public void testResolveEffectiveThresholdHundredPercent() {
+    // 100% of 50 = 50
+    Assert.assertEquals(ClusterConfig.resolveEffectiveThreshold(-1, 100, 50), 50);
+  }
+
+  @Test
+  public void testResolveEffectiveThresholdLargeCluster() {
+    // 5% of 500 = 25, absolute=30. Stricter is 25.
+    Assert.assertEquals(ClusterConfig.resolveEffectiveThreshold(30, 5, 500), 25);
+  }
 
   private void trySetInvalidAbnormalStatesResolverMap(ClusterConfig testConfig,
       Map<String, String> resolverMap) {


### PR DESCRIPTION
Currently maintenance mode entry/exit thresholds (MAX_OFFLINE_INSTANCES_ALLOWED, NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT) only support absolute counts, requiring operators to re-tune them as clusters scale. This adds percentage-based alternatives that adapt automatically to cluster size.

New ClusterConfig properties:
- MAX_OFFLINE_INSTANCES_ALLOWED_PERCENTAGE (0-100)
- NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT_PERCENTAGE (0-100)

When both absolute and percentage thresholds are configured, the stricter (lower effective count) value wins. Percentage is computed against total routable instances using integer truncation (conservative rounding).

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
