### PR TITLE
Fix NPE in HelixTaskExecutor.reset() when a task completes during shutdown

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/handling/HelixTaskExecutor.java
@@ -738,10 +738,11 @@ public class HelixTaskExecutor implements MessageListener, TaskExecutor {
     // this is a potential area to improve. https://github.com/apache/helix/issues/1245
 
     StringBuilder sb = new StringBuilder();
-    // Log all tasks that fail to terminate
-    for (String taskId : _taskMap.keySet()) {
-      MessageTaskInfo info = _taskMap.get(taskId);
-      sb.append("Task: " + taskId + " fails to terminate. Message: " + info._task.getMessage() + "\n");
+    // Log all tasks that fail to terminate. Iterate entrySet() because each entry is read atomically: a task
+    // completing concurrently removes itself from the map, so keySet() + get() could observe a null value and NPE.
+    for (Map.Entry<String, MessageTaskInfo> entry : _taskMap.entrySet()) {
+      sb.append(
+          "Task: " + entry.getKey() + " fails to terminate. Message: " + entry.getValue()._task.getMessage() + "\n");
     }
 
     LOG.info(sb.toString());


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #3167

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

`HelixTaskExecutor.reset()` ends with a loop that logs tasks failing to terminate by iterating `_taskMap.keySet()` and then calling `get(taskId)`. `_taskMap` is a `ConcurrentHashMap` and message tasks remove themselves from it when they finish, so a task completing while `reset()` runs disappears between the two calls: `get` returns null and reading `info._task` throws

```
java.lang.NullPointerException: Cannot read field "_task" because "info" is null
```

which propagates out of `reset()` and can fail the participant disconnect (observed intermittently in Apache Pinot integration-test teardowns).

This change iterates `entrySet()` instead: each entry is read atomically, so a concurrently-completing task is either logged or skipped, but can never yield a null value. No behavior change for tasks genuinely still present.

### Tests

- [ ] The following tests are written for this issue:

None — the fix removes a data race in a shutdown logging loop; the race window (concurrent task completion between two map reads inside `reset()`) is not deterministically reproducible from a unit test without intrusive instrumentation.

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines and follow the commit message guidelines.

### Code Quality

- My diff has been formatted using helix-style.xml
